### PR TITLE
CORE: Fixed retrieval of password reset request

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/UsersManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/UsersManagerImpl.java
@@ -1273,8 +1273,8 @@ public class UsersManagerImpl implements UsersManagerImplApi {
 
 		int validWindow = BeansUtils.getCoreConfig().getPwdresetValidationWindow();
 
-		Pair<String,String> result = new Pair<>();
 		try {
+			Pair<String,String> result;
 			if (Compatibility.isPostgreSql()) {
 
 				result = jdbc.queryForObject("select namespace, mail from pwdreset where user_id=? and id=? and (created_at > (now() - interval '" + validWindow + " hours'))",
@@ -1290,7 +1290,7 @@ public class UsersManagerImpl implements UsersManagerImplApi {
 			return result;
 
 		} catch (EmptyResultDataAccessException ex) {
-			return result;
+			return null;
 		}
 
 	}


### PR DESCRIPTION
- When there is no password reset request or its expired, we
  must return NULL and not empty Pair<> as API and its usage
  expect it.
  It caused to mix-up the errors (expired request vs.
  user has no login in null namespace).