### PR TITLE
REGISTRAR: Optimized checks on already submitted applications

### DIFF
--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/exceptions/DuplicateRegistrationAttemptException.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/exceptions/DuplicateRegistrationAttemptException.java
@@ -1,6 +1,10 @@
 package cz.metacentrum.perun.registrar.exceptions;
 
 import cz.metacentrum.perun.core.api.exceptions.PerunException;
+import cz.metacentrum.perun.registrar.model.Application;
+import cz.metacentrum.perun.registrar.model.ApplicationFormItemData;
+
+import java.util.List;
 
 /**
  * Thrown when initial application for the user already exists.
@@ -8,26 +12,22 @@ import cz.metacentrum.perun.core.api.exceptions.PerunException;
  * @author Martin Kuba makub@ics.muni.cz
  */
 public class DuplicateRegistrationAttemptException extends PerunException {
-	private final String actor;
-	private final String extSourceName;
-	private final int appId;
 
-	public DuplicateRegistrationAttemptException(String message, String actor, String extSourceName, int appId) {
+	private final Application application;
+	private final List<ApplicationFormItemData> applicationData;
+
+	public DuplicateRegistrationAttemptException(String message, Application application, List<ApplicationFormItemData> data) {
 		super(message);
-		this.actor = actor;
-		this.extSourceName = extSourceName;
-		this.appId = appId;
+		this.application = application;
+		this.applicationData = data;
 	}
 
-	public String getActor() {
-		return actor;
+	public Application getApplication() {
+		return application;
 	}
 
-	public String getExtSourceName() {
-		return extSourceName;
+	public List<ApplicationFormItemData> getApplicationData() {
+		return applicationData;
 	}
 
-	public int getApplicationId() {
-		return appId;
-	}
 }


### PR DESCRIPTION
- Repetitive code moved to new private method checkDuplicateRegistration().
- Removed unused setters and properties.
- Enhanced DuplicateRegistrationAttemptException with full application
  and application data of existing registration.