### PR TITLE
CORE: Check that Member and Group are from the same VO

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/MemberGroupMismatchException.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/MemberGroupMismatchException.java
@@ -1,11 +1,17 @@
 package cz.metacentrum.perun.core.api.exceptions;
 
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.Member;
+
 /**
  * This exception is thrown when the member and group are not in the same VO
  *
  * @author Pavel Zlámal <zlamal@cesnet.cz>
  */
 public class MemberGroupMismatchException extends PerunException {
+
+	private Member member;
+	private Group group;
 
 	/**
 	 * Constructor with a Throwable object
@@ -36,6 +42,26 @@ public class MemberGroupMismatchException extends PerunException {
 	 * Constructor with no arguments
 	 */
 	public MemberGroupMismatchException() {
+	}
+
+	public MemberGroupMismatchException(String message, Member member, Group group) {
+		super(message);
+		this.member = member;
+		this.group = group;
+	}
+
+	public MemberGroupMismatchException(String message, Throwable cause, Member member, Group group) {
+		super(message, cause);
+		this.member = member;
+		this.group = group;
+	}
+
+	public Member getMember() {
+		return member;
+	}
+
+	public Group getGroup() {
+		return group;
 	}
 
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/AttributesManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/AttributesManager.java
@@ -241,7 +241,7 @@ public interface AttributesManager {
 	 * @throws GroupNotExistsException           if the group doesn't exists in underlying data source
 	 * @throws MemberNotExistsException          if the member doesn't have access to this resource
 	 */
-	List<Attribute> getAttributes(PerunSession sess, Member member, Group group) throws GroupNotExistsException, InternalErrorException, MemberNotExistsException;
+	List<Attribute> getAttributes(PerunSession sess, Member member, Group group) throws GroupNotExistsException, InternalErrorException, MemberNotExistsException, MemberGroupMismatchException;
 
 	/**
 	 * Get all attributes (empty and virtual too)associated with the member in the group which have name in list attrNames.
@@ -255,7 +255,7 @@ public interface AttributesManager {
 	 * @throws InternalErrorException            if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 * @throws MemberNotExistsException          if the member doesn't have access to this resource
 	 */
-	List<Attribute> getAttributes(PerunSession sess, Member member, Group group, List<String> attrNames) throws GroupNotExistsException, InternalErrorException, MemberNotExistsException;
+	List<Attribute> getAttributes(PerunSession sess, Member member, Group group, List<String> attrNames) throws GroupNotExistsException, InternalErrorException, MemberNotExistsException, MemberGroupMismatchException;
 
 	/**
 	 * Get all attributes associated with the member in the group which have name in list attrNames (empty too).
@@ -271,7 +271,7 @@ public interface AttributesManager {
 	 * @throws InternalErrorException            if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 * @throws MemberNotExistsException          if the member doesn't have access to this resource
 	 */
-	List<Attribute> getAttributes(PerunSession sess, Member member, Group group, List<String> attrNames, boolean workWithUserAttributes) throws GroupNotExistsException, InternalErrorException, MemberNotExistsException;
+	List<Attribute> getAttributes(PerunSession sess, Member member, Group group, List<String> attrNames, boolean workWithUserAttributes) throws GroupNotExistsException, InternalErrorException, MemberNotExistsException, MemberGroupMismatchException;
 
 	/**
 	 * Get all entityless attributes with subject equaled String key
@@ -349,7 +349,7 @@ public interface AttributesManager {
 	 * @throws ResourceNotExistsException if the resource doesn't exist
 	 * @throws MemberNotExistsException if the member doesn't exist
 	 */
-	List<Attribute> getAttributes(PerunSession sess, Resource resource, Group group, Member member, List<String> attrNames) throws InternalErrorException, ResourceNotExistsException, GroupNotExistsException, MemberNotExistsException, GroupResourceMismatchException, MemberResourceMismatchException;
+	List<Attribute> getAttributes(PerunSession sess, Resource resource, Group group, Member member, List<String> attrNames) throws InternalErrorException, ResourceNotExistsException, GroupNotExistsException, MemberNotExistsException, GroupResourceMismatchException, MemberResourceMismatchException, MemberGroupMismatchException;
 
 	/**
 	 * Get all <b>non-empty</b> attributes associated with the group and resource.
@@ -758,7 +758,7 @@ public interface AttributesManager {
 	 * @throws WrongAttributeAssignmentException     if attribute is not member-resource attribute
 	 * @throws WrongReferenceAttributeValueException if attribute which is reference for used attribute has illegal value
 	 */
-	void setAttributes(PerunSession sess, Member member, Group group, List<Attribute> attributes) throws PrivilegeException, GroupNotExistsException, InternalErrorException, MemberNotExistsException, AttributeNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException;
+	void setAttributes(PerunSession sess, Member member, Group group, List<Attribute> attributes) throws PrivilegeException, GroupNotExistsException, InternalErrorException, MemberNotExistsException, AttributeNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, MemberGroupMismatchException;
 
 	/**
 	 * Store the attributes associated with the member and group combination. If an attribute is core attribute then the attribute isn't stored (It's skipped without any notification).
@@ -780,7 +780,7 @@ public interface AttributesManager {
 	 * @throws WrongAttributeAssignmentException     if attribute is not member-resource attribute
 	 * @throws WrongReferenceAttributeValueException if attribute which is reference for used attribute has illegal value
 	 */
-	void setAttributes(PerunSession sess, Member member, Group group, List<Attribute> attributes, boolean workWithUserAttributes) throws PrivilegeException, GroupNotExistsException, InternalErrorException, MemberNotExistsException, AttributeNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException;
+	void setAttributes(PerunSession sess, Member member, Group group, List<Attribute> attributes, boolean workWithUserAttributes) throws PrivilegeException, GroupNotExistsException, InternalErrorException, MemberNotExistsException, AttributeNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, MemberGroupMismatchException;
 
 	/**
 	 * Store the attributes associated with member and user (which we get from this member) if workWithUserAttributes is true.
@@ -841,7 +841,7 @@ public interface AttributesManager {
 	 * @throws WrongAttributeValueException      if the attribute value is illegal
 	 * @throws WrongAttributeAssignmentException if attribute is not one of user, member, user-facility, member-group, member-resource
 	 */
-	void setAttributes(PerunSession sess, Facility facility, Resource resource, Group group, User user, Member member, List<Attribute> attributes) throws PrivilegeException, ResourceNotExistsException, InternalErrorException, MemberNotExistsException, FacilityNotExistsException, UserNotExistsException, AttributeNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, GroupNotExistsException, GroupResourceMismatchException, MemberResourceMismatchException;
+	void setAttributes(PerunSession sess, Facility facility, Resource resource, Group group, User user, Member member, List<Attribute> attributes) throws PrivilegeException, ResourceNotExistsException, InternalErrorException, MemberNotExistsException, FacilityNotExistsException, UserNotExistsException, AttributeNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, GroupNotExistsException, GroupResourceMismatchException, MemberResourceMismatchException, MemberGroupMismatchException;
 
 	/**
 	 * Store the attributes associated with the resource. If an attribute is core attribute then the attribute isn't stored (It's skipped without any notification).
@@ -1075,7 +1075,7 @@ public interface AttributesManager {
 	 * @throws WrongAttributeAssignmentException if attribute is not member_group attribute
 	 * @throws AttributeNotExistsException       if the attribute doesn't exists in the underlying data source
 	 */
-	Attribute getAttribute(PerunSession sess, Member member, Group group, String attributeName) throws PrivilegeException, GroupNotExistsException, InternalErrorException, AttributeNotExistsException, MemberNotExistsException, WrongAttributeAssignmentException;
+	Attribute getAttribute(PerunSession sess, Member member, Group group, String attributeName) throws PrivilegeException, GroupNotExistsException, InternalErrorException, AttributeNotExistsException, MemberNotExistsException, WrongAttributeAssignmentException, MemberGroupMismatchException;
 
 	/**
 	 * Get particular attribute for the member.
@@ -1543,7 +1543,7 @@ public interface AttributesManager {
 	 * @throws WrongAttributeValueException      if the attribute value is illegal
 	 * @throws WrongAttributeAssignmentException if attribute is not member-resource attribute or if it is core attribute
 	 */
-	void setAttribute(PerunSession sess, Member member, Group group, Attribute attribute) throws PrivilegeException, GroupNotExistsException, InternalErrorException, MemberNotExistsException, AttributeNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException;
+	void setAttribute(PerunSession sess, Member member, Group group, Attribute attribute) throws PrivilegeException, GroupNotExistsException, InternalErrorException, MemberNotExistsException, AttributeNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, MemberGroupMismatchException;
 
 	/**
 	 * Store the particular attribute associated with the member.  Core attributes can't be set this way.
@@ -1771,7 +1771,7 @@ public interface AttributesManager {
 	 * @return list of group-resource's attributes which are required by services defined on specified resource
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 */
-	List<Attribute> getResourceRequiredAttributes(PerunSession sess, Resource resourceToGetServicesFrom, Member member, Group group) throws InternalErrorException, ResourceNotExistsException, MemberNotExistsException, GroupNotExistsException;
+	List<Attribute> getResourceRequiredAttributes(PerunSession sess, Resource resourceToGetServicesFrom, Member member, Group group) throws InternalErrorException, ResourceNotExistsException, MemberNotExistsException, GroupNotExistsException, MemberGroupMismatchException;
 
 	/**
 	 * Get member-group attributes which are required by services defined on specified resource and if workWithUserAttributes is true also user and member attributes.
@@ -1787,7 +1787,7 @@ public interface AttributesManager {
 	 * @return list of group-resource's attributes which are required by services defined on specified resource
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 */
-	List<Attribute> getResourceRequiredAttributes(PerunSession sess, Resource resourceToGetServicesFrom, Member member, Group group, boolean workWithUserAttributes) throws InternalErrorException, ResourceNotExistsException, MemberNotExistsException, GroupNotExistsException;
+	List<Attribute> getResourceRequiredAttributes(PerunSession sess, Resource resourceToGetServicesFrom, Member member, Group group, boolean workWithUserAttributes) throws InternalErrorException, ResourceNotExistsException, MemberNotExistsException, GroupNotExistsException, MemberGroupMismatchException;
 
 	/**
 	 * Get member, user, member-resource and user-facility attributes which are required by services which are defined on "resourceToGetServicesFrom" resource.
@@ -1973,7 +1973,7 @@ public interface AttributesManager {
 	 * @return list of member, member-group and optionally user attributes which are required by services which are related to this member
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 */
-	List<Attribute> getRequiredAttributes(PerunSession sess, Member member, Group group, boolean workWithUserAttributes) throws InternalErrorException, MemberNotExistsException, GroupNotExistsException;
+	List<Attribute> getRequiredAttributes(PerunSession sess, Member member, Group group, boolean workWithUserAttributes) throws InternalErrorException, MemberNotExistsException, GroupNotExistsException, MemberGroupMismatchException;
 
 	/**
 	 * Get user attributes which are required by services which are relater to this user.
@@ -2228,14 +2228,14 @@ public interface AttributesManager {
 	 * @throws ServiceNotExistsException if the service doesn't exists in underlying data source
 	 * @throws MemberNotExistsException  if the member doesn't have access to this resource
 	 */
-	List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Member member, Group group) throws InternalErrorException, ServiceNotExistsException, MemberNotExistsException, GroupNotExistsException;
+	List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Member member, Group group) throws InternalErrorException, ServiceNotExistsException, MemberNotExistsException, GroupNotExistsException, MemberGroupMismatchException;
 
 	/**
 	 * PRIVILEGE: Get only those required attributes principal has access to.
 	 * <p>
 	 * !!WARNING THIS IS VERY TIME-CONSUMING METHOD. DON'T USE IT IN BATCH!!
 	 */
-	List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Member member, Group group, boolean workWithUserAttributes) throws InternalErrorException, ServiceNotExistsException, MemberNotExistsException, GroupNotExistsException;
+	List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Member member, Group group, boolean workWithUserAttributes) throws InternalErrorException, ServiceNotExistsException, MemberNotExistsException, GroupNotExistsException, MemberGroupMismatchException;
 
 	/**
 	 * Get member attributes which are required by the service.
@@ -2361,7 +2361,7 @@ public interface AttributesManager {
 	 * @throws MemberNotExistsException    if member doesn't exists in underlying data source or he doesn't have access to this resource
 	 * @throws GroupNotExistsException     if group doesn't exists
 	 */
-	Attribute fillAttribute(PerunSession sess, Member member, Group group, Attribute attribute) throws PrivilegeException, InternalErrorException, MemberNotExistsException, GroupNotExistsException, WrongAttributeAssignmentException;
+	Attribute fillAttribute(PerunSession sess, Member member, Group group, Attribute attribute) throws PrivilegeException, InternalErrorException, MemberNotExistsException, GroupNotExistsException, WrongAttributeAssignmentException, MemberGroupMismatchException;
 
 	/**
 	 * PRIVILEGE: Fill attributes only when principal has access to write on them.
@@ -2370,7 +2370,7 @@ public interface AttributesManager {
 	 *
 	 * @see cz.metacentrum.perun.core.api.AttributesManager#fillAttribute(PerunSession, Member, Group, Attribute)
 	 */
-	List<Attribute> fillAttributes(PerunSession sess, Member member, Group group, List<Attribute> attributes) throws InternalErrorException, MemberNotExistsException, GroupNotExistsException, AttributeNotExistsException, WrongAttributeAssignmentException;
+	List<Attribute> fillAttributes(PerunSession sess, Member member, Group group, List<Attribute> attributes) throws InternalErrorException, MemberNotExistsException, GroupNotExistsException, AttributeNotExistsException, WrongAttributeAssignmentException, MemberGroupMismatchException;
 
 	/**
 	 * PRIVILEGE: Fill attributes only when principal has access to write on them.
@@ -2378,7 +2378,7 @@ public interface AttributesManager {
 	 * @param workWithUserAttributes method can process also user and member attributes (user is automatically get from member)
 	 *                               !!WARNING THIS IS VERY TIME-CONSUMING METHOD. DON'T USE IT IN BATCH!!
 	 */
-	List<Attribute> fillAttributes(PerunSession sess, Member member, Group group, List<Attribute> attributes, boolean workWithUserAttributes) throws InternalErrorException, MemberNotExistsException, AttributeNotExistsException, WrongAttributeAssignmentException, GroupNotExistsException;
+	List<Attribute> fillAttributes(PerunSession sess, Member member, Group group, List<Attribute> attributes, boolean workWithUserAttributes) throws InternalErrorException, MemberNotExistsException, AttributeNotExistsException, WrongAttributeAssignmentException, GroupNotExistsException, MemberGroupMismatchException;
 
 	/**
 	 * This method tries to fill value of the user, member, member-resource and user-facility attributes. This value is automatically generated, but not all attributes can be filled this way.
@@ -2696,7 +2696,7 @@ public interface AttributesManager {
 	 * @throws MemberNotExistsException          if specified member does not exist
 	 * @throws AttributeNotExistsException       if given attribute does not exist
 	 */
-	void checkAttributeSemantics(PerunSession sess, Member member, Group group, Attribute attribute) throws PrivilegeException, InternalErrorException, GroupNotExistsException, MemberNotExistsException, WrongAttributeAssignmentException, AttributeNotExistsException;
+	void checkAttributeSemantics(PerunSession sess, Member member, Group group, Attribute attribute) throws PrivilegeException, InternalErrorException, GroupNotExistsException, MemberNotExistsException, WrongAttributeAssignmentException, AttributeNotExistsException, MemberGroupMismatchException;
 
 	/**
 	 * PRIVILEGE: Check attributes only when principal has access to write on them.
@@ -2705,7 +2705,7 @@ public interface AttributesManager {
 	 *
 	 * @see cz.metacentrum.perun.core.api.AttributesManager#checkAttributeSemantics(PerunSession, Member, Group, Attribute)
 	 */
-	void checkAttributesSemantics(PerunSession sess, Member member, Group group, List<Attribute> attributes) throws PrivilegeException, InternalErrorException, MemberNotExistsException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, AttributeNotExistsException, GroupNotExistsException;
+	void checkAttributesSemantics(PerunSession sess, Member member, Group group, List<Attribute> attributes) throws PrivilegeException, InternalErrorException, MemberNotExistsException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, AttributeNotExistsException, GroupNotExistsException, MemberGroupMismatchException;
 
 	/**
 	 * PRIVILEGE: Check attributes only when principal has access to write on them.
@@ -2716,7 +2716,7 @@ public interface AttributesManager {
 	 *                               !!WARNING THIS IS VERY TIME-CONSUMING METHOD. DON'T USE IT IN BATCH!!
 	 * @see cz.metacentrum.perun.core.api.AttributesManager#checkAttributeSemantics(PerunSession, Member, Group, Attribute)
 	 */
-	void checkAttributesSemantics(PerunSession sess, Member member, Group group, List<Attribute> attributes, boolean workWithUserAttributes) throws PrivilegeException, InternalErrorException, MemberNotExistsException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, AttributeNotExistsException, GroupNotExistsException;
+	void checkAttributesSemantics(PerunSession sess, Member member, Group group, List<Attribute> attributes, boolean workWithUserAttributes) throws PrivilegeException, InternalErrorException, MemberNotExistsException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, AttributeNotExistsException, GroupNotExistsException, MemberGroupMismatchException;
 
 	/**
 	 * Check if value of attributes has valid semantics. Attributes can be from namespace: member, user, member-resource and user-facility.
@@ -3037,7 +3037,7 @@ public interface AttributesManager {
 	 * @throws MemberNotExistsException          if the member doesn't exist in the underlying data source
 	 * @throws AttributeNotExistsException       if the attribute does not exist in underlying data source
 	 */
-	void checkAttributeSyntax(PerunSession sess, Member member, Group group, Attribute attribute) throws PrivilegeException, InternalErrorException, GroupNotExistsException, MemberNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, AttributeNotExistsException;
+	void checkAttributeSyntax(PerunSession sess, Member member, Group group, Attribute attribute) throws PrivilegeException, InternalErrorException, GroupNotExistsException, MemberNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, AttributeNotExistsException, MemberGroupMismatchException;
 
 	/**
 	 * PRIVILEGE: Check attributes only when principal has access to write on them.
@@ -3046,7 +3046,7 @@ public interface AttributesManager {
 	 *
 	 * @see cz.metacentrum.perun.core.api.AttributesManager#checkAttributeSyntax(PerunSession, Member, Group, Attribute)
 	 */
-	void checkAttributesSyntax(PerunSession sess, Member member, Group group, List<Attribute> attributes) throws PrivilegeException, InternalErrorException, MemberNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, AttributeNotExistsException, GroupNotExistsException;
+	void checkAttributesSyntax(PerunSession sess, Member member, Group group, List<Attribute> attributes) throws PrivilegeException, InternalErrorException, MemberNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, AttributeNotExistsException, GroupNotExistsException, MemberGroupMismatchException;
 
 	/**
 	 * PRIVILEGE: Check attributes only when principal has access to write on them.
@@ -3057,7 +3057,7 @@ public interface AttributesManager {
 	 *                               !!WARNING THIS IS VERY TIME-CONSUMING METHOD. DON'T USE IT IN BATCH!!
 	 * @see cz.metacentrum.perun.core.api.AttributesManager#checkAttributeSyntax(PerunSession, Member, Group, Attribute)
 	 */
-	void checkAttributesSyntax(PerunSession sess, Member member, Group group, List<Attribute> attributes, boolean workWithUserAttributes) throws PrivilegeException, InternalErrorException, MemberNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, AttributeNotExistsException, GroupNotExistsException;
+	void checkAttributesSyntax(PerunSession sess, Member member, Group group, List<Attribute> attributes, boolean workWithUserAttributes) throws PrivilegeException, InternalErrorException, MemberNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, AttributeNotExistsException, GroupNotExistsException, MemberGroupMismatchException;
 
 	/**
 	 * Check if value of attributes has valid syntax. Attributes can be from namespace: member, user, member-resource and user-facility.
@@ -3497,7 +3497,7 @@ public interface AttributesManager {
 	 * @throws WrongAttributeValueException      if the attribute value is illegal
 	 * @throws WrongAttributeAssignmentException if attribute is not member-resource, user, member or user-facility attribute
 	 */
-	void removeAttributes(PerunSession sess, Facility facility, Resource resource, Group group, User user, Member member, List<? extends AttributeDefinition> attributes) throws PrivilegeException, ResourceNotExistsException, InternalErrorException, MemberNotExistsException, FacilityNotExistsException, UserNotExistsException, AttributeNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, GroupNotExistsException, GroupResourceMismatchException, MemberResourceMismatchException;
+	void removeAttributes(PerunSession sess, Facility facility, Resource resource, Group group, User user, Member member, List<? extends AttributeDefinition> attributes) throws PrivilegeException, ResourceNotExistsException, InternalErrorException, MemberNotExistsException, FacilityNotExistsException, UserNotExistsException, AttributeNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, GroupNotExistsException, GroupResourceMismatchException, MemberResourceMismatchException, MemberGroupMismatchException;
 
 	/**
 	 * Unset all attributes for the resource.
@@ -3571,7 +3571,7 @@ public interface AttributesManager {
 	 * @throws GroupNotExistsException           if the resource doesn't exists in underlying data source
 	 * @throws WrongAttributeAssignmentException if attribute isn't member-resource attribute or if it is core attribute
 	 */
-	void removeAttribute(PerunSession sess, Member member, Group group, AttributeDefinition attribute) throws InternalErrorException, PrivilegeException, AttributeNotExistsException, MemberNotExistsException, GroupNotExistsException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException;
+	void removeAttribute(PerunSession sess, Member member, Group group, AttributeDefinition attribute) throws InternalErrorException, PrivilegeException, AttributeNotExistsException, MemberNotExistsException, GroupNotExistsException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException, MemberGroupMismatchException;
 
 	/**
 	 * PRIVILEGE: Remove attributes only when principal has access to write on them.
@@ -3581,7 +3581,7 @@ public interface AttributesManager {
 	 * @throws AttributeNotExistsException if the any of attributes doesn't exists in underlying data source
 	 * @see cz.metacentrum.perun.core.api.AttributesManager#removeAttribute(PerunSession, Member, Group, AttributeDefinition)
 	 */
-	void removeAttributes(PerunSession sess, Member member, Group group, List<? extends AttributeDefinition> attributes) throws InternalErrorException, PrivilegeException, AttributeNotExistsException, MemberNotExistsException, GroupNotExistsException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException;
+	void removeAttributes(PerunSession sess, Member member, Group group, List<? extends AttributeDefinition> attributes) throws InternalErrorException, PrivilegeException, AttributeNotExistsException, MemberNotExistsException, GroupNotExistsException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException, MemberGroupMismatchException;
 
 
 	/**
@@ -3595,7 +3595,7 @@ public interface AttributesManager {
 	 * @throws AttributeNotExistsException if the any of attributes doesn't exists in underlying data source
 	 * @see cz.metacentrum.perun.core.api.AttributesManager#removeAttribute(PerunSession, Member, Group, AttributeDefinition)
 	 */
-	void removeAttributes(PerunSession sess, Member member, Group group, List<? extends AttributeDefinition> attributes, boolean workWithUserAttributes) throws InternalErrorException, PrivilegeException, AttributeNotExistsException, MemberNotExistsException, GroupNotExistsException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException;
+	void removeAttributes(PerunSession sess, Member member, Group group, List<? extends AttributeDefinition> attributes, boolean workWithUserAttributes) throws InternalErrorException, PrivilegeException, AttributeNotExistsException, MemberNotExistsException, GroupNotExistsException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException, MemberGroupMismatchException;
 
 	/**
 	 * Unset all attributes for the member in the group.
@@ -3610,7 +3610,7 @@ public interface AttributesManager {
 	 * @throws MemberNotExistsException if the member doesn't exists in underlying data source
 	 * @throws GroupNotExistsException  if the resource doesn't exists in underlying data source
 	 */
-	void removeAllAttributes(PerunSession sess, Member member, Group group) throws InternalErrorException, PrivilegeException, MemberNotExistsException, GroupNotExistsException, WrongAttributeValueException, WrongReferenceAttributeValueException;
+	void removeAllAttributes(PerunSession sess, Member member, Group group) throws InternalErrorException, PrivilegeException, MemberNotExistsException, GroupNotExistsException, WrongAttributeValueException, WrongReferenceAttributeValueException, MemberGroupMismatchException;
 
 	/**
 	 * Unset particular attribute for the member. Core attributes can't be removed this way.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/AttributesManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/AttributesManager.java
@@ -1341,7 +1341,7 @@ public interface AttributesManager {
 	 * @throws WrongAttributeAssignmentException if attribute isn't member-group attribute
 	 * @throws AttributeNotExistsException       if the attribute doesn't exists in the underlying data source
 	 */
-	Attribute getAttributeById(PerunSession sess, Member member, Group group, int id) throws PrivilegeException, GroupNotExistsException, InternalErrorException, AttributeNotExistsException, MemberNotExistsException, WrongAttributeAssignmentException;
+	Attribute getAttributeById(PerunSession sess, Member member, Group group, int id) throws PrivilegeException, GroupNotExistsException, InternalErrorException, AttributeNotExistsException, MemberNotExistsException, WrongAttributeAssignmentException, MemberGroupMismatchException;
 
 	/**
 	 * Get particular attribute for the member.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
@@ -23,6 +23,7 @@ import cz.metacentrum.perun.core.api.exceptions.AttributeDefinitionExistsExcepti
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.GroupResourceMismatchException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.MemberGroupMismatchException;
 import cz.metacentrum.perun.core.api.exceptions.MemberResourceMismatchException;
 import cz.metacentrum.perun.core.api.exceptions.ModuleNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
@@ -203,7 +204,7 @@ public interface AttributesManagerBl {
 	 *
 	 * !!WARNING THIS IS VERY TIME-CONSUMING METHOD. DON'T USE IT IN BATCH!!
 	 */
-	List<Attribute> getAttributes(PerunSession sess, Group group, Member member, Resource resource, List<String> attrNames, boolean workWithUserAttributes) throws InternalErrorException, MemberResourceMismatchException, GroupResourceMismatchException;
+	List<Attribute> getAttributes(PerunSession sess, Group group, Member member, Resource resource, List<String> attrNames, boolean workWithUserAttributes) throws InternalErrorException, MemberResourceMismatchException, GroupResourceMismatchException, MemberGroupMismatchException;
 
 	/**
 	 * Get all <b>non-empty</b> attributes associated with the member in the group.
@@ -215,7 +216,7 @@ public interface AttributesManagerBl {
 	 *
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 */
-	List<Attribute> getAttributes(PerunSession sess, Member member, Group group) throws InternalErrorException;
+	List<Attribute> getAttributes(PerunSession sess, Member member, Group group) throws InternalErrorException, MemberGroupMismatchException;
 
 	/**
 	 * Get all attributes (empty and virtual too) associated with the member in the group which have name in list attrNames.
@@ -228,7 +229,7 @@ public interface AttributesManagerBl {
 	 *
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 */
-	List<Attribute> getAttributes(PerunSession sess, Member member, Group group, List<String> attrNames) throws InternalErrorException;
+	List<Attribute> getAttributes(PerunSession sess, Member member, Group group, List<String> attrNames) throws InternalErrorException, MemberGroupMismatchException;
 
 	/**
 	 * Get all attributes associated with the member in the group and if workWithUserAttributes is true, gets also all <b>non-empty</b> user and member attributes.
@@ -241,7 +242,7 @@ public interface AttributesManagerBl {
 	 *
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 */
-	List<Attribute> getAttributes(PerunSession sess, Member member, Group group, boolean workWithUserAttributes) throws InternalErrorException;
+	List<Attribute> getAttributes(PerunSession sess, Member member, Group group, boolean workWithUserAttributes) throws InternalErrorException, MemberGroupMismatchException;
 
 	/**
 	 * Get all attributes associated with the member in the group which have name in list attrNames (empty too).
@@ -256,7 +257,7 @@ public interface AttributesManagerBl {
 	 *
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 */
-	List<Attribute> getAttributes(PerunSession sess, Member member, Group group, List<String> attrNames, boolean workWithUserAttributes) throws InternalErrorException;
+	List<Attribute> getAttributes(PerunSession sess, Member member, Group group, List<String> attrNames, boolean workWithUserAttributes) throws InternalErrorException, MemberGroupMismatchException;
 
 	/**
 	 * Get all <b>non-empty</b> attributes associated with the member and if workWithUserAttributes is
@@ -308,7 +309,7 @@ public interface AttributesManagerBl {
 	 * @throws GroupResourceMismatchException if resource and group are not from the same vo
 	 * @throws MemberResourceMismatchException if member and resource are not from the same vo
 	 */
-	List<Attribute> getAttributes(PerunSession sess, Resource resource, Group group, Member member, List<String> attrNames) throws InternalErrorException, GroupResourceMismatchException, MemberResourceMismatchException;
+	List<Attribute> getAttributes(PerunSession sess, Resource resource, Group group, Member member, List<String> attrNames) throws InternalErrorException, GroupResourceMismatchException, MemberResourceMismatchException, MemberGroupMismatchException;
 
 	/**
 	 * Get all <b>non-empty</b> attributes associated with the group starts with name startPartOfName.
@@ -679,7 +680,7 @@ public interface AttributesManagerBl {
 	 * @throws WrongAttributeValueException
 	 * @throws WrongReferenceAttributeValueException
 	 */
-	boolean setAttributeWithoutCheck(PerunSession sess, Member member, Group group, Attribute attribute, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException;
+	boolean setAttributeWithoutCheck(PerunSession sess, Member member, Group group, Attribute attribute, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException, MemberGroupMismatchException;
 
 	/**
 	 * Just store the particular attribute associated with the member, doesn't preform any value check. Core attributes can't be set this way.
@@ -813,7 +814,7 @@ public interface AttributesManagerBl {
 	 * @throws WrongAttributeAssignmentException if attribute is not member-resource attribute
 	 * @throws WrongReferenceAttributeValueException
 	 */
-	void setAttributes(PerunSession sess, Member member, Group group, List<Attribute> attributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException;
+	void setAttributes(PerunSession sess, Member member, Group group, List<Attribute> attributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, MemberGroupMismatchException;
 
 	/**
 	 * Store the attributes associated with the resource and member combination. If an attribute is core attribute then the attribute isn't stored (It's skipped without any notification).
@@ -830,7 +831,7 @@ public interface AttributesManagerBl {
 	 * @throws WrongAttributeAssignmentException if attribute is not member-resource attribute
 	 * @throws WrongReferenceAttributeValueException
 	 */
-	void setAttributes(PerunSession sess, Member member, Group group, List<Attribute> attributes, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException;
+	void setAttributes(PerunSession sess, Member member, Group group, List<Attribute> attributes, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, MemberGroupMismatchException;
 
 	/**
 	 * Store the member, user, member-resource and user-facility attributes. If an attribute is core attribute then the attribute isn't stored (It's skipped without any notification).
@@ -864,7 +865,7 @@ public interface AttributesManagerBl {
 	 * @throws WrongAttributeAssignmentException if attribute is not member-resource attribute
 	 * @throws WrongReferenceAttributeValueException
 	 */
-	void setAttributes(PerunSession sess, Facility facility, Resource resource, Group group, User user, Member member, List<Attribute> attributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, GroupResourceMismatchException, MemberResourceMismatchException;
+	void setAttributes(PerunSession sess, Facility facility, Resource resource, Group group, User user, Member member, List<Attribute> attributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, GroupResourceMismatchException, MemberResourceMismatchException, MemberGroupMismatchException;
 
 	/**
 	 * Store the attributes associated with the resource. If an attribute is core attribute then the attribute isn't stored (It's skipped without any notification).
@@ -1042,7 +1043,7 @@ public interface AttributesManagerBl {
 	 * @throws WrongAttributeAssignmentException
 	 * @throws AttributeNotExistsException if the attribute doesn't exists in the underlying data source
 	 */
-	Attribute getAttribute(PerunSession sess, Member member, Group group, String attributeName) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException;
+	Attribute getAttribute(PerunSession sess, Member member, Group group, String attributeName) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException, MemberGroupMismatchException;
 
 	/**
 	 * Get particular attribute for the member.
@@ -1655,7 +1656,7 @@ public interface AttributesManagerBl {
 	 * @throws WrongAttributeAssignmentException if attribute is not member-resource attribute or if it is core attribute
 	 * @throws WrongReferenceAttributeValueException
 	 */
-	void setAttribute(PerunSession sess, Member member, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException;
+	void setAttribute(PerunSession sess, Member member, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, MemberGroupMismatchException;
 
 	/**
 	 * Store the particular attribute associated with the member-group relationship. Core attributes can't be set this way.
@@ -1672,7 +1673,7 @@ public interface AttributesManagerBl {
 	 * @throws WrongAttributeAssignmentException if attribute is not member-group attribute or if it is core attribute
 	 * @throws WrongReferenceAttributeValueException
 	 */
-	void setAttributeInNestedTransaction(PerunSession sess, Member member, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, AttributeNotExistsException;
+	void setAttributeInNestedTransaction(PerunSession sess, Member member, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, AttributeNotExistsException, MemberGroupMismatchException;
 
 	/**
 	 * Store the particular attribute associated with the member.  Core attributes can't be set this way.
@@ -1969,7 +1970,7 @@ public interface AttributesManagerBl {
 	 *
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 */
-	List<Attribute> getResourceRequiredAttributes(PerunSession sess, Resource resourceToGetServicesFrom, Member member, Group group) throws InternalErrorException;
+	List<Attribute> getResourceRequiredAttributes(PerunSession sess, Resource resourceToGetServicesFrom, Member member, Group group) throws InternalErrorException, MemberGroupMismatchException;
 
 	/**
 	 * Get member-group attributes which are required by services if workWithUserAttributes is true also user and member attributes.
@@ -1984,7 +1985,7 @@ public interface AttributesManagerBl {
 	 *
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 */
-	List<Attribute> getResourceRequiredAttributes(PerunSession sess, Resource resourceToGetServicesFrom, Member member, Group group, boolean workWithUserAttributes) throws InternalErrorException;
+	List<Attribute> getResourceRequiredAttributes(PerunSession sess, Resource resourceToGetServicesFrom, Member member, Group group, boolean workWithUserAttributes) throws InternalErrorException, MemberGroupMismatchException;
 
 	/**
 	 * Get member, user, member-resource and user-facility attributes which are required by services which are defined on "resourceToGetServicesFrom" resource.
@@ -2176,7 +2177,7 @@ public interface AttributesManagerBl {
 	 * @return list of attributes which are required by services which are related to this member and group
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 */
-	List<Attribute> getRequiredAttributes(PerunSession sess, Member member, Group group, boolean workWithUserAttributes) throws InternalErrorException;
+	List<Attribute> getRequiredAttributes(PerunSession sess, Member member, Group group, boolean workWithUserAttributes) throws InternalErrorException, MemberGroupMismatchException;
 
 	/**
 	 * Get all attributes which are required by service.
@@ -2342,9 +2343,9 @@ public interface AttributesManagerBl {
 	 *
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 */
-	List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Member member, Group group) throws InternalErrorException;
+	List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Member member, Group group) throws InternalErrorException, MemberGroupMismatchException;
 
-	List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Member member, Group group, boolean workWithUserAttributes) throws InternalErrorException;
+	List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Member member, Group group, boolean workWithUserAttributes) throws InternalErrorException, MemberGroupMismatchException;
 
 	/**
 	 * Get memner, user, member-resource, user-facility attributes which are required by the service.
@@ -2488,20 +2489,20 @@ public interface AttributesManagerBl {
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 * @throws WrongAttributeAssignmentException
 	 */
-	Attribute fillAttribute(PerunSession sess, Member member, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeAssignmentException;
+	Attribute fillAttribute(PerunSession sess, Member member, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeAssignmentException, MemberGroupMismatchException;
 
 	/**
 	 *  Batch version of fillAttribute. This method skips all attributes with not-null value.
 	 *  @throws WrongAttributeAssignmentException if any of attributes values is wrong/illegal
 	 *  @see cz.metacentrum.perun.core.api.AttributesManager#fillAttribute(PerunSession,Member,Group,Attribute)
 	 */
-	List<Attribute> fillAttributes(PerunSession sess, Member member, Group group, List<Attribute> attributes) throws InternalErrorException, WrongAttributeAssignmentException;
+	List<Attribute> fillAttributes(PerunSession sess, Member member, Group group, List<Attribute> attributes) throws InternalErrorException, WrongAttributeAssignmentException, MemberGroupMismatchException;
 
 	/**
 	 * @param workWithUserAttributes method can process also user and memebr attributes (user is automatically get from member)
 	 * !!WARNING THIS IS VERY TIME-CONSUMING METHOD. DON'T USE IT IN BATCH!!
 	 */
-	List<Attribute> fillAttributes(PerunSession sess, Member member, Group group, List<Attribute> attributes, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeAssignmentException;
+	List<Attribute> fillAttributes(PerunSession sess, Member member, Group group, List<Attribute> attributes, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeAssignmentException, MemberGroupMismatchException;
 
 	/**
 	 *
@@ -2660,7 +2661,7 @@ public interface AttributesManagerBl {
 
 	/**
 	 * Batch version of fillAttribute. This method skips all attributes with not-null value.
-	 * @see cz.metacentrAttributesManager#fillAttribute(PerunSession, UserExtSource, Attribute)
+	 * @see cz.metacentrum.perun.core.api.AttributesManager#fillAttribute(PerunSession, UserExtSource, Attribute)
 	 */
 	List<Attribute> fillAttributes(PerunSession sess, UserExtSource ues, List<Attribute> attributes) throws InternalErrorException, WrongAttributeAssignmentException;
 
@@ -2785,13 +2786,13 @@ public interface AttributesManagerBl {
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 * @throws WrongAttributeAssignmentException if attribute isn't member-resource attribute
 	 */
-	void checkAttributeSemantics(PerunSession sess, Member member, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeAssignmentException;
+	void checkAttributeSemantics(PerunSession sess, Member member, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeAssignmentException, MemberGroupMismatchException;
 
 	/**
 	 *  Batch version of checkAttributeSemantics
 	 *  @see cz.metacentrum.perun.core.api.AttributesManager#checkAttributeSemantics(PerunSession,Member,Group,Attribute)
 	 */
-	void checkAttributesSemantics(PerunSession sess, Member member, Group group, List<Attribute> attributes) throws InternalErrorException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException;
+	void checkAttributesSemantics(PerunSession sess, Member member, Group group, List<Attribute> attributes) throws InternalErrorException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, MemberGroupMismatchException;
 
 	/**
 	 *  Batch version of checkAttributeSemantics
@@ -2799,7 +2800,7 @@ public interface AttributesManagerBl {
 	 * @param workWithUserAttributes method can process also user and member attributes (user is automatically get from member)
 	 * !!WARNING THIS IS VERY TIME-CONSUMING METHOD. DON'T USE IT IN BATCH!!
 	 */
-	void checkAttributesSemantics(PerunSession sess, Member member, Group group, List<Attribute> attributes, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException;
+	void checkAttributesSemantics(PerunSession sess, Member member, Group group, List<Attribute> attributes, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, MemberGroupMismatchException;
 
 	/**
 	 * Check if value of attributes has valid semantics. Attributes can be from namespace: member, user, member-resource and user-facility.
@@ -2854,7 +2855,7 @@ public interface AttributesManagerBl {
 	 * @throws GroupResourceMismatchException if group and resource are not in the same VO
 	 * @throws MemberResourceMismatchException if member and resource are not in the same VO
 	 */
-	void checkAttributesSemantics(PerunSession sess, Facility facility, Resource resource, Group group, User user, Member member, List<Attribute> attributes) throws InternalErrorException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, GroupResourceMismatchException, MemberResourceMismatchException;
+	void checkAttributesSemantics(PerunSession sess, Facility facility, Resource resource, Group group, User user, Member member, List<Attribute> attributes) throws InternalErrorException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, GroupResourceMismatchException, MemberResourceMismatchException, MemberGroupMismatchException;
 
 	/**
 	 * Check if value of this member attribute has valid semantics.
@@ -3110,13 +3111,13 @@ public interface AttributesManagerBl {
 	 * @throws WrongAttributeValueException if the attribute value has wrong/illegal syntax
 	 * @throws WrongAttributeAssignmentException if attribute isn't member-group attribute
 	 */
-	void checkAttributeSyntax(PerunSession sess, Member member, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException;
+	void checkAttributeSyntax(PerunSession sess, Member member, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, MemberGroupMismatchException;
 
 	/**
 	 *  Batch version of checkAttributeSyntax
 	 *  @see cz.metacentrum.perun.core.api.AttributesManager#checkAttributeSyntax(PerunSession,Member,Group,Attribute)
 	 */
-	void checkAttributesSyntax(PerunSession sess, Member member, Group group, List<Attribute> attributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException;
+	void checkAttributesSyntax(PerunSession sess, Member member, Group group, List<Attribute> attributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, MemberGroupMismatchException;
 
 	/**
 	 *  Batch version of checkAttributeSyntax
@@ -3124,7 +3125,7 @@ public interface AttributesManagerBl {
 	 * @param workWithUserAttributes method can process also user and member attributes (user is automatically get from member)
 	 * !!WARNING THIS IS VERY TIME-CONSUMING METHOD. DON'T USE IT IN BATCH!!
 	 */
-	void checkAttributesSyntax(PerunSession sess, Member member, Group group, List<Attribute> attributes, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException;
+	void checkAttributesSyntax(PerunSession sess, Member member, Group group, List<Attribute> attributes, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, MemberGroupMismatchException;
 
 	/**
 	 * Check if value of attributes has valid syntax. Attributes can be from namespace: member, user, member-resource and user-facility.
@@ -3159,7 +3160,7 @@ public interface AttributesManagerBl {
 	 * @throws GroupResourceMismatchException if group and resource are not in the same VO
 	 * @throws MemberResourceMismatchException if member and resource are not in the same VO
 	 */
-	void checkAttributesSyntax(PerunSession sess, Facility facility, Resource resource, Group group, User user, Member member, List<Attribute> attributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, GroupResourceMismatchException, MemberResourceMismatchException;
+	void checkAttributesSyntax(PerunSession sess, Facility facility, Resource resource, Group group, User user, Member member, List<Attribute> attributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, GroupResourceMismatchException, MemberResourceMismatchException, MemberGroupMismatchException;
 
 	/**
 	 * Check if value of this member attribute has valid syntax.
@@ -3440,7 +3441,7 @@ public interface AttributesManagerBl {
 	 * @throws WrongAttributeAssignmentException if attribute is not member-resource, user, member or user-facility attribute
 	 * @throws WrongReferenceAttributeValueException
 	 */
-	void removeAttributes(PerunSession sess, Facility facility, Resource resource, Group group, User user, Member member, List<? extends AttributeDefinition> attributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, GroupResourceMismatchException, MemberResourceMismatchException;
+	void removeAttributes(PerunSession sess, Facility facility, Resource resource, Group group, User user, Member member, List<? extends AttributeDefinition> attributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, GroupResourceMismatchException, MemberResourceMismatchException, MemberGroupMismatchException;
 
 	/**
 	 * Unset all attributes for the facility.
@@ -3608,16 +3609,16 @@ public interface AttributesManagerBl {
 	 * @throws WrongAttributeValueException
 	 * @throws WrongAttributeAssignmentException if attribute isn't member-resource attribute or if it is core attribute
 	 */
-	void removeAttribute(PerunSession sess, Member member, Group group, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException;
+	void removeAttribute(PerunSession sess, Member member, Group group, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException, MemberGroupMismatchException;
 
 	/**
 	 * Batch version of removeAttribute. This method automatically skip all core attributes which can't be removed this way.
 	 * @throws AttributeNotExistsException if the any of attributes doesn't exists in underlying data source
 	 * @see cz.metacentrum.perun.core.api.AttributesManager#removeAttribute(PerunSession, Member, Group, AttributeDefinition)
 	 */
-	void removeAttributes(PerunSession sess, Member member, Group group, List<? extends AttributeDefinition> attributes) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException;
+	void removeAttributes(PerunSession sess, Member member, Group group, List<? extends AttributeDefinition> attributes) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException, MemberGroupMismatchException;
 
-	void removeAttributes(PerunSession sess, Member member, Group group, List<? extends AttributeDefinition> attributes, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException;
+	void removeAttributes(PerunSession sess, Member member, Group group, List<? extends AttributeDefinition> attributes, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException, MemberGroupMismatchException;
 
 	/**
 	 * Unset all attributes for the member in the group.
@@ -3629,7 +3630,7 @@ public interface AttributesManagerBl {
 	 * @throws WrongReferenceAttributeValueException
 	 * @throws WrongAttributeValueException
 	 */
-	void removeAllAttributes(PerunSession sess, Member member, Group group) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException;
+	void removeAllAttributes(PerunSession sess, Member member, Group group) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, MemberGroupMismatchException;
 
 	/**
 	 * Unset particular attribute for the member. Core attributes can't be removed this way.
@@ -3910,7 +3911,7 @@ public interface AttributesManagerBl {
 	 * @throws InternalErrorException
 	 * @throws WrongAttributeAssignmentException
 	 */
-	boolean removeAttributeWithoutCheck(PerunSession sess, Member member, Group group, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException;
+	boolean removeAttributeWithoutCheck(PerunSession sess, Member member, Group group, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException, MemberGroupMismatchException;
 
 	/**
 	 * Unset all attributes for the member without check of value.
@@ -4181,7 +4182,7 @@ public interface AttributesManagerBl {
 	 * @throws InternalErrorException
 	 * @throws WrongAttributeAssignmentException
 	 */
-	boolean isTrulyRequiredAttribute(PerunSession sess, Member member, Group group, AttributeDefinition attributeDefinition) throws InternalErrorException, WrongAttributeAssignmentException;
+	boolean isTrulyRequiredAttribute(PerunSession sess, Member member, Group group, AttributeDefinition attributeDefinition) throws InternalErrorException, WrongAttributeAssignmentException, MemberGroupMismatchException;
 
 	/**
 	 * Same as doTheMagic(sess, member, false);
@@ -4370,7 +4371,7 @@ public interface AttributesManagerBl {
 	 * @throws MemberResourceMismatchException
 	 * @throws GroupResourceMismatchException
 	 */
-	List<RichAttribute> getRichAttributesWithHoldersForAttributeDefinition(PerunSession sess, AttributeDefinition attrDef, RichAttribute aidingAttr) throws InternalErrorException, AttributeNotExistsException, VoNotExistsException, UserNotExistsException, WrongAttributeAssignmentException, GroupResourceMismatchException, MemberResourceMismatchException;
+	List<RichAttribute> getRichAttributesWithHoldersForAttributeDefinition(PerunSession sess, AttributeDefinition attrDef, RichAttribute aidingAttr) throws InternalErrorException, AttributeNotExistsException, VoNotExistsException, UserNotExistsException, WrongAttributeAssignmentException, GroupResourceMismatchException, MemberResourceMismatchException, MemberGroupMismatchException;
 
 	/**
 	 * Get All user_facility attributes for any existing user

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
@@ -1274,7 +1274,7 @@ public interface AttributesManagerBl {
 	 * @throws WrongAttributeAssignmentException
 	 * @throws AttributeNotExistsException if the attribute doesn't exists in the underlying data source
 	 */
-	Attribute getAttributeById(PerunSession sess, Member member, Group group, int id) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException;
+	Attribute getAttributeById(PerunSession sess, Member member, Group group, int id) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException, MemberGroupMismatchException;
 
 	/**
 	 * Get particular attribute for the member.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/GroupsManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/GroupsManagerBl.java
@@ -34,6 +34,7 @@ import cz.metacentrum.perun.core.api.exceptions.GroupResourceMismatchException;
 import cz.metacentrum.perun.core.api.exceptions.GroupStructureSynchronizationAlreadyRunningException;
 import cz.metacentrum.perun.core.api.exceptions.GroupSynchronizationAlreadyRunningException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.MemberGroupMismatchException;
 import cz.metacentrum.perun.core.api.exceptions.MemberNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.MemberResourceMismatchException;
 import cz.metacentrum.perun.core.api.exceptions.NotGroupMemberException;
@@ -1320,8 +1321,9 @@ public interface GroupsManagerBl {
 	 * @throws InternalErrorException
 	 * @throws GroupResourceMismatchException if group is not assigned to resource
 	 * @throws MemberResourceMismatchException if member is not assigned to group
+	 * @throws MemberGroupMismatchException if member is not in the same vo as group
 	 */
-	List<RichGroup> convertGroupsToRichGroupsWithAttributes(PerunSession sess, Member member, Resource resource, List<Group> groups, List<String> attrNames) throws InternalErrorException, GroupResourceMismatchException, MemberResourceMismatchException;
+	List<RichGroup> convertGroupsToRichGroupsWithAttributes(PerunSession sess, Member member, Resource resource, List<Group> groups, List<String> attrNames) throws InternalErrorException, GroupResourceMismatchException, MemberResourceMismatchException, MemberGroupMismatchException;
 
 	/**
 	 * Get all RichGroups with selected attributes assigned to the resource.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -1631,12 +1631,13 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	}
 
 	@Override
-	public Attribute getAttributeById(PerunSession sess, Member member, Group group, int id) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
+	public Attribute getAttributeById(PerunSession sess, Member member, Group group, int id) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException, MemberGroupMismatchException {
 		AttributeDefinition attributeDefinition = getAttributeDefinitionById(sess, id);
 
 		if (getAttributesManagerImpl().isFromNamespace(attributeDefinition, AttributesManager.NS_MEMBER_GROUP_ATTR)) {
 			Attribute attribute = getAttributesManagerImpl().getAttributeById(sess, member, group, id);
 			getAttributesManagerImpl().checkNamespace(sess, attribute, NS_MEMBER_GROUP_ATTR);
+			checkMemberIsFromTheSameVoLikeGroup(sess, member, group);
 			return attribute;
 		} else if (getAttributesManagerImpl().isFromNamespace(attributeDefinition, AttributesManager.NS_MEMBER_ATTR)) {
 			return getAttributesManagerImpl().getAttributeById(sess, member, id);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -364,6 +364,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	@Override
 	public List<Attribute> getAttributes(PerunSession sess, Group group, Member member, Resource resource, List<String> attrNames, boolean workWithUserAttributes) throws InternalErrorException, MemberResourceMismatchException, GroupResourceMismatchException, MemberGroupMismatchException {
 		checkGroupIsFromTheSameVoLikeResource(sess, group, resource);
+		checkMemberIsFromTheSameVoLikeGroup(sess, member, group);
 		List<Attribute> attributes = getAttributes(sess, member, resource, attrNames, workWithUserAttributes);
 
 		if (attrNames.isEmpty()) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -79,6 +79,7 @@ import cz.metacentrum.perun.core.api.exceptions.ConsistencyErrorException;
 import cz.metacentrum.perun.core.api.exceptions.FacilityNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.GroupResourceMismatchException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.MemberGroupMismatchException;
 import cz.metacentrum.perun.core.api.exceptions.MemberNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.MemberResourceMismatchException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
@@ -238,7 +239,8 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	}
 
 	@Override
-	public List<Attribute> getAttributes(PerunSession sess, Member member, Group group) throws InternalErrorException {
+	public List<Attribute> getAttributes(PerunSession sess, Member member, Group group) throws InternalErrorException, MemberGroupMismatchException {
+		this.checkMemberIsFromTheSameVoLikeGroup(sess, member, group);
 		// get virtual attributes
 		List<Attribute> attributes = getAttributesManagerImpl().getVirtualAttributes(sess, member, group);
 		// filter out virtual attributes with null value
@@ -249,14 +251,16 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	}
 
 	@Override
-	public List<Attribute> getAttributes(PerunSession sess, Member member, Group group, List<String> attrNames) throws InternalErrorException {
+	public List<Attribute> getAttributes(PerunSession sess, Member member, Group group, List<String> attrNames) throws InternalErrorException, MemberGroupMismatchException {
+		this.checkMemberIsFromTheSameVoLikeGroup(sess, member, group);
 		if (attrNames.isEmpty()) return new ArrayList<>();
 		// adds all attributes which names are in attrNames list (virtual and empty too)
 		return getAttributesManagerImpl().getAttributes(sess, member, group, attrNames);
 	}
 
 	@Override
-	public List<Attribute> getAttributes(PerunSession sess, Member member, Group group, boolean workWithUserAttributes) throws InternalErrorException {
+	public List<Attribute> getAttributes(PerunSession sess, Member member, Group group, boolean workWithUserAttributes) throws InternalErrorException, MemberGroupMismatchException {
+		this.checkMemberIsFromTheSameVoLikeGroup(sess, member, group);
 		// get virtual attributes
 		List<Attribute> attributes = getAttributesManagerImpl().getVirtualAttributes(sess, member, group);
 		// filter out virtual attributes with null value
@@ -273,8 +277,10 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	}
 
 	@Override
-	public List<Attribute> getAttributes(PerunSession sess, Member member, Group group, List<String> attrNames, boolean workWithUserAttributes) throws InternalErrorException {
+	public List<Attribute> getAttributes(PerunSession sess, Member member, Group group, List<String> attrNames, boolean workWithUserAttributes) throws InternalErrorException, MemberGroupMismatchException {
 		if (attrNames.isEmpty()) return this.getAttributes(sess, member, group, workWithUserAttributes);
+
+		this.checkMemberIsFromTheSameVoLikeGroup(sess, member, group);
 
 		//differentiate between user+member and member-group namespace
 		List<String> userAndMemberAttributeNames = new ArrayList<>();
@@ -356,7 +362,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	}
 
 	@Override
-	public List<Attribute> getAttributes(PerunSession sess, Group group, Member member, Resource resource, List<String> attrNames, boolean workWithUserAttributes) throws InternalErrorException, MemberResourceMismatchException, GroupResourceMismatchException {
+	public List<Attribute> getAttributes(PerunSession sess, Group group, Member member, Resource resource, List<String> attrNames, boolean workWithUserAttributes) throws InternalErrorException, MemberResourceMismatchException, GroupResourceMismatchException, MemberGroupMismatchException {
 		checkGroupIsFromTheSameVoLikeResource(sess, group, resource);
 		List<Attribute> attributes = getAttributes(sess, member, resource, attrNames, workWithUserAttributes);
 
@@ -445,7 +451,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	}
 
 	@Override
-	public List<Attribute> getAttributes(PerunSession sess, Resource resource, Group group, Member member, List<String> attrNames) throws InternalErrorException, GroupResourceMismatchException, MemberResourceMismatchException {
+	public List<Attribute> getAttributes(PerunSession sess, Resource resource, Group group, Member member, List<String> attrNames) throws InternalErrorException, GroupResourceMismatchException, MemberResourceMismatchException, MemberGroupMismatchException {
 		List<Attribute> attributes = new ArrayList<>();
 		if (attrNames.isEmpty()) return attributes;
 
@@ -806,12 +812,12 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	}
 
 	@Override
-	public void setAttributes(PerunSession sess, Member member, Group group, List<Attribute> attributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
+	public void setAttributes(PerunSession sess, Member member, Group group, List<Attribute> attributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, MemberGroupMismatchException {
 		setAttributes(sess, member, group, attributes, false);
 	}
 
 	@Override
-	public void setAttributes(PerunSession sess, Member member, Group group, List<Attribute> attributes, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
+	public void setAttributes(PerunSession sess, Member member, Group group, List<Attribute> attributes, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, MemberGroupMismatchException {
 		// classification of attributes to attributes to remove and attributes to set
 		List<Attribute> attributesToRemove = new ArrayList<>();
 		List<Attribute> attributesToSet = new ArrayList<>();
@@ -990,7 +996,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	}
 
 	@Override
-	public void setAttributes(PerunSession sess, Facility facility, Resource resource, Group group, User user, Member member, List<Attribute> attributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, GroupResourceMismatchException, MemberResourceMismatchException {
+	public void setAttributes(PerunSession sess, Facility facility, Resource resource, Group group, User user, Member member, List<Attribute> attributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, GroupResourceMismatchException, MemberResourceMismatchException, MemberGroupMismatchException {
 		// classification of attributes to attributes to remove and attributes to set
 		List<Attribute> attributesToRemove = new ArrayList<>();
 		List<Attribute> attributesToSet = new ArrayList<>();
@@ -1349,7 +1355,8 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	}
 
 	@Override
-	public Attribute getAttribute(PerunSession sess, Member member, Group group, String attributeName) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
+	public Attribute getAttribute(PerunSession sess, Member member, Group group, String attributeName) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException, MemberGroupMismatchException {
+		this.checkMemberIsFromTheSameVoLikeGroup(sess, member, group);
 		// check namespace
 		if (!attributeName.startsWith(AttributesManager.NS_MEMBER_GROUP_ATTR))
 			throw new WrongAttributeAssignmentException("Attribute name=" + attributeName);
@@ -1949,7 +1956,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	}
 
 	@Override
-	public void setAttribute(PerunSession sess, Member member, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
+	public void setAttribute(PerunSession sess, Member member, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, MemberGroupMismatchException {
 		convertEmptyAttrValueToNull(attribute);
 		if (attribute.getValue() == null) {
 			removeAttribute(sess, member, group, attribute);
@@ -1963,7 +1970,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	}
 
 	@Override
-	public void setAttributeInNestedTransaction(PerunSession sess, Member member, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, AttributeNotExistsException {
+	public void setAttributeInNestedTransaction(PerunSession sess, Member member, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, AttributeNotExistsException, MemberGroupMismatchException {
 		setAttribute(sess, member, group, attribute);
 	}
 
@@ -2046,7 +2053,8 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	}
 
 	@Override
-	public boolean setAttributeWithoutCheck(PerunSession sess, Member member, Group group, Attribute attribute, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException {
+	public boolean setAttributeWithoutCheck(PerunSession sess, Member member, Group group, Attribute attribute, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException, MemberGroupMismatchException {
+		this.checkMemberIsFromTheSameVoLikeGroup(sess, member, group);
 		if (getAttributesManagerImpl().isCoreAttribute(sess, attribute))
 			throw new WrongAttributeAssignmentException(attribute);
 
@@ -2646,12 +2654,13 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	}
 
 	@Override
-	public List<Attribute> getResourceRequiredAttributes(PerunSession sess, Resource resourceToGetServicesFrom, Member member, Group group) throws InternalErrorException {
+	public List<Attribute> getResourceRequiredAttributes(PerunSession sess, Resource resourceToGetServicesFrom, Member member, Group group) throws InternalErrorException, MemberGroupMismatchException {
 		return getResourceRequiredAttributes(sess, resourceToGetServicesFrom, member, group, false);
 	}
 
 	@Override
-	public List<Attribute> getResourceRequiredAttributes(PerunSession sess, Resource resourceToGetServicesFrom, Member member, Group group, boolean workWithUserAttributes) throws InternalErrorException {
+	public List<Attribute> getResourceRequiredAttributes(PerunSession sess, Resource resourceToGetServicesFrom, Member member, Group group, boolean workWithUserAttributes) throws InternalErrorException, MemberGroupMismatchException {
+		this.checkMemberIsFromTheSameVoLikeGroup(sess, member, group);
 
 		List<Attribute> attributes = new ArrayList<>(getAttributesManagerImpl().getRequiredAttributes(sess, resourceToGetServicesFrom, member, group));
 
@@ -2734,8 +2743,8 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	}
 
 	@Override
-	public List<Attribute> getRequiredAttributes(PerunSession sess, Member member, Group group, boolean workWithUserAttributes) throws InternalErrorException {
-
+	public List<Attribute> getRequiredAttributes(PerunSession sess, Member member, Group group, boolean workWithUserAttributes) throws InternalErrorException, MemberGroupMismatchException {
+		this.checkMemberIsFromTheSameVoLikeGroup(sess, member, group);
 		List<Resource> memberResources = getPerunBl().getResourcesManagerBl().getAssignedResources(sess, member);
 		List<Resource> groupResources = getPerunBl().getResourcesManagerBl().getAssignedResources(sess, group);
 		// get intersection of resources to determine correct set of services
@@ -2987,12 +2996,14 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	}
 
 	@Override
-	public List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Member member, Group group) throws InternalErrorException {
+	public List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Member member, Group group) throws InternalErrorException, MemberGroupMismatchException {
+		this.checkMemberIsFromTheSameVoLikeGroup(sess, member, group);
 		return getAttributesManagerImpl().getRequiredAttributes(sess, service, member, group);
 	}
 
 	@Override
-	public List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Member member, Group group, boolean workWithUserAttributes) throws InternalErrorException {
+	public List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Member member, Group group, boolean workWithUserAttributes) throws InternalErrorException, MemberGroupMismatchException {
+		this.checkMemberIsFromTheSameVoLikeGroup(sess, member, group);
 		if (!workWithUserAttributes)
 			return getAttributesManagerImpl().getRequiredAttributes(sess, service, member, group);
 
@@ -3141,22 +3152,24 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	}
 
 	@Override
-	public Attribute fillAttribute(PerunSession sess, Member member, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeAssignmentException {
+	public Attribute fillAttribute(PerunSession sess, Member member, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeAssignmentException, MemberGroupMismatchException {
 		getAttributesManagerImpl().checkNamespace(sess, attribute, NS_MEMBER_GROUP_ATTR);
+		this.checkMemberIsFromTheSameVoLikeGroup(sess, member, group);
 		return getAttributesManagerImpl().fillAttribute(sess, member, group, attribute);
 	}
 
 	@Override
-	public List<Attribute> fillAttributes(PerunSession sess, Member member, Group group, List<Attribute> attributes) throws InternalErrorException, WrongAttributeAssignmentException {
+	public List<Attribute> fillAttributes(PerunSession sess, Member member, Group group, List<Attribute> attributes) throws InternalErrorException, WrongAttributeAssignmentException, MemberGroupMismatchException {
 		return fillAttributes(sess, member, group, attributes, false);
 	}
 
 	@Override
-	public List<Attribute> fillAttributes(PerunSession sess, Member member, Group group, List<Attribute> attributes, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeAssignmentException {
+	public List<Attribute> fillAttributes(PerunSession sess, Member member, Group group, List<Attribute> attributes, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeAssignmentException, MemberGroupMismatchException {
 		if (!workWithUserAttributes) {
 			List<Attribute> filledAttributes = new ArrayList<>();
 			for (Attribute attribute : attributes) {
 				getAttributesManagerImpl().checkNamespace(sess, attribute, NS_MEMBER_GROUP_ATTR);
+				this.checkMemberIsFromTheSameVoLikeGroup(sess, member, group);
 				if (attribute.getValue() == null) {
 					filledAttributes.add(getAttributesManagerImpl().fillAttribute(sess, member, group, attribute));
 				} else {
@@ -3167,6 +3180,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 			return filledAttributes;
 		}
 
+		this.checkMemberIsFromTheSameVoLikeGroup(sess, member, group);
 		User user = getPerunBl().getUsersManagerBl().getUserByMember(sess, member);
 
 		List<Attribute> filledAttributes = new ArrayList<>();
@@ -3499,7 +3513,8 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	}
 
 	@Override
-	public void checkAttributeSemantics(PerunSession sess, Member member, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeAssignmentException {
+	public void checkAttributeSemantics(PerunSession sess, Member member, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeAssignmentException, MemberGroupMismatchException {
+		this.checkMemberIsFromTheSameVoLikeGroup(sess, member, group);
 		getAttributesManagerImpl().checkNamespace(sess, attribute, NS_MEMBER_GROUP_ATTR);
 
 		if (attribute.getValue() == null && !isTrulyRequiredAttribute(sess, member, group, attribute)) return;
@@ -3507,20 +3522,22 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	}
 
 	@Override
-	public void checkAttributesSemantics(PerunSession sess, Member member, Group group, List<Attribute> attributes) throws InternalErrorException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
+	public void checkAttributesSemantics(PerunSession sess, Member member, Group group, List<Attribute> attributes) throws InternalErrorException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, MemberGroupMismatchException {
 		checkAttributesSemantics(sess, member, group, attributes, false);
 	}
 
 	@Override
-	public void checkAttributesSemantics(PerunSession sess, Member member, Group group, List<Attribute> attributes, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
+	public void checkAttributesSemantics(PerunSession sess, Member member, Group group, List<Attribute> attributes, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, MemberGroupMismatchException {
 		if (!workWithUserAttributes) {
 			getAttributesManagerImpl().checkNamespace(sess, attributes, NS_MEMBER_GROUP_ATTR);
+			this.checkMemberIsFromTheSameVoLikeGroup(sess, member, group);
 
 			for (Attribute attribute : attributes) {
 				if (attribute.getValue() == null && !isTrulyRequiredAttribute(sess, member, group, attribute)) continue;
 				getAttributesManagerImpl().checkAttributeSemantics(sess, member, group, attribute);
 			}
 		} else {
+			this.checkMemberIsFromTheSameVoLikeGroup(sess, member, group);
 			User user = getPerunBl().getUsersManagerBl().getUserByMember(sess, member);
 
 			for (Attribute attribute : attributes) {
@@ -3643,7 +3660,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	}
 
 	@Override
-	public void checkAttributesSemantics(PerunSession sess, Facility facility, Resource resource, Group group, User user, Member member, List<Attribute> attributes) throws InternalErrorException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, GroupResourceMismatchException, MemberResourceMismatchException {
+	public void checkAttributesSemantics(PerunSession sess, Facility facility, Resource resource, Group group, User user, Member member, List<Attribute> attributes) throws InternalErrorException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, GroupResourceMismatchException, MemberResourceMismatchException, MemberGroupMismatchException {
 		this.checkMemberIsFromTheSameVoLikeResource(sess, member, resource);
 		this.checkGroupIsFromTheSameVoLikeResource(sess, group, resource);
 		for (Attribute attribute : attributes) {
@@ -3866,20 +3883,21 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	}
 
 	@Override
-	public void checkAttributeSyntax(PerunSession sess, Member member, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException {
+	public void checkAttributeSyntax(PerunSession sess, Member member, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, MemberGroupMismatchException {
 		getAttributesManagerImpl().checkNamespace(sess, attribute, NS_MEMBER_GROUP_ATTR);
+		this.checkMemberIsFromTheSameVoLikeGroup(sess, member, group);
 		if (attribute.getValue() != null) getAttributesManagerImpl().checkAttributeSyntax(sess, member, group, attribute);
 	}
 
 	@Override
-	public void checkAttributesSyntax(PerunSession sess, Member member, Group group, List<Attribute> attributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException {
+	public void checkAttributesSyntax(PerunSession sess, Member member, Group group, List<Attribute> attributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, MemberGroupMismatchException {
 		for (Attribute attribute : attributes) {
 			checkAttributeSyntax(sess, member, group, attribute);
 		}
 	}
 
 	@Override
-	public void checkAttributesSyntax(PerunSession sess, Member member, Group group, List<Attribute> attributes, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException {
+	public void checkAttributesSyntax(PerunSession sess, Member member, Group group, List<Attribute> attributes, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, MemberGroupMismatchException {
 		if (!workWithUserAttributes) {
 			// delegate
 			checkAttributesSyntax(sess, member, group, attributes);
@@ -3952,7 +3970,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	}
 
 	@Override
-	public void checkAttributesSyntax(PerunSession sess, Facility facility, Resource resource, Group group, User user, Member member, List<Attribute> attributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, GroupResourceMismatchException, MemberResourceMismatchException {
+	public void checkAttributesSyntax(PerunSession sess, Facility facility, Resource resource, Group group, User user, Member member, List<Attribute> attributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, GroupResourceMismatchException, MemberResourceMismatchException, MemberGroupMismatchException {
 		this.checkMemberIsFromTheSameVoLikeResource(sess, member, resource);
 		this.checkGroupIsFromTheSameVoLikeResource(sess, group, resource);
 		for (Attribute attribute : attributes) {
@@ -4224,7 +4242,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	}
 
 	@Override
-	public void removeAttributes(PerunSession sess, Facility facility, Resource resource, Group group, User user, Member member, List<? extends AttributeDefinition> attributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, GroupResourceMismatchException, MemberResourceMismatchException {
+	public void removeAttributes(PerunSession sess, Facility facility, Resource resource, Group group, User user, Member member, List<? extends AttributeDefinition> attributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, GroupResourceMismatchException, MemberResourceMismatchException, MemberGroupMismatchException {
 		this.checkMemberIsFromTheSameVoLikeResource(sess, member, resource);
 		this.checkGroupIsFromTheSameVoLikeResource(sess, group, resource);
 		List<AttributeDefinition> attributesToCheck = new ArrayList<>();
@@ -4665,7 +4683,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	}
 
 	@Override
-	public void removeAttribute(PerunSession sess, Member member, Group group, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException {
+	public void removeAttribute(PerunSession sess, Member member, Group group, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException, MemberGroupMismatchException {
 		if (removeAttributeWithoutCheck(sess, member, group, attribute)) {
 			checkAttributeSemantics(sess, member, group, new Attribute(attribute));
 			this.checkAttributeDependencies(sess, new RichAttribute<>(member, group, new Attribute(attribute)));
@@ -4674,7 +4692,8 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 
 	// s workWithUserAttr.
 	@Override
-	public boolean removeAttributeWithoutCheck(PerunSession sess, Member member, Group group, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException {
+	public boolean removeAttributeWithoutCheck(PerunSession sess, Member member, Group group, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException, MemberGroupMismatchException {
+		this.checkMemberIsFromTheSameVoLikeGroup(sess, member, group);
 		getAttributesManagerImpl().checkNamespace(sess, attribute, NS_MEMBER_GROUP_ATTR);
 		if (getAttributesManagerImpl().isCoreAttribute(sess, attribute))
 			throw new WrongAttributeAssignmentException(attribute);
@@ -4690,12 +4709,13 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	}
 
 	@Override
-	public void removeAttributes(PerunSession sess, Member member, Group group, List<? extends AttributeDefinition> attributes) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException {
+	public void removeAttributes(PerunSession sess, Member member, Group group, List<? extends AttributeDefinition> attributes) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException, MemberGroupMismatchException {
 		removeAttributes(sess, member, group, attributes, false);
 	}
 
 	@Override
-	public void removeAttributes(PerunSession sess, Member member, Group group, List<? extends AttributeDefinition> attributes, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException {
+	public void removeAttributes(PerunSession sess, Member member, Group group, List<? extends AttributeDefinition> attributes, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException, MemberGroupMismatchException {
+		this.checkMemberIsFromTheSameVoLikeGroup(sess, member, group);
 		if (!workWithUserAttributes) {
 			getAttributesManagerImpl().checkNamespace(sess, attributes, NS_MEMBER_GROUP_ATTR);
 			List<AttributeDefinition> attributesToCheck = new ArrayList<>();
@@ -4729,7 +4749,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	}
 
 	@Override
-	public void removeAllAttributes(PerunSession sess, Member member, Group group) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException {
+	public void removeAllAttributes(PerunSession sess, Member member, Group group) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, MemberGroupMismatchException {
 		List<Attribute> attributes = getAttributes(sess, member, group);
 		if (getAttributesManagerImpl().removeAllAttributes(sess, member, group)) {
 			getPerunBl().getAuditer().log(sess, new AllAttributesRemovedForMemberAndGroup(member, group));
@@ -5295,7 +5315,8 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	}
 
 	@Override
-	public boolean isTrulyRequiredAttribute(PerunSession sess, Member member, Group group, AttributeDefinition attributeDefinition) throws InternalErrorException, WrongAttributeAssignmentException {
+	public boolean isTrulyRequiredAttribute(PerunSession sess, Member member, Group group, AttributeDefinition attributeDefinition) throws InternalErrorException, WrongAttributeAssignmentException, MemberGroupMismatchException {
+		this.checkMemberIsFromTheSameVoLikeGroup(sess, member, group);
 		this.checkNamespace(sess, attributeDefinition, NS_MEMBER_GROUP_ATTR);
 		List<Resource> assignedResources = getPerunBl().getResourcesManagerBl().getAssignedResources(sess, group);
 		for (Resource resource : assignedResources) {
@@ -5751,7 +5772,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 					}
 					try {
 						richAttributesToCheck = getRichAttributesWithHoldersForAttributeDefinition(sess, dependency, richAttr);
-					} catch (AttributeNotExistsException | VoNotExistsException | UserNotExistsException | GroupResourceMismatchException | MemberResourceMismatchException ex) {
+					} catch (AttributeNotExistsException | VoNotExistsException | UserNotExistsException | GroupResourceMismatchException | MemberResourceMismatchException | MemberGroupMismatchException ex) {
 						throw new InternalErrorException(ex);
 					}
 					for (RichAttribute richAttribute : richAttributesToCheck) {
@@ -5886,13 +5907,21 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 						} else if (getAttributesManagerImpl().isFromNamespace(richAttribute.getAttribute(), NS_MEMBER_GROUP_ATTR)) {
 							if (richAttribute.getPrimaryHolder() != null && richAttribute.getPrimaryHolder() instanceof Group) {
 								if (richAttribute.getSecondaryHolder() != null && richAttribute.getSecondaryHolder() instanceof Member) {
-									this.checkAttributeSemantics(sess, (Member) richAttribute.getSecondaryHolder(), (Group) richAttribute.getPrimaryHolder(), richAttribute.getAttribute());
+									try {
+										this.checkAttributeSemantics(sess, (Member) richAttribute.getSecondaryHolder(), (Group) richAttribute.getPrimaryHolder(), richAttribute.getAttribute());
+									} catch (MemberGroupMismatchException ex) {
+										throw new ConsistencyErrorException(ex);
+									}
 								} else {
 									throw new InternalErrorException("Secondary Holder for Member_Group Attribute is null or its not member or group");
 								}
 							} else if (richAttribute.getSecondaryHolder() != null && richAttribute.getSecondaryHolder() instanceof Group) {
 								if (richAttribute.getPrimaryHolder() != null && richAttribute.getPrimaryHolder() instanceof Member) {
-									this.checkAttributeSemantics(sess, (Member) richAttribute.getPrimaryHolder(), (Group) richAttribute.getSecondaryHolder(), richAttribute.getAttribute());
+									try {
+										this.checkAttributeSemantics(sess, (Member) richAttribute.getPrimaryHolder(), (Group) richAttribute.getSecondaryHolder(), richAttribute.getAttribute());
+									} catch (MemberGroupMismatchException ex) {
+										throw new ConsistencyErrorException(ex);
+									}
 								} else {
 									throw new InternalErrorException("Secondary Holder for Member_Group Attribute is null or its not member or group");
 								}
@@ -5923,7 +5952,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	}
 
 	@Override
-	public List<RichAttribute> getRichAttributesWithHoldersForAttributeDefinition(PerunSession sess, AttributeDefinition attrDef, RichAttribute aidingAttr) throws InternalErrorException, AttributeNotExistsException, UserNotExistsException, VoNotExistsException, WrongAttributeAssignmentException, GroupResourceMismatchException, MemberResourceMismatchException {
+	public List<RichAttribute> getRichAttributesWithHoldersForAttributeDefinition(PerunSession sess, AttributeDefinition attrDef, RichAttribute aidingAttr) throws InternalErrorException, AttributeNotExistsException, UserNotExistsException, VoNotExistsException, WrongAttributeAssignmentException, GroupResourceMismatchException, MemberResourceMismatchException, MemberGroupMismatchException {
 		//Filling objects from aidingAttr
 		if (aidingAttr == null) throw new InternalErrorException("Aiding attribute cant be null.");
 		if (attrDef == null) throw new InternalErrorException("attrDef cant be null.");
@@ -7806,6 +7835,18 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	@Override
 	public UserVirtualAttributesModuleImplApi getUserVirtualAttributeModule(PerunSession sess, AttributeDefinition attribute) throws InternalErrorException {
 		return getAttributesManagerImpl().getUserVirtualAttributeModule(sess, attribute);
+	}
+
+	/**
+	 * Check if Member is from the same VO like Group. If not, throw MemberGroupMismatchException
+	 */
+	private void checkMemberIsFromTheSameVoLikeGroup(PerunSession sess, Member member, Group group) throws MemberGroupMismatchException, InternalErrorException {
+		Utils.notNull(sess, "sess");
+		Utils.notNull(member, "member");
+		Utils.notNull(group, "group");
+
+		if (member.getVoId() != group.getVoId())
+			throw new MemberGroupMismatchException("Member is not from the same vo like Group: " + member + " " + group, member, group);
 	}
 
 	/**
@@ -10077,7 +10118,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	 * @param attrDef type of attribute that will be returned
 	 * @return List of RichAttribute
 	 */
-	private List<RichAttribute> getMemberGroupAttributes(PerunSession sess, User user, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
+	private List<RichAttribute> getMemberGroupAttributes(PerunSession sess, User user, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException, MemberGroupMismatchException {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		List<Member> membersFromUser = getPerunBl().getMembersManagerBl().getMembersByUser(sess, user);
 		for (Member memberElement : membersFromUser) {
@@ -10098,7 +10139,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	 * @param attrDef type of attribute that will be returned
 	 * @return List of RichAttribute
 	 */
-	private List<RichAttribute> getMemberGroupAttributes(PerunSession sess, Member member, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
+	private List<RichAttribute> getMemberGroupAttributes(PerunSession sess, Member member, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException, MemberGroupMismatchException {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		if (getPerunBl().getMembersManagerBl().isMemberAllowed(sess, member)) {
 			List<Group> groupsFromMembers = getPerunBl().getGroupsManagerBl().getAllMemberGroups(sess, member);
@@ -10122,7 +10163,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	 * @param attrDef type of attribute that will be returned
 	 * @return List of RichAttribute
 	 */
-	private List<RichAttribute> getMemberGroupAttributes(PerunSession sess, Group group, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
+	private List<RichAttribute> getMemberGroupAttributes(PerunSession sess, Group group, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException, MemberGroupMismatchException {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		List<Member> membersFromGroups = getPerunBl().getGroupsManagerBl().getGroupMembers(sess, group);
 		for (Member memberElement : membersFromGroups) {
@@ -10146,7 +10187,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	 * @param attrDef  type of attribute that will be returned
 	 * @return List of RichAttribute
 	 */
-	private List<RichAttribute> getMemberGroupAttributes(PerunSession sess, Resource resource, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
+	private List<RichAttribute> getMemberGroupAttributes(PerunSession sess, Resource resource, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException, MemberGroupMismatchException {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		List<Group> groupsFromResources = getPerunBl().getResourcesManagerBl().getAssignedGroups(sess, resource);
 		for (Group groupElement : groupsFromResources) {
@@ -10167,7 +10208,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	 * @param attrDef type of attribute that will be returned
 	 * @return List of RichAttribute
 	 */
-	private List<RichAttribute> getMemberGroupAttributes(PerunSession sess, Vo vo, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
+	private List<RichAttribute> getMemberGroupAttributes(PerunSession sess, Vo vo, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException, MemberGroupMismatchException {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		List<Group> groupsFromVo = getPerunBl().getGroupsManagerBl().getAllGroups(sess, vo);
 		for (Group groupElement : groupsFromVo) {
@@ -10188,7 +10229,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	 * @param attrDef  type of attribute that will be returned
 	 * @return List of RichAttribute
 	 */
-	private List<RichAttribute> getMemberGroupAttributes(PerunSession sess, Facility facility, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
+	private List<RichAttribute> getMemberGroupAttributes(PerunSession sess, Facility facility, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException, MemberGroupMismatchException {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		List<Group> groupsFromFacility = getPerunBl().getGroupsManagerBl().getAssignedGroupsToFacility(sess, facility);
 		for (Group groupElement : groupsFromFacility) {
@@ -10209,7 +10250,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	 * @param attrDef type of attribute that will be returned
 	 * @return List of RichAttribute
 	 */
-	private List<RichAttribute> getMemberGroupAttributes(PerunSession sess, Host host, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
+	private List<RichAttribute> getMemberGroupAttributes(PerunSession sess, Host host, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException, MemberGroupMismatchException {
 		Facility facility = getPerunBl().getFacilitiesManagerBl().getFacilityForHost(sess, host);
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>(getMemberGroupAttributes(sess, facility, attrDef));
 		return listOfRichAttributes;
@@ -10226,7 +10267,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	 * @param attrDef       type of attribute that will be returned
 	 * @return List of RichAttribute
 	 */
-	private List<RichAttribute> getMemberGroupAttributes(PerunSession sess, UserExtSource userExtSource, AttributeDefinition attrDef) throws InternalErrorException, UserNotExistsException, AttributeNotExistsException, WrongAttributeAssignmentException {
+	private List<RichAttribute> getMemberGroupAttributes(PerunSession sess, UserExtSource userExtSource, AttributeDefinition attrDef) throws InternalErrorException, UserNotExistsException, AttributeNotExistsException, WrongAttributeAssignmentException, MemberGroupMismatchException {
 		User user = getPerunBl().getUsersManagerBl().getUserByUserExtSource(sess, userExtSource);
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>(getMemberGroupAttributes(sess, user, attrDef));
 		return listOfRichAttributes;
@@ -10244,7 +10285,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	 * @param attrDef type of attribute that will be returned
 	 * @return List of RichAttribute
 	 */
-	private List<RichAttribute> getMemberGroupAttributes(PerunSession sess, Member member, Group group, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
+	private List<RichAttribute> getMemberGroupAttributes(PerunSession sess, Member member, Group group, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException, MemberGroupMismatchException {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		if (getPerunBl().getMembersManagerBl().isMemberAllowed(sess, member)) {
 			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, member, group, attrDef.getName());
@@ -10265,7 +10306,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	 * @param attrDef  type of attribute that will be returned
 	 * @return List of RichAttribute
 	 */
-	private List<RichAttribute> getMemberGroupAttributes(PerunSession sess, Member member, Resource resource, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
+	private List<RichAttribute> getMemberGroupAttributes(PerunSession sess, Member member, Resource resource, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException, MemberGroupMismatchException {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		//If member is not allowed, skip whole process
 		if (!getPerunBl().getMembersManagerBl().isMemberAllowed(sess, member)) return listOfRichAttributes;
@@ -10296,7 +10337,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	 * @param attrDef  type of attribute that will be returned
 	 * @return List of RichAttribute
 	 */
-	private List<RichAttribute> getMemberGroupAttributes(PerunSession sess, User user, Facility facility, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
+	private List<RichAttribute> getMemberGroupAttributes(PerunSession sess, User user, Facility facility, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException, MemberGroupMismatchException {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		// get all groups from facility
 		List<Group> groupsFromFacility = getPerunBl().getGroupsManagerBl().getAssignedGroupsToFacility(sess, facility);
@@ -10336,7 +10377,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	 * @param attrDef type of attribute that will be returned
 	 * @return List of RichAttribute
 	 */
-	private List<RichAttribute> getMemberGroupAttributes(PerunSession sess, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
+	private List<RichAttribute> getMemberGroupAttributes(PerunSession sess, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException, MemberGroupMismatchException {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		List<Vo> vos = getPerunBl().getVosManagerBl().getVos(sess);
 		List<Group> groupsFromVo = new ArrayList<>();

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -3530,24 +3530,25 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 
 	@Override
 	public void checkAttributesSemantics(PerunSession sess, Member member, Group group, List<Attribute> attributes, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, MemberGroupMismatchException {
+		this.checkMemberIsFromTheSameVoLikeGroup(sess, member, group);
 		if (!workWithUserAttributes) {
 			getAttributesManagerImpl().checkNamespace(sess, attributes, NS_MEMBER_GROUP_ATTR);
-			this.checkMemberIsFromTheSameVoLikeGroup(sess, member, group);
 
 			for (Attribute attribute : attributes) {
 				if (attribute.getValue() == null && !isTrulyRequiredAttribute(sess, member, group, attribute)) continue;
 				getAttributesManagerImpl().checkAttributeSemantics(sess, member, group, attribute);
 			}
 		} else {
-			this.checkMemberIsFromTheSameVoLikeGroup(sess, member, group);
-			User user = getPerunBl().getUsersManagerBl().getUserByMember(sess, member);
 
+			User user = null;
 			for (Attribute attribute : attributes) {
 				if (getAttributesManagerImpl().isFromNamespace(attribute, AttributesManager.NS_MEMBER_GROUP_ATTR)) {
 					if (attribute.getValue() == null && !isTrulyRequiredAttribute(sess, member, group, attribute))
 						continue;
 					getAttributesManagerImpl().checkAttributeSemantics(sess, member, group, attribute);
 				} else if (getAttributesManagerImpl().isFromNamespace(attribute, AttributesManager.NS_USER_ATTR)) {
+					// lazy load user
+					if (user == null) user = getPerunBl().getUsersManagerBl().getUserByMember(sess, member);
 					if (attribute.getValue() == null && !isTrulyRequiredAttribute(sess, user, attribute)) continue;
 					getAttributesManagerImpl().checkAttributeSemantics(sess, user, attribute);
 				} else if (getAttributesManagerImpl().isFromNamespace(attribute, AttributesManager.NS_MEMBER_ATTR)) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ServicesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ServicesManagerBlImpl.java
@@ -30,6 +30,7 @@ import cz.metacentrum.perun.audit.events.ServicesManagerEvents.ServicesPackageDe
 import cz.metacentrum.perun.audit.events.ServicesManagerEvents.ServicesPackageUpdated;
 import cz.metacentrum.perun.controller.model.ServiceForGUI;
 import cz.metacentrum.perun.core.api.MemberGroupStatus;
+import cz.metacentrum.perun.core.api.exceptions.MemberGroupMismatchException;
 import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
 import cz.metacentrum.perun.core.api.exceptions.ServiceAlreadyBannedException;
 import org.slf4j.Logger;
@@ -453,7 +454,11 @@ public class ServicesManagerBlImpl implements ServicesManagerBl {
 			if (memberAttributes.get(member) != null) {
 				tempAttrs.addAttributes(memberAttributes.get(member).getAttributes());
 			}
-			tempAttrs.addAttributes(getPerunBl().getAttributesManagerBl().getRequiredAttributes(sess, service, member, group));
+			try {
+				tempAttrs.addAttributes(getPerunBl().getAttributesManagerBl().getRequiredAttributes(sess, service, member, group));
+			} catch (MemberGroupMismatchException e) {
+				throw new InternalErrorException(e);
+			}
 			groupsMembersElement.addChildElement(tempAttrs);
 		}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/AttributesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/AttributesManagerEntry.java
@@ -1301,7 +1301,7 @@ public class AttributesManagerEntry implements AttributesManager {
 	}
 
 	@Override
-	public Attribute getAttributeById(PerunSession sess, Member member, Group group, int id) throws PrivilegeException, GroupNotExistsException, InternalErrorException, AttributeNotExistsException, MemberNotExistsException, WrongAttributeAssignmentException {
+	public Attribute getAttributeById(PerunSession sess, Member member, Group group, int id) throws PrivilegeException, GroupNotExistsException, InternalErrorException, AttributeNotExistsException, MemberNotExistsException, WrongAttributeAssignmentException, MemberGroupMismatchException {
 		Utils.checkPerunSession(sess);
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
 		getPerunBl().getGroupsManagerBl().checkGroupExists(sess, group);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/AttributesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/AttributesManagerEntry.java
@@ -236,7 +236,7 @@ public class AttributesManagerEntry implements AttributesManager {
 	}
 
 	@Override
-	public List<Attribute> getAttributes(PerunSession sess, Member member, Group group) throws GroupNotExistsException, InternalErrorException, MemberNotExistsException {
+	public List<Attribute> getAttributes(PerunSession sess, Member member, Group group) throws GroupNotExistsException, InternalErrorException, MemberNotExistsException, MemberGroupMismatchException {
 		Utils.checkPerunSession(sess);
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
 		getPerunBl().getGroupsManagerBl().checkGroupExists(sess, group);
@@ -254,7 +254,7 @@ public class AttributesManagerEntry implements AttributesManager {
 	}
 
 	@Override
-	public List<Attribute> getAttributes(PerunSession sess, Member member, Group group, List<String> attrNames) throws GroupNotExistsException, InternalErrorException, MemberNotExistsException {
+	public List<Attribute> getAttributes(PerunSession sess, Member member, Group group, List<String> attrNames) throws GroupNotExistsException, InternalErrorException, MemberNotExistsException, MemberGroupMismatchException {
 		Utils.checkPerunSession(sess);
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
 		getPerunBl().getGroupsManagerBl().checkGroupExists(sess, group);
@@ -272,7 +272,7 @@ public class AttributesManagerEntry implements AttributesManager {
 	}
 
 	@Override
-	public List<Attribute> getAttributes(PerunSession sess, Member member, Group group, List<String> attrNames, boolean workWithUserAttributes) throws GroupNotExistsException, InternalErrorException, MemberNotExistsException {
+	public List<Attribute> getAttributes(PerunSession sess, Member member, Group group, List<String> attrNames, boolean workWithUserAttributes) throws GroupNotExistsException, InternalErrorException, MemberNotExistsException, MemberGroupMismatchException {
 		Utils.checkPerunSession(sess);
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
 		getPerunBl().getGroupsManagerBl().checkGroupExists(sess, group);
@@ -347,7 +347,7 @@ public class AttributesManagerEntry implements AttributesManager {
 	}
 
 	@Override
-	public List<Attribute> getAttributes(PerunSession sess, Resource resource, Group group, Member member, List<String> attrNames) throws InternalErrorException, ResourceNotExistsException, GroupNotExistsException, MemberNotExistsException, GroupResourceMismatchException, MemberResourceMismatchException {
+	public List<Attribute> getAttributes(PerunSession sess, Resource resource, Group group, Member member, List<String> attrNames) throws InternalErrorException, ResourceNotExistsException, GroupNotExistsException, MemberNotExistsException, GroupResourceMismatchException, MemberResourceMismatchException, MemberGroupMismatchException {
 		Utils.checkPerunSession(sess);
 		Utils.notNull(attrNames, "attrNames");
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
@@ -810,7 +810,7 @@ public class AttributesManagerEntry implements AttributesManager {
 	}
 
 	@Override
-	public void setAttributes(PerunSession sess, Member member, Group group, List<Attribute> attributes) throws PrivilegeException, GroupNotExistsException, InternalErrorException, MemberNotExistsException, AttributeNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
+	public void setAttributes(PerunSession sess, Member member, Group group, List<Attribute> attributes) throws PrivilegeException, GroupNotExistsException, InternalErrorException, MemberNotExistsException, AttributeNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, MemberGroupMismatchException {
 		Utils.checkPerunSession(sess);
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
 		getPerunBl().getGroupsManagerBl().checkGroupExists(sess, group);
@@ -824,7 +824,7 @@ public class AttributesManagerEntry implements AttributesManager {
 	}
 
 	@Override
-	public void setAttributes(PerunSession sess, Member member, Group group, List<Attribute> attributes, boolean workWithUserAttributes) throws PrivilegeException, GroupNotExistsException, InternalErrorException, MemberNotExistsException, AttributeNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
+	public void setAttributes(PerunSession sess, Member member, Group group, List<Attribute> attributes, boolean workWithUserAttributes) throws PrivilegeException, GroupNotExistsException, InternalErrorException, MemberNotExistsException, AttributeNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, MemberGroupMismatchException {
 		Utils.checkPerunSession(sess);
 		getPerunBl().getGroupsManagerBl().checkGroupExists(sess, group);
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
@@ -920,7 +920,7 @@ public class AttributesManagerEntry implements AttributesManager {
 	}
 
 	@Override
-	public void setAttributes(PerunSession sess, Facility facility, Resource resource, Group group, User user, Member member, List<Attribute> attributes) throws PrivilegeException, ResourceNotExistsException, InternalErrorException, MemberNotExistsException, FacilityNotExistsException, UserNotExistsException, AttributeNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, GroupNotExistsException, GroupResourceMismatchException, MemberResourceMismatchException {
+	public void setAttributes(PerunSession sess, Facility facility, Resource resource, Group group, User user, Member member, List<Attribute> attributes) throws PrivilegeException, ResourceNotExistsException, InternalErrorException, MemberNotExistsException, FacilityNotExistsException, UserNotExistsException, AttributeNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, GroupNotExistsException, GroupResourceMismatchException, MemberResourceMismatchException, MemberGroupMismatchException {
 		Utils.checkPerunSession(sess);
 		getPerunBl().getResourcesManagerBl().checkResourceExists(sess, resource);
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
@@ -1109,7 +1109,7 @@ public class AttributesManagerEntry implements AttributesManager {
 	}
 
 	@Override
-	public Attribute getAttribute(PerunSession sess, Member member, Group group, String attributeName) throws PrivilegeException, GroupNotExistsException, InternalErrorException, AttributeNotExistsException, MemberNotExistsException, WrongAttributeAssignmentException {
+	public Attribute getAttribute(PerunSession sess, Member member, Group group, String attributeName) throws PrivilegeException, GroupNotExistsException, InternalErrorException, AttributeNotExistsException, MemberNotExistsException, WrongAttributeAssignmentException, MemberGroupMismatchException {
 		Utils.checkPerunSession(sess);
 		Utils.notNull(attributeName, "attributeName");
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
@@ -1442,7 +1442,7 @@ public class AttributesManagerEntry implements AttributesManager {
 	}
 
 	@Override
-	public void setAttribute(PerunSession sess, Member member, Group group, Attribute attribute) throws PrivilegeException, GroupNotExistsException, InternalErrorException, MemberNotExistsException, AttributeNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
+	public void setAttribute(PerunSession sess, Member member, Group group, Attribute attribute) throws PrivilegeException, GroupNotExistsException, InternalErrorException, MemberNotExistsException, AttributeNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, MemberGroupMismatchException {
 		Utils.checkPerunSession(sess);
 		getAttributesManagerBl().checkAttributeExists(sess, attribute);
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
@@ -1616,7 +1616,7 @@ public class AttributesManagerEntry implements AttributesManager {
 	}
 
 	@Override
-	public List<Attribute> getResourceRequiredAttributes(PerunSession sess, Resource resourceToGetServicesFrom, Member member, Group group) throws InternalErrorException, ResourceNotExistsException, MemberNotExistsException, GroupNotExistsException {
+	public List<Attribute> getResourceRequiredAttributes(PerunSession sess, Resource resourceToGetServicesFrom, Member member, Group group) throws InternalErrorException, ResourceNotExistsException, MemberNotExistsException, GroupNotExistsException, MemberGroupMismatchException {
 		Utils.checkPerunSession(sess);
 		getPerunBl().getResourcesManagerBl().checkResourceExists(sess, resourceToGetServicesFrom);
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
@@ -1634,7 +1634,7 @@ public class AttributesManagerEntry implements AttributesManager {
 	}
 
 	@Override
-	public List<Attribute> getResourceRequiredAttributes(PerunSession sess, Resource resourceToGetServicesFrom, Member member, Group group, boolean workWithUserAttributes) throws InternalErrorException, ResourceNotExistsException, MemberNotExistsException, GroupNotExistsException {
+	public List<Attribute> getResourceRequiredAttributes(PerunSession sess, Resource resourceToGetServicesFrom, Member member, Group group, boolean workWithUserAttributes) throws InternalErrorException, ResourceNotExistsException, MemberNotExistsException, GroupNotExistsException, MemberGroupMismatchException {
 		Utils.checkPerunSession(sess);
 		getPerunBl().getResourcesManagerBl().checkResourceExists(sess, resourceToGetServicesFrom);
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
@@ -1800,7 +1800,7 @@ public class AttributesManagerEntry implements AttributesManager {
 			throw new GroupResourceMismatchException("Group and resource are not in the same VO.");
 		}
 		if(member.getVoId() != group.getVoId()) {
-			throw new MemberGroupMismatchException("Member and Group are not in the same VO.");
+			throw new MemberGroupMismatchException("Member and Group are not in the same VO.", member, group);
 		}
 
 		List<Attribute> attributes = getAttributesManagerBl().getResourceRequiredAttributes(sess, resourceToGetServicesFrom, member, resource, workWithUserAttributes);
@@ -1958,7 +1958,7 @@ public class AttributesManagerEntry implements AttributesManager {
 	}
 
 	@Override
-	public List<Attribute> getRequiredAttributes(PerunSession sess, Member member, Group group, boolean workWithUserAttributes) throws InternalErrorException, MemberNotExistsException, GroupNotExistsException {
+	public List<Attribute> getRequiredAttributes(PerunSession sess, Member member, Group group, boolean workWithUserAttributes) throws InternalErrorException, MemberNotExistsException, GroupNotExistsException, MemberGroupMismatchException {
 		Utils.checkPerunSession(sess);
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
 		getPerunBl().getGroupsManagerBl().checkGroupExists(sess, group);
@@ -2373,7 +2373,7 @@ public class AttributesManagerEntry implements AttributesManager {
 	}
 
 	@Override
-	public List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Member member, Group group) throws InternalErrorException, ServiceNotExistsException, MemberNotExistsException, GroupNotExistsException {
+	public List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Member member, Group group) throws InternalErrorException, ServiceNotExistsException, MemberNotExistsException, GroupNotExistsException, MemberGroupMismatchException {
 		Utils.checkPerunSession(sess);
 		getPerunBl().getServicesManagerBl().checkServiceExists(sess, service);
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
@@ -2392,7 +2392,7 @@ public class AttributesManagerEntry implements AttributesManager {
 	}
 
 	@Override
-	public List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Member member, Group group, boolean workWithUserAttributes) throws InternalErrorException, ServiceNotExistsException, MemberNotExistsException, GroupNotExistsException {
+	public List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Member member, Group group, boolean workWithUserAttributes) throws InternalErrorException, ServiceNotExistsException, MemberNotExistsException, GroupNotExistsException, MemberGroupMismatchException {
 		Utils.checkPerunSession(sess);
 		getPerunBl().getServicesManagerBl().checkServiceExists(sess, service);
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
@@ -2593,7 +2593,7 @@ public class AttributesManagerEntry implements AttributesManager {
 	}
 
 	@Override
-	public Attribute fillAttribute(PerunSession sess, Member member, Group group, Attribute attribute) throws PrivilegeException, InternalErrorException, MemberNotExistsException, GroupNotExistsException, WrongAttributeAssignmentException {
+	public Attribute fillAttribute(PerunSession sess, Member member, Group group, Attribute attribute) throws PrivilegeException, InternalErrorException, MemberNotExistsException, GroupNotExistsException, WrongAttributeAssignmentException, MemberGroupMismatchException {
 		Utils.checkPerunSession(sess);
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
 		getPerunBl().getGroupsManagerBl().checkGroupExists(sess, group);
@@ -2606,7 +2606,7 @@ public class AttributesManagerEntry implements AttributesManager {
 	}
 
 	@Override
-	public List<Attribute> fillAttributes(PerunSession sess, Member member, Group group, List<Attribute> attributes) throws InternalErrorException, MemberNotExistsException, GroupNotExistsException, AttributeNotExistsException, WrongAttributeAssignmentException {
+	public List<Attribute> fillAttributes(PerunSession sess, Member member, Group group, List<Attribute> attributes) throws InternalErrorException, MemberNotExistsException, GroupNotExistsException, AttributeNotExistsException, WrongAttributeAssignmentException, MemberGroupMismatchException {
 		Utils.checkPerunSession(sess);
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
 		getPerunBl().getGroupsManagerBl().checkGroupExists(sess, group);
@@ -2624,7 +2624,7 @@ public class AttributesManagerEntry implements AttributesManager {
 	}
 
 	@Override
-	public List<Attribute> fillAttributes(PerunSession sess, Member member, Group group, List<Attribute> attributes, boolean workWithUserAttributes) throws InternalErrorException, MemberNotExistsException, AttributeNotExistsException, WrongAttributeAssignmentException, GroupNotExistsException {
+	public List<Attribute> fillAttributes(PerunSession sess, Member member, Group group, List<Attribute> attributes, boolean workWithUserAttributes) throws InternalErrorException, MemberNotExistsException, AttributeNotExistsException, WrongAttributeAssignmentException, GroupNotExistsException, MemberGroupMismatchException {
 		Utils.checkPerunSession(sess);
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
 		getPerunBl().getGroupsManagerBl().checkGroupExists(sess, group);
@@ -3049,7 +3049,7 @@ public class AttributesManagerEntry implements AttributesManager {
 	}
 
 	@Override
-	public void checkAttributeSemantics(PerunSession sess, Member member, Group group, Attribute attribute) throws PrivilegeException, InternalErrorException, GroupNotExistsException, MemberNotExistsException, WrongAttributeAssignmentException, AttributeNotExistsException {
+	public void checkAttributeSemantics(PerunSession sess, Member member, Group group, Attribute attribute) throws PrivilegeException, InternalErrorException, GroupNotExistsException, MemberNotExistsException, WrongAttributeAssignmentException, AttributeNotExistsException, MemberGroupMismatchException {
 		Utils.checkPerunSession(sess);
 		getAttributesManagerBl().checkAttributeExists(sess, attribute);
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
@@ -3061,7 +3061,7 @@ public class AttributesManagerEntry implements AttributesManager {
 	}
 
 	@Override
-	public void checkAttributesSemantics(PerunSession sess, Member member, Group group, List<Attribute> attributes) throws PrivilegeException, InternalErrorException, MemberNotExistsException, GroupNotExistsException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, AttributeNotExistsException {
+	public void checkAttributesSemantics(PerunSession sess, Member member, Group group, List<Attribute> attributes) throws PrivilegeException, InternalErrorException, MemberNotExistsException, GroupNotExistsException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, AttributeNotExistsException, MemberGroupMismatchException {
 		Utils.checkPerunSession(sess);
 		getAttributesManagerBl().checkAttributesExists(sess, attributes);
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
@@ -3074,7 +3074,7 @@ public class AttributesManagerEntry implements AttributesManager {
 	}
 
 	@Override
-	public void checkAttributesSemantics(PerunSession sess, Member member, Group group, List<Attribute> attributes, boolean workWithUserAttributes) throws PrivilegeException, InternalErrorException, MemberNotExistsException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, AttributeNotExistsException, GroupNotExistsException {
+	public void checkAttributesSemantics(PerunSession sess, Member member, Group group, List<Attribute> attributes, boolean workWithUserAttributes) throws PrivilegeException, InternalErrorException, MemberNotExistsException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, AttributeNotExistsException, GroupNotExistsException, MemberGroupMismatchException {
 		Utils.checkPerunSession(sess);
 		getAttributesManagerBl().checkAttributesExists(sess, attributes);
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
@@ -3423,7 +3423,7 @@ public class AttributesManagerEntry implements AttributesManager {
 	}
 
 	@Override
-	public void checkAttributeSyntax(PerunSession sess, Member member, Group group, Attribute attribute) throws PrivilegeException, InternalErrorException, GroupNotExistsException, MemberNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, AttributeNotExistsException {
+	public void checkAttributeSyntax(PerunSession sess, Member member, Group group, Attribute attribute) throws PrivilegeException, InternalErrorException, GroupNotExistsException, MemberNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, AttributeNotExistsException, MemberGroupMismatchException {
 		Utils.checkPerunSession(sess);
 		getAttributesManagerBl().checkAttributeExists(sess, attribute);
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
@@ -3435,7 +3435,7 @@ public class AttributesManagerEntry implements AttributesManager {
 	}
 
 	@Override
-	public void checkAttributesSyntax(PerunSession sess, Member member, Group group, List<Attribute> attributes) throws PrivilegeException, InternalErrorException, MemberNotExistsException, GroupNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, AttributeNotExistsException {
+	public void checkAttributesSyntax(PerunSession sess, Member member, Group group, List<Attribute> attributes) throws PrivilegeException, InternalErrorException, MemberNotExistsException, GroupNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, AttributeNotExistsException, MemberGroupMismatchException {
 		Utils.checkPerunSession(sess);
 		getAttributesManagerBl().checkAttributesExists(sess, attributes);
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
@@ -3448,7 +3448,7 @@ public class AttributesManagerEntry implements AttributesManager {
 	}
 
 	@Override
-	public void checkAttributesSyntax(PerunSession sess, Member member, Group group, List<Attribute> attributes, boolean workWithUserAttributes) throws PrivilegeException, InternalErrorException, MemberNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, AttributeNotExistsException, GroupNotExistsException {
+	public void checkAttributesSyntax(PerunSession sess, Member member, Group group, List<Attribute> attributes, boolean workWithUserAttributes) throws PrivilegeException, InternalErrorException, MemberNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, AttributeNotExistsException, GroupNotExistsException, MemberGroupMismatchException {
 		Utils.checkPerunSession(sess);
 		getAttributesManagerBl().checkAttributesExists(sess, attributes);
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
@@ -3783,7 +3783,7 @@ public class AttributesManagerEntry implements AttributesManager {
 	}
 
 	@Override
-	public void removeAttributes(PerunSession sess, Facility facility, Resource resource, Group group, User user, Member member, List<? extends AttributeDefinition> attributes) throws PrivilegeException, ResourceNotExistsException, InternalErrorException, MemberNotExistsException, FacilityNotExistsException, UserNotExistsException, AttributeNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, GroupNotExistsException, GroupResourceMismatchException, MemberResourceMismatchException {
+	public void removeAttributes(PerunSession sess, Facility facility, Resource resource, Group group, User user, Member member, List<? extends AttributeDefinition> attributes) throws PrivilegeException, ResourceNotExistsException, InternalErrorException, MemberNotExistsException, FacilityNotExistsException, UserNotExistsException, AttributeNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, GroupNotExistsException, GroupResourceMismatchException, MemberResourceMismatchException, MemberGroupMismatchException {
 		Utils.checkPerunSession(sess);
 		getPerunBl().getFacilitiesManagerBl().checkFacilityExists(sess, facility);
 		getAttributesManagerBl().checkAttributesExists(sess, attributes);
@@ -4019,7 +4019,7 @@ public class AttributesManagerEntry implements AttributesManager {
 	}
 
 	@Override
-	public void removeAttribute(PerunSession sess, Member member, Group group, AttributeDefinition attribute) throws InternalErrorException, PrivilegeException, AttributeNotExistsException, MemberNotExistsException, GroupNotExistsException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException {
+	public void removeAttribute(PerunSession sess, Member member, Group group, AttributeDefinition attribute) throws InternalErrorException, PrivilegeException, AttributeNotExistsException, MemberNotExistsException, GroupNotExistsException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException, MemberGroupMismatchException {
 		Utils.checkPerunSession(sess);
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
 		getPerunBl().getGroupsManagerBl().checkGroupExists(sess, group);
@@ -4031,12 +4031,12 @@ public class AttributesManagerEntry implements AttributesManager {
 	}
 
 	@Override
-	public void removeAttributes(PerunSession sess, Member member, Group group, List<? extends AttributeDefinition> attributes) throws InternalErrorException, PrivilegeException, AttributeNotExistsException, MemberNotExistsException, GroupNotExistsException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException {
+	public void removeAttributes(PerunSession sess, Member member, Group group, List<? extends AttributeDefinition> attributes) throws InternalErrorException, PrivilegeException, AttributeNotExistsException, MemberNotExistsException, GroupNotExistsException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException, MemberGroupMismatchException {
 		removeAttributes(sess, member, group, attributes, false);
 	}
 
 	@Override
-	public void removeAttributes(PerunSession sess, Member member, Group group, List<? extends AttributeDefinition> attributes, boolean workWithUserAttributes) throws InternalErrorException, PrivilegeException, AttributeNotExistsException, MemberNotExistsException, GroupNotExistsException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException {
+	public void removeAttributes(PerunSession sess, Member member, Group group, List<? extends AttributeDefinition> attributes, boolean workWithUserAttributes) throws InternalErrorException, PrivilegeException, AttributeNotExistsException, MemberNotExistsException, GroupNotExistsException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException, MemberGroupMismatchException {
 		Utils.checkPerunSession(sess);
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
 		getPerunBl().getGroupsManagerBl().checkGroupExists(sess, group);
@@ -4049,7 +4049,7 @@ public class AttributesManagerEntry implements AttributesManager {
 	}
 
 	@Override
-	public void removeAllAttributes(PerunSession sess, Member member, Group group) throws InternalErrorException, PrivilegeException, MemberNotExistsException, GroupNotExistsException, WrongAttributeValueException, WrongReferenceAttributeValueException {
+	public void removeAllAttributes(PerunSession sess, Member member, Group group) throws InternalErrorException, PrivilegeException, MemberNotExistsException, GroupNotExistsException, WrongAttributeValueException, WrongReferenceAttributeValueException, MemberGroupMismatchException {
 		Utils.checkPerunSession(sess);
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
 		getPerunBl().getGroupsManagerBl().checkGroupExists(sess, group);

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/AttributesManagerEntryIntegrationTestAbstract.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/AttributesManagerEntryIntegrationTestAbstract.java
@@ -5453,7 +5453,7 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 						break;
 					case "member_group":
 						attributesManager.setAttribute(sess, member1OfUser1, group1InVo1, a);
-						attributesManager.setAttribute(sess, member2OfUser1, group1InVo1, b);
+						attributesManager.setAttribute(sess, member2OfUser2, group2InVo1, b);
 						break;
 					case "user_facility":
 						attributesManager.setAttribute(sess, facility1, user1, a);
@@ -5607,7 +5607,8 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 							break;
 						case "member_group":
 							attributesManager.setAttribute(sess, member1OfUser1, group1InVo1, a);
-							attributesManager.setAttribute(sess, member2OfUser1, group1InVo1, b);
+							attributesManager.setAttribute(sess, member2OfUser2, group2InVo1, b);
+							//attributesManager.setAttribute(sess, member2OfUser1, group1InVo1, b);
 							break;
 						case "user_facility":
 							attributesManager.setAttribute(sess, facility1, user1, a);
@@ -5686,7 +5687,7 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 						assertThat("member with duplicate value is not the one",mId_gId.getLeft(), is(member1OfUser1.getId()));
 						assertThat("group with duplicate value is not the one",mId_gId.getRight(), is(group1InVo1.getId()));
 						attributesManager.removeAttribute(sess, member1OfUser1, group1InVo1, a);
-						attributesManager.setAttribute(sess, member2OfUser1, group1InVo1, b);
+						attributesManager.setAttribute(sess, member2OfUser2, group2InVo1, b);
 						break;
 					case "user_facility":
 						Pair<Integer,Integer> uId_fId = BeansUtils.getSinglePair(attributesManagerBl.getPerunBeanIdsForUniqueAttributeValue(sess, b));

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/AttributesManagerEntryIntegrationTestAbstract.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/AttributesManagerEntryIntegrationTestAbstract.java
@@ -5608,7 +5608,6 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 						case "member_group":
 							attributesManager.setAttribute(sess, member1OfUser1, group1InVo1, a);
 							attributesManager.setAttribute(sess, member2OfUser2, group2InVo1, b);
-							//attributesManager.setAttribute(sess, member2OfUser1, group1InVo1, b);
 							break;
 						case "user_facility":
 							attributesManager.setAttribute(sess, facility1, user1, a);

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/ExpirationNotifScheduler.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/ExpirationNotifScheduler.java
@@ -21,6 +21,7 @@ import cz.metacentrum.perun.core.api.Vo;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ExtendMembershipException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.MemberGroupMismatchException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
@@ -507,7 +508,7 @@ public class ExpirationNotifScheduler {
 					try {
 						perun.getGroupsManagerBl().expireMemberInGroup(sess, member, group);
 						log.info("Switching {} in {} to EXPIRED state, due to expiration {}.", member, group, perun.getAttributesManagerBl().getAttribute(sess, member, group, AttributesManager.NS_MEMBER_GROUP_ATTR_DEF + ":groupMembershipExpiration").getValue());
-					} catch (InternalErrorException e) {
+					} catch (InternalErrorException | MemberGroupMismatchException e) {
 						log.error("Consistency error while trying to expire member {} in {}, exception {}", member, group, e);
 					} catch (AttributeNotExistsException e) {
 						log.warn("Synchronizer: checkGroupMembersState, attribute definition for membershipExpiration in group doesn't exist.", e);
@@ -543,7 +544,7 @@ public class ExpirationNotifScheduler {
 					try {
 						perun.getGroupsManagerBl().validateMemberInGroup(sess, member, group);
 						log.info("Switching {} in {} to VALID state, due to changed expiration {}.", member, group, perun.getAttributesManagerBl().getAttribute(sess, member, group, AttributesManager.NS_MEMBER_GROUP_ATTR_DEF + ":groupMembershipExpiration").getValue());
-					} catch (InternalErrorException e) {
+					} catch (InternalErrorException | MemberGroupMismatchException e) {
 						log.error("Error during validating member {} in {}, exception {}", member, group, e);
 					} catch (AttributeNotExistsException e) {
 						log.warn("Synchronizer: checkGroupMemberValidation, attribute definition for membershipExpiration in group doesn't exist.", e);

--- a/perun-registrar-lib/src/test/java/cz/metacentrum/perun/registrar/ExpirationNotifSchedulerTest.java
+++ b/perun-registrar-lib/src/test/java/cz/metacentrum/perun/registrar/ExpirationNotifSchedulerTest.java
@@ -324,12 +324,6 @@ public class ExpirationNotifSchedulerTest extends RegistrarBaseIntegrationTest {
 	// ----------------- PRIVATE METHODS -------------------------------------------
 
 	private Group setUpGroup() throws Exception {
-
-		Vo vo = new Vo();
-		vo.setName("test Vo");
-		vo.setShortName("testVo");
-		perun.getVosManagerBl().createVo(session, vo);
-
 		Group group = new Group();
 		group.setName("Test group");
 		return perun.getGroupsManagerBl().createGroup(session, vo, group);

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/AttributesManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/AttributesManagerMethod.java
@@ -127,6 +127,7 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	 * @throw GroupNotExistsException When Group with <code>id</code> doesn't exist.
 	 * @throw MemberResourceMismatchException When Member is not from the same Vo as Resource.
 	 * @throw GroupResourceMismatchException When Group is not from the same Vo as Resource.
+	 * @throw MemberGroupMismatchException When Member is not from the same Vo as Group.
 	 */
 	/*#
 	 * Returns all non-empty Group-Resource attributes for selected Group and Resource.
@@ -187,6 +188,7 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	 * @return List<Attribute> Specified Member-Group attributes
 	 * @throw GroupNotExistsException When Group with <code>id</code> doesn't exist.
 	 * @throw MemberNotExistsException When Member with <code>id</code> doesn't exist.
+	 * @throw MemberGroupMismatchException When Member is not from the same Vo as Group.
 	 */
 	/*#
 	 * Returns all non-empty Member attributes for selected Member.
@@ -213,6 +215,7 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	 * @return List<Attribute> Specified Member-Group attributes
 	 * @throw GroupNotExistsException When Group with <code>id</code> doesn't exist.
 	 * @throw MemberNotExistsException When Member with <code>id</code> doesn't exist.
+	 * @throw MemberGroupMismatchException When Member is not from the same Vo as Group.
 	 */
 	/*#
 	 * Returns all specified Member attributes for selected Member.
@@ -231,6 +234,7 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	 * @return List<Attribute> All Member-Group attributes
 	 * @throw GroupNotExistsException When Group with <code>id</code> doesn't exist.
 	 * @throw MemberNotExistsException When Member with <code>id</code> doesn't exist.
+	 * @throw MemberGroupMismatchException When Member is not from the same Vo as Group.
 	 */
 	/*#
 	 * Returns all non-empty User attributes for selected User.
@@ -495,6 +499,14 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	 * @param resource int Resource <code>id</code>
 	 * @param group in Group <code>id</code>
 	 * @param attributes List<Attribute> List of attributes
+	 * @throw UserNotExistsException When User not exists by its <code>id</code>.
+	 * @throw FacilityNotExistsException When Facility not exists by its <code>id</code>.
+	 * @throw ResourceNotExistsException When Resource not exists by its <code>id</code>.
+	 * @throw GroupNotExistsException When Group not exists by its <code>id</code>.
+	 * @throw MemberNotExistsException When Member not exists by its <code>id</code>.
+	 * @throw MemberGroupMismatchException When Member is not from the same Vo as Group.
+	 * @throw GroupResourceMismatchException When Group is not from the same Vo as Resource.
+	 * @throw MemberResourceMismatchException When Member is not from the same Vo as Resource.
 	 */
 	/*#
 	 * Sets the attributes.
@@ -564,6 +576,9 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	 * @param group int Group <code>id</code>
 	 * @param attributes List<Attribute> List of attributes
 	 * @param workWithUserAttributes boolean If <code>true</code>, store also User and Member attributes. <code>False</code> is default.
+	 * @throw GroupNotExistsException When Group not exists by its <code>id</code>.
+	 * @throw MemberNotExistsException When Member not exists by its <code>id</code>.
+	 * @throw MemberGroupMismatchException When Member is not from the same Vo as Group.
 	 */
 	/*#
 	 * Sets the attributes.
@@ -578,6 +593,9 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	 * @param member int Member <code>id</code>
 	 * @param group int Group <code>id</code>
 	 * @param attributes List<Attribute> List of attributes
+	 * @throw GroupNotExistsException When Group not exists by its <code>id</code>.
+	 * @throw MemberNotExistsException When Member not exists by its <code>id</code>.
+	 * @throw MemberGroupMismatchException When Member is not from the same Vo as Group.
 	 */
 	/*#
 	 * Sets the attributes.
@@ -773,6 +791,9 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	 * @param group int Group <code>id</code>
 	 * @param attributeId int Attribute <code>id</code>
 	 * @return Attribute Found Attribute
+	 * @throw GroupNotExistsException When Group not exists by its <code>id</code>.
+	 * @throw MemberNotExistsException When Member not exists by its <code>id</code>.
+	 * @throw MemberGroupMismatchException When Member is not from the same Vo as Group.
 	 */
 	/*#
 	 * Returns an Attribute by its <code>id</code>.
@@ -860,6 +881,9 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	 * @param member int Member <code>id</code>
 	 * @param group int Group <code>id</code>
 	 * @param attributeName String Attribute name
+	 * @throw MemberNotExistsException When Member not exists by its <code>id</code>.
+	 * @throw GroupNotExistsException When Group not exists by its <code>id</code>.
+	 * @throw MemberGroupMismatchException When Member is not from the same Vo as Group.
 	 * @return Attribute Found Attribute
 	 */
 	/*#
@@ -1214,6 +1238,9 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	 * @param member int Member <code>id</code>
 	 * @param group int Group <code>id</code>
 	 * @param attribute Attribute JSON object
+	 * @throw MemberNotExistsException When Member not exists by its <code>id</code>.
+	 * @throw GroupNotExistsException When Group not exists by its <code>id</code>.
+	 * @throw MemberGroupMismatchException When Member is not from the same Vo as Group.
 	 */
 	/*#
 	 * Sets an Attribute.
@@ -1232,7 +1259,6 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	 *
 	 * @param group int Group <code>id</code>
 	 * @param attribute Attribute JSON object
-	 *
 	 */
 	/*#
 	 * Sets an Attribute.
@@ -1468,6 +1494,10 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	 * @param group int Group <code>id</code>
 	 * @param workWithUserAttributes boolean If <code>true</code>, return also User and Member attributes. <code>False</code> is default.
 	 * @return List<Attribute> Required Attributes
+	 * @throw ServiceNotExistsException When Service not exists by its <code>id</code>.
+	 * @throw MemberNotExistsException When Member not exists by its <code>id</code>.
+	 * @throw GroupNotExistsException When Group not exists by its <code>id</code>.
+	 * @throw MemberGroupMismatchException When Member is not from the same Vo as Group.
 	 */
 	/*#
 	 * Returns member-group attributes required by specified service.
@@ -1476,6 +1506,10 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	 * @param member int Member <code>id</code>
 	 * @param group int Group <code>id</code>
 	 * @return List<Attribute> Required Attributes
+	 * @throw ServiceNotExistsException When Service not exists by its <code>id</code>.
+	 * @throw MemberNotExistsException When Member not exists by its <code>id</code>.
+	 * @throw GroupNotExistsException When Group not exists by its <code>id</code>.
+	 * @throw MemberGroupMismatchException When Member is not from the same Vo as Group.
 	 */
 	/*#
 	 * Returns facility attributes required by specified service.
@@ -1567,6 +1601,9 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	 * @param member int Member <code>id</code>
 	 * @param group int Group <code>id</code>
 	 * @return List<Attribute> Required Attributes
+	 * @throw MemberNotExistsException When Member not exists by its <code>id</code>.
+	 * @throw GroupNotExistsException When Group not exists by its <code>id</code>.
+	 * @throw MemberGroupMismatchException When Member is not from the same Vo as Group.
 	 */
 	/*#
 	 * Returns member and member-group required attributes.
@@ -1576,9 +1613,9 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	 * @param group int Group <code>id</code>
 	 * @param workWithUserAttributes boolean Work with user attributes. False is default value.
 	 * @return List<Attribute> Required Attributes
-	 */
-	/*#
-	 * Returns
+	 * @throw MemberNotExistsException When Member not exists by its <code>id</code>.
+	 * @throw GroupNotExistsException When Group not exists by its <code>id</code>.
+	 * @throw MemberGroupMismatchException When Member is not from the same Vo as Group.
 	 */
 	/*#
 	 * Returns required user attributes.
@@ -1792,6 +1829,10 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	 * @param group int Group <code>id</code>
 	 * @param workWithUserAttributes boolean If <code>true</code>, return also User and Member attributes. <code>False</code> is default.
 	 * @return List<Attribute> Member-group attributes
+	 * @throw ResourceNotExistsException When Resource not exists by its <code>id</code>.
+	 * @throw MemberNotExistsException When Member not exists by its <code>id</code>.
+	 * @throw GroupNotExistsException When Group not exists by its <code>id</code>.
+	 * @throw MemberGroupMismatchException When Member is not from the same Vo as Group.
 	 */
 	/*#
 	 * Gets member-group attributes.
@@ -1801,6 +1842,10 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	 * @param member int Member <code>id</code>
 	 * @param group int Group <code>id</code>
 	 * @return List<Attribute> Member-group attributes
+	 * @throw ResourceNotExistsException When Resource not exists by its <code>id</code>.
+	 * @throw MemberNotExistsException When Member not exists by its <code>id</code>.
+	 * @throw GroupNotExistsException When Group not exists by its <code>id</code>.
+	 * @throw MemberGroupMismatchException When Member is not from the same Vo as Group.
 	 */
 	/*#
 	 * Gets member attributes.
@@ -2038,6 +2083,9 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	 * @param group int Group <code>id</code>
 	 * @param attribute int Attribute <code>id</code>
 	 * @return Attribute attribute which MAY have filled value
+	 * @throw MemberNotExistsException When Member not exists by its <code>id</code>.
+	 * @throw GroupNotExistsException When Group not exists by its <code>id</code>.
+	 * @throw MemberGroupMismatchException When Member is not from the same Vo as Group.
 	 */
 	/*#
 	 * Tries to fill member attribute.
@@ -2176,6 +2224,9 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	 * @param attributes List<Attribute> List of attributes
 	 * @param workWithUserAttributes boolean If <code>true</code>, process also User and Member attributes. <code>False</code> is default.
 	 * @return List<Attribute> attributes which MAY have filled value
+	 * @throw MemberNotExistsException When Member not exists by its <code>id</code>.
+	 * @throw GroupNotExistsException When Group not exists by its <code>id</code>.
+	 * @throw MemberGroupMismatchException When Member is not from the same Vo as Group.
 	 */
 	/*#
 	 * Tries to fill member-group attributes.
@@ -2184,6 +2235,9 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	 * @param group int Group <code>id</code>
 	 * @param attributes List<Attribute> List of attributes
 	 * @return List<Attribute> attributes which MAY have filled value
+	 * @throw MemberNotExistsException When Member not exists by its <code>id</code>.
+	 * @throw GroupNotExistsException When Group not exists by its <code>id</code>.
+	 * @throw MemberGroupMismatchException When Member is not from the same Vo as Group.
 	 */
 	/*#
 	 * Tries to fill member attributes.
@@ -2625,6 +2679,7 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	 * @throw WrongAttributeValueException When the attribute value has wrong/illegal syntax.
 	 * @throw WrongAttributeAssignmentException When the attribute with <code>id</code> isn't member-group attribute.
 	 * @throw AttributeNotExistsException When the attribute with <code>id</code> doesn't exist.
+	 * @throw MemberGroupMismatchException When Member is not from the same Vo as Group.
 	 */
 	/*#
 	 * Checks if this member attribute has valid syntax.
@@ -2839,6 +2894,7 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	 *
 	 * @throw MemberNotExistsException When the member with <code>id</code> doesn't exist.
 	 * @throw GroupNotExistsException When the group with <code>id</code> doesn't exist.
+	 * @throw MemberGroupMismatchException When Member is not from the same Vo as Group.
 	 * @throw WrongAttributeValueException When the attribute value is wrong/illegal.
 	 * @throw WrongAttributeAssignmentException When the attribute with <code>id</code> isn't member-group attribute.
 	 * @throw WrongReferenceAttributeValueException When value of some Attribute is not correct regarding to other Attribute value.
@@ -3233,6 +3289,12 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	 * @param group int Group <code>id</code>
 	 * @param attributes List<Attribute> Attributes List
 	 * @param workWithUserAttributes boolean If <code>true</code>, process also User and Member attributes. <code>false</code> is default.
+	 * @throw MemberNotExistsException When the member with <code>id</code> doesn't exist.
+	 * @throw GroupNotExistsException When the group with <code>id</code> doesn't exist.
+	 * @throw MemberGroupMismatchException When Member is not from the same Vo as Group.
+	 * @throw WrongAttributeAssignmentException When the attribute with <code>id</code> isn't member-group attribute.
+	 * @throw WrongReferenceAttributeValueException When value of some Attribute is not correct regarding to other Attribute value.
+	 * @throw AttributeNotExistsException When the attribute with <code>id</code> doesn't exist.
 	 */
 	/*#
 	 * Checks if these member-group attributes have valid semantics.
@@ -3240,6 +3302,12 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	 * @param member int Member <code>id</code>
 	 * @param group int Group <code>id</code>
 	 * @param attributes List<Attribute> Attributes List
+	 * @throw MemberNotExistsException When the member with <code>id</code> doesn't exist.
+	 * @throw GroupNotExistsException When the group with <code>id</code> doesn't exist.
+	 * @throw MemberGroupMismatchException When Member is not from the same Vo as Group.
+	 * @throw WrongAttributeAssignmentException When the attribute with <code>id</code> isn't member-group attribute.
+	 * @throw WrongReferenceAttributeValueException When value of some Attribute is not correct regarding to other Attribute value.
+	 * @throw AttributeNotExistsException When the attribute with <code>id</code> doesn't exist.
 	 */
 	/*#
 	 * Checks if these member attributes have valid semantics.
@@ -3416,6 +3484,12 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	 * @param group int Group <code>id</code>
 	 * @param attributes List<Attribute> Attributes List
 	 * @param workWithUserAttributes boolean If <code>true</code>, process also User and Member attributes. <code>false</code> is default.
+	 * @throw MemberNotExistsException When the member with <code>id</code> doesn't exist.
+	 * @throw GroupNotExistsException When the group with <code>id</code> doesn't exist.
+	 * @throw MemberGroupMismatchException When Member is not from the same Vo as Group.
+	 * @throw WrongAttributeAssignmentException When the attribute with <code>id</code> isn't member-group attribute.
+	 * @throw WrongAttributeValueException When the attribute value has wrong/illegal syntax.
+	 * @throw AttributeNotExistsException When the attribute with <code>id</code> doesn't exist.
 	 */
 	/*#
 	 * Checks if these member-group attributes have valid syntax.
@@ -3423,6 +3497,12 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	 * @param member int Member <code>id</code>
 	 * @param group int Group <code>id</code>
 	 * @param attributes List<Attribute> Attributes List
+	 * @throw MemberNotExistsException When the member with <code>id</code> doesn't exist.
+	 * @throw GroupNotExistsException When the group with <code>id</code> doesn't exist.
+	 * @throw MemberGroupMismatchException When Member is not from the same Vo as Group.
+	 * @throw WrongAttributeAssignmentException When the attribute with <code>id</code> isn't member-group attribute.
+	 * @throw WrongAttributeValueException When the attribute value has wrong/illegal syntax.
+	 * @throw AttributeNotExistsException When the attribute with <code>id</code> doesn't exist.
 	 */
 	/*#
 	 * Checks if these member attributes have valid syntax.
@@ -3546,6 +3626,16 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	 * @param member int Member <code>id</code>
 	 * @param resource int Resource <code>id</code>
 	 * @param attributes List<Integer> List of attributes IDs to remove
+	 *
+	 * @throw MemberNotExistsException When the member with <code>id</code> doesn't exist.
+	 * @throw GroupNotExistsException When the group with <code>id</code> doesn't exist.
+	 * @throw UserNotExistsException When the User with <code>id</code> doesn't exist.
+	 * @throw FacilityNotExistsException When the Facility with <code>id</code> doesn't exist.
+	 * @throw MemberGroupMismatchException When Member is not from the same Vo as Group.
+	 * @throw WrongAttributeAssignmentException When the attribute with <code>id</code> isn't member-group attribute.
+	 * @throw WrongAttributeValueException When the attribute value has wrong/illegal syntax.
+	 * @throw WrongReferenceAttributeValueException When value of some Attribute is not correct regarding to other Attribute value.
+	 * @throw AttributeNotExistsException When the attribute with <code>id</code> doesn't exist.
 	 */
 	/*#
 	 * Remove attributes of namespace:
@@ -3637,6 +3727,32 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	 * @param member int Member <code>id</code>
 	 * @param group int Group <code>id</code>
 	 * @param attributes List<Integer> List of attributes IDs to remove
+	 *
+	 * @throw MemberNotExistsException When the member with <code>id</code> doesn't exist.
+	 * @throw GroupNotExistsException When the group with <code>id</code> doesn't exist.
+	 * @throw MemberGroupMismatchException When Member is not from the same Vo as Group.
+	 * @throw WrongAttributeAssignmentException When the attribute with <code>id</code> isn't member-group attribute.
+	 * @throw WrongAttributeValueException When the attribute value has wrong/illegal syntax.
+	 * @throw WrongReferenceAttributeValueException When value of some Attribute is not correct regarding to other Attribute value.
+	 * @throw AttributeNotExistsException When the attribute with <code>id</code> doesn't exist.
+	 */
+	/*#
+	 * Remove attributes of namespace:
+	 *
+	 * member-group, optionally also member and user
+	 *
+	 * @param member int Member <code>id</code>
+	 * @param group int Group <code>id</code>
+	 * @param workWithUserAttributes boolean If <code>true</code>, process also User and Member attributes. <code>false</code> is default.
+	 * @param attributes List<Integer> List of attributes IDs to remove
+	 *
+	 * @throw MemberNotExistsException When the member with <code>id</code> doesn't exist.
+	 * @throw GroupNotExistsException When the group with <code>id</code> doesn't exist.
+	 * @throw MemberGroupMismatchException When Member is not from the same Vo as Group.
+	 * @throw WrongAttributeAssignmentException When the attribute with <code>id</code> isn't member-group attribute.
+	 * @throw WrongAttributeValueException When the attribute value has wrong/illegal syntax.
+	 * @throw WrongReferenceAttributeValueException When value of some Attribute is not correct regarding to other Attribute value.
+	 * @throw AttributeNotExistsException When the attribute with <code>id</code> doesn't exist.
 	 */
 	/*#
 	 * Remove attributes of namespace:
@@ -3849,6 +3965,14 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	 * @param member int Member <code>id</code>
 	 * @param group int Group <code>id</code>
 	 * @param attribute int <code>id</code> of attribute to remove
+	 *
+	 * @throw MemberNotExistsException When the member with <code>id</code> doesn't exist.
+	 * @throw GroupNotExistsException When the group with <code>id</code> doesn't exist.
+	 * @throw MemberGroupMismatchException When Member is not from the same Vo as Group.
+	 * @throw WrongAttributeAssignmentException When the attribute with <code>id</code> isn't member-group attribute.
+	 * @throw WrongAttributeValueException When the attribute value has wrong/illegal syntax.
+	 * @throw WrongReferenceAttributeValueException When value of some Attribute is not correct regarding to other Attribute value.
+	 * @throw AttributeNotExistsException When the attribute with <code>id</code> doesn't exist.
 	 */
 	/*#
 	 * Remove attribute of namespace:
@@ -4022,6 +4146,14 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	 *
 	 * @param member int Member <code>id</code>
 	 * @param group int Group <code>id</code>
+	 *
+	 * @throw MemberNotExistsException When the member with <code>id</code> doesn't exist.
+	 * @throw GroupNotExistsException When the group with <code>id</code> doesn't exist.
+	 * @throw MemberGroupMismatchException When Member is not from the same Vo as Group.
+	 * @throw WrongAttributeAssignmentException When the attribute with <code>id</code> isn't member-group attribute.
+	 * @throw WrongAttributeValueException When the attribute value has wrong/illegal syntax.
+	 * @throw WrongReferenceAttributeValueException When value of some Attribute is not correct regarding to other Attribute value.
+	 * @throw AttributeNotExistsException When the attribute with <code>id</code> doesn't exist.
 	 */
 	/*#
 	 * Unset all member attributes.


### PR DESCRIPTION
- We could and probably should check, that Member and Group on the input
  are from the same VO. We already check group-resource and member-resource
  versions and this check was missing.
- Added check to the expected methods working with member-group attributes.
  It throws MemberGroupMismatchException. This exception should be catched
  by inner method logic, if there is no member/group in the method input and converted
  to either InternalErrorException or ConsistencyErrorException.
- This check might be missing from methods, which already check member-resource
  and group-resource, since they transitively must come from the same VO. 
- Some tests were fixed, since we used member from different VO than group.