### PR TITLE
CORE: Use trim() on mails in user:virt:tcsMails

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_tcsMails_mu.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_tcsMails_mu.java
@@ -66,9 +66,11 @@ public class urn_perun_user_attribute_def_virt_tcsMails_mu extends UserVirtualAt
 			if (sourceAttribute != null) {
 				// gather values of all attributes
 				if (sourceAttribute.getType().equals(String.class.getName())) {
-					if (sourceAttribute.getValue() != null) tcsMailsValue.add(sourceAttribute.valueAsString());
+					if (sourceAttribute.getValue() != null) tcsMailsValue.add(sourceAttribute.valueAsString().trim());
 				} else if (sourceAttribute.getType().equals(ArrayList.class.getName())) {
-					if (sourceAttribute.getValue() != null) tcsMailsValue.addAll(sourceAttribute.valueAsList());
+					if (sourceAttribute.getValue() != null) {
+						tcsMailsValue.addAll(sourceAttribute.valueAsList().stream().map(String::trim).collect(Collectors.toList()));
+					}
 				} else {
 					//unexpected type of value, log it and skip the attribute
 					log.error("Unexpected type of attribute (should be String or ArrayList) {}. It will be skipped.", sourceAttribute);

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_tcsMails_muTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_tcsMails_muTest.java
@@ -40,15 +40,16 @@ public class urn_perun_user_attribute_def_virt_tcsMails_muTest {
 	private final User user = new User(10, "Joe", "Doe", "W.", "", "");
 
 	private final String email1 = "Zemail1@mail.cz";
-	private final String email2 = "email2@mail.cz";
+	private final String email2 = "email2@mail.cz "; // to check for the trim()
 	private final String email3 = "email3@mail.cz";
 	private final String email4 = "email4@mail.cz";
 	private final String email5 = "email5@mail.cz";
+	private final String email6 = " email5@mail.cz"; // to check for the trim() and uniqueness
 
 	Attribute preferredMailAttr = setUpUserAttribute(1, "preferredMail", String.class.getName(), email1);
 	Attribute isMailAttr = setUpUserAttribute(2, "ISMail", String.class.getName(), email2);
 	Attribute o365MailsAttr = setUpUserAttribute(3, "o365EmailAddresses:mu", ArrayList.class.getName(), new ArrayList<>(Arrays.asList(email3, email4)));
-	Attribute publicMailsAttr = setUpUserAttribute(4, "publicAliasMails", ArrayList.class.getName(), new ArrayList<>(Arrays.asList(email4, email5)));
+	Attribute publicMailsAttr = setUpUserAttribute(4, "publicAliasMails", ArrayList.class.getName(), new ArrayList<>(Arrays.asList(email4, email5, email6)));
 	Attribute privateMailsAttr = setUpUserAttribute(5, "privateAliasMails", ArrayList.class.getName(), new ArrayList<>(Arrays.asList(email1, email3, email5)));
 
 	private final String expectedTestOfMessage = "friendlyName=<tcsMails:mu>";
@@ -89,11 +90,13 @@ public class urn_perun_user_attribute_def_virt_tcsMails_muTest {
 		assertNotNull(attributeValue);
 		//we want to be sure, that preferredEmail is first (defined by sorting in module)
 		assertEquals(attributeValue.get(0), email1);
-		assertEquals(attributeValue.get(1), email2);
+		assertEquals(attributeValue.get(1), email2.trim()); // check if was trimmed
 		assertEquals(attributeValue.get(2), email3);
 		assertEquals(attributeValue.get(3), email4);
 		assertEquals(attributeValue.get(4), email5);
+		assertEquals(attributeValue.get(4), email6.trim()); // check if was trimmed and then equals "email5"
 		assertEquals(5, attributeValue.size());
+
 	}
 
 	@Test


### PR DESCRIPTION
- Source attributes sometimes provides values with ending
  whitespace and such values were not unified using Set.
  Now we explicitly trim() all values before adding them
  to the result.
- Updated tests to check that values are trimmed.