### PR TITLE
 Fix bug where two http requests changed shared stateChanging attribute

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/rpc/deserializer/Deserializer.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/rpc/deserializer/Deserializer.java
@@ -160,4 +160,14 @@ public abstract class Deserializer {
 		throw new UnsupportedOperationException("getServletRequest()");
 	}
 
+	/**
+	 * Check whether method that changes state is not GET.
+	 *
+	 * @throws RpcException if method is GET
+	 */
+	public void stateChangingCheck() throws RpcException {
+		if (getServletRequest().getMethod().equals("GET")) {
+			throw new RpcException(RpcException.Type.STATE_CHANGING_CALL, "This is a state changing operation. Please use HTTP POST request.");
+		}
+	}
 }

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/Api.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/Api.java
@@ -680,9 +680,6 @@ public class Api extends HttpServlet {
 				out.close();
 			}
 
-			// In case of GET requests (read ones) set changing state to false
-			caller.setStateChanging(!isGet);
-
 			// Store identification of the request only if supported by app (it passed unique callbackName)
 			if (callbackName != null) {
 

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/ApiCaller.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/ApiCaller.java
@@ -451,22 +451,6 @@ public class ApiCaller {
 		return session;
 	}
 
-	private boolean stateChanging = true;
-
-	public boolean isStateChanging() {
-		return stateChanging;
-	}
-
-	public void setStateChanging(boolean stateChanging) {
-		this.stateChanging = stateChanging;
-	}
-
-	public void stateChangingCheck() throws RpcException {
-		if (!stateChanging) {
-			throw new RpcException(RpcException.Type.STATE_CHANGING_CALL, "This is a state changing operation. Please use HTTP POST request.");
-		}
-	}
-
 	public Object call(String managerName, String methodName, Deserializer parms) throws PerunException {
 		return PerunManager.call(managerName, methodName, this, parms);
 	}

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/AttributesManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/AttributesManagerMethod.java
@@ -625,7 +625,7 @@ public enum AttributesManagerMethod implements ManagerMethod {
 
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			if (parms.contains("facility")) {
 				if (parms.contains("user")) {
@@ -1276,7 +1276,7 @@ public enum AttributesManagerMethod implements ManagerMethod {
 
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			if (parms.contains("facility")) {
 				if (parms.contains("user")) {
@@ -1374,7 +1374,7 @@ public enum AttributesManagerMethod implements ManagerMethod {
 
 		@Override
 		public AttributeDefinition call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			if (parms.contains("attribute")) {
 				return ac.getAttributesManager().createAttribute(ac.getSession(),
@@ -1405,7 +1405,7 @@ public enum AttributesManagerMethod implements ManagerMethod {
 
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			ac.getAttributesManager().deleteAttribute(ac.getSession(),
 					ac.getAttributeDefinitionById(parms.readInt("attribute")));
@@ -1422,7 +1422,7 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	deleteAttributes {
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 			List<Integer> attDefs = parms.readList("attributes", Integer.class);
 			for (Integer id : attDefs) {
 				ac.getAttributesManager().deleteAttribute(ac.getSession(),
@@ -2105,7 +2105,7 @@ public enum AttributesManagerMethod implements ManagerMethod {
 
 		@Override
 		public Attribute call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			if (parms.contains("host")) {
 				Host host = ac.getHostById(parms.readInt("host"));
@@ -2272,7 +2272,7 @@ public enum AttributesManagerMethod implements ManagerMethod {
 
 		@Override
 		public List<Attribute> call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			List<Attribute> attributes = new ArrayList<Attribute>();
 			if (parms.contains("attributes")) {
@@ -3798,7 +3798,7 @@ public enum AttributesManagerMethod implements ManagerMethod {
 
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			int[] ids = parms.readArrayOfInts("attributes");
 			List<AttributeDefinition> attributes = new ArrayList<AttributeDefinition>(ids.length);
@@ -4026,7 +4026,7 @@ public enum AttributesManagerMethod implements ManagerMethod {
 
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			if (parms.contains("facility")) {
 				if (parms.contains("user")) {
@@ -4184,7 +4184,7 @@ public enum AttributesManagerMethod implements ManagerMethod {
 
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			if (parms.contains("facility")) {
 				if (parms.contains("user")) {
@@ -4279,7 +4279,7 @@ public enum AttributesManagerMethod implements ManagerMethod {
 
 		@Override
 		public AttributeDefinition call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			return ac.getAttributesManager().updateAttributeDefinition(ac.getSession(),
 					parms.read("attributeDefinition", AttributeDefinition.class));
@@ -4331,7 +4331,7 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	setAttributeRights {
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			ac.getAttributesManager().setAttributeRights(ac.getSession(),
 					parms.readList("rights", AttributeRights.class));
@@ -4351,7 +4351,7 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	convertAttributeToUnique {
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws InternalErrorException, AttributeAlreadyMarkedUniqueException, PrivilegeException, AttributeNotExistsException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 			ac.getAttributesManager().convertAttributeToUnique(ac.getSession(), parms.readInt("attrDefId"));
 			return null;
 		}

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/AuditMessagesManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/AuditMessagesManagerMethod.java
@@ -70,7 +70,7 @@ public enum AuditMessagesManagerMethod implements ManagerMethod {
 	setLastProcessedId {
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 			ac.getAuditMessagesManager().setLastProcessedId(ac.getSession(), parms.readString("consumerName"),
 			  parms.readInt("lastProcessedId"));
 			return null;
@@ -86,7 +86,7 @@ public enum AuditMessagesManagerMethod implements ManagerMethod {
 	createAuditerConsumer {
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 			ac.getAuditMessagesManager().createAuditerConsumer(ac.getSession(), parms.readString("consumerName"));
 			return null;
 		}
@@ -136,7 +136,7 @@ public enum AuditMessagesManagerMethod implements ManagerMethod {
 	log {
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 			ac.getAuditMessagesManager().log(ac.getSession(), parms.readString("msg"));
 			return null;
 		}

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/AuthzResolverMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/AuthzResolverMethod.java
@@ -238,7 +238,7 @@ public enum AuthzResolverMethod implements ManagerMethod {
 	setRole {
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 			//get role by name
 			String roleName = parms.readString("role");
 			if (!cz.metacentrum.perun.core.api.AuthzResolver.roleExists(roleName)) {
@@ -401,7 +401,7 @@ public enum AuthzResolverMethod implements ManagerMethod {
 	unsetRole {
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 			//get role by name
 			String roleName = parms.readString("role");
 			if (!cz.metacentrum.perun.core.api.AuthzResolver.roleExists(roleName)) {

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/CabinetManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/CabinetManagerMethod.java
@@ -41,7 +41,7 @@ public enum CabinetManagerMethod implements ManagerMethod {
 	 */
 	deletePublicationSystem {
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 			ac.getCabinetManager().deletePublicationSystem(ac.getSession(), ac.getPublicationSystemById(parms.readInt("id")));
 			return null;
 		}
@@ -55,7 +55,7 @@ public enum CabinetManagerMethod implements ManagerMethod {
 	 */
 	createPublicationSystem {
 		public PublicationSystem call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 			return ac.getCabinetManager().createPublicationSystem(ac.getSession(), parms.read("pubsys", PublicationSystem.class));
 		}
 	},
@@ -68,7 +68,7 @@ public enum CabinetManagerMethod implements ManagerMethod {
 	 */
 	updatePublicationSystem {
 		public PublicationSystem call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 			return ac.getCabinetManager().updatePublicationSystem(ac.getSession(), parms.read("pubsys", PublicationSystem.class));
 		}
 	},
@@ -104,7 +104,7 @@ public enum CabinetManagerMethod implements ManagerMethod {
 	 */
 	createCategory {
 		public Category call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 			if (parms.contains("category")) {
 				return ac.getCabinetManager().createCategory(ac.getSession(), parms.read("category", Category.class));
 			} else if (parms.contains("name") && parms.contains("rank")) {
@@ -131,7 +131,7 @@ public enum CabinetManagerMethod implements ManagerMethod {
 	 */
 	updateCategory {
 		public Category call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 			return ac.getCabinetManager().updateCategory(ac.getSession(), parms.read("category", Category.class));
 		}
 	},
@@ -145,7 +145,7 @@ public enum CabinetManagerMethod implements ManagerMethod {
 	 */
 	deleteCategory {
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 			ac.getCabinetManager().deleteCategory(ac.getSession(), ac.getCategoryById(parms.readInt("id")));
 			return null;
 		}
@@ -159,7 +159,7 @@ public enum CabinetManagerMethod implements ManagerMethod {
 	 */
 	createThanks {
 		public Thanks call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 			return ac.getCabinetManager().createThanks(ac.getSession(), parms.read("thanks", Thanks.class));
 		}
 	},
@@ -172,7 +172,7 @@ public enum CabinetManagerMethod implements ManagerMethod {
 	 */
 	deleteThanks {
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 			ac.getCabinetManager().deleteThanks(ac.getSession(), ac.getThanksById(parms.readInt("id")));
 			return null;
 		}
@@ -200,7 +200,7 @@ public enum CabinetManagerMethod implements ManagerMethod {
 	 */
 	createAuthorship {
 		public Authorship call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 			Authorship auth = parms.read("authorship", Authorship.class);
 			if (ac.getCabinetManager().authorshipExists(auth)) {
 				// exists - return existing
@@ -221,7 +221,7 @@ public enum CabinetManagerMethod implements ManagerMethod {
 	 */
 	deleteAuthorship {
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 			Authorship authorship = ac.getCabinetManager().getAuthorshipByUserAndPublicationId(parms.readInt("userId"),parms.readInt("publicationId"));
 			ac.getCabinetManager().deleteAuthorship(ac.getSession(), authorship);
 			return null;
@@ -285,7 +285,7 @@ public enum CabinetManagerMethod implements ManagerMethod {
 	 */
 	createPublication {
 		public Publication call(ApiCaller ac, Deserializer parms) throws PerunException, CabinetException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 			Publication pub = parms.read("publication", Publication.class);
 			if (ac.getCabinetManager().publicationExists(pub)) {
 				// get for external pubs
@@ -310,7 +310,7 @@ public enum CabinetManagerMethod implements ManagerMethod {
 	 */
 	updatePublication {
 		public PublicationForGUI call(ApiCaller ac, Deserializer parms) throws PerunException, CabinetException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 			Publication pub = parms.read("publication", Publication.class);
 			ac.getCabinetManager().updatePublication(ac.getSession(), pub);
 			return ac.getCabinetManager().getRichPublicationById(pub.getId());
@@ -327,7 +327,7 @@ public enum CabinetManagerMethod implements ManagerMethod {
 	 */
 	deletePublication {
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 			ac.getCabinetManager().deletePublication(ac.getSession(), ac.getPublicationById(parms.readInt("id")));
 			return null;
 		}
@@ -453,7 +453,7 @@ public enum CabinetManagerMethod implements ManagerMethod {
 	 */
 	lockPublications {
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 			List<Publication> pubs = parms.readList("publications", Publication.class);
 			boolean lock = parms.readBoolean("lock");
 			ac.getCabinetManager().lockPublications(ac.getSession(), lock, pubs);

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/ExtSourcesManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/ExtSourcesManagerMethod.java
@@ -25,7 +25,7 @@ public enum ExtSourcesManagerMethod implements ManagerMethod {
 
 		@Override
 		public ExtSource call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			if (parms.contains("extSource")) {
 				return ac.getExtSourcesManager().createExtSource(ac.getSession(), parms.read("extSource", ExtSource.class), null);
@@ -47,7 +47,7 @@ public enum ExtSourcesManagerMethod implements ManagerMethod {
 
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 			ac.getExtSourcesManager().deleteExtSource(ac.getSession(), ac.getExtSourceById(parms.readInt("id")));
 			return null;
 		}
@@ -140,7 +140,7 @@ public enum ExtSourcesManagerMethod implements ManagerMethod {
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms)
 		throws PerunException {
-		ac.stateChangingCheck();
+		parms.stateChangingCheck();
 
 		if(parms.contains("vo")) {
 			ac.getExtSourcesManager().addExtSource(ac.getSession(),
@@ -175,7 +175,7 @@ public enum ExtSourcesManagerMethod implements ManagerMethod {
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms)
 		throws PerunException {
-		ac.stateChangingCheck();
+		parms.stateChangingCheck();
 
 		if(parms.contains("vo")) {
 			ac.getExtSourcesManager().removeExtSource(ac.getSession(),

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/FacilitiesManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/FacilitiesManagerMethod.java
@@ -490,7 +490,7 @@ public enum FacilitiesManagerMethod implements ManagerMethod {
 	addHosts {
 		@Override
 		public List<Host> call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			Facility facility = ac.getFacilityById(parms.readInt("facility"));
 
@@ -508,7 +508,7 @@ public enum FacilitiesManagerMethod implements ManagerMethod {
 	removeHosts {
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			Facility facility = ac.getFacilityById(parms.readInt("facility"));
 
@@ -535,7 +535,7 @@ public enum FacilitiesManagerMethod implements ManagerMethod {
 	addHost {
 		@Override
 		public Host call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			Facility facility = ac.getFacilityById(parms.readInt("facility"));
 
@@ -554,7 +554,7 @@ public enum FacilitiesManagerMethod implements ManagerMethod {
 	removeHost {
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			int id = parms.readInt("host");
 
@@ -626,7 +626,7 @@ public enum FacilitiesManagerMethod implements ManagerMethod {
 	addAdmin {
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 			if (parms.contains("user")) {
 				ac.getFacilitiesManager().addAdmin(ac.getSession(),
 						ac.getFacilityById(parms.readInt("facility")),
@@ -655,7 +655,7 @@ public enum FacilitiesManagerMethod implements ManagerMethod {
 	removeAdmin {
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 			if (parms.contains("user")) {
 				ac.getFacilitiesManager().removeAdmin(ac.getSession(),
 						ac.getFacilityById(parms.readInt("facility")),
@@ -909,7 +909,7 @@ public enum FacilitiesManagerMethod implements ManagerMethod {
 
 		@Override
 		public Object call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			ac.getFacilitiesManager().copyOwners(ac.getSession(),
 					ac.getFacilityById(parms.readInt("srcFacility")),
@@ -931,7 +931,7 @@ public enum FacilitiesManagerMethod implements ManagerMethod {
 
 		@Override
 		public Object call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			ac.getFacilitiesManager().copyManagers(ac.getSession(),
 					ac.getFacilityById(parms.readInt("srcFacility")),
@@ -953,7 +953,7 @@ public enum FacilitiesManagerMethod implements ManagerMethod {
 
 		@Override
 		public Object call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			ac.getFacilitiesManager().copyAttributes(ac.getSession(),
 					ac.getFacilityById(parms.readInt("srcFacility")),
@@ -1048,7 +1048,7 @@ public enum FacilitiesManagerMethod implements ManagerMethod {
 	addFacilityContacts {
 		@Override
 		public Object call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			ac.getFacilitiesManager().addFacilityContacts(ac.getSession(),
 					parms.readList("contactGroupsToAdd", ContactGroup.class));
@@ -1065,7 +1065,7 @@ public enum FacilitiesManagerMethod implements ManagerMethod {
 	addFacilityContact {
 		@Override
 		public Object call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			ac.getFacilitiesManager().addFacilityContact(ac.getSession(),
 					parms.read("contactGroupToAdd", ContactGroup.class));
@@ -1082,7 +1082,7 @@ public enum FacilitiesManagerMethod implements ManagerMethod {
 	removeFacilityContacts {
 		@Override
 		public Object call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			ac.getFacilitiesManager().removeFacilityContacts(ac.getSession(),
 					parms.readList("contactGroupsToRemove", ContactGroup.class));
@@ -1099,7 +1099,7 @@ public enum FacilitiesManagerMethod implements ManagerMethod {
 	removeFacilityContact {
 		@Override
 		public Object call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			ac.getFacilitiesManager().removeFacilityContact(ac.getSession(),
 					parms.read("contactGroupToRemove", ContactGroup.class));
@@ -1168,7 +1168,7 @@ public enum FacilitiesManagerMethod implements ManagerMethod {
 
 		@Override
 		public BanOnFacility call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			return ac.getFacilitiesManager().setBan(ac.getSession(),
 					parms.read("banOnFacility", BanOnFacility.class));
@@ -1255,7 +1255,7 @@ public enum FacilitiesManagerMethod implements ManagerMethod {
 
 		@Override
 		public BanOnFacility call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			return ac.getFacilitiesManager().updateBan(ac.getSession(),
 					parms.read("banOnFacility", BanOnFacility.class));
@@ -1278,7 +1278,7 @@ public enum FacilitiesManagerMethod implements ManagerMethod {
 
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			if(parms.contains("banId")) {
 				ac.getFacilitiesManager().removeBan(ac.getSession(),

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/GroupsManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/GroupsManagerMethod.java
@@ -94,7 +94,7 @@ public enum GroupsManagerMethod implements ManagerMethod {
 
 		@Override
 		public Group call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			if (parms.contains("group")) {
 				if (parms.contains("parentGroup")) {
@@ -156,7 +156,7 @@ public enum GroupsManagerMethod implements ManagerMethod {
 
 		@Override
 		public Group call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			return ac.getGroupsManager().createGroupUnion(ac.getSession(),
 					ac.getGroupById(parms.readInt("resultGroup")),
@@ -193,7 +193,7 @@ public enum GroupsManagerMethod implements ManagerMethod {
 
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			if(parms.contains("force") && parms.readBoolean("force")) {
 				ac.getGroupsManager().deleteGroup(ac.getSession(),
@@ -224,7 +224,7 @@ public enum GroupsManagerMethod implements ManagerMethod {
 
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			//TODO: optimalizovat?
 			int[] ids = parms.readArrayOfInts("groups");
@@ -255,7 +255,7 @@ public enum GroupsManagerMethod implements ManagerMethod {
 
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			ac.getGroupsManager().removeGroupUnion(ac.getSession(),
 					ac.getGroupById(parms.readInt("resultGroup")),
@@ -277,7 +277,7 @@ public enum GroupsManagerMethod implements ManagerMethod {
 
 		@Override
 		public Group call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			return ac.getGroupsManager().updateGroup(ac.getSession(),
 					parms.read("group", Group.class));
@@ -309,7 +309,7 @@ public enum GroupsManagerMethod implements ManagerMethod {
 
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			if(parms.contains("destinationGroup")) {
 				ac.getGroupsManager().moveGroup(ac.getSession(),
@@ -392,7 +392,7 @@ public enum GroupsManagerMethod implements ManagerMethod {
 	addMembers {
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			List<Integer> memberInts = parms.readList("members", Integer.class);
 			if (memberInts == null) {
@@ -440,7 +440,7 @@ public enum GroupsManagerMethod implements ManagerMethod {
 
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			if (parms.contains("group")) {
 				ac.getGroupsManager().addMember(ac.getSession(),
@@ -488,7 +488,7 @@ public enum GroupsManagerMethod implements ManagerMethod {
 	removeMembers {
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 			List<Integer> memberInts = parms.readList("members", Integer.class);
 			if (memberInts == null) {
 				throw new RpcException(RpcException.Type.MISSING_VALUE, "Non-empty list of members not sent.");
@@ -543,7 +543,7 @@ public enum GroupsManagerMethod implements ManagerMethod {
 	removeMember {
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 			if (parms.contains("group")) {
 				ac.getGroupsManager().removeMember(ac.getSession(),
 					ac.getGroupById(parms.readInt("group")),
@@ -793,7 +793,7 @@ public enum GroupsManagerMethod implements ManagerMethod {
 	addAdmin {
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 			if (parms.contains("user")) {
 				ac.getGroupsManager().addAdmin(ac.getSession(),
 						ac.getGroupById(parms.readInt("group")),
@@ -829,7 +829,7 @@ public enum GroupsManagerMethod implements ManagerMethod {
 	removeAdmin {
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 			if (parms.contains("user")) {
 				ac.getGroupsManager().removeAdmin(ac.getSession(),
 						ac.getGroupById(parms.readInt("group")),
@@ -1171,7 +1171,7 @@ public enum GroupsManagerMethod implements ManagerMethod {
 
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			ac.getGroupsManager().deleteAllGroups(ac.getSession(),
 					ac.getVoById(parms.readInt("vo")));
@@ -1210,7 +1210,7 @@ public enum GroupsManagerMethod implements ManagerMethod {
 
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			ac.getGroupsManager().forceGroupStructureSynchronization(ac.getSession(),
 					ac.getGroupById(parms.readInt("group")));
@@ -1682,7 +1682,7 @@ public enum GroupsManagerMethod implements ManagerMethod {
 	setGroupsMemberStatus {
 		@Override
 		public Member call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			MemberGroupStatus status = MemberGroupStatus.valueOf(parms.readString("status"));
 			return ac.getGroupsManager().setMemberGroupStatus(ac.getSession(),

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/MembersManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/MembersManagerMethod.java
@@ -25,7 +25,7 @@ public enum MembersManagerMethod implements ManagerMethod {
 	deleteMember {
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			ac.getMembersManager().deleteMember(ac.getSession(), ac.getMemberById(parms.readInt("member")));
 			return null;
@@ -40,7 +40,7 @@ public enum MembersManagerMethod implements ManagerMethod {
 	deleteMembers {
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			int[] ids = parms.readArrayOfInts("members");
 			List<Member> members = new ArrayList<>(ids.length);
@@ -82,7 +82,7 @@ public enum MembersManagerMethod implements ManagerMethod {
 	createSpecificMember {
 		@Override
 		public Member call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			if (parms.contains("groups") ) {
 				return ac.getMembersManager().createSpecificMember(ac.getSession(),
@@ -118,7 +118,7 @@ public enum MembersManagerMethod implements ManagerMethod {
 		@SuppressWarnings("unchecked")
 		@Override
 		public Member call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 			return ac.getMembersManager().createSponsoredAccount(ac.getSession(),
 					parms.read("parameters", HashMap.class),
 					parms.readString("namespace"),
@@ -161,7 +161,7 @@ public enum MembersManagerMethod implements ManagerMethod {
 	createSponsoredMember {
 		@Override
 		public RichMember call(ApiCaller ac, Deserializer params) throws PerunException {
-			ac.stateChangingCheck();
+			params.stateChangingCheck();
 			String password = params.readString("password");
 			Vo vo =  ac.getVoById(params.readInt("vo"));
 			String namespace = params.readString("namespace");
@@ -194,7 +194,7 @@ public enum MembersManagerMethod implements ManagerMethod {
 	setSponsorshipForMember {
 		@Override
 		public RichMember call(ApiCaller ac, Deserializer params) throws PerunException {
-			ac.stateChangingCheck();
+			params.stateChangingCheck();
 			Member sponsoredMember = ac.getMemberById(params.readInt("sponsoredMember"));
 			User sponsor = null;
 			if (params.contains("sponsor")) {
@@ -214,7 +214,7 @@ public enum MembersManagerMethod implements ManagerMethod {
 	unsetSponsorshipForMember {
 		@Override
 		public RichMember call(ApiCaller ac, Deserializer params) throws PerunException {
-			ac.stateChangingCheck();
+			params.stateChangingCheck();
 			Member sponsoredMember = ac.getMemberById(params.readInt("sponsoredMember"));
 			return ac.getMembersManager().unsetSponsorshipForMember(ac.getSession(), sponsoredMember);
 		}
@@ -232,7 +232,7 @@ public enum MembersManagerMethod implements ManagerMethod {
 	sponsorMember {
 		@Override
 		public RichMember call(ApiCaller ac, Deserializer params) throws PerunException {
-			ac.stateChangingCheck();
+			params.stateChangingCheck();
 			Member sponsored = ac.getMemberById(params.readInt("member"));
 			User sponsor = ac.getUserById(params.readInt("sponsor"));
 			return ac.getMembersManager().sponsorMember(ac.getSession(), sponsored, sponsor);
@@ -250,7 +250,7 @@ public enum MembersManagerMethod implements ManagerMethod {
 	removeSponsor {
 		@Override
 		public Void call(ApiCaller ac, Deserializer params) throws PerunException {
-			ac.stateChangingCheck();
+			params.stateChangingCheck();
 			Member sponsoredMember = ac.getMemberById(params.readInt("member"));
 			User sponsorToRemove = ac.getUserById(params.readInt("sponsor"));
 			ac.getMembersManager().removeSponsor(ac.getSession(), sponsoredMember, sponsorToRemove);
@@ -271,7 +271,7 @@ public enum MembersManagerMethod implements ManagerMethod {
 	extendExpirationForSponsoredMember {
 		@Override
 		public String call(ApiCaller ac, Deserializer params) throws PerunException {
-			ac.stateChangingCheck();
+			params.stateChangingCheck();
 			Member sponsored = ac.getMemberById(params.readInt("member"));
 			User sponsor = ac.getUserById(params.readInt("sponsor"));
 			return ac.getMembersManager().extendExpirationForSponsoredMember(ac.getSession(), sponsored, sponsor);
@@ -418,7 +418,7 @@ public enum MembersManagerMethod implements ManagerMethod {
 	createMember {
 		@Override
 		public Member call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			if (parms.contains("extSourceName") && parms.contains("extSourceType") && parms.contains("login")) {
 				if (parms.contains("groups")) {
@@ -869,7 +869,7 @@ public enum MembersManagerMethod implements ManagerMethod {
 	deleteAllMembers {
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			ac.getMembersManager().deleteAllMembers(ac.getSession(), ac.getVoById(parms.readInt("vo")));
 			return null;
@@ -1139,7 +1139,7 @@ public enum MembersManagerMethod implements ManagerMethod {
 	setStatus {
 		@Override
 		public Member call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			Status status = Status.valueOf(parms.readString("status"));
 			if (parms.contains("message")){
@@ -1160,7 +1160,7 @@ public enum MembersManagerMethod implements ManagerMethod {
 	suspendMemberTo {
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			String suspendedToString = parms.readString("suspendedTo");
 
@@ -1187,7 +1187,7 @@ public enum MembersManagerMethod implements ManagerMethod {
 	unsuspendMember {
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			ac.getMembersManager().unsuspendMember(ac.getSession(), ac.getMemberById(parms.readInt("member")));
 
@@ -1227,7 +1227,7 @@ public enum MembersManagerMethod implements ManagerMethod {
 	validateMemberAsync {
 		@Override
 		public Member call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			return ac.getMembersManager().validateMemberAsync(ac.getSession(), ac.getMemberById(parms.readInt("member")));
 		}
@@ -1356,7 +1356,7 @@ public enum MembersManagerMethod implements ManagerMethod {
 	sendPasswordResetLinkEmail {
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			ac.getMembersManager().sendPasswordResetLinkEmail(ac.getSession(), ac.getMemberById(parms.readInt("member")),
 					parms.readString("namespace"), parms.getServletRequest().getRequestURL().toString(),

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/NotificationManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/NotificationManagerMethod.java
@@ -68,7 +68,7 @@ public enum NotificationManagerMethod implements ManagerMethod {
 	createPerunNotifReceiver {
 		@Override
 		public PerunNotifReceiver call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 			if (parms.contains("receiver")) {
 				return ac.getNotificationManager().createPerunNotifReceiver(ac.getSession(), parms.read("receiver", PerunNotifReceiver.class));
 			} else if (parms.contains("target") && parms.contains("type") && parms.contains("templateId") && parms.contains("locale") ) {
@@ -94,7 +94,7 @@ public enum NotificationManagerMethod implements ManagerMethod {
 	updatePerunNotifReceiver {
 		@Override
 		public PerunNotifReceiver call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 			if (parms.contains("receiver")) {
 				return ac.getNotificationManager().updatePerunNotifReceiver(ac.getSession(), parms.read("receiver", PerunNotifReceiver.class));
 			} else {
@@ -111,7 +111,7 @@ public enum NotificationManagerMethod implements ManagerMethod {
 	removePerunNotifReceiverById {
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			ac.getNotificationManager().removePerunNotifReceiverById(ac.getSession(), parms.readInt("id"));
 			return null;
@@ -158,7 +158,7 @@ public enum NotificationManagerMethod implements ManagerMethod {
 	createPerunNotifRegex {
 		@Override
 		public PerunNotifRegex call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			return ac.getNotificationManager().createPerunNotifRegex(ac.getSession(), parms.read("regex", PerunNotifRegex.class));
 		}
@@ -174,7 +174,7 @@ public enum NotificationManagerMethod implements ManagerMethod {
 	updatePerunNotifRegex {
 		@Override
 		public PerunNotifRegex call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 			if (parms.contains("regex")) {
 				return ac.getNotificationManager().updatePerunNotifRegex(ac.getSession(), parms.read("regex", PerunNotifRegex.class));
 			} else {
@@ -192,7 +192,7 @@ public enum NotificationManagerMethod implements ManagerMethod {
 	removePerunNotifRegexById {
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			try {
 				ac.getNotificationManager().removePerunNotifRegexById(ac.getSession(), parms.readInt("id"));
@@ -212,7 +212,7 @@ public enum NotificationManagerMethod implements ManagerMethod {
 	saveTemplateRegexRelation {
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			ac.getNotificationManager().saveTemplateRegexRelation(ac.getSession(), parms.readInt("templateId"), parms.readInt("regexId"));
 			return null;
@@ -241,7 +241,7 @@ public enum NotificationManagerMethod implements ManagerMethod {
 	removePerunNotifTemplateRegexRelation {
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			ac.getNotificationManager().removePerunNotifTemplateRegexRelation(ac.getSession(), parms.readInt("templateId"), parms.readInt("regexId"));
 			return null;
@@ -287,7 +287,7 @@ public enum NotificationManagerMethod implements ManagerMethod {
 	createPerunNotifTemplateMessage {
 		@Override
 		public PerunNotifTemplateMessage call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			return ac.getNotificationManager().createPerunNotifTemplateMessage(ac.getSession(), parms.read("message", PerunNotifTemplateMessage.class));
 		}
@@ -302,7 +302,7 @@ public enum NotificationManagerMethod implements ManagerMethod {
 	updatePerunNotifTemplateMessage {
 		@Override
 		public PerunNotifTemplateMessage call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 			if (parms.contains("message")) {
 				return ac.getNotificationManager().updatePerunNotifTemplateMessage(ac.getSession(), parms.read("message", PerunNotifTemplateMessage.class));
 			} else {
@@ -319,7 +319,7 @@ public enum NotificationManagerMethod implements ManagerMethod {
 	removePerunNotifTemplateMessage {
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			ac.getNotificationManager().removePerunNotifTemplateMessage(ac.getSession(), parms.readInt("id"));
 			return null;
@@ -365,7 +365,7 @@ public enum NotificationManagerMethod implements ManagerMethod {
 	createPerunNotifTemplate {
 		@Override
 		public PerunNotifTemplate call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			return ac.getNotificationManager().createPerunNotifTemplate(ac.getSession(), parms.read("template", PerunNotifTemplate.class));
 		}
@@ -381,7 +381,7 @@ public enum NotificationManagerMethod implements ManagerMethod {
 	updatePerunNotifTemplate {
 		@Override
 		public PerunNotifTemplate call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 			if (parms.contains("template")) {
 				return ac.getNotificationManager().updatePerunNotifTemplate(ac.getSession(), parms.read("template", PerunNotifTemplate.class));
 			} else {
@@ -398,7 +398,7 @@ public enum NotificationManagerMethod implements ManagerMethod {
 	removePerunNotifTemplateById {
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			ac.getNotificationManager().removePerunNotifTemplateById(ac.getSession(), parms.readInt("id"));
 			return null;

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/OwnersManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/OwnersManagerMethod.java
@@ -35,7 +35,7 @@ public enum OwnersManagerMethod implements ManagerMethod {
 	createOwner {
 		@Override
 		public Owner call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			if (parms.contains("owner")) {
 				return ac.getOwnersManager().createOwner(ac.getSession(),
@@ -61,7 +61,7 @@ public enum OwnersManagerMethod implements ManagerMethod {
 	deleteOwner {
 		@Override
 		public Owner call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			ac.getOwnersManager().deleteOwner(ac.getSession(),
 					ac.getOwnerById(parms.readInt("owner")));

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/RegistrarManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/RegistrarManagerMethod.java
@@ -100,7 +100,7 @@ public enum RegistrarManagerMethod implements ManagerMethod {
 
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			if (parms.contains("userId")) {
 				if (parms.contains("groupId")) {
@@ -156,7 +156,7 @@ public enum RegistrarManagerMethod implements ManagerMethod {
 
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			if (parms.readString("mailType").equals("APP_REJECTED_USER")) {
 
@@ -317,7 +317,7 @@ public enum RegistrarManagerMethod implements ManagerMethod {
 
 		@Override
 		public Integer call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			if (parms.contains("vo")) {
 				return ac.getRegistrarManager().updateFormItems(ac.getSession(),
@@ -346,7 +346,7 @@ public enum RegistrarManagerMethod implements ManagerMethod {
 
 		@Override
 		public Object call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			ApplicationForm form = parms.read("form", ApplicationForm.class);
 			int result = ac.getRegistrarManager().updateForm(ac.getSession(), form);
@@ -375,7 +375,7 @@ public enum RegistrarManagerMethod implements ManagerMethod {
 
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			ApplicationFormItem item = parms.read("formItem", ApplicationFormItem.class);
 			if (parms.contains("locale")) {
@@ -590,7 +590,7 @@ public enum RegistrarManagerMethod implements ManagerMethod {
 
 		@Override
 		public List<ApplicationFormItemData> call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			Application app = parms.read("app", Application.class);
 			List<ApplicationFormItemData> data = parms.readList("data", ApplicationFormItemData.class);
@@ -610,7 +610,7 @@ public enum RegistrarManagerMethod implements ManagerMethod {
 
 		@Override
 		public Object call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			Application app = ac.getRegistrarManager().getApplicationById(ac.getSession(), parms.readInt("id"));
 			ac.getRegistrarManager().deleteApplication(ac.getSession(), app);
@@ -631,7 +631,7 @@ public enum RegistrarManagerMethod implements ManagerMethod {
 
 		@Override
 		public Application call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			return ac.getRegistrarManager().approveApplication(ac.getSession(), parms.readInt("id"));
 
@@ -676,7 +676,7 @@ public enum RegistrarManagerMethod implements ManagerMethod {
 
 		@Override
 		public Application call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			if (parms.contains("reason")) {
 				return ac.getRegistrarManager().rejectApplication(ac.getSession(), parms.readInt("id"), parms.readString("reason"));
@@ -699,7 +699,7 @@ public enum RegistrarManagerMethod implements ManagerMethod {
 
 		@Override
 		public Application call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			return ac.getRegistrarManager().verifyApplication(ac.getSession(), parms.readInt("id"));
 
@@ -752,7 +752,7 @@ public enum RegistrarManagerMethod implements ManagerMethod {
 
 		@Override
 		public ApplicationFormItem call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			if (parms.contains("vo")) {
 				return ac.getRegistrarManager().addFormItem(ac.getSession(),
@@ -792,7 +792,7 @@ public enum RegistrarManagerMethod implements ManagerMethod {
 
 		@Override
 		public Object call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			if (parms.contains("vo")) {
 				ac.getRegistrarManager().deleteFormItem(ac.getSession(),
@@ -844,7 +844,7 @@ public enum RegistrarManagerMethod implements ManagerMethod {
 
 		@Override
 		public Object call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			if (parms.contains("fromVo")) {
 
@@ -918,7 +918,7 @@ public enum RegistrarManagerMethod implements ManagerMethod {
 
 		@Override
 		public Object call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			if (parms.contains("fromVo")) {
 
@@ -1009,7 +1009,7 @@ public enum RegistrarManagerMethod implements ManagerMethod {
 
 		@Override
 		public Integer call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			if (parms.contains("vo")) {
 				return ac.getRegistrarManager().getMailManager().addMail(ac.getSession(),
@@ -1045,7 +1045,7 @@ public enum RegistrarManagerMethod implements ManagerMethod {
 
 		@Override
 		public Object call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			if (parms.contains("vo")) {
 				ac.getRegistrarManager().getMailManager().deleteMailById(ac.getSession(),
@@ -1074,7 +1074,7 @@ public enum RegistrarManagerMethod implements ManagerMethod {
 
 		@Override
 		public Object call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 			ac.getRegistrarManager().getMailManager().updateMailById(ac.getSession(), parms.read("mail", ApplicationMail.class));
 			return null;
 		}
@@ -1107,7 +1107,7 @@ public enum RegistrarManagerMethod implements ManagerMethod {
 
 		@Override
 		public Object call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			ac.getRegistrarManager().getMailManager().setSendingEnabled(ac.getSession(),
 					parms.readList("mails", ApplicationMail.class),
@@ -1261,7 +1261,7 @@ public enum RegistrarManagerMethod implements ManagerMethod {
 
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 			ac.getRegistrarManager().updateFormItemData(ac.getSession(), parms.readInt("appId"), parms.read("data", ApplicationFormItemData.class));
 			return null;
 		}

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/ResourcesManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/ResourcesManagerMethod.java
@@ -89,7 +89,7 @@ public enum ResourcesManagerMethod implements ManagerMethod {
 
 		@Override
 		public Resource call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			if (parms.contains("resource")) {
 				return ac.getResourcesManager().createResource(ac.getSession(),
@@ -125,7 +125,7 @@ public enum ResourcesManagerMethod implements ManagerMethod {
 	copyResource {
 		@Override
 		public Resource call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			return ac.getResourcesManager().copyResource(ac.getSession(),
 					parms.read("templateResource", Resource.class),
@@ -144,7 +144,7 @@ public enum ResourcesManagerMethod implements ManagerMethod {
 
 		@Override
 		public Resource call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			return ac.getResourcesManager().updateResource(ac.getSession(),
 					parms.read("resource", Resource.class));
@@ -160,7 +160,7 @@ public enum ResourcesManagerMethod implements ManagerMethod {
 
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			ac.getResourcesManager().deleteResource(ac.getSession(),
 					ac.getResourceById(parms.readInt("resource")));
@@ -238,7 +238,7 @@ public enum ResourcesManagerMethod implements ManagerMethod {
 
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			ac.getResourcesManager().assignGroupToResource(ac.getSession(),
 					ac.getGroupById(parms.readInt("group")),
@@ -257,7 +257,7 @@ public enum ResourcesManagerMethod implements ManagerMethod {
 
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			List<Integer> ids = parms.readList("groups", Integer.class);
 			List<Group> groups = new ArrayList<Group>();
@@ -281,7 +281,7 @@ public enum ResourcesManagerMethod implements ManagerMethod {
 
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			List<Integer> ids = parms.readList("resources", Integer.class);
 			List<Resource> resources = new ArrayList<Resource>();
@@ -306,7 +306,7 @@ public enum ResourcesManagerMethod implements ManagerMethod {
 
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			ac.getResourcesManager().removeGroupFromResource(ac.getSession(),
 					ac.getGroupById(parms.readInt("group")),
@@ -326,7 +326,7 @@ public enum ResourcesManagerMethod implements ManagerMethod {
 
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			List<Integer> ids = parms.readList("groups", Integer.class);
 			List<Group> groups = new ArrayList<Group>();
@@ -351,7 +351,7 @@ public enum ResourcesManagerMethod implements ManagerMethod {
 
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			List<Integer> ids = parms.readList("resources", Integer.class);
 			List<Resource> resources = new ArrayList<Resource>();
@@ -504,7 +504,7 @@ public enum ResourcesManagerMethod implements ManagerMethod {
 	addAdmin {
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 			if (parms.contains("user")) {
 				ac.getResourcesManager().addAdmin(ac.getSession(),
 						ac.getResourceById(parms.readInt("resource")),
@@ -533,7 +533,7 @@ public enum ResourcesManagerMethod implements ManagerMethod {
 	removeAdmin {
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 			if (parms.contains("user")) {
 				ac.getResourcesManager().removeAdmin(ac.getSession(),
 						ac.getResourceById(parms.readInt("resource")),
@@ -678,7 +678,7 @@ public enum ResourcesManagerMethod implements ManagerMethod {
 
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			ac.getResourcesManager().assignService(ac.getSession(),
 					ac.getResourceById(parms.readInt("resource")),
@@ -697,7 +697,7 @@ public enum ResourcesManagerMethod implements ManagerMethod {
 
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			ac.getResourcesManager().assignServicesPackage(ac.getSession(),
 					ac.getResourceById(parms.readInt("resource")),
@@ -716,7 +716,7 @@ public enum ResourcesManagerMethod implements ManagerMethod {
 
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			ac.getResourcesManager().removeService(ac.getSession(),
 					ac.getResourceById(parms.readInt("resource")),
@@ -735,7 +735,7 @@ public enum ResourcesManagerMethod implements ManagerMethod {
 
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			ac.getResourcesManager().removeServicesPackage(ac.getSession(),
 					ac.getResourceById(parms.readInt("resource")),
@@ -803,7 +803,7 @@ public enum ResourcesManagerMethod implements ManagerMethod {
 
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			ac.getResourcesManager().deleteAllResources(ac.getSession(),
 					ac.getVoById(parms.readInt("vo")));
@@ -1020,7 +1020,7 @@ public enum ResourcesManagerMethod implements ManagerMethod {
 
 		@Override
 		public BanOnResource call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			return ac.getResourcesManager().setBan(ac.getSession(),
 					parms.read("banOnResource", BanOnResource.class));
@@ -1107,7 +1107,7 @@ public enum ResourcesManagerMethod implements ManagerMethod {
 
 		@Override
 		public BanOnResource call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			return ac.getResourcesManager().updateBan(ac.getSession(),
 					parms.read("banOnResource", BanOnResource.class));
@@ -1130,7 +1130,7 @@ public enum ResourcesManagerMethod implements ManagerMethod {
 
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			if(parms.contains("banId")) {
 				ac.getResourcesManager().removeBan(ac.getSession(),
@@ -1152,7 +1152,7 @@ public enum ResourcesManagerMethod implements ManagerMethod {
 	addResourceSelfServiceUser {
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			ac.getResourcesManager().addResourceSelfServiceUser(ac.getSession(),
 				ac.getResourceById(parms.readInt("resourceId")), ac.getUserById(parms.readInt("userId")));
@@ -1170,7 +1170,7 @@ public enum ResourcesManagerMethod implements ManagerMethod {
 	addResourceSelfServiceGroup {
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			ac.getResourcesManager().addResourceSelfServiceGroup(ac.getSession(),
 				ac.getResourceById(parms.readInt("resourceId")), ac.getGroupById(parms.readInt("groupId")));
@@ -1188,7 +1188,7 @@ public enum ResourcesManagerMethod implements ManagerMethod {
 	removeResourceSelfServiceUser {
 		@Override
 		public Object call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			ac.getResourcesManager().removeResourceSelfServiceUser(ac.getSession(),
 				ac.getResourceById(parms.readInt("resourceId")), ac.getUserById(parms.readInt("userId")));
@@ -1206,7 +1206,7 @@ public enum ResourcesManagerMethod implements ManagerMethod {
 	removeResourceSelfServiceGroup {
 		@Override
 		public Object call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			ac.getResourcesManager().removeResourceSelfServiceGroup(ac.getSession(),
 				ac.getResourceById(parms.readInt("resourceId")), ac.getGroupById(parms.readInt("groupId")));

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/SearcherMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/SearcherMethod.java
@@ -32,7 +32,7 @@ public enum SearcherMethod implements ManagerMethod {
 
 		@Override
 		public List<User> call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			return ac.getSearcher().getUsers(ac.getSession(),
 					parms.read("attributesWithSearchingValues", LinkedHashMap.class));
@@ -61,7 +61,7 @@ public enum SearcherMethod implements ManagerMethod {
 
 		@Override
 		public List<Member> call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			return ac.getSearcher().getMembersByUserAttributes(ac.getSession(),
 					ac.getVoById(parms.readInt("vo")),
@@ -85,7 +85,7 @@ public enum SearcherMethod implements ManagerMethod {
 	getFacilities {
 		@Override
 		public List<Facility> call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			return ac.getSearcher().getFacilities(ac.getSession(),
 					parms.read("attributesWithSearchingValues", LinkedHashMap.class));
@@ -122,7 +122,7 @@ public enum SearcherMethod implements ManagerMethod {
 	getResources {
 		@Override
 		public List<Resource> call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			if (parms.contains("allowPartialMatchForString")) {
 				return ac.getSearcher().getResources(ac.getSession(),

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/SecurityTeamsManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/SecurityTeamsManagerMethod.java
@@ -62,7 +62,7 @@ public enum SecurityTeamsManagerMethod implements ManagerMethod {
 	createSecurityTeam {
 		@Override
 		public SecurityTeam call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			if (parms.contains("securityTeam")) {
 				return ac.getSecurityTeamsManager().createSecurityTeam(ac.getSession(), parms.read("securityTeam", SecurityTeam.class));
@@ -89,7 +89,7 @@ public enum SecurityTeamsManagerMethod implements ManagerMethod {
 	updateSecurityTeam {
 		@Override
 		public SecurityTeam call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			return ac.getSecurityTeamsManager().updateSecurityTeam(ac.getSession(), parms.read("securityTeam", SecurityTeam.class));
 		}
@@ -111,7 +111,7 @@ public enum SecurityTeamsManagerMethod implements ManagerMethod {
 	deleteSecurityTeam {
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			if (parms.contains("force")) {
 				ac.getSecurityTeamsManager().deleteSecurityTeam(ac.getSession(), ac.getSecurityTeamById(parms.readInt("securityTeam")), parms.readBoolean("force"));
@@ -193,7 +193,7 @@ public enum SecurityTeamsManagerMethod implements ManagerMethod {
 	addAdmin {
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			if (parms.contains("group")) {
 				ac.getSecurityTeamsManager().addAdmin(ac.getSession(), ac.getSecurityTeamById(parms.readInt("securityTeam")),
@@ -221,7 +221,7 @@ public enum SecurityTeamsManagerMethod implements ManagerMethod {
 	removeAdmin {
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			if (parms.contains("group")) {
 				ac.getSecurityTeamsManager().removeAdmin(ac.getSession(), ac.getSecurityTeamById(parms.readInt("securityTeam")),
@@ -243,7 +243,7 @@ public enum SecurityTeamsManagerMethod implements ManagerMethod {
 	addUserToBlacklist {
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			ac.getSecurityTeamsManager().addUserToBlacklist(ac.getSession(), ac.getSecurityTeamById(parms.readInt("securityTeam")),
 					ac.getUserById(parms.readInt("user")),
@@ -261,7 +261,7 @@ public enum SecurityTeamsManagerMethod implements ManagerMethod {
 	removeUserFromBlacklist {
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			ac.getSecurityTeamsManager().removeUserFromBlacklist(ac.getSession(), ac.getSecurityTeamById(parms.readInt("securityTeam")),
 					ac.getUserById(parms.readInt("user")));

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/ServicesManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/ServicesManagerMethod.java
@@ -338,7 +338,7 @@ public enum ServicesManagerMethod implements ManagerMethod {
 
 		@Override
 		public Service call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			if (parms.contains("service")) {
 				return ac.getServicesManager().createService(ac.getSession(),
@@ -364,7 +364,7 @@ public enum ServicesManagerMethod implements ManagerMethod {
 
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			ac.getServicesManager().deleteService(ac.getSession(),
 					ac.getServiceById(parms.readInt("service")));
@@ -381,7 +381,7 @@ public enum ServicesManagerMethod implements ManagerMethod {
 
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			ac.getServicesManager().updateService(ac.getSession(),
 					parms.read("service", Service.class));
@@ -1002,7 +1002,7 @@ public enum ServicesManagerMethod implements ManagerMethod {
 
 		@Override
 		public ServicesPackage call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			if (parms.contains("servicesPackage")) {
 				return ac.getServicesManager().createServicesPackage(ac.getSession(),
@@ -1027,7 +1027,7 @@ public enum ServicesManagerMethod implements ManagerMethod {
 
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			ac.getServicesManager().deleteServicesPackage(ac.getSession(),
 					ac.getServicesPackageById(parms.readInt("servicesPackage")));
@@ -1044,7 +1044,7 @@ public enum ServicesManagerMethod implements ManagerMethod {
 
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			ac.getServicesManager().updateServicesPackage(ac.getSession(),
 					parms.read("servicesPackage", ServicesPackage.class));
@@ -1062,7 +1062,7 @@ public enum ServicesManagerMethod implements ManagerMethod {
 
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			ac.getServicesManager().addServiceToServicesPackage(ac.getSession(),
 					ac.getServicesPackageById(parms.readInt("servicesPackage")),
@@ -1081,7 +1081,7 @@ public enum ServicesManagerMethod implements ManagerMethod {
 
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			ac.getServicesManager().removeServiceFromServicesPackage(ac.getSession(),
 					ac.getServicesPackageById(parms.readInt("servicesPackage")),
@@ -1116,7 +1116,7 @@ public enum ServicesManagerMethod implements ManagerMethod {
 
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			ac.getServicesManager().addRequiredAttribute(ac.getSession(),
 					ac.getServiceById(parms.readInt("service")),
@@ -1135,7 +1135,7 @@ public enum ServicesManagerMethod implements ManagerMethod {
 
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			int[] ids = parms.readArrayOfInts("attributes");
 			List<AttributeDefinition> attributes = new ArrayList<AttributeDefinition>(ids.length);
@@ -1161,7 +1161,7 @@ public enum ServicesManagerMethod implements ManagerMethod {
 
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			ac.getServicesManager().removeRequiredAttribute(ac.getSession(),
 					ac.getServiceById(parms.readInt("service")),
@@ -1180,7 +1180,7 @@ public enum ServicesManagerMethod implements ManagerMethod {
 
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			int[] ids = parms.readArrayOfInts("attributes");
 			List<AttributeDefinition> attributes = new ArrayList<AttributeDefinition>(ids.length);
@@ -1205,7 +1205,7 @@ public enum ServicesManagerMethod implements ManagerMethod {
 
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			ac.getServicesManager().removeAllRequiredAttributes(ac.getSession(),
 					ac.getServiceById(parms.readInt("service")));
@@ -1335,7 +1335,7 @@ public enum ServicesManagerMethod implements ManagerMethod {
 
 		@Override
 		public Destination call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			Destination destination;
 
@@ -1382,7 +1382,7 @@ public enum ServicesManagerMethod implements ManagerMethod {
 
 		@Override
 		public List<Destination> call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			Destination destination;
 
@@ -1426,7 +1426,7 @@ public enum ServicesManagerMethod implements ManagerMethod {
 
 		@Override
 		public List<Destination> call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			if(parms.contains("service")) {
 				return ac.getServicesManager().addDestinationsDefinedByHostsOnFacility(ac.getSession(),
@@ -1456,7 +1456,7 @@ public enum ServicesManagerMethod implements ManagerMethod {
 
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			ac.getServicesManager().removeDestination(ac.getSession(),
 					ac.getServiceById(parms.readInt("service")),
@@ -1477,7 +1477,7 @@ public enum ServicesManagerMethod implements ManagerMethod {
 
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			ac.getServicesManager().removeAllDestinations(ac.getSession(),
 					ac.getServiceById(parms.readInt("service")),

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/UsersManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/UsersManagerMethod.java
@@ -127,7 +127,7 @@ public enum UsersManagerMethod implements ManagerMethod {
 
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 			ac.getUsersManager().addSpecificUserOwner(ac.getSession(),
 					ac.getUserById(parms.readInt("user")),
 					ac.getUserById(parms.readInt("specificUser")));
@@ -146,7 +146,7 @@ public enum UsersManagerMethod implements ManagerMethod {
 
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 			ac.getUsersManager().removeSpecificUserOwner(ac.getSession(),
 					ac.getUserById(parms.readInt("user")),
 					ac.getUserById(parms.readInt("specificUser")));
@@ -167,7 +167,7 @@ public enum UsersManagerMethod implements ManagerMethod {
 
 		@Override
 		public User call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 			User owner = ac.getUserById(parms.readInt("owner"));
 			User specificUser = ac.getUserById(parms.readInt("specificUser"));
 			SpecificUserType specificUserType = SpecificUserType.valueOf(parms.readString("specificUserType"));
@@ -187,7 +187,7 @@ public enum UsersManagerMethod implements ManagerMethod {
 
 		@Override
 		public User call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 			User specificUser = ac.getUserById(parms.readInt("specificUser"));
 			SpecificUserType specificUserType = SpecificUserType.valueOf(parms.readString("specificUserType"));
 
@@ -265,7 +265,7 @@ public enum UsersManagerMethod implements ManagerMethod {
 
 		@Override
 		public List<RichUser> call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			return ac.getUsersManager().getRichUsersFromListOfUsers(ac.getSession(),
 					parms.readList("users", User.class));
@@ -282,7 +282,7 @@ public enum UsersManagerMethod implements ManagerMethod {
 
 		@Override
 		public List<RichUser> call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			return ac.getUsersManager().getRichUsersWithAttributesFromListOfUsers(ac.getSession(),
 					parms.readList("users", User.class));
@@ -413,7 +413,7 @@ public enum UsersManagerMethod implements ManagerMethod {
 
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			if (parms.contains("force") && parms.readBoolean("force")) {
 				ac.getUsersManager().deleteUser(ac.getSession(),
@@ -436,7 +436,7 @@ public enum UsersManagerMethod implements ManagerMethod {
 
 		@Override
 		public User call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			return ac.getUsersManager().updateUser(ac.getSession(),
 					parms.read("user", User.class));
@@ -457,7 +457,7 @@ public enum UsersManagerMethod implements ManagerMethod {
 
 		@Override
 		public User call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			return ac.getUsersManager().updateNameTitles(ac.getSession(),
 					parms.read("user", User.class));
@@ -474,7 +474,7 @@ public enum UsersManagerMethod implements ManagerMethod {
 
 		@Override
 		public UserExtSource call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			return ac.getUsersManager().updateUserExtSource(ac.getSession(),
 					parms.read("userExtSource", UserExtSource.class));
@@ -535,7 +535,7 @@ public enum UsersManagerMethod implements ManagerMethod {
 
 		@Override
 		public UserExtSource call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			return ac.getUsersManager().addUserExtSource(ac.getSession(),
 					ac.getUserById(parms.readInt("user")),
@@ -554,7 +554,7 @@ public enum UsersManagerMethod implements ManagerMethod {
 
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			if (parms.contains("force") && parms.readBoolean("force")) {
 				ac.getUsersManager().removeUserExtSource(ac.getSession(),
@@ -580,7 +580,7 @@ public enum UsersManagerMethod implements ManagerMethod {
 
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			ac.getUsersManager().moveUserExtSource(ac.getSession(),
 					ac.getUserById(parms.readInt("sourceUser")),
@@ -964,7 +964,7 @@ public enum UsersManagerMethod implements ManagerMethod {
 	changePassword {
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			if (parms.contains("login")) {
 				String login = parms.readString("login");
@@ -995,7 +995,7 @@ public enum UsersManagerMethod implements ManagerMethod {
 	changeNonAuthzPassword {
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			ac.getUsersManager().changeNonAuthzPassword(ac.getSession(), parms.readString("i"), parms.readString("m"), parms.readString("password"), (parms.contains("lang") ? parms.readString("lang") : null));
 
@@ -1012,7 +1012,7 @@ public enum UsersManagerMethod implements ManagerMethod {
 	reserveRandomPassword {
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			ac.getUsersManager().reserveRandomPassword(ac.getSession(), ac.getUserById(parms.readInt("user")), parms.readString("namespace"));
 
@@ -1037,7 +1037,7 @@ public enum UsersManagerMethod implements ManagerMethod {
 	reservePassword {
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			if (parms.contains("user")) {
 				ac.getUsersManager().reservePassword(ac.getSession(), ac.getUserById(parms.readInt("user")), parms.readString("namespace"), parms.readString("password"));
@@ -1066,7 +1066,7 @@ public enum UsersManagerMethod implements ManagerMethod {
 	validatePassword {
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			if (parms.contains("user")) {
 				ac.getUsersManager().validatePassword(ac.getSession(), ac.getUserById(parms.readInt("user")), parms.readString("namespace"));
@@ -1090,7 +1090,7 @@ public enum UsersManagerMethod implements ManagerMethod {
 	validatePasswordAndSetExtSources {
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			ac.getUsersManager().validatePasswordAndSetExtSources(ac.getSession(), ac.getUserById(parms.readInt("user")), parms.readString("login"), parms.readString("namespace"));
 
@@ -1109,7 +1109,7 @@ public enum UsersManagerMethod implements ManagerMethod {
 	setLogin {
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			ac.getUsersManager().setLogin(ac.getSession(), ac.getUserById(parms.readInt("user")), parms.readString("namespace"), parms.readString("login"));
 
@@ -1132,7 +1132,7 @@ public enum UsersManagerMethod implements ManagerMethod {
 	requestPreferredEmailChange {
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			String referer = parms.getServletRequest().getHeader("Referer");
 			if (referer == null || referer.isEmpty()) {
@@ -1260,7 +1260,7 @@ public enum UsersManagerMethod implements ManagerMethod {
 
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 			ac.getUsersManager().updateUserExtSourceLastAccess(ac.getSession(),
 					ac.getUserExtSourceById(parms.readInt("userExtSource")));
 
@@ -1288,7 +1288,7 @@ public enum UsersManagerMethod implements ManagerMethod {
 
 		@Override
 		public Map<String, String> call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 			return ac.getUsersManager().generateAccount(ac.getSession(),
 					parms.readString("namespace"),
 					parms.read("parameters", HashMap.class));
@@ -1309,7 +1309,7 @@ public enum UsersManagerMethod implements ManagerMethod {
 	changePasswordRandom {
 		@Override
 		public Object call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			return ac.getUsersManager().changePasswordRandom(ac.getSession(),
 				ac.getUserById(parms.readInt("userId")),

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/VosManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/VosManagerMethod.java
@@ -54,7 +54,7 @@ public enum VosManagerMethod implements ManagerMethod {
 	deleteVo {
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			if (parms.contains("force")) {
 				ac.getVosManager().deleteVo(ac.getSession(), ac.getVoById(parms.readInt("vo")), parms.readBoolean("force"));
@@ -92,7 +92,7 @@ public enum VosManagerMethod implements ManagerMethod {
 	createVo {
 		@Override
 		public Vo call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			if (parms.contains("vo")) {
 				return ac.getVosManager().createVo(ac.getSession(), parms.read("vo", Vo.class));
@@ -118,7 +118,7 @@ public enum VosManagerMethod implements ManagerMethod {
 	updateVo {
 		@Override
 		public Vo call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 
 			return ac.getVosManager().updateVo(ac.getSession(), parms.read("vo", Vo.class));
 		}
@@ -281,7 +281,7 @@ public enum VosManagerMethod implements ManagerMethod {
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms)
 				throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 			if (parms.contains("user")) {
 				ac.getVosManager().addAdmin(ac.getSession(),
 						ac.getVoById(parms.readInt("vo")),
@@ -317,7 +317,7 @@ public enum VosManagerMethod implements ManagerMethod {
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms)
 				throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 			Vo vo = ac.getVoById(parms.readInt("vo"));
 			if (parms.contains("user")) {
 				ac.getVosManager().addSponsorRole(ac.getSession(), vo, ac.getUserById(parms.readInt("user")));
@@ -352,7 +352,7 @@ public enum VosManagerMethod implements ManagerMethod {
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms)
 				throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 			if (parms.contains("user")) {
 				ac.getVosManager().removeAdmin(ac.getSession(),
 						ac.getVoById(parms.readInt("vo")),
@@ -389,7 +389,7 @@ public enum VosManagerMethod implements ManagerMethod {
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms)
 				throws PerunException {
-			ac.stateChangingCheck();
+			parms.stateChangingCheck();
 			if (parms.contains("user")) {
 				ac.getVosManager().removeSponsorRole(ac.getSession(),
 						ac.getVoById(parms.readInt("vo")),


### PR DESCRIPTION
- check whether method is GET, POST, or PUT moved to Deserializer and it no longer uses shared attribute but checks the called method
- attributed stateChanging removed from ApiCaller and its usage from Api