### PR TITLE
CORE: Optimized and cleaned-up getAllowed/Assigned() methods

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/FacilitiesManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/FacilitiesManager.java
@@ -179,7 +179,7 @@ public interface FacilitiesManager {
 	 *
 	 * @return list of users
 	 */
-	List<User> getAllowedUsers(PerunSession perunSession, Facility facility) throws InternalErrorException, PrivilegeException, FacilityNotExistsException;
+	List<User> getAllowedUsers(PerunSession perunSession, Facility facility) throws PrivilegeException, FacilityNotExistsException;
 
 
 	/**

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/UsersManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/UsersManager.java
@@ -583,11 +583,10 @@ public interface UsersManager {
 	 * @param user
 	 * @return list of resources which have the user acess on
 	 *
-	 * @throws InternalErrorException
 	 * @throws UserNotExistsException
 	 * @throws PrivilegeException
 	 */
-	List<Resource> getAllowedResources(PerunSession sess, User user) throws InternalErrorException, UserNotExistsException, PrivilegeException;
+	List<Resource> getAllowedResources(PerunSession sess, User user) throws UserNotExistsException, PrivilegeException;
 
 	/**
 	 * Get all rich resources which have the user assigned.
@@ -596,11 +595,10 @@ public interface UsersManager {
 	 * @param user
 	 * @return list of rich resources which have the user assigned
 	 *
-	 * @throws InternalErrorException
 	 * @throws UserNotExistsException
 	 * @throws PrivilegeException
 	 */
-	List<RichResource> getAssignedRichResources(PerunSession sess, User user) throws InternalErrorException, UserNotExistsException, PrivilegeException;
+	List<RichResource> getAssignedRichResources(PerunSession sess, User user) throws UserNotExistsException, PrivilegeException;
 
 	/**
 	 * Returns list of users who matches the searchString, searching name, email, logins.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/FacilitiesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/FacilitiesManagerBl.java
@@ -238,9 +238,8 @@ public interface FacilitiesManagerBl {
 	 * @param sess
 	 * @param facility
 	 * @return list of users
-	 * @throws InternalErrorException
 	 */
-	List<User> getAllowedUsers(PerunSession sess, Facility facility) throws InternalErrorException;
+	List<User> getAllowedUsers(PerunSession sess, Facility facility);
 
 	/**
 	 * Return all users who can use this facility

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/FacilitiesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/FacilitiesManagerBl.java
@@ -268,7 +268,7 @@ public interface FacilitiesManagerBl {
 	 * @return list of users
 	 * @throws InternalErrorException
 	 */
-	List<User> getAllowedUsersNotExpired(PerunSession sess, Facility facility, Vo specificVo, Service specificService) throws InternalErrorException;
+	List<User> getAllowedUsersNotExpiredInGroup(PerunSession sess, Facility facility, Vo specificVo, Service specificService) throws InternalErrorException;
 
 	/**
 	 * Return all members, which are "allowed" on facility.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/FacilitiesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/FacilitiesManagerBl.java
@@ -267,7 +267,7 @@ public interface FacilitiesManagerBl {
 	 * @return list of users
 	 * @throws InternalErrorException
 	 */
-	List<User> getAllowedUsersNotExpiredInGroup(PerunSession sess, Facility facility, Vo specificVo, Service specificService) throws InternalErrorException;
+	List<User> getAllowedUsersNotExpiredInGroups(PerunSession sess, Facility facility, Vo specificVo, Service specificService) throws InternalErrorException;
 
 	/**
 	 * Return all members, which are "allowed" on facility.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ResourcesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ResourcesManagerBl.java
@@ -206,7 +206,7 @@ public interface ResourcesManagerBl {
 	 *
 	 * @throws InternalErrorException
 	 */
-	List<Member> getAllowedMembersNotExpired(PerunSession perunSession, Resource resource) throws InternalErrorException;
+	List<Member> getAllowedMembersNotExpiredInGroup(PerunSession perunSession, Resource resource) throws InternalErrorException;
 
 	/**
 	 * Returns all members assigned to the resource.
@@ -248,7 +248,7 @@ public interface ResourcesManagerBl {
 	 * @return list of users
 	 * @throws InternalErrorException
 	 */
-	List<User> getAllowedUsersNotExpired(PerunSession sess, Resource resource) throws InternalErrorException;
+	List<User> getAllowedUsersNotExpiredInGroup(PerunSession sess, Resource resource) throws InternalErrorException;
 
 	/**
 	 * Assign group to a resource. Check if attributes for each member form group are valid. Fill members' attributes with missing value.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ResourcesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ResourcesManagerBl.java
@@ -206,7 +206,7 @@ public interface ResourcesManagerBl {
 	 *
 	 * @throws InternalErrorException
 	 */
-	List<Member> getAllowedMembersNotExpiredInGroup(PerunSession perunSession, Resource resource) throws InternalErrorException;
+	List<Member> getAllowedMembersNotExpiredInGroups(PerunSession perunSession, Resource resource) throws InternalErrorException;
 
 	/**
 	 * Returns all members assigned to the resource.
@@ -248,7 +248,7 @@ public interface ResourcesManagerBl {
 	 * @return list of users
 	 * @throws InternalErrorException
 	 */
-	List<User> getAllowedUsersNotExpiredInGroup(PerunSession sess, Resource resource) throws InternalErrorException;
+	List<User> getAllowedUsersNotExpiredInGroups(PerunSession sess, Resource resource) throws InternalErrorException;
 
 	/**
 	 * Assign group to a resource. Check if attributes for each member form group are valid. Fill members' attributes with missing value.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ResourcesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ResourcesManagerBl.java
@@ -336,6 +336,17 @@ public interface ResourcesManagerBl {
 	void removeGroupFromResources(PerunSession perunSession, Group group, List<Resource> resources) throws InternalErrorException, GroupNotDefinedOnResourceException, GroupAlreadyRemovedFromResourceException;
 
 	/**
+	 * Returns all users assigned to the resource.
+	 *
+	 * @param perunSession
+	 * @param resource
+	 * @return list of users assigned to the resource
+	 *
+	 * @throws InternalErrorException
+	 */
+	List<User> getAssignedUsers(PerunSession perunSession, Resource resource) throws InternalErrorException;
+
+	/**
 	 * List all groups associated with the resource.
 	 *
 	 * @param perunSession

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
@@ -650,9 +650,8 @@ public interface UsersManagerBl {
 	 * @param facility
 	 * @param user
 	 * @return list of resources which have the user access on
-	 * @throws InternalErrorException
 	 */
-	List<Resource> getAssignedResources(PerunSession sess, Facility facility, User user) throws InternalErrorException;
+	List<Resource> getAssignedResources(PerunSession sess, Facility facility, User user);
 
 	/**
 	 * Get all resources which have the user access on.
@@ -660,9 +659,8 @@ public interface UsersManagerBl {
 	 * @param sess
 	 * @param user
 	 * @return list of resources which have the user access on
-	 * @throws InternalErrorException
 	 */
-	List<Resource> getAllowedResources(PerunSession sess, User user) throws InternalErrorException;
+	List<Resource> getAllowedResources(PerunSession sess, User user);
 
 	/**
 	 * Get all resources where the user is assigned.
@@ -670,9 +668,8 @@ public interface UsersManagerBl {
 	 * @param sess
 	 * @param user
 	 * @return list of resources which have the user access on
-	 * @throws InternalErrorException
 	 */
-	List<Resource> getAssignedResources(PerunSession sess, User user) throws InternalErrorException;
+	List<Resource> getAssignedResources(PerunSession sess, User user);
 
 	/**
 	 * Get all rich resources where the user is assigned.
@@ -680,9 +677,8 @@ public interface UsersManagerBl {
 	 * @param sess
 	 * @param user
 	 * @return list of rich resources which have the user access on
-	 * @throws InternalErrorException
 	 */
-	List<RichResource> getAssignedRichResources(PerunSession sess, User user) throws InternalErrorException;
+	List<RichResource> getAssignedRichResources(PerunSession sess, User user);
 
 	/**
 	 * Returns all users who have set the attribute with the value. Searching only def and opt attributes.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/FacilitiesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/FacilitiesManagerBlImpl.java
@@ -216,15 +216,7 @@ public class FacilitiesManagerBlImpl implements FacilitiesManagerBl {
 
 	@Override
 	public List<User> getAllowedUsers(PerunSession sess, Facility facility) throws InternalErrorException {
-		//Get all facilities resources
-		List<Resource> resources = this.getAssignedResources(sess, facility);
-
-		Set<User> users = new TreeSet<>();
-		for (Resource resource: resources) {
-			users.addAll(getPerunBl().getResourcesManagerBl().getAllowedUsers(sess, resource));
-		}
-
-		return new ArrayList<>(users);
+		return getFacilitiesManagerImpl().getAllowedUsers(sess, facility);
 	}
 
 	@Override
@@ -242,14 +234,14 @@ public class FacilitiesManagerBlImpl implements FacilitiesManagerBl {
 	}
 
 	@Override
-	public List<User> getAllowedUsersNotExpired(PerunSession sess, Facility facility, Vo specificVo, Service specificService) throws InternalErrorException {
+	public List<User> getAllowedUsersNotExpiredInGroup(PerunSession sess, Facility facility, Vo specificVo, Service specificService) throws InternalErrorException {
 
 		//Get all facilities resources
 		List<Resource> resources = getAssignedResources(sess, facility, specificVo, specificService);
 
 		Set<User> users = new TreeSet<>();
 		for (Resource resource: resources) {
-			users.addAll(getPerunBl().getResourcesManagerBl().getAllowedUsersNotExpired(sess, resource));
+			users.addAll(getPerunBl().getResourcesManagerBl().getAllowedUsersNotExpiredInGroup(sess, resource));
 		}
 
 		return new ArrayList<>(users);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/FacilitiesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/FacilitiesManagerBlImpl.java
@@ -215,7 +215,7 @@ public class FacilitiesManagerBlImpl implements FacilitiesManagerBl {
 	}
 
 	@Override
-	public List<User> getAllowedUsers(PerunSession sess, Facility facility) throws InternalErrorException {
+	public List<User> getAllowedUsers(PerunSession sess, Facility facility) {
 		return getFacilitiesManagerImpl().getAllowedUsers(sess, facility);
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/FacilitiesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/FacilitiesManagerBlImpl.java
@@ -41,7 +41,6 @@ import cz.metacentrum.perun.core.api.RichUser;
 import cz.metacentrum.perun.core.api.Role;
 import cz.metacentrum.perun.core.api.SecurityTeam;
 import cz.metacentrum.perun.core.api.Service;
-import cz.metacentrum.perun.core.api.Status;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.Vo;
 import cz.metacentrum.perun.core.api.exceptions.AlreadyAdminException;
@@ -234,14 +233,14 @@ public class FacilitiesManagerBlImpl implements FacilitiesManagerBl {
 	}
 
 	@Override
-	public List<User> getAllowedUsersNotExpiredInGroup(PerunSession sess, Facility facility, Vo specificVo, Service specificService) throws InternalErrorException {
+	public List<User> getAllowedUsersNotExpiredInGroups(PerunSession sess, Facility facility, Vo specificVo, Service specificService) throws InternalErrorException {
 
 		//Get all facilities resources
 		List<Resource> resources = getAssignedResources(sess, facility, specificVo, specificService);
 
 		Set<User> users = new TreeSet<>();
 		for (Resource resource: resources) {
-			users.addAll(getPerunBl().getResourcesManagerBl().getAllowedUsersNotExpiredInGroup(sess, resource));
+			users.addAll(getPerunBl().getResourcesManagerBl().getAllowedUsersNotExpiredInGroups(sess, resource));
 		}
 
 		return new ArrayList<>(users);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ResourcesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ResourcesManagerBlImpl.java
@@ -295,8 +295,8 @@ public class ResourcesManagerBlImpl implements ResourcesManagerBl {
 	}
 
 	@Override
-	public List<User> getAllowedUsersNotExpired(PerunSession sess, Resource resource) throws InternalErrorException {
-		return getResourcesManagerImpl().getAllowedUsersNotExpired(sess, resource);
+	public List<User> getAllowedUsersNotExpiredInGroup(PerunSession sess, Resource resource) throws InternalErrorException {
+		return getResourcesManagerImpl().getAllowedUsersNotExpiredInGroup(sess, resource);
 	}
 
 	@Override
@@ -331,8 +331,8 @@ public class ResourcesManagerBlImpl implements ResourcesManagerBl {
 	}
 
 	@Override
-	public List<Member> getAllowedMembersNotExpired(PerunSession sess, Resource resource) throws InternalErrorException {
-		return getResourcesManagerImpl().getAllowedMembersNotExpired(sess, resource);
+	public List<Member> getAllowedMembersNotExpiredInGroup(PerunSession sess, Resource resource) throws InternalErrorException {
+		return getResourcesManagerImpl().getAllowedMembersNotExpiredInGroup(sess, resource);
 	}
 
 	@Override
@@ -437,13 +437,13 @@ public class ResourcesManagerBlImpl implements ResourcesManagerBl {
 		}
 
 		//check attributes and set new correct values if necessary
-		List<Member> groupsMembers = getPerunBl().getGroupsManagerBl().getGroupMembers(sess, group);
+		List<User> groupsUsers = getPerunBl().getGroupsManagerBl().getGroupUsers(sess, group);
 		Facility facility = getFacility(sess, resource);
 		List<User> allowedUsers = getPerunBl().getFacilitiesManagerBl().getAllowedUsers(sess, facility);
-		for(Member member : groupsMembers) {
-			User user = getPerunBl().getUsersManagerBl().getUserByMember(sess, member);
-			if(!allowedUsers.contains(user)) { //user don't have acess to facility now
-				//his attributes can keep original value
+		for(User user : groupsUsers) {
+			if(!allowedUsers.contains(user)) {
+
+				// user from removed group is no longer "allowed" on facility
 
 				//find required user-facility attributes (that which are not required can keep original value)
 				List<Attribute> userFacilityAttributes = getPerunBl().getAttributesManagerBl().getRequiredAttributes(sess, facility, user);
@@ -504,8 +504,7 @@ public class ResourcesManagerBlImpl implements ResourcesManagerBl {
 
 	@Override
 	public List<Resource> getAssignedResources(PerunSession sess, Group group) throws InternalErrorException {
-		Vo vo = getPerunBl().getGroupsManagerBl().getVo(sess, group);
-		return getResourcesManagerImpl().getAssignedResources(sess, vo, group);
+		return getResourcesManagerImpl().getAssignedResources(sess, group);
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ResourcesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ResourcesManagerBlImpl.java
@@ -306,18 +306,7 @@ public class ResourcesManagerBlImpl implements ResourcesManagerBl {
 
 	@Override
 	public boolean isUserAllowed(PerunSession sess, User user, Resource resource) throws InternalErrorException {
-		if (this.isUserAssigned(sess, user, resource)) {
-			Vo vo = this.getVo(sess, resource);
-			Member member;
-			try {
-				member = getPerunBl().getMembersManagerBl().getMemberByUser(sess, vo, user);
-			} catch (MemberNotExistsException e) {
-				throw new ConsistencyErrorException("Non-existent member is assigned to the resource.", e);
-			}
-			return !getPerunBl().getMembersManagerBl().haveStatus(sess, member, Status.INVALID);
-		} else {
-			return false;
-		}
+		return getResourcesManagerImpl().isUserAllowed(sess, user, resource);
 	}
 
 	@Override
@@ -490,6 +479,11 @@ public class ResourcesManagerBlImpl implements ResourcesManagerBl {
 		for(Resource r: resources) {
 			this.removeGroupFromResource(perunSession, group, r);
 		}
+	}
+
+	@Override
+	public List<User> getAssignedUsers(PerunSession sess, Resource resource) throws InternalErrorException {
+		return getResourcesManagerImpl().getAssignedUsers(sess, resource);
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ResourcesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ResourcesManagerBlImpl.java
@@ -295,7 +295,7 @@ public class ResourcesManagerBlImpl implements ResourcesManagerBl {
 	}
 
 	@Override
-	public List<User> getAllowedUsersNotExpiredInGroup(PerunSession sess, Resource resource) throws InternalErrorException {
+	public List<User> getAllowedUsersNotExpiredInGroups(PerunSession sess, Resource resource) throws InternalErrorException {
 		return getResourcesManagerImpl().getAllowedUsersNotExpiredInGroup(sess, resource);
 	}
 
@@ -320,7 +320,7 @@ public class ResourcesManagerBlImpl implements ResourcesManagerBl {
 	}
 
 	@Override
-	public List<Member> getAllowedMembersNotExpiredInGroup(PerunSession sess, Resource resource) throws InternalErrorException {
+	public List<Member> getAllowedMembersNotExpiredInGroups(PerunSession sess, Resource resource) throws InternalErrorException {
 		return getResourcesManagerImpl().getAllowedMembersNotExpiredInGroup(sess, resource);
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ServicesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ServicesManagerBlImpl.java
@@ -326,7 +326,7 @@ public class ServicesManagerBlImpl implements ServicesManagerBl {
 
 		List<Member> members;
 		if (filterExpiredMembers) {
-			members = getPerunBl().getResourcesManagerBl().getAllowedMembersNotExpired(sess, resource);
+			members = getPerunBl().getResourcesManagerBl().getAllowedMembersNotExpiredInGroup(sess, resource);
 		} else {
 			members = getPerunBl().getResourcesManagerBl().getAllowedMembers(sess, resource);
 		}
@@ -368,7 +368,7 @@ public class ServicesManagerBlImpl implements ServicesManagerBl {
 
 		List<Member> members;
 		if (filterExpiredMembers) {
-			members = getPerunBl().getResourcesManagerBl().getAllowedMembersNotExpired(sess, resource);
+			members = getPerunBl().getResourcesManagerBl().getAllowedMembersNotExpiredInGroup(sess, resource);
 		} else {
 			members = getPerunBl().getResourcesManagerBl().getAllowedMembers(sess, resource);
 		}
@@ -519,7 +519,7 @@ public class ServicesManagerBlImpl implements ServicesManagerBl {
 		ServiceAttributes allUsersServiceAttributes = new ServiceAttributes();
 		List<User> facilityUsers;
 		if (filterExpiredMembers) {
-			facilityUsers = getPerunBl().getFacilitiesManagerBl().getAllowedUsersNotExpired(sess, facility, null, service);
+			facilityUsers = getPerunBl().getFacilitiesManagerBl().getAllowedUsersNotExpiredInGroup(sess, facility, null, service);
 		} else {
 			facilityUsers = getPerunBl().getFacilitiesManagerBl().getAllowedUsers(sess, facility, null, service);
 		}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ServicesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ServicesManagerBlImpl.java
@@ -326,7 +326,7 @@ public class ServicesManagerBlImpl implements ServicesManagerBl {
 
 		List<Member> members;
 		if (filterExpiredMembers) {
-			members = getPerunBl().getResourcesManagerBl().getAllowedMembersNotExpiredInGroup(sess, resource);
+			members = getPerunBl().getResourcesManagerBl().getAllowedMembersNotExpiredInGroups(sess, resource);
 		} else {
 			members = getPerunBl().getResourcesManagerBl().getAllowedMembers(sess, resource);
 		}
@@ -368,7 +368,7 @@ public class ServicesManagerBlImpl implements ServicesManagerBl {
 
 		List<Member> members;
 		if (filterExpiredMembers) {
-			members = getPerunBl().getResourcesManagerBl().getAllowedMembersNotExpiredInGroup(sess, resource);
+			members = getPerunBl().getResourcesManagerBl().getAllowedMembersNotExpiredInGroups(sess, resource);
 		} else {
 			members = getPerunBl().getResourcesManagerBl().getAllowedMembers(sess, resource);
 		}
@@ -519,7 +519,7 @@ public class ServicesManagerBlImpl implements ServicesManagerBl {
 		ServiceAttributes allUsersServiceAttributes = new ServiceAttributes();
 		List<User> facilityUsers;
 		if (filterExpiredMembers) {
-			facilityUsers = getPerunBl().getFacilitiesManagerBl().getAllowedUsersNotExpiredInGroup(sess, facility, null, service);
+			facilityUsers = getPerunBl().getFacilitiesManagerBl().getAllowedUsersNotExpiredInGroups(sess, facility, null, service);
 		} else {
 			facilityUsers = getPerunBl().getFacilitiesManagerBl().getAllowedUsers(sess, facility, null, service);
 		}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
@@ -855,50 +855,22 @@ public class UsersManagerBlImpl implements UsersManagerBl {
 
 	@Override
 	public List<Resource> getAssignedResources(PerunSession sess, Facility facility, User user) throws InternalErrorException {
-		List<Resource> allowedResources = new ArrayList<>();
-
-		List<Resource> resources = getPerunBl().getFacilitiesManagerBl().getAssignedResources(sess, facility);
-		for(Resource resource : resources) {
-			if (getPerunBl().getResourcesManagerBl().isUserAssigned(sess, user, resource)) {
-				allowedResources.add(resource);
-			}
-		}
-		return allowedResources;
+		return getUsersManagerImpl().getAssignedResources(sess, facility, user);
 	}
 
 	@Override
 	public List<Resource> getAllowedResources(PerunSession sess, User user) throws InternalErrorException {
-		//TODO do this method in more efficient way
-		Set<Resource> resources = new HashSet<>();
-		List<Member> members = getPerunBl().getMembersManagerBl().getMembersByUser(sess, user);
-		for(Member member : members) {
-			if(!getPerunBl().getMembersManagerBl().haveStatus(sess, member, Status.INVALID)) {
-				resources.addAll(getPerunBl().getResourcesManagerBl().getAllowedResources(sess, member));
-			}
-		}
-		return new ArrayList<>(resources);
+		return getUsersManagerImpl().getAllowedResources(sess, user);
 	}
 
 	@Override
 	public List<Resource> getAssignedResources(PerunSession sess, User user) throws InternalErrorException {
-		Set<Resource> resources = new HashSet<>();
-		List<Member> members = getPerunBl().getMembersManagerBl().getMembersByUser(sess, user);
-
-		for(Member member : members) {
-			resources.addAll(getPerunBl().getResourcesManagerBl().getAssignedResources(sess, member));
-		}
-		return new ArrayList<>(resources);
+		return getUsersManagerImpl().getAssignedResources(sess, user);
 	}
 
 	@Override
 	public List<RichResource> getAssignedRichResources(PerunSession sess, User user) throws InternalErrorException {
-		Set<RichResource> resources = new HashSet<>();
-		List<Member> members = getPerunBl().getMembersManagerBl().getMembersByUser(sess, user);
-
-		for(Member member : members) {
-			resources.addAll(getPerunBl().getResourcesManagerBl().getAssignedRichResources(sess, member));
-		}
-		return new ArrayList<>(resources);
+		return getUsersManagerImpl().getAssignedRichResources(sess, user);
 	}
 
 	private List<User> getUsersByVirtualAttribute(PerunSession sess, AttributeDefinition attributeDef, String attributeValue) throws InternalErrorException {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
@@ -854,22 +854,22 @@ public class UsersManagerBlImpl implements UsersManagerBl {
 	}
 
 	@Override
-	public List<Resource> getAssignedResources(PerunSession sess, Facility facility, User user) throws InternalErrorException {
+	public List<Resource> getAssignedResources(PerunSession sess, Facility facility, User user) {
 		return getUsersManagerImpl().getAssignedResources(sess, facility, user);
 	}
 
 	@Override
-	public List<Resource> getAllowedResources(PerunSession sess, User user) throws InternalErrorException {
+	public List<Resource> getAllowedResources(PerunSession sess, User user) {
 		return getUsersManagerImpl().getAllowedResources(sess, user);
 	}
 
 	@Override
-	public List<Resource> getAssignedResources(PerunSession sess, User user) throws InternalErrorException {
+	public List<Resource> getAssignedResources(PerunSession sess, User user) {
 		return getUsersManagerImpl().getAssignedResources(sess, user);
 	}
 
 	@Override
-	public List<RichResource> getAssignedRichResources(PerunSession sess, User user) throws InternalErrorException {
+	public List<RichResource> getAssignedRichResources(PerunSession sess, User user) {
 		return getUsersManagerImpl().getAssignedRichResources(sess, user);
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntry.java
@@ -375,7 +375,7 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 	}
 
 	@Override
-	public List<User> getAllowedUsers(PerunSession sess, Facility facility) throws InternalErrorException, PrivilegeException, FacilityNotExistsException{
+	public List<User> getAllowedUsers(PerunSession sess, Facility facility) throws PrivilegeException, FacilityNotExistsException {
 		Utils.checkPerunSession(sess);
 
 		// Authorization

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
@@ -741,7 +741,7 @@ public class UsersManagerEntry implements UsersManager {
 	}
 
 	@Override
-	public List<Resource> getAllowedResources(PerunSession sess, User user) throws InternalErrorException, UserNotExistsException, PrivilegeException {
+	public List<Resource> getAllowedResources(PerunSession sess, User user) throws UserNotExistsException, PrivilegeException {
 		Utils.checkPerunSession(sess);
 
 		if(!AuthzResolver.isAuthorized(sess, Role.SELF, user) &&
@@ -755,7 +755,7 @@ public class UsersManagerEntry implements UsersManager {
 	}
 
 	@Override
-	public List<RichResource> getAssignedRichResources(PerunSession sess, User user) throws InternalErrorException, UserNotExistsException, PrivilegeException {
+	public List<RichResource> getAssignedRichResources(PerunSession sess, User user) throws UserNotExistsException, PrivilegeException {
 		Utils.checkPerunSession(sess);
 
 		if(!AuthzResolver.isAuthorized(sess, Role.SELF, user) &&

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/FacilitiesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/FacilitiesManagerImpl.java
@@ -555,7 +555,7 @@ public class FacilitiesManagerImpl implements FacilitiesManagerImplApi {
 	@Override
 	public List<RichResource> getAssignedRichResources(PerunSession sess, Facility facility) throws InternalErrorException {
 		try {
-			return jdbc.query("select " + ResourcesManagerImpl.resourceMappingSelectQuery + ", " + VosManagerImpl.voMappingSelectQuery + ", "
+			return jdbc.query("select distinct " + ResourcesManagerImpl.resourceMappingSelectQuery + ", " + VosManagerImpl.voMappingSelectQuery + ", "
 					+ facilityMappingSelectQuery + ", " + ResourcesManagerImpl.resourceTagMappingSelectQuery + " from resources" +
 					" join vos on resources.vo_id=vos.id" +
 					" join facilities on resources.facility_id=facilities.id" +

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/FacilitiesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/FacilitiesManagerImpl.java
@@ -804,7 +804,7 @@ public class FacilitiesManagerImpl implements FacilitiesManagerImplApi {
 	@Override
 	public List<User> getAssignedUsers(PerunSession sess, Facility facility)throws InternalErrorException{
 		try {
-			return jdbc.query("select " + UsersManagerImpl.userMappingSelectQuery + " from users"
+			return jdbc.query("select distinct " + UsersManagerImpl.userMappingSelectQuery + " from users"
 					+ " join members on users.id = members.user_id"
 					+ " join groups_members on members.id = groups_members.member_id"
 					+ " join groups_resources on groups_members.group_id = groups_resources.group_id"
@@ -819,7 +819,7 @@ public class FacilitiesManagerImpl implements FacilitiesManagerImplApi {
 	public List<User> getAssignedUsers(PerunSession sess, Facility facility, Service service)throws InternalErrorException{
 		try {
 			// FIXME - can we optimize this to start from most limited table (resources.facility_id)?
-			return jdbc.query("select " + UsersManagerImpl.userMappingSelectQuery + " from users"
+			return jdbc.query("select distinct " + UsersManagerImpl.userMappingSelectQuery + " from users"
 					+ " join members on users.id = members.user_id"
 					+ " join groups_members on members.id = groups_members.member_id"
 					+ " join groups_resources on groups_members.group_id = groups_resources.group_id"

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/FacilitiesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/FacilitiesManagerImpl.java
@@ -553,13 +553,13 @@ public class FacilitiesManagerImpl implements FacilitiesManagerImplApi {
 	@Override
 	public List<RichResource> getAssignedRichResources(PerunSession sess, Facility facility) throws InternalErrorException {
 		try {
-			return jdbc.query("select distinct " + ResourcesManagerImpl.resourceMappingSelectQuery + ", " + VosManagerImpl.voMappingSelectQuery + ", "
-					+ facilityMappingSelectQuery + ", " + ResourcesManagerImpl.resourceTagMappingSelectQuery + " from resources" +
-					" join vos on resources.vo_id=vos.id" +
-					" join facilities on resources.facility_id=facilities.id" +
-					" left outer join tags_resources on resources.id=tags_resources.resource_id" +
-					" left outer join res_tags on tags_resources.tag_id=res_tags.id" +
-					" where resources.facility_id=?",
+			return jdbc.query("select distinct " + ResourcesManagerImpl.resourceMappingSelectQuery + ", " + VosManagerImpl.voMappingSelectQuery + ", " +
+							facilityMappingSelectQuery + ", " + ResourcesManagerImpl.resourceTagMappingSelectQuery + " from resources" +
+							" join vos on resources.vo_id=vos.id" +
+							" join facilities on resources.facility_id=facilities.id" +
+							" left outer join tags_resources on resources.id=tags_resources.resource_id" +
+							" left outer join res_tags on tags_resources.tag_id=res_tags.id" +
+							" where resources.facility_id=?",
 					ResourcesManagerImpl.RICH_RESOURCE_WITH_TAGS_EXTRACTOR, facility.getId());
 		} catch (RuntimeException ex) {
 			throw new InternalErrorException(ex);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/FacilitiesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/FacilitiesManagerImpl.java
@@ -456,7 +456,7 @@ public class FacilitiesManagerImpl implements FacilitiesManagerImplApi {
 	}
 
 	@Override
-	public List<User> getAllowedUsers(PerunSession sess, Facility facility) throws InternalErrorException {
+	public List<User> getAllowedUsers(PerunSession sess, Facility facility) {
 		try  {
 			return jdbc.query("select distinct " + UsersManagerImpl.userMappingSelectQuery + " from resources" +
 							" join groups_resources on groups_resources.resource_id=resources.id"+
@@ -466,8 +466,6 @@ public class FacilitiesManagerImpl implements FacilitiesManagerImplApi {
 							" where resources.facility_id=? and members.status!=? and members.status!=?",
 					UsersManagerImpl.USER_MAPPER, facility.getId(),
 					String.valueOf(Status.INVALID.getCode()), String.valueOf(Status.DISABLED.getCode()));
-		} catch (EmptyResultDataAccessException e) {
-			return new ArrayList<>();
 		} catch (RuntimeException e) {
 			throw new InternalErrorException(e);
 		}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ResourcesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ResourcesManagerImpl.java
@@ -549,7 +549,7 @@ public class ResourcesManagerImpl implements ResourcesManagerImplApi {
 
 		try {
 			// FIXME - can we optimize SQL to limit joined data at start (start select from groups_resources) ?
-			return jdbc.query("select " + resourceMappingSelectQuery + ", " + VosManagerImpl.voMappingSelectQuery + ", " +
+			return jdbc.query("select distinct " + resourceMappingSelectQuery + ", " + VosManagerImpl.voMappingSelectQuery + ", " +
 					FacilitiesManagerImpl.facilityMappingSelectQuery + ", "+resourceTagMappingSelectQuery+" from resources" +
 					" join vos on resources.vo_id=vos.id" +
 					" join facilities on resources.facility_id=facilities.id" +
@@ -568,7 +568,7 @@ public class ResourcesManagerImpl implements ResourcesManagerImplApi {
 	@Override
 	public List<RichResource> getAssignedRichResources(PerunSession sess, Member member) throws InternalErrorException {
 		try  {
-			return jdbc.query("select " + resourceMappingSelectQuery + ", " + VosManagerImpl.voMappingSelectQuery + ", " +
+			return jdbc.query("select distinct " + resourceMappingSelectQuery + ", " + VosManagerImpl.voMappingSelectQuery + ", " +
 					FacilitiesManagerImpl.facilityMappingSelectQuery + ", "+resourceTagMappingSelectQuery+" from resources" +
 					" join vos on resources.vo_id=vos.id" +
 					" join facilities on resources.facility_id=facilities.id" +
@@ -589,7 +589,7 @@ public class ResourcesManagerImpl implements ResourcesManagerImplApi {
 	@Override
 	public List<RichResource> getAssignedRichResources(PerunSession sess, Member member, Service service) throws InternalErrorException {
 		try  {
-			return jdbc.query("select " + resourceMappingSelectQuery + ", " + VosManagerImpl.voMappingSelectQuery + ", " +
+			return jdbc.query("select distinct " + resourceMappingSelectQuery + ", " + VosManagerImpl.voMappingSelectQuery + ", " +
 					FacilitiesManagerImpl.facilityMappingSelectQuery + ", "+resourceTagMappingSelectQuery+" from resources" +
 							" join vos on resources.vo_id=vos.id" +
 							" join facilities on resources.facility_id=facilities.id" +

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ResourcesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ResourcesManagerImpl.java
@@ -439,7 +439,7 @@ public class ResourcesManagerImpl implements ResourcesManagerImplApi {
 	}
 
 	@Override
-	public boolean isUserAllowed(PerunSession sess, User user, Resource resource) throws InternalErrorException {
+	public boolean isUserAllowed(PerunSession sess, User user, Resource resource) {
 		try {
 			return (0 < jdbc.queryForInt("select count(*) from groups_resources" +
 					" join groups on groups_resources.group_id=groups.id" +

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ResourcesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ResourcesManagerImpl.java
@@ -438,6 +438,20 @@ public class ResourcesManagerImpl implements ResourcesManagerImplApi {
 		}
 	}
 
+	@Override
+	public boolean isUserAllowed(PerunSession sess, User user, Resource resource) throws InternalErrorException {
+		try {
+			return (0 < jdbc.queryForInt("select count(*) from groups_resources" +
+					" join groups on groups_resources.group_id=groups.id" +
+					" join groups_members on groups.id=groups_members.group_id" +
+					" join members on groups_members.member_id=members.id" +
+					" where groups_resources.resource_id=? and members.user_id=? and members.status!=? and members.status!=?",
+					resource.getId(), user.getId(), String.valueOf(Status.INVALID.getCode()),
+					String.valueOf(Status.DISABLED.getCode())));
+		} catch (RuntimeException e) {
+			throw new InternalErrorException(e);
+		}
+	}
 
 	@Override
 	public void assignGroupToResource(PerunSession sess, Group group, Resource resource) throws InternalErrorException, GroupAlreadyAssignedException {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/UsersManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/UsersManagerImpl.java
@@ -1389,22 +1389,20 @@ public class UsersManagerImpl implements UsersManagerImplApi {
 	}
 
 	@Override
-	public List<Resource> getAssignedResources(PerunSession sess, User user) throws InternalErrorException {
+	public List<Resource> getAssignedResources(PerunSession sess, User user) {
 		try  {
 			return jdbc.query("select distinct " + resourceMappingSelectQuery + " from resources join groups_resources on resources.id=groups_resources.resource_id " +
 					" join groups on groups_resources.group_id=groups.id" +
 					" join groups_members on groups.id=groups_members.group_id " +
 					" join members on groups_members.member_id=members.id " +
 					" where members.user_id=?", RESOURCE_MAPPER, user.getId());
-		} catch (EmptyResultDataAccessException e) {
-			return new ArrayList<>();
 		} catch (RuntimeException e) {
 			throw new InternalErrorException(e);
 		}
 	}
 
 	@Override
-	public List<Resource> getAllowedResources(PerunSession sess, User user) throws InternalErrorException {
+	public List<Resource> getAllowedResources(PerunSession sess, User user) {
 		try  {
 			return jdbc.query("select distinct " + resourceMappingSelectQuery + " from resources join groups_resources on resources.id=groups_resources.resource_id " +
 					" join groups on groups_resources.group_id=groups.id" +
@@ -1412,15 +1410,13 @@ public class UsersManagerImpl implements UsersManagerImplApi {
 					" join members on groups_members.member_id=members.id " +
 					" where members.user_id=? and members.status!=? and members.status!=?",
 					RESOURCE_MAPPER, user.getId(), String.valueOf(Status.INVALID.getCode()), String.valueOf(Status.DISABLED.getCode()));
-		} catch (EmptyResultDataAccessException e) {
-			return new ArrayList<>();
 		} catch (RuntimeException e) {
 			throw new InternalErrorException(e);
 		}
 	}
 
 	@Override
-	public List<Resource> getAssignedResources(PerunSession sess, Facility facility, User user) throws InternalErrorException {
+	public List<Resource> getAssignedResources(PerunSession sess, Facility facility, User user) {
 		try {
 			return jdbc.query("select distinct " + ResourcesManagerImpl.resourceMappingSelectQuery + " from resources "+
 							" join groups_resources on groups_resources.resource_id=resources.id" +
@@ -1428,15 +1424,13 @@ public class UsersManagerImpl implements UsersManagerImplApi {
 							" join members on members.id=groups_members.member_id" +
 							" where resources.facility_id=? and members.user_id=?",
 					RESOURCE_MAPPER, facility.getId(), user.getId());
-		} catch (EmptyResultDataAccessException e) {
-			return new ArrayList<>();
-		}	catch (RuntimeException e) {
+		} catch (RuntimeException e) {
 			throw new InternalErrorException(e);
 		}
 	}
 
 	@Override
-	public List<RichResource> getAssignedRichResources(PerunSession sess, User user) throws InternalErrorException {
+	public List<RichResource> getAssignedRichResources(PerunSession sess, User user) {
 		try  {
 			return jdbc.query("select distinct " + resourceMappingSelectQuery + ", " + VosManagerImpl.voMappingSelectQuery + ", " +
 					FacilitiesManagerImpl.facilityMappingSelectQuery + ", "+resourceTagMappingSelectQuery+" from resources" +
@@ -1449,8 +1443,6 @@ public class UsersManagerImpl implements UsersManagerImplApi {
 					" left outer join tags_resources on resources.id=tags_resources.resource_id" +
 					" left outer join res_tags on tags_resources.tag_id=res_tags.id" +
 					" where members.user_id=?", RICH_RESOURCE_WITH_TAGS_EXTRACTOR, user.getId());
-		} catch (EmptyResultDataAccessException e) {
-			return new ArrayList<>();
 		} catch (RuntimeException e) {
 			throw new InternalErrorException(e);
 		}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/UsersManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/UsersManagerImpl.java
@@ -1391,7 +1391,8 @@ public class UsersManagerImpl implements UsersManagerImplApi {
 	@Override
 	public List<Resource> getAssignedResources(PerunSession sess, User user) {
 		try  {
-			return jdbc.query("select distinct " + resourceMappingSelectQuery + " from resources join groups_resources on resources.id=groups_resources.resource_id " +
+			return jdbc.query("select distinct " + resourceMappingSelectQuery + " from resources" +
+					" join groups_resources on resources.id=groups_resources.resource_id " +
 					" join groups on groups_resources.group_id=groups.id" +
 					" join groups_members on groups.id=groups_members.group_id " +
 					" join members on groups_members.member_id=members.id " +
@@ -1404,11 +1405,12 @@ public class UsersManagerImpl implements UsersManagerImplApi {
 	@Override
 	public List<Resource> getAllowedResources(PerunSession sess, User user) {
 		try  {
-			return jdbc.query("select distinct " + resourceMappingSelectQuery + " from resources join groups_resources on resources.id=groups_resources.resource_id " +
-					" join groups on groups_resources.group_id=groups.id" +
-					" join groups_members on groups.id=groups_members.group_id " +
-					" join members on groups_members.member_id=members.id " +
-					" where members.user_id=? and members.status!=? and members.status!=?",
+			return jdbc.query("select distinct " + resourceMappingSelectQuery + " from resources" +
+							" join groups_resources on resources.id=groups_resources.resource_id " +
+							" join groups on groups_resources.group_id=groups.id" +
+							" join groups_members on groups.id=groups_members.group_id " +
+							" join members on groups_members.member_id=members.id " +
+							" where members.user_id=? and members.status!=? and members.status!=?",
 					RESOURCE_MAPPER, user.getId(), String.valueOf(Status.INVALID.getCode()), String.valueOf(Status.DISABLED.getCode()));
 		} catch (RuntimeException e) {
 			throw new InternalErrorException(e);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/UsersManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/UsersManagerImpl.java
@@ -4,12 +4,16 @@ import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.BeansUtils;
 import cz.metacentrum.perun.core.api.ExtSource;
+import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.Member;
 import cz.metacentrum.perun.core.api.Pair;
 import cz.metacentrum.perun.core.api.PerunSession;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.RichResource;
 import cz.metacentrum.perun.core.api.Role;
 import cz.metacentrum.perun.core.api.SpecificUserType;
+import cz.metacentrum.perun.core.api.Status;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.UserExtSource;
 import cz.metacentrum.perun.core.api.Vo;
@@ -50,6 +54,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
+
+import static cz.metacentrum.perun.core.impl.ResourcesManagerImpl.RESOURCE_MAPPER;
+import static cz.metacentrum.perun.core.impl.ResourcesManagerImpl.RICH_RESOURCE_WITH_TAGS_EXTRACTOR;
+import static cz.metacentrum.perun.core.impl.ResourcesManagerImpl.resourceMappingSelectQuery;
+import static cz.metacentrum.perun.core.impl.ResourcesManagerImpl.resourceTagMappingSelectQuery;
 
 /**
  * UsersManager implementation.
@@ -1378,4 +1387,72 @@ public class UsersManagerImpl implements UsersManagerImplApi {
 		}
 
 	}
+
+	@Override
+	public List<Resource> getAssignedResources(PerunSession sess, User user) throws InternalErrorException {
+		try  {
+			return jdbc.query("select distinct " + resourceMappingSelectQuery + " from resources join groups_resources on resources.id=groups_resources.resource_id " +
+					" join groups on groups_resources.group_id=groups.id" +
+					" join groups_members on groups.id=groups_members.group_id " +
+					" join members on groups_members.member_id=members.id " +
+					" where members.user_id=?", RESOURCE_MAPPER, user.getId());
+		} catch (EmptyResultDataAccessException e) {
+			return new ArrayList<>();
+		} catch (RuntimeException e) {
+			throw new InternalErrorException(e);
+		}
+	}
+
+	@Override
+	public List<Resource> getAllowedResources(PerunSession sess, User user) throws InternalErrorException {
+		try  {
+			return jdbc.query("select distinct " + resourceMappingSelectQuery + " from resources join groups_resources on resources.id=groups_resources.resource_id " +
+					" join groups on groups_resources.group_id=groups.id" +
+					" join groups_members on groups.id=groups_members.group_id " +
+					" join members on groups_members.member_id=members.id " +
+					" where members.user_id=? and members.status!=? and members.status!=?",
+					RESOURCE_MAPPER, user.getId(), String.valueOf(Status.INVALID.getCode()), String.valueOf(Status.DISABLED.getCode()));
+		} catch (EmptyResultDataAccessException e) {
+			return new ArrayList<>();
+		} catch (RuntimeException e) {
+			throw new InternalErrorException(e);
+		}
+	}
+
+	@Override
+	public List<Resource> getAssignedResources(PerunSession sess, Facility facility, User user) throws InternalErrorException {
+		try {
+			return jdbc.query("select distinct " + ResourcesManagerImpl.resourceMappingSelectQuery + " from resources "+
+							" join groups_resources on groups_resources.resource_id=resources.id" +
+							" join groups_members on groups_members.group_id=groups_resources.group_id" +
+							" join members on members.id=groups_members.member_id" +
+							" where resources.facility_id=? and members.user_id=?",
+					RESOURCE_MAPPER, facility.getId(), user.getId());
+		} catch (EmptyResultDataAccessException e) {
+			return new ArrayList<>();
+		}	catch (RuntimeException e) {
+			throw new InternalErrorException(e);
+		}
+	}
+
+	@Override
+	public List<RichResource> getAssignedRichResources(PerunSession sess, User user) throws InternalErrorException {
+		try  {
+			return jdbc.query("select " + resourceMappingSelectQuery + ", " + VosManagerImpl.voMappingSelectQuery + ", " +
+					FacilitiesManagerImpl.facilityMappingSelectQuery + ", "+resourceTagMappingSelectQuery+" from resources" +
+					" join vos on resources.vo_id=vos.id " +
+					" join facilities on resources.facility_id=facilities.id " +
+					" join groups_resources on resources.id=groups_resources.resource_id " +
+					" join groups on groups_resources.group_id=groups.id " +
+					" join groups_members on groups.id=groups_members.group_id " +
+					" join members on groups_members.member_id=members.id " +
+					" left outer join tags_resources on resources.id=tags_resources.resource_id left outer join res_tags on tags_resources.tag_id=res_tags.id" +
+					" where members.user_id=?", RICH_RESOURCE_WITH_TAGS_EXTRACTOR, user.getId());
+		} catch (EmptyResultDataAccessException e) {
+			return new ArrayList<>();
+		} catch (RuntimeException e) {
+			throw new InternalErrorException(e);
+		}
+	}
+
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/UsersManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/UsersManagerImpl.java
@@ -1438,7 +1438,7 @@ public class UsersManagerImpl implements UsersManagerImplApi {
 	@Override
 	public List<RichResource> getAssignedRichResources(PerunSession sess, User user) throws InternalErrorException {
 		try  {
-			return jdbc.query("select " + resourceMappingSelectQuery + ", " + VosManagerImpl.voMappingSelectQuery + ", " +
+			return jdbc.query("select distinct " + resourceMappingSelectQuery + ", " + VosManagerImpl.voMappingSelectQuery + ", " +
 					FacilitiesManagerImpl.facilityMappingSelectQuery + ", "+resourceTagMappingSelectQuery+" from resources" +
 					" join vos on resources.vo_id=vos.id " +
 					" join facilities on resources.facility_id=facilities.id " +
@@ -1446,7 +1446,8 @@ public class UsersManagerImpl implements UsersManagerImplApi {
 					" join groups on groups_resources.group_id=groups.id " +
 					" join groups_members on groups.id=groups_members.group_id " +
 					" join members on groups_members.member_id=members.id " +
-					" left outer join tags_resources on resources.id=tags_resources.resource_id left outer join res_tags on tags_resources.tag_id=res_tags.id" +
+					" left outer join tags_resources on resources.id=tags_resources.resource_id" +
+					" left outer join res_tags on tags_resources.tag_id=res_tags.id" +
 					" where members.user_id=?", RICH_RESOURCE_WITH_TAGS_EXTRACTOR, user.getId());
 		} catch (EmptyResultDataAccessException e) {
 			return new ArrayList<>();

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/FacilitiesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/FacilitiesManagerImplApi.java
@@ -186,9 +186,8 @@ public interface FacilitiesManagerImplApi {
 	 * @param sess
 	 * @param facility
 	 * @return list of allowed users
-	 * @throws InternalErrorException
 	 */
-	List<User> getAllowedUsers(PerunSession sess, Facility facility) throws InternalErrorException;
+	List<User> getAllowedUsers(PerunSession sess, Facility facility);
 
 	/**
 	 * Return all allowed facilities of the user.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/FacilitiesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/FacilitiesManagerImplApi.java
@@ -167,7 +167,9 @@ public interface FacilitiesManagerImplApi {
 	List<Vo> getAllowedVos(PerunSession perunSession, Facility facility) throws InternalErrorException;
 
 	/**
-	 * Return all members, which are "allowed" on facility.
+	 * Return all members, which are "allowed" on facility through any resource disregarding
+	 * their possible expired status in a group. All members include all group statuses, through which they can
+	 * be filtered if necessary.
 	 *
 	 * @param sess
 	 * @param facility
@@ -177,6 +179,16 @@ public interface FacilitiesManagerImplApi {
 	 * @throws InternalErrorException
 	 */
 	List<Member> getAllowedMembers(PerunSession sess, Facility facility) throws InternalErrorException;
+
+	/**
+	 * Return all users, which are "allowed" on facility through any member/resource.
+	 *
+	 * @param sess
+	 * @param facility
+	 * @return list of allowed users
+	 * @throws InternalErrorException
+	 */
+	List<User> getAllowedUsers(PerunSession sess, Facility facility) throws InternalErrorException;
 
 	/**
 	 * Return all allowed facilities of the user.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/ResourcesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/ResourcesManagerImplApi.java
@@ -153,9 +153,8 @@ public interface ResourcesManagerImplApi {
 	 * @param user
 	 * @param resource
 	 * @return true if the user is allowed as a member on the selected resource.
-	 * @throws InternalErrorException
 	 */
-	boolean isUserAllowed(PerunSession sess, User user, Resource resource) throws InternalErrorException;
+	boolean isUserAllowed(PerunSession sess, User user, Resource resource);
 
 	/**
 	 * List all resources associated with the group.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/ResourcesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/ResourcesManagerImplApi.java
@@ -147,6 +147,17 @@ public interface ResourcesManagerImplApi {
 	boolean isUserAssigned(PerunSession sess, User user, Resource resource) throws InternalErrorException;
 
 	/**
+	 * Check if the user is allowed as a member on the selected resource.
+	 *
+	 * @param sess
+	 * @param user
+	 * @param resource
+	 * @return true if the user is allowed as a member on the selected resource.
+	 * @throws InternalErrorException
+	 */
+	boolean isUserAllowed(PerunSession sess, User user, Resource resource) throws InternalErrorException;
+
+	/**
 	 * List all resources associated with the group.
 	 *
 	 * @param perunSession

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/ResourcesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/ResourcesManagerImplApi.java
@@ -109,7 +109,7 @@ public interface ResourcesManagerImplApi {
 	 *
 	 * @throws InternalErrorException
 	 */
-	List<User> getUsers(PerunSession perunSession, Resource resource) throws InternalErrorException;
+	List<User> getAssignedUsers(PerunSession perunSession, Resource resource) throws InternalErrorException;
 
 	/**
 	 * Assign group to a resource.
@@ -136,20 +136,6 @@ public interface ResourcesManagerImplApi {
 	void removeGroupFromResource(PerunSession perunSession, Group group, Resource resource) throws InternalErrorException, GroupAlreadyRemovedFromResourceException;
 
 	/**
-	 * List all groups' id associated with the resource.
-	 *
-	 * @param perunSession
-	 * @param resource
-	 * @param withSubGroups get all group (and subgroups) if it's true
-	 *                      get only immediate groups (without subgroups) if it's false
-	 *
-	 * @throws InternalErrorException
-	 * @return list of assigned groups' id
-	 */
-	// GROUPER OUT
-	//List<Integer> getAssignedGroupsIds(PerunSession perunSession, Resource resource, boolean withSubGroups) throws InternalErrorException;
-
-	/**
 	 * Check if the user is assigned as a member on the selected resource.
 	 *
 	 * @param sess
@@ -164,13 +150,12 @@ public interface ResourcesManagerImplApi {
 	 * List all resources associated with the group.
 	 *
 	 * @param perunSession
-	 * @param vo
 	 * @param group
 	 *
 	 * @throws InternalErrorException
 	 * @return list of assigned resources
 	 */
-	List<Resource> getAssignedResources(PerunSession perunSession, Vo vo, Group group) throws InternalErrorException;
+	List<Resource> getAssignedResources(PerunSession perunSession, Group group) throws InternalErrorException;
 
 	/**
 	 * List of all rich resources associated with the group.
@@ -203,18 +188,6 @@ public interface ResourcesManagerImplApi {
 	 * @throws InternalErrorException
 	 */
 	List<RichResource> getAssignedRichResources(PerunSession sess, Member member, Service service) throws InternalErrorException;
-
-	/**
-	 * List of all resources assigned to the member defined by user and vo.
-	 *
-	 * @param sess
-	 * @param user
-	 * @param vo
-	 * @return list of assigned resources
-	 * @throws InternalErrorException
-	 */
-	// GROUPER OUT
-	//List<Resource> getAssignedResources(PerunSession sess, User user, Vo vo) throws InternalErrorException;
 
 	/**
 	 * List all services' id associated with the resource.
@@ -357,24 +330,24 @@ public interface ResourcesManagerImplApi {
 	List<User> getAllowedUsers(PerunSession sess, Resource resource) throws InternalErrorException;
 
 	/**
-	 * Returns all users who are allowed on the defined resource and not expired in at least one group.
+	 * Returns all users which are allowed on the resource and are not expired within their assigned groups.
+	 * It means if user is allowed on the resource, but only through expired groups, it is filtered out.
 	 *
 	 * @param sess
 	 * @param resource
 	 * @return list of users
 	 * @throws InternalErrorException
 	 */
-	List<User> getAllowedUsersNotExpired(PerunSession sess, Resource resource) throws InternalErrorException;
-
+	List<User> getAllowedUsersNotExpiredInGroup(PerunSession sess, Resource resource) throws InternalErrorException;
 
 	/**
-	 * Return all resources which are under the facility and has member of the user with status other than INVALID.
+	 * Return all resources through which user is allowed on facility.
 	 *
 	 * @param sess
 	 * @param facility
 	 * @param user
 	 *
-	 * @return list of resources allowed for user (user has there member with status other than INVALID)
+	 * @return List of allowed resources for the user on facility
 	 * @throws InternalErrorException
 	 */
 	List<Resource> getAllowedResources(PerunSession sess, Facility facility, User user) throws InternalErrorException;
@@ -390,7 +363,8 @@ public interface ResourcesManagerImplApi {
 	List<Member> getAssignedMembers(PerunSession sess, Resource resource) throws InternalErrorException;
 
 	/**
-	 * Returns all members who are allowed on the defined resource.
+	 * Returns all members who are "allowed" on the resource disregarding their possible expired status
+	 * in a group. All members include all group statuses, through which they can be filtered if necessary.
 	 *
 	 * @param sess
 	 * @param resource
@@ -400,14 +374,15 @@ public interface ResourcesManagerImplApi {
 	List<Member> getAllowedMembers(PerunSession sess, Resource resource) throws InternalErrorException;
 
 	/**
-	 * Returns all members who are allowed on the defined resource and also valid in at least one group associated to the resources.
+	 * Returns all members which are allowed on the resource and are not expired within their assigned groups.
+	 * It means if member is allowed on the resource, but only through expired groups, it is filtered out.
 	 *
 	 * @param sess
 	 * @param resource
 	 * @return list of members
 	 * @throws InternalErrorException
 	 */
-	List<Member> getAllowedMembersNotExpired(PerunSession sess, Resource resource) throws InternalErrorException;
+	List<Member> getAllowedMembersNotExpiredInGroup(PerunSession sess, Resource resource) throws InternalErrorException;
 
 	/**
 	 * Returns all resources where the member is assigned through the groups.
@@ -420,7 +395,7 @@ public interface ResourcesManagerImplApi {
 	List<Resource> getAssignedResources(PerunSession sess, Member member) throws InternalErrorException;
 
 	/**
-	 * Returns all resources where the service and the member are assigned through the groups.
+	 * Returns all resources where member and service are assigned together.
 	 *
 	 * @param sess
 	 * @param member
@@ -431,7 +406,8 @@ public interface ResourcesManagerImplApi {
 	List<Resource> getAssignedResources(PerunSession sess, Member member, Service service) throws InternalErrorException;
 
 	/**
-	 * Returns all resources where the user is assigned through the vo and groups.
+	 * Returns all resources where the user is assigned through the specified vo and its groups.
+	 * @see #getAssignedResources(PerunSession, Member)
 	 *
 	 * @param sess
 	 * @param user

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/UsersManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/UsersManagerImplApi.java
@@ -779,9 +779,8 @@ public interface UsersManagerImplApi {
 	 * @param sess
 	 * @param user
 	 * @return All resources where user is assigned
-	 * @throws InternalErrorException
 	 */
-	List<Resource> getAssignedResources(PerunSession sess, User user) throws InternalErrorException;
+	List<Resource> getAssignedResources(PerunSession sess, User user);
 
 	/**
 	 * Return all resources, where user is allowed by all his members.
@@ -789,9 +788,8 @@ public interface UsersManagerImplApi {
 	 * @param sess
 	 * @param user
 	 * @return All resources where user is allowed
-	 * @throws InternalErrorException
 	 */
-	List<Resource> getAllowedResources(PerunSession sess, User user) throws InternalErrorException;
+	List<Resource> getAllowedResources(PerunSession sess, User user);
 
 	/**
 	 * Return all resources of specified facility, where user is assigned through all his members.
@@ -800,9 +798,8 @@ public interface UsersManagerImplApi {
 	 * @param facility
 	 * @param user
 	 * @return All resources where user is assigned
-	 * @throws InternalErrorException
 	 */
-	List<Resource> getAssignedResources(PerunSession sess, Facility facility, User user) throws InternalErrorException;
+	List<Resource> getAssignedResources(PerunSession sess, Facility facility, User user);
 
 	/**
 	 * Return all rich resources, where user is assigned through all his members.
@@ -810,8 +807,7 @@ public interface UsersManagerImplApi {
 	 * @param sess
 	 * @param user
 	 * @return All resources where user is assigned
-	 * @throws InternalErrorException
 	 */
-	List<RichResource> getAssignedRichResources(PerunSession sess, User user) throws InternalErrorException;
+	List<RichResource> getAssignedRichResources(PerunSession sess, User user);
 
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/UsersManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/UsersManagerImplApi.java
@@ -3,10 +3,13 @@ package cz.metacentrum.perun.core.implApi;
 import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.ExtSource;
+import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.Member;
 import cz.metacentrum.perun.core.api.Pair;
 import cz.metacentrum.perun.core.api.PerunSession;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.RichResource;
 import cz.metacentrum.perun.core.api.SpecificUserType;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.UserExtSource;
@@ -769,4 +772,46 @@ public interface UsersManagerImplApi {
 	 * Implements search for #UsersManagerBl.findUsersWithExtSourceAttributeValueEnding().
 	 */
 	List<User> findUsersWithExtSourceAttributeValueEnding(PerunSessionImpl sess, String attributeName, String valueEnd, List<String> excludeValueEnds) throws InternalErrorException;
+
+	/**
+	 * Return all resources, where user is assigned through all his members.
+	 *
+	 * @param sess
+	 * @param user
+	 * @return All resources where user is assigned
+	 * @throws InternalErrorException
+	 */
+	List<Resource> getAssignedResources(PerunSession sess, User user) throws InternalErrorException;
+
+	/**
+	 * Return all resources, where user is allowed by all his members.
+	 *
+	 * @param sess
+	 * @param user
+	 * @return All resources where user is allowed
+	 * @throws InternalErrorException
+	 */
+	List<Resource> getAllowedResources(PerunSession sess, User user) throws InternalErrorException;
+
+	/**
+	 * Return all resources of specified facility, where user is assigned through all his members.
+	 *
+	 * @param sess
+	 * @param facility
+	 * @param user
+	 * @return All resources where user is assigned
+	 * @throws InternalErrorException
+	 */
+	List<Resource> getAssignedResources(PerunSession sess, Facility facility, User user) throws InternalErrorException;
+
+	/**
+	 * Return all rich resources, where user is assigned through all his members.
+	 *
+	 * @param sess
+	 * @param user
+	 * @return All resources where user is assigned
+	 * @throws InternalErrorException
+	 */
+	List<RichResource> getAssignedRichResources(PerunSession sess, User user) throws InternalErrorException;
+
 }

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/bl/ResourcesManagerBlImplTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/bl/ResourcesManagerBlImplTest.java
@@ -260,74 +260,74 @@ public class ResourcesManagerBlImplTest {
 
 	@Test
 	public void getAllowedUsersNotExpiredTest() throws Exception {
-		System.out.println("ResourcesManagerBlImpl.getAllowedUsersNotExpired(resource)");
+		System.out.println("ResourcesManagerBlImpl.getAllowedUsersNotExpiredInGrouús(resource)");
 
-		List<User> users = perun.getResourcesManagerBl().getAllowedUsersNotExpiredInGroup(sess, resource);
+		List<User> users = perun.getResourcesManagerBl().getAllowedUsersNotExpiredInGroups(sess, resource);
 		Assert.assertEquals(1, users.size());
 		Assert.assertTrue(users.contains(user));
 
-		users = perun.getResourcesManagerBl().getAllowedUsersNotExpiredInGroup(sess, resource2);
+		users = perun.getResourcesManagerBl().getAllowedUsersNotExpiredInGroups(sess, resource2);
 		Assert.assertEquals(1, users.size());
 		Assert.assertTrue(users.contains(user));
 
-		users = perun.getResourcesManagerBl().getAllowedUsersNotExpiredInGroup(sess, resource3);
+		users = perun.getResourcesManagerBl().getAllowedUsersNotExpiredInGroups(sess, resource3);
 		Assert.assertEquals(1, users.size());
 		Assert.assertTrue(users.contains(user));
 
 		// expiring member2 in group2 should have effect
 		perun.getGroupsManagerBl().expireMemberInGroup(sess, member2, group2);
 
-		users = perun.getResourcesManagerBl().getAllowedUsersNotExpiredInGroup(sess, resource);
+		users = perun.getResourcesManagerBl().getAllowedUsersNotExpiredInGroups(sess, resource);
 		Assert.assertEquals(1, users.size());
 		Assert.assertTrue(users.contains(user));
 
-		users = perun.getResourcesManagerBl().getAllowedUsersNotExpiredInGroup(sess, resource2);
+		users = perun.getResourcesManagerBl().getAllowedUsersNotExpiredInGroups(sess, resource2);
 		Assert.assertTrue(users.isEmpty());
 
-		users = perun.getResourcesManagerBl().getAllowedUsersNotExpiredInGroup(sess, resource3);
+		users = perun.getResourcesManagerBl().getAllowedUsersNotExpiredInGroups(sess, resource3);
 		Assert.assertTrue(users.isEmpty());
 
 		// disabling member should have effect too
 		perun.getMembersManagerBl().disableMember(sess, member);
 
-		users = perun.getResourcesManagerBl().getAllowedUsersNotExpiredInGroup(sess, resource);
+		users = perun.getResourcesManagerBl().getAllowedUsersNotExpiredInGroups(sess, resource);
 		Assert.assertTrue(users.isEmpty());
 
 	}
 
 	@Test
 	public void getAllowedMembersNotExpiredInGroup() throws Exception {
-		System.out.println("ResourcesManagerBlImpl.getAllowedMembersNotExpired(resource)");
+		System.out.println("ResourcesManagerBlImpl.getAllowedMembersNotExpiredInGroups(resource)");
 
-		List<Member> members = perun.getResourcesManagerBl().getAllowedMembersNotExpiredInGroup(sess, resource);
+		List<Member> members = perun.getResourcesManagerBl().getAllowedMembersNotExpiredInGroups(sess, resource);
 		Assert.assertEquals(1, members.size());
 		Assert.assertTrue(members.contains(member));
 
-		members = perun.getResourcesManagerBl().getAllowedMembersNotExpiredInGroup(sess, resource2);
+		members = perun.getResourcesManagerBl().getAllowedMembersNotExpiredInGroups(sess, resource2);
 		Assert.assertEquals(1, members.size());
 		Assert.assertTrue(members.contains(member2));
 
-		members = perun.getResourcesManagerBl().getAllowedMembersNotExpiredInGroup(sess, resource3);
+		members = perun.getResourcesManagerBl().getAllowedMembersNotExpiredInGroups(sess, resource3);
 		Assert.assertEquals(1, members.size());
 		Assert.assertTrue(members.contains(member2));
 
 		// expiring member2 in group2 should have effect
 		perun.getGroupsManagerBl().expireMemberInGroup(sess, member2, group2);
 
-		members = perun.getResourcesManagerBl().getAllowedMembersNotExpiredInGroup(sess, resource);
+		members = perun.getResourcesManagerBl().getAllowedMembersNotExpiredInGroups(sess, resource);
 		Assert.assertEquals(1, members.size());
 		Assert.assertTrue(members.contains(member));
 
-		members = perun.getResourcesManagerBl().getAllowedMembersNotExpiredInGroup(sess, resource2);
+		members = perun.getResourcesManagerBl().getAllowedMembersNotExpiredInGroups(sess, resource2);
 		Assert.assertTrue(members.isEmpty());
 
-		members = perun.getResourcesManagerBl().getAllowedMembersNotExpiredInGroup(sess, resource3);
+		members = perun.getResourcesManagerBl().getAllowedMembersNotExpiredInGroups(sess, resource3);
 		Assert.assertTrue(members.isEmpty());
 
 		// disabling member should have effect too
 		perun.getMembersManagerBl().disableMember(sess, member);
 
-		members = perun.getResourcesManagerBl().getAllowedMembersNotExpiredInGroup(sess, resource);
+		members = perun.getResourcesManagerBl().getAllowedMembersNotExpiredInGroups(sess, resource);
 		Assert.assertTrue(members.isEmpty());
 
 	}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/bl/ResourcesManagerBlImplTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/bl/ResourcesManagerBlImplTest.java
@@ -1,0 +1,335 @@
+package cz.metacentrum.perun.core.bl;
+
+import cz.metacentrum.perun.core.api.Candidate;
+import cz.metacentrum.perun.core.api.ExtSource;
+import cz.metacentrum.perun.core.api.ExtSourcesManager;
+import cz.metacentrum.perun.core.api.Facility;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.Member;
+import cz.metacentrum.perun.core.api.PerunClient;
+import cz.metacentrum.perun.core.api.PerunPrincipal;
+import cz.metacentrum.perun.core.api.PerunSession;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.UserExtSource;
+import cz.metacentrum.perun.core.api.Vo;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.ContextHierarchy;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+
+/**
+ * @author Pavel Zlamal <zlamal@cesnet.cz>
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextHierarchy({
+		@ContextConfiguration(locations = { "classpath:perun-base.xml", "classpath:perun-core.xml" })
+})
+@Transactional(transactionManager = "springTransactionManager")
+public class ResourcesManagerBlImplTest {
+
+	@Autowired
+	private PerunBl perun;
+
+	private PerunSession sess;
+	private User user;
+	private Vo vo;
+	private Member member;
+	private Group group;
+	private Resource resource;
+	private Facility facility;
+
+	private Vo vo2;
+	private Member member2;
+	private Group group2;
+	private Resource resource2;
+
+	private Resource resource3;
+	private Facility facility2;
+
+	private static final String EXT_SOURCE_NAME = "ResourcesManagerBlExtSource";
+	private ExtSource extSource = new ExtSource(0, EXT_SOURCE_NAME, ExtSourcesManager.EXTSOURCE_INTERNAL);
+	private Candidate candidate;
+	private UserExtSource ues;
+
+
+	@Before
+	public void setUp() throws Exception {
+
+		candidate = new Candidate();
+		candidate.setFirstName("some");
+		candidate.setId(0);
+		candidate.setMiddleName("");
+		candidate.setLastName("testingUser");
+		candidate.setTitleBefore("");
+		candidate.setTitleAfter("");
+		ues = new UserExtSource(extSource, "extLogin");
+		candidate.setUserExtSource(ues);
+		candidate.setAttributes(new HashMap<>());
+
+		sess = perun.getPerunSession(
+				new PerunPrincipal("perunTests", ExtSourcesManager.EXTSOURCE_NAME_INTERNAL, ExtSourcesManager.EXTSOURCE_INTERNAL),
+				new PerunClient());
+
+
+		vo = new Vo(0, "ResourcesBlImplTestVo", "ResMgrBlImplTestVo");
+		vo = perun.getVosManagerBl().createVo(sess, vo);
+
+		member = perun.getMembersManagerBl().createMemberSync(sess, vo, candidate);
+
+		group = new Group("testGroup", "testGroup");
+		group = perun.getGroupsManagerBl().createGroup(sess, vo, group);
+
+		perun.getGroupsManagerBl().addMember(sess, group, member);
+
+		facility = new Facility(0, "testFac");
+		facility = perun.getFacilitiesManagerBl().createFacility(sess, facility);
+
+		resource = new Resource(0, "testRes", null, facility.getId(), vo.getId());
+		resource = perun.getResourcesManagerBl().createResource(sess, resource, vo, facility);
+
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource);
+
+		// second branch
+
+		vo2 = new Vo(0, "FacilitiesManagerBlImplTestVo2", "FacMgrBlImplTestVo2");
+		vo2 = perun.getVosManagerBl().createVo(sess, vo2);
+
+		member2 = perun.getMembersManagerBl().createMemberSync(sess, vo2, candidate);
+
+		group2 = new Group("testGroup", "testGroup");
+		group2 = perun.getGroupsManagerBl().createGroup(sess, vo2, group2);
+
+		perun.getGroupsManagerBl().addMember(sess, group2, member2);
+
+		resource2 = new Resource(0, "testRes2", null, facility.getId(), vo2.getId());
+		resource2 = perun.getResourcesManagerBl().createResource(sess, resource2, vo2, facility);
+
+		// third branch
+
+		facility2 = new Facility(0, "testFac2");
+		facility2 = perun.getFacilitiesManagerBl().createFacility(sess, facility2);
+
+		resource3 = new Resource(0, "testRes3", null, facility2.getId(), vo2.getId());
+		resource3 = perun.getResourcesManagerBl().createResource(sess, resource3, vo2, facility2);
+
+		perun.getResourcesManagerBl().assignGroupToResources(sess, group2, Arrays.asList(resource2, resource3));
+
+		user = perun.getUsersManagerBl().getUserByMember(sess, member);
+
+	}
+
+
+	@Test
+	public void getAssignedResourcesForUserAndVo() throws Exception {
+		System.out.println("ResourcesManagerBlImpl.getAssignedResources(user,vo)");
+
+		List<Resource> resourceList = perun.getResourcesManagerBl().getAssignedResources(sess, user, vo);
+		Assert.assertTrue(resourceList.contains(resource));
+		Assert.assertEquals(1, resourceList.size());
+
+		resourceList = perun.getResourcesManagerBl().getAssignedResources(sess, user, vo2);
+		Assert.assertTrue(resourceList.containsAll(Arrays.asList(resource2, resource3)));
+		Assert.assertEquals(2, resourceList.size());
+
+		// disabling member should have no effect
+		perun.getMembersManagerBl().disableMember(sess, member);
+
+		resourceList = perun.getResourcesManagerBl().getAssignedResources(sess, user, vo);
+		Assert.assertTrue(resourceList.contains(resource));
+		Assert.assertEquals(1, resourceList.size());
+
+		resourceList = perun.getResourcesManagerBl().getAssignedResources(sess, user, vo2);
+		Assert.assertTrue(resourceList.containsAll(Arrays.asList(resource2, resource3)));
+		Assert.assertEquals(2, resourceList.size());
+
+		// removing member2 from group2 should have effect
+		perun.getGroupsManagerBl().removeMember(sess, group2, member2);
+
+		resourceList = perun.getResourcesManagerBl().getAssignedResources(sess, user, vo);
+		Assert.assertTrue(resourceList.contains(resource));
+		Assert.assertEquals(1, resourceList.size());
+
+		resourceList = perun.getResourcesManagerBl().getAssignedResources(sess, user, vo2);
+		Assert.assertTrue(resourceList.isEmpty());
+
+	}
+
+	@Test
+	public void getAssignedUsers() throws Exception {
+		System.out.println("ResourcesManagerBlImpl.getAssignedUsers(resource)");
+
+		List<User> usersList = perun.getResourcesManagerBl().getAssignedUsers(sess, resource);
+		Assert.assertTrue(usersList.contains(user));
+		Assert.assertEquals(1, usersList.size());
+
+		usersList = perun.getResourcesManagerBl().getAssignedUsers(sess, resource2);
+		Assert.assertTrue(usersList.contains(user));
+		Assert.assertEquals(1, usersList.size());
+
+		usersList = perun.getResourcesManagerBl().getAssignedUsers(sess, resource3);
+		Assert.assertTrue(usersList.contains(user));
+		Assert.assertEquals(1, usersList.size());
+
+		// disabling member should have no effect
+		perun.getMembersManagerBl().disableMember(sess, member);
+
+		usersList = perun.getResourcesManagerBl().getAssignedUsers(sess, resource);
+		Assert.assertTrue(usersList.contains(user));
+		Assert.assertEquals(1, usersList.size());
+
+		usersList = perun.getResourcesManagerBl().getAssignedUsers(sess, resource2);
+		Assert.assertTrue(usersList.contains(user));
+		Assert.assertEquals(1, usersList.size());
+
+		usersList = perun.getResourcesManagerBl().getAssignedUsers(sess, resource3);
+		Assert.assertTrue(usersList.contains(user));
+		Assert.assertEquals(1, usersList.size());
+
+		// removing member2 from group2 should have effect
+		perun.getGroupsManagerBl().removeMember(sess, group2, member2);
+
+		usersList = perun.getResourcesManagerBl().getAssignedUsers(sess, resource);
+		Assert.assertTrue(usersList.contains(user));
+		Assert.assertEquals(1, usersList.size());
+
+		usersList = perun.getResourcesManagerBl().getAssignedUsers(sess, resource2);
+		Assert.assertTrue(usersList.isEmpty());
+
+		usersList = perun.getResourcesManagerBl().getAssignedUsers(sess, resource3);
+		Assert.assertTrue(usersList.isEmpty());
+
+	}
+
+	@Test
+	public void isUserAssigned() throws Exception {
+		System.out.println("ResourcesManagerBlImpl.isUserAssigned(user, resource)");
+
+		Assert.assertTrue(perun.getResourcesManagerBl().isUserAssigned(sess, user, resource));
+		Assert.assertTrue(perun.getResourcesManagerBl().isUserAssigned(sess, user, resource2));
+		Assert.assertTrue(perun.getResourcesManagerBl().isUserAssigned(sess, user, resource3));
+
+		// disabling member should have no effect
+		perun.getMembersManagerBl().disableMember(sess, member);
+
+		Assert.assertTrue(perun.getResourcesManagerBl().isUserAssigned(sess, user, resource));
+		Assert.assertTrue(perun.getResourcesManagerBl().isUserAssigned(sess, user, resource2));
+		Assert.assertTrue(perun.getResourcesManagerBl().isUserAssigned(sess, user, resource3));
+
+		// removing member2 from group2 should have effect
+		perun.getGroupsManagerBl().removeMember(sess, group2, member2);
+
+		Assert.assertTrue(perun.getResourcesManagerBl().isUserAssigned(sess, user, resource));
+		Assert.assertFalse(perun.getResourcesManagerBl().isUserAssigned(sess, user, resource2));
+		Assert.assertFalse(perun.getResourcesManagerBl().isUserAssigned(sess, user, resource3));
+
+	}
+
+	@Test
+	public void isUserAllowed() throws Exception {
+		System.out.println("ResourcesManagerBlImpl.isUserAllowed(user, resource)");
+
+		Assert.assertTrue(perun.getResourcesManagerBl().isUserAllowed(sess, user, resource));
+		Assert.assertTrue(perun.getResourcesManagerBl().isUserAllowed(sess, user, resource2));
+		Assert.assertTrue(perun.getResourcesManagerBl().isUserAllowed(sess, user, resource3));
+
+		// disabling member should have effect
+		perun.getMembersManagerBl().disableMember(sess, member);
+
+		Assert.assertFalse(perun.getResourcesManagerBl().isUserAllowed(sess, user, resource));
+		Assert.assertTrue(perun.getResourcesManagerBl().isUserAllowed(sess, user, resource2));
+		Assert.assertTrue(perun.getResourcesManagerBl().isUserAllowed(sess, user, resource3));
+
+		// removing member2 from group2 should have effect too
+		perun.getGroupsManagerBl().removeMember(sess, group2, member2);
+
+		Assert.assertFalse(perun.getResourcesManagerBl().isUserAllowed(sess, user, resource));
+		Assert.assertFalse(perun.getResourcesManagerBl().isUserAllowed(sess, user, resource2));
+		Assert.assertFalse(perun.getResourcesManagerBl().isUserAllowed(sess, user, resource3));
+
+	}
+
+	@Test
+	public void getAllowedUsersNotExpiredTest() throws Exception {
+		System.out.println("ResourcesManagerBlImpl.getAllowedUsersNotExpired(resource)");
+
+		List<User> users = perun.getResourcesManagerBl().getAllowedUsersNotExpiredInGroup(sess, resource);
+		Assert.assertEquals(1, users.size());
+		Assert.assertTrue(users.contains(user));
+
+		users = perun.getResourcesManagerBl().getAllowedUsersNotExpiredInGroup(sess, resource2);
+		Assert.assertEquals(1, users.size());
+		Assert.assertTrue(users.contains(user));
+
+		users = perun.getResourcesManagerBl().getAllowedUsersNotExpiredInGroup(sess, resource3);
+		Assert.assertEquals(1, users.size());
+		Assert.assertTrue(users.contains(user));
+
+		// expiring member2 in group2 should have effect
+		perun.getGroupsManagerBl().expireMemberInGroup(sess, member2, group2);
+
+		users = perun.getResourcesManagerBl().getAllowedUsersNotExpiredInGroup(sess, resource);
+		Assert.assertEquals(1, users.size());
+		Assert.assertTrue(users.contains(user));
+
+		users = perun.getResourcesManagerBl().getAllowedUsersNotExpiredInGroup(sess, resource2);
+		Assert.assertTrue(users.isEmpty());
+
+		users = perun.getResourcesManagerBl().getAllowedUsersNotExpiredInGroup(sess, resource3);
+		Assert.assertTrue(users.isEmpty());
+
+		// disabling member should have effect too
+		perun.getMembersManagerBl().disableMember(sess, member);
+
+		users = perun.getResourcesManagerBl().getAllowedUsersNotExpiredInGroup(sess, resource);
+		Assert.assertTrue(users.isEmpty());
+
+	}
+
+	@Test
+	public void getAllowedMembersNotExpiredInGroup() throws Exception {
+		System.out.println("ResourcesManagerBlImpl.getAllowedMembersNotExpired(resource)");
+
+		List<Member> members = perun.getResourcesManagerBl().getAllowedMembersNotExpiredInGroup(sess, resource);
+		Assert.assertEquals(1, members.size());
+		Assert.assertTrue(members.contains(member));
+
+		members = perun.getResourcesManagerBl().getAllowedMembersNotExpiredInGroup(sess, resource2);
+		Assert.assertEquals(1, members.size());
+		Assert.assertTrue(members.contains(member2));
+
+		members = perun.getResourcesManagerBl().getAllowedMembersNotExpiredInGroup(sess, resource3);
+		Assert.assertEquals(1, members.size());
+		Assert.assertTrue(members.contains(member2));
+
+		// expiring member2 in group2 should have effect
+		perun.getGroupsManagerBl().expireMemberInGroup(sess, member2, group2);
+
+		members = perun.getResourcesManagerBl().getAllowedMembersNotExpiredInGroup(sess, resource);
+		Assert.assertEquals(1, members.size());
+		Assert.assertTrue(members.contains(member));
+
+		members = perun.getResourcesManagerBl().getAllowedMembersNotExpiredInGroup(sess, resource2);
+		Assert.assertTrue(members.isEmpty());
+
+		members = perun.getResourcesManagerBl().getAllowedMembersNotExpiredInGroup(sess, resource3);
+		Assert.assertTrue(members.isEmpty());
+
+		// disabling member should have effect too
+		perun.getMembersManagerBl().disableMember(sess, member);
+
+		members = perun.getResourcesManagerBl().getAllowedMembersNotExpiredInGroup(sess, resource);
+		Assert.assertTrue(members.isEmpty());
+
+	}
+
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/bl/UsersManagerBlImplTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/bl/UsersManagerBlImplTest.java
@@ -1,0 +1,286 @@
+package cz.metacentrum.perun.core.bl;
+
+import cz.metacentrum.perun.core.api.Candidate;
+import cz.metacentrum.perun.core.api.ExtSource;
+import cz.metacentrum.perun.core.api.ExtSourcesManager;
+import cz.metacentrum.perun.core.api.Facility;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.Member;
+import cz.metacentrum.perun.core.api.PerunClient;
+import cz.metacentrum.perun.core.api.PerunPrincipal;
+import cz.metacentrum.perun.core.api.PerunSession;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.RichResource;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.UserExtSource;
+import cz.metacentrum.perun.core.api.Vo;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.ContextHierarchy;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+
+/**
+ * @author Pavel Zlamal <zlamal@cesnet.cz>
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextHierarchy({
+		@ContextConfiguration(locations = { "classpath:perun-base.xml", "classpath:perun-core.xml" })
+})
+@Transactional(transactionManager = "springTransactionManager")
+public class UsersManagerBlImplTest {
+
+	@Autowired
+	private PerunBl perun;
+
+	private PerunSession sess;
+	private User user;
+	private Vo vo;
+	private Member member;
+	private Group group;
+	private Resource resource;
+	private Facility facility;
+
+	private Vo vo2;
+	private Member member2;
+	private Group group2;
+	private Resource resource2;
+
+	private Resource resource3;
+	private Facility facility2;
+
+	private static final String EXT_SOURCE_NAME = "UsersManagerBlExtSource";
+	private ExtSource extSource = new ExtSource(0, EXT_SOURCE_NAME, ExtSourcesManager.EXTSOURCE_INTERNAL);
+	private Candidate candidate;
+	private UserExtSource ues;
+
+
+	@Before
+	public void setUp() throws Exception {
+
+		candidate = new Candidate();
+		candidate.setFirstName("some");
+		candidate.setId(0);
+		candidate.setMiddleName("");
+		candidate.setLastName("testingUser");
+		candidate.setTitleBefore("");
+		candidate.setTitleAfter("");
+		ues = new UserExtSource(extSource, "extLogin");
+		candidate.setUserExtSource(ues);
+		candidate.setAttributes(new HashMap<>());
+
+		sess = perun.getPerunSession(
+				new PerunPrincipal("perunTests", ExtSourcesManager.EXTSOURCE_NAME_INTERNAL, ExtSourcesManager.EXTSOURCE_INTERNAL),
+				new PerunClient());
+
+
+		vo = new Vo(0, "UsersBlImplTestVo", "UsrMgrBlImplTestVo");
+		vo = perun.getVosManagerBl().createVo(sess, vo);
+
+		member = perun.getMembersManagerBl().createMemberSync(sess, vo, candidate);
+
+		group = new Group("testGroup", "testGroup");
+		group = perun.getGroupsManagerBl().createGroup(sess, vo, group);
+
+		perun.getGroupsManagerBl().addMember(sess, group, member);
+
+		facility = new Facility(0, "testFac");
+		facility = perun.getFacilitiesManagerBl().createFacility(sess, facility);
+
+		resource = new Resource(0, "testRes", null, facility.getId(), vo.getId());
+		resource = perun.getResourcesManagerBl().createResource(sess, resource, vo, facility);
+
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource);
+
+		// second branch
+
+		vo2 = new Vo(0, "FacilitiesManagerBlImplTestVo2", "FacMgrBlImplTestVo2");
+		vo2 = perun.getVosManagerBl().createVo(sess, vo2);
+
+		member2 = perun.getMembersManagerBl().createMemberSync(sess, vo2, candidate);
+
+		group2 = new Group("testGroup", "testGroup");
+		group2 = perun.getGroupsManagerBl().createGroup(sess, vo2, group2);
+
+		perun.getGroupsManagerBl().addMember(sess, group2, member2);
+
+		resource2 = new Resource(0, "testRes2", null, facility.getId(), vo2.getId());
+		resource2 = perun.getResourcesManagerBl().createResource(sess, resource2, vo2, facility);
+
+		// third branch
+
+		facility2 = new Facility(0, "testFac2");
+		facility2 = perun.getFacilitiesManagerBl().createFacility(sess, facility2);
+
+		resource3 = new Resource(0, "testRes3", null, facility2.getId(), vo2.getId());
+		resource3 = perun.getResourcesManagerBl().createResource(sess, resource3, vo2, facility2);
+
+		perun.getResourcesManagerBl().assignGroupToResources(sess, group2, Arrays.asList(resource2, resource3));
+
+		user = perun.getUsersManagerBl().getUserByMember(sess, member);
+
+	}
+
+	@Test
+	public void getAllowedResourcesForFacilityAndUserTest() throws Exception {
+		System.out.println("UsersManagerBlImpl.getAllowedResources(facility,user)");
+
+		List<Resource> resourceList = perun.getUsersManagerBl().getAllowedResources(sess, facility, user);
+		Assert.assertTrue(resourceList.containsAll(Arrays.asList(resource, resource2)));
+		Assert.assertEquals(2, resourceList.size());
+
+		resourceList = perun.getUsersManagerBl().getAllowedResources(sess, facility2, user);
+		Assert.assertTrue(resourceList.contains(resource3));
+		Assert.assertEquals(1, resourceList.size());
+
+		// disable member 1, we should have only single allowed resource
+
+		perun.getMembersManagerBl().disableMember(sess, member);
+
+		resourceList = perun.getUsersManagerBl().getAllowedResources(sess, facility, user);
+		Assert.assertTrue(resourceList.contains(resource2));
+		Assert.assertEquals(1, resourceList.size());
+
+		resourceList = perun.getUsersManagerBl().getAllowedResources(sess, facility2, user);
+		Assert.assertTrue(resourceList.contains(resource3));
+		Assert.assertEquals(1, resourceList.size());
+
+		// disable member 2, we should have only single allowed resource
+
+		perun.getMembersManagerBl().disableMember(sess, member2);
+
+		resourceList = perun.getUsersManagerBl().getAllowedResources(sess, facility, user);
+		Assert.assertTrue(resourceList.isEmpty());
+
+		resourceList = perun.getUsersManagerBl().getAllowedResources(sess, facility2, user);
+		Assert.assertTrue(resourceList.isEmpty());
+
+	}
+
+	@Test
+	public void getAssignedResourcesForFacilityAndUserTest() throws Exception {
+		System.out.println("UsersManagerBlImpl.getAssignedResources(facility,user)");
+
+		List<Resource> resourceList = perun.getUsersManagerBl().getAssignedResources(sess, facility, user);
+		Assert.assertTrue(resourceList.containsAll(Arrays.asList(resource, resource2)));
+		Assert.assertEquals(2, resourceList.size());
+
+		resourceList = perun.getUsersManagerBl().getAssignedResources(sess, facility2, user);
+		Assert.assertTrue(resourceList.contains(resource3));
+		Assert.assertEquals(1, resourceList.size());
+
+		// disable member 1, it shouldn't have any effect
+
+		perun.getMembersManagerBl().disableMember(sess, member);
+
+		resourceList = perun.getUsersManagerBl().getAssignedResources(sess, facility, user);
+		Assert.assertTrue(resourceList.containsAll(Arrays.asList(resource, resource2)));
+		Assert.assertEquals(2, resourceList.size());
+
+		resourceList = perun.getUsersManagerBl().getAssignedResources(sess, facility2, user);
+		Assert.assertTrue(resourceList.contains(resource3));
+		Assert.assertEquals(1, resourceList.size());
+
+		// remove member2 from group2
+
+		perun.getGroupsManagerBl().removeMember(sess, group2, member2);
+
+		resourceList = perun.getUsersManagerBl().getAssignedResources(sess, facility, user);
+		Assert.assertTrue(resourceList.contains(resource));
+		Assert.assertEquals(1, resourceList.size());
+
+		resourceList = perun.getUsersManagerBl().getAssignedResources(sess, facility2, user);
+		Assert.assertTrue(resourceList.isEmpty());
+
+	}
+
+	@Test
+	public void getAllowedResourcesForUserTest() throws Exception {
+		System.out.println("UsersManagerBlImpl.getAllowedResources(user)");
+
+		List<Resource> resourceList = perun.getUsersManagerBl().getAllowedResources(sess, user);
+		Assert.assertTrue(resourceList.containsAll(Arrays.asList(resource, resource2, resource3)));
+		Assert.assertEquals(3, resourceList.size());
+
+		// disable member 1, we should have only two allowed resource from two facilities
+
+		perun.getMembersManagerBl().disableMember(sess, member);
+
+		resourceList = perun.getUsersManagerBl().getAllowedResources(sess, user);
+		Assert.assertTrue(resourceList.containsAll(Arrays.asList(resource2, resource3)));
+		Assert.assertEquals(2, resourceList.size());
+
+		// disable member 2, we shouldn't have any allowed resource
+
+		perun.getMembersManagerBl().disableMember(sess, member2);
+
+		resourceList = perun.getUsersManagerBl().getAllowedResources(sess, user);
+		Assert.assertTrue(resourceList.isEmpty());
+
+	}
+
+	@Test
+	public void getAssignedResourcesForUserTest() throws Exception {
+		System.out.println("UsersManagerBlImpl.getAssignedResources(user)");
+
+		List<Resource> resourceList = perun.getUsersManagerBl().getAssignedResources(sess, user);
+		Assert.assertTrue(resourceList.containsAll(Arrays.asList(resource, resource2, resource3)));
+		Assert.assertEquals(3, resourceList.size());
+
+		// disable member 1, it shouldn't have any effect
+
+		perun.getMembersManagerBl().disableMember(sess, member);
+
+		resourceList = perun.getUsersManagerBl().getAssignedResources(sess, user);
+		Assert.assertTrue(resourceList.containsAll(Arrays.asList(resource, resource2, resource3)));
+		Assert.assertEquals(3, resourceList.size());
+
+		// remove member2 from group2, we should have single resource left
+
+		perun.getGroupsManagerBl().removeMember(sess, group2, member2);
+
+		resourceList = perun.getUsersManagerBl().getAssignedResources(sess, user);
+		Assert.assertTrue(resourceList.contains(resource));
+		Assert.assertEquals(1, resourceList.size());
+
+	}
+
+	@Test
+	public void getAssignedRichResourcesForUserTest() throws Exception {
+		System.out.println("UsersManagerBlImpl.getAssignedRichResources(user)");
+
+		RichResource rr = perun.getResourcesManagerBl().getRichResourceById(sess, resource.getId());
+		RichResource rr2 = perun.getResourcesManagerBl().getRichResourceById(sess, resource2.getId());
+		RichResource rr3 = perun.getResourcesManagerBl().getRichResourceById(sess, resource3.getId());
+
+		List<RichResource> resourceList = perun.getUsersManagerBl().getAssignedRichResources(sess, user);
+		Assert.assertTrue(resourceList.containsAll(Arrays.asList(rr, rr2, rr3)));
+		Assert.assertEquals(3, resourceList.size());
+
+		// disable member 1, it shouldn't have any effect
+
+		perun.getMembersManagerBl().disableMember(sess, member);
+
+		resourceList = perun.getUsersManagerBl().getAssignedRichResources(sess, user);
+		Assert.assertTrue(resourceList.containsAll(Arrays.asList(rr, rr2, rr3)));
+		Assert.assertEquals(3, resourceList.size());
+
+		// remove member2 from group2, we should have single resource left
+
+		perun.getGroupsManagerBl().removeMember(sess, group2, member2);
+
+		resourceList = perun.getUsersManagerBl().getAssignedRichResources(sess, user);
+		Assert.assertTrue(resourceList.contains(rr));
+		Assert.assertEquals(1, resourceList.size());
+
+	}
+
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ResourcesManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ResourcesManagerEntryIntegrationTest.java
@@ -40,6 +40,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -574,7 +575,6 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 
 	}
 
-
 	@Test
 	public void getAssignedGroups() throws Exception {
 		System.out.println(CLASS_NAME + "getAssignedGroups");
@@ -679,8 +679,8 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 	}
 
 	@Test
-	public void getAssignedResourcesForMember() throws Exception {
-		System.out.println(CLASS_NAME + "getAssignedResourcesForMember");
+	public void getAssignedResourcesForMemberAndService() throws Exception {
+		System.out.println(CLASS_NAME + "getAssignedResourcesForMemberAndService");
 
 		vo = setUpVo();
 		member = setUpMember(vo);
@@ -702,8 +702,43 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 	}
 
 	@Test
-	public void getAssignedRichResourcesForMember() throws Exception {
-		System.out.println(CLASS_NAME + "getAssignedRichResourcesForMember");
+	public void getAssignedResourcesForMember() throws Exception {
+		System.out.println(CLASS_NAME + "getAssignedResourcesForMember");
+
+		vo = setUpVo();
+		member = setUpMember(vo);
+		group = setUpGroup(vo, member);
+		facility = setUpFacility();
+		resource = setUpResource();
+		Resource sndResource = setUpResource2();
+
+		// both the resources assign to the group
+		resourcesManager.assignGroupToResource(sess, group, resource);
+		resourcesManager.assignGroupToResource(sess, group, sndResource);
+
+		List<Resource> resources = resourcesManager.getAssignedResources(sess, member);
+		assertTrue("member should be assigned to 2 resources",resources.size() == 2);
+		assertTrue("assigned resources should be in returned list",resources.containsAll(Arrays.asList(resource, sndResource)));
+
+		// disabling member shouldn't have any effect
+		perun.getMembersManagerBl().disableMember(sess, member);
+
+		resources = resourcesManager.getAssignedResources(sess, member);
+		assertTrue("member should be assigned to 2 resources",resources.size() == 2);
+		assertTrue("assigned resources should be in returned list",resources.containsAll(Arrays.asList(resource, sndResource)));
+
+		// removing group should have effect
+		resourcesManager.removeGroupFromResource(sess, group, sndResource);
+
+		resources = resourcesManager.getAssignedResources(sess, member);
+		assertTrue("member should be assigned to single resources",resources.size() == 1);
+		assertTrue("assigned resource should be in returned list",resources.contains(resource));
+
+	}
+
+	@Test
+	public void getAssignedRichResourcesForMemberAndService() throws Exception {
+		System.out.println(CLASS_NAME + "getAssignedRichResourcesForMemberAndService");
 
 		vo = setUpVo();
 		member = setUpMember(vo);
@@ -712,6 +747,7 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 		resource = setUpResource();
 		RichResource richResource = new RichResource(resource);
 		richResource.setFacility(facility);
+		richResource.setVo(vo);
 		Resource sndResource = setUpResource2();
 		service = setUpService();
 
@@ -724,6 +760,93 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 		List<RichResource> resources = resourcesManager.getAssignedRichResources(sess, member, service);
 		assertTrue("there should have been only 1 assigned rich resource",resources.size() == 1);
 		assertTrue("our rich resource should be in our resource list",resources.contains(richResource));
+
+	}
+
+	@Test
+	public void getAssignedRichResourcesForMember() throws Exception {
+		System.out.println(CLASS_NAME + "getAssignedRichResourcesForMember");
+
+		vo = setUpVo();
+		member = setUpMember(vo);
+		group = setUpGroup(vo, member);
+		facility = setUpFacility();
+		resource = setUpResource();
+		RichResource richResource = new RichResource(resource);
+		richResource.setFacility(facility);
+		richResource.setVo(vo);
+		Resource sndResource = setUpResource2();
+
+		resourcesManager.assignGroupToResource(sess, group, resource);
+		resourcesManager.assignGroupToResource(sess, group, sndResource);
+
+		RichResource rr = perun.getResourcesManagerBl().getRichResourceById(sess, resource.getId());
+		RichResource rr2 = perun.getResourcesManagerBl().getRichResourceById(sess, sndResource.getId());
+
+		List<RichResource> resources = resourcesManager.getAssignedRichResources(sess, member);
+		assertTrue("member should be assigned to 2 resources",resources.size() == 2);
+		assertTrue("assigned resources should be in returned list",resources.containsAll(Arrays.asList(rr, rr2)));
+
+		// disabling member shouldn't have any effect
+		perun.getMembersManagerBl().disableMember(sess, member);
+
+		resources = resourcesManager.getAssignedRichResources(sess, member);
+		assertTrue("member should be assigned to 2 resources",resources.size() == 2);
+		assertTrue("assigned resources should be in returned list",resources.containsAll(Arrays.asList(rr, rr2)));
+
+		// removing group should have effect
+		resourcesManager.removeGroupFromResource(sess, group, sndResource);
+
+		resources = resourcesManager.getAssignedRichResources(sess, member);
+		assertTrue("member should be assigned to single resources",resources.size() == 1);
+		assertTrue("assigned resource should be in returned list",resources.contains(rr));
+
+	}
+
+	@Test
+	public void getAssignedMembers() throws Exception {
+		System.out.println(CLASS_NAME + "getAssignedMembers");
+
+		vo = setUpVo();
+		member = setUpMember(vo);
+		group = setUpGroup(vo, member);
+		facility = setUpFacility();
+		resource = setUpResource();
+		Resource sndResource = setUpResource2();
+
+		// both the resources assign to the group
+		resourcesManager.assignGroupToResource(sess, group, resource);
+		resourcesManager.assignGroupToResource(sess, group, sndResource);
+
+		List<Member> members = resourcesManager.getAssignedMembers(sess, resource);
+		assertTrue(members.size() == 1);
+		assertTrue(members.contains(member));
+
+		members = resourcesManager.getAssignedMembers(sess, sndResource);
+		assertTrue(members.size() == 1);
+		assertTrue(members.contains(member));
+
+		// disabling member shouldn't have any effect
+		perun.getMembersManagerBl().disableMember(sess, member);
+
+		members = resourcesManager.getAssignedMembers(sess, resource);
+		assertTrue(members.size() == 1);
+		assertTrue(members.contains(member));
+
+		members = resourcesManager.getAssignedMembers(sess, sndResource);
+		assertTrue(members.size() == 1);
+		assertTrue(members.contains(member));
+
+		// removing group should have effect
+		resourcesManager.removeGroupFromResource(sess, group, sndResource);
+
+		members = resourcesManager.getAssignedMembers(sess, resource);
+		assertTrue(members.size() == 1);
+		assertTrue(members.contains(member));
+
+		members = resourcesManager.getAssignedMembers(sess, sndResource);
+		assertTrue(members.isEmpty());
+
 	}
 
 	@Test


### PR DESCRIPTION
- Aligned SQL, so that "join" and "where" keywords start
  on the new line (its more readable).
- Removed unnecessary "inner" from some "inner join" statements.
- In getAllowedResources(facility,user) in ResourcesManagerImpl
  removed unnecessary "left outer" from the "join" since we
  want explicit connection anyway. No other sql on the same
  tables returning allowed entities uses "left outer".
  Also removed join with facilities table, since we can filter
  by facility_id in resources table directly.
- Renamed getAllowed(Users/Members)NotExpired() to
  getAllowed(Users/Members)NotExpiredInGroup() since its more
  explanatory, if expired is referring to vo or group status.
  Also propagate this change to the Bl, where its used.
- Removed VO param from getAssignedResources(sess, vo, group)
  in ResourceManagerImpl, since it was not used in SQL.
- Added getAllowedUsers(sess, facility) to the FacilitiesMangerImpl,
  so we perform direct select rather than iterate over all resources.
- Updated javadoc for some methods.