### PR TITLE
CORE,GUI: Login / password checks for einfra

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/InvalidLoginException.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/InvalidLoginException.java
@@ -1,0 +1,40 @@
+package cz.metacentrum.perun.core.api.exceptions;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * This exception is thrown when the login fails syntax check enforced by its namespace
+ *
+ * @author Pavel Zlámal <zlamal@cesnet.cz>
+ */
+public class InvalidLoginException extends PerunException {
+
+	static final long serialVersionUID = 0;
+
+	/**
+	 * Simple constructor with a message
+	 * @param message message with details about the cause
+	 */
+	public InvalidLoginException(String message) {
+		super(message);
+	}
+
+	/**
+	 * Constructor with a message and Throwable object
+	 * @param message message with details about the cause
+	 * @param cause Throwable that caused throwing of this exception
+	 */
+	public InvalidLoginException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	/**
+	 * Constructor with a Throwable object
+	 * @param cause Throwable that caused throwing of this exception
+	 */
+	public InvalidLoginException(Throwable cause) {
+		super(cause);
+	}
+
+}

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/PasswordStrengthException.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/PasswordStrengthException.java
@@ -1,0 +1,40 @@
+package cz.metacentrum.perun.core.api.exceptions;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * This exception is thrown when password fails strength check required by the namespace
+ *
+ * @author Pavel Zlámal <zlamal@cesnet.cz>
+ */
+public class PasswordStrengthException extends PerunException {
+
+	static final long serialVersionUID = 0;
+
+	/**
+	 * Simple constructor with a message
+	 * @param message message with details about the cause
+	 */
+	public PasswordStrengthException(String message) {
+		super(message);
+	}
+
+	/**
+	 * Constructor with a message and Throwable object
+	 * @param message message with details about the cause
+	 * @param cause Throwable that caused throwing of this exception
+	 */
+	public PasswordStrengthException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	/**
+	 * Constructor with a Throwable object
+	 * @param cause Throwable that caused throwing of this exception
+	 */
+	public PasswordStrengthException(Throwable cause) {
+		super(cause);
+	}
+
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/MembersManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/MembersManager.java
@@ -9,6 +9,7 @@ import cz.metacentrum.perun.core.api.exceptions.ExtendMembershipException;
 import cz.metacentrum.perun.core.api.exceptions.GroupNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.GroupResourceMismatchException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.InvalidLoginException;
 import cz.metacentrum.perun.core.api.exceptions.LoginNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.MemberAlreadyRemovedException;
 import cz.metacentrum.perun.core.api.exceptions.MemberNotExistsException;
@@ -18,6 +19,7 @@ import cz.metacentrum.perun.core.api.exceptions.MemberNotValidYetException;
 import cz.metacentrum.perun.core.api.exceptions.ParentGroupNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.PasswordCreationFailedException;
 import cz.metacentrum.perun.core.api.exceptions.PasswordOperationTimeoutException;
+import cz.metacentrum.perun.core.api.exceptions.PasswordStrengthException;
 import cz.metacentrum.perun.core.api.exceptions.PasswordStrengthFailedException;
 import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
 import cz.metacentrum.perun.core.api.exceptions.ResourceNotExistsException;
@@ -247,7 +249,7 @@ public interface MembersManager {
 	 * @deprecated replaced by {@link #createSponsoredMember(PerunSession, Vo, String, String, String, User)}
 	 */
 	@Deprecated
-	Member createSponsoredAccount(PerunSession sess, Map<String, String> params, String namespace, ExtSource extSource, String extSourcePostfix, Vo vo, int loa) throws InternalErrorException, PrivilegeException, UserNotExistsException, ExtSourceNotExistsException, UserExtSourceNotExistsException, WrongReferenceAttributeValueException, LoginNotExistsException, PasswordCreationFailedException, ExtendMembershipException, AlreadyMemberException, PasswordStrengthFailedException, PasswordOperationTimeoutException, WrongAttributeValueException;
+	Member createSponsoredAccount(PerunSession sess, Map<String, String> params, String namespace, ExtSource extSource, String extSourcePostfix, Vo vo, int loa) throws InternalErrorException, PrivilegeException, UserNotExistsException, ExtSourceNotExistsException, UserExtSourceNotExistsException, WrongReferenceAttributeValueException, LoginNotExistsException, PasswordCreationFailedException, ExtendMembershipException, AlreadyMemberException, PasswordStrengthFailedException, PasswordOperationTimeoutException, WrongAttributeValueException, PasswordStrengthException, InvalidLoginException;
 
 	/**
 	 * Creates a new member from candidate returned by the method VosManager.findCandidates which fills Candidate.userExtSource.
@@ -1170,7 +1172,7 @@ public interface MembersManager {
 	 * @throws WrongReferenceAttributeValueException
 	 * @throws UserNotInRoleException
 	 */
-	RichMember createSponsoredMember(PerunSession session, Vo vo, String namespace, Map<String, String> name, String password, User sponsor) throws InternalErrorException, PrivilegeException, AlreadyMemberException, LoginNotExistsException, PasswordCreationFailedException, ExtendMembershipException, WrongAttributeValueException, ExtSourceNotExistsException, WrongReferenceAttributeValueException, UserNotInRoleException;
+	RichMember createSponsoredMember(PerunSession session, Vo vo, String namespace, Map<String, String> name, String password, User sponsor) throws InternalErrorException, PrivilegeException, AlreadyMemberException, LoginNotExistsException, PasswordCreationFailedException, ExtendMembershipException, WrongAttributeValueException, ExtSourceNotExistsException, WrongReferenceAttributeValueException, UserNotInRoleException, PasswordStrengthException, InvalidLoginException;
 
 	/**
 	 * Transform non-sponsored member to sponsored one with defined sponsor

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/UsersManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/UsersManager.java
@@ -4,6 +4,7 @@ import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ExtSourceNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.FacilityNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.InvalidLoginException;
 import cz.metacentrum.perun.core.api.exceptions.LoginExistsException;
 import cz.metacentrum.perun.core.api.exceptions.LoginNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.MemberAlreadyRemovedException;
@@ -14,6 +15,7 @@ import cz.metacentrum.perun.core.api.exceptions.PasswordCreationFailedException;
 import cz.metacentrum.perun.core.api.exceptions.PasswordDeletionFailedException;
 import cz.metacentrum.perun.core.api.exceptions.PasswordDoesntMatchException;
 import cz.metacentrum.perun.core.api.exceptions.PasswordOperationTimeoutException;
+import cz.metacentrum.perun.core.api.exceptions.PasswordStrengthException;
 import cz.metacentrum.perun.core.api.exceptions.PasswordStrengthFailedException;
 import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
 import cz.metacentrum.perun.core.api.exceptions.RelationExistsException;
@@ -673,15 +675,16 @@ public interface UsersManager {
 	List<User> findUsersByExactName(PerunSession sess, String searchString) throws InternalErrorException, PrivilegeException;
 
 	/**
-	 * Checks if the login is available in the namespace.
+	 * Checks if the login is available in the namespace. Returns FALSE is is already occupied,
+	 * throws exception if value is not allowed.
 	 *
 	 * @param sess
 	 * @param loginNamespace in which the login will be checked (provide only the name of the namespace, not the whole attribute name)
 	 * @param login to be checked
-	 * @return true if login available, false otherwise
-	 * @throws InternalErrorException
+	 * @return true if login is available, false otherwise
+	 * @throws InvalidLoginException When login to check has invalid syntax.
 	 */
-	boolean isLoginAvailable(PerunSession sess, String loginNamespace, String login) throws InternalErrorException;
+	boolean isLoginAvailable(PerunSession sess, String loginNamespace, String login) throws InvalidLoginException;
 
 
 	/**
@@ -771,7 +774,7 @@ public interface UsersManager {
 	 * @throws PasswordChangeFailedException
 	 */
 	void changePassword(PerunSession sess, String login, String loginNamespace, String oldPassword, String newPassword, boolean checkOldPassword)
-			throws InternalErrorException, PrivilegeException, LoginNotExistsException, PasswordDoesntMatchException, PasswordChangeFailedException, PasswordOperationTimeoutException, PasswordStrengthFailedException;
+			throws InternalErrorException, PrivilegeException, LoginNotExistsException, PasswordDoesntMatchException, PasswordChangeFailedException, PasswordOperationTimeoutException, PasswordStrengthFailedException, InvalidLoginException, PasswordStrengthException;
 
 	/**
 	 * Changes user password in defined login-namespace. If checkOldPassword is true, then ask authentication system if old password is correct.
@@ -790,7 +793,7 @@ public interface UsersManager {
 	 * @throws PasswordChangeFailedException
 	 */
 	void changePassword(PerunSession sess, User user, String loginNamespace, String oldPassword, String newPassword, boolean checkOldPassword)
-			throws InternalErrorException, PrivilegeException, UserNotExistsException, LoginNotExistsException, PasswordDoesntMatchException, PasswordChangeFailedException, PasswordOperationTimeoutException, PasswordStrengthFailedException;
+			throws InternalErrorException, PrivilegeException, UserNotExistsException, LoginNotExistsException, PasswordDoesntMatchException, PasswordChangeFailedException, PasswordOperationTimeoutException, PasswordStrengthFailedException, InvalidLoginException, PasswordStrengthException;
 
 
 	/**
@@ -807,7 +810,7 @@ public interface UsersManager {
 	 * @throws PasswordChangeFailedException
 	 */
 	void changeNonAuthzPassword(PerunSession sess, String i, String m, String password, String lang)
-			throws InternalErrorException, UserNotExistsException, LoginNotExistsException, PasswordChangeFailedException, PasswordOperationTimeoutException, PasswordStrengthFailedException;
+			throws InternalErrorException, UserNotExistsException, LoginNotExistsException, PasswordChangeFailedException, PasswordOperationTimeoutException, PasswordStrengthFailedException, InvalidLoginException, PasswordStrengthException;
 
 	/**
 	 * Reserves random password in external system. User must not exists.
@@ -820,7 +823,7 @@ public interface UsersManager {
 	 * @throws UserNotExistsException
 	 * @throws LoginNotExistsException
 	 */
-	void reserveRandomPassword(PerunSession sess, User user, String loginNamespace) throws InternalErrorException, PasswordCreationFailedException, PrivilegeException, UserNotExistsException, LoginNotExistsException, PasswordOperationTimeoutException, PasswordStrengthFailedException;
+	void reserveRandomPassword(PerunSession sess, User user, String loginNamespace) throws InternalErrorException, PasswordCreationFailedException, PrivilegeException, UserNotExistsException, LoginNotExistsException, PasswordOperationTimeoutException, PasswordStrengthFailedException, InvalidLoginException;
 
 	/**
 	 * Reserves the password in external system. User must not exists.
@@ -831,9 +834,10 @@ public interface UsersManager {
 	 * @param password
 	 * @throws InternalErrorException
 	 * @throws PasswordCreationFailedException
+	 * @throws InvalidLoginException
 	 */
 	void reservePassword(PerunSession sess, String userLogin, String loginNamespace, String password)
-			throws InternalErrorException, PasswordCreationFailedException, PrivilegeException, PasswordOperationTimeoutException, PasswordStrengthFailedException;
+			throws InternalErrorException, PasswordCreationFailedException, PrivilegeException, PasswordOperationTimeoutException, PasswordStrengthFailedException, InvalidLoginException, PasswordStrengthException;
 
 	/**
 	 * Reserves the password in external system. User must exists.
@@ -849,7 +853,7 @@ public interface UsersManager {
 	 * @throws PrivilegeException
 	 */
 	void reservePassword(PerunSession sess, User user, String loginNamespace, String password)
-			throws InternalErrorException, PasswordCreationFailedException, PrivilegeException, UserNotExistsException, LoginNotExistsException, PasswordOperationTimeoutException, PasswordStrengthFailedException;
+			throws InternalErrorException, PasswordCreationFailedException, PrivilegeException, UserNotExistsException, LoginNotExistsException, PasswordOperationTimeoutException, PasswordStrengthFailedException, InvalidLoginException, PasswordStrengthException;
 
 	/**
 	 * Validates the password in external system. User must not exists.
@@ -859,9 +863,10 @@ public interface UsersManager {
 	 * @param loginNamespace
 	 * @throws InternalErrorException
 	 * @throws PasswordCreationFailedException
+	 * @throws InvalidLoginException
 	 */
 	void validatePassword(PerunSession sess, String userLogin, String loginNamespace)
-		throws InternalErrorException, PasswordCreationFailedException, PrivilegeException;
+			throws InternalErrorException, PasswordCreationFailedException, PrivilegeException, InvalidLoginException;
 
 	/**
 	 * Validates the password in external system and set user extSources and extSource related attributes. User must exists.
@@ -878,8 +883,9 @@ public interface UsersManager {
 	 * @throws ExtSourceNotExistsException
 	 * @throws WrongAttributeValueException
 	 * @throws WrongReferenceAttributeValueException
+	 * @throws InvalidLoginException
 	 */
-	void validatePasswordAndSetExtSources(PerunSession sess, User user, String userLogin, String loginNamespace) throws InternalErrorException, PrivilegeException, PasswordCreationFailedException, LoginNotExistsException, ExtSourceNotExistsException, WrongAttributeValueException, WrongReferenceAttributeValueException;
+	void validatePasswordAndSetExtSources(PerunSession sess, User user, String userLogin, String loginNamespace) throws InternalErrorException, PrivilegeException, PasswordCreationFailedException, LoginNotExistsException, ExtSourceNotExistsException, InvalidLoginException, WrongReferenceAttributeValueException, WrongAttributeValueException;
 
 
 	/**
@@ -895,7 +901,7 @@ public interface UsersManager {
 	 * @throws PrivilegeException
 	 */
 	void validatePassword(PerunSession sess, User user, String loginNamespace)
-		throws InternalErrorException, PasswordCreationFailedException, PrivilegeException, UserNotExistsException, LoginNotExistsException;
+		throws InternalErrorException, PasswordCreationFailedException, PrivilegeException, UserNotExistsException, LoginNotExistsException, InvalidLoginException;
 
 	/**
 	 * Deletes password in external system. User must not exists.
@@ -906,9 +912,10 @@ public interface UsersManager {
 	 * @throws InternalErrorException
 	 * @throws PasswordDeletionFailedException
 	 * @throws LoginNotExistsException
+	 * @throws InvalidLoginException
 	 */
 	void deletePassword(PerunSession sess, String userLogin, String loginNamespace)
-			throws InternalErrorException, PasswordDeletionFailedException, PrivilegeException, LoginNotExistsException, PasswordOperationTimeoutException;
+			throws InternalErrorException, PasswordDeletionFailedException, PrivilegeException, LoginNotExistsException, PasswordOperationTimeoutException, InvalidLoginException;
 
 	/**
 	 * Creates alternative password in external system.
@@ -924,7 +931,7 @@ public interface UsersManager {
 	 * @throws LoginNotExistsException
 	 * @throws PrivilegeException
 	 */
-	void createAlternativePassword(PerunSession sess, User user, String description, String loginNamespace, String password) throws InternalErrorException, PasswordCreationFailedException, PrivilegeException, UserNotExistsException, LoginNotExistsException;
+	void createAlternativePassword(PerunSession sess, User user, String description, String loginNamespace, String password) throws InternalErrorException, PasswordCreationFailedException, PrivilegeException, UserNotExistsException, LoginNotExistsException, PasswordStrengthException;
 
 	/**
 	 * Deletes alternative password in external system.
@@ -1030,8 +1037,9 @@ public interface UsersManager {
 	 * @throws PrivilegeException
 	 * @throws UserNotExistsException
 	 * @throws LoginExistsException
+	 * @throws InvalidLoginException
 	 */
-	void setLogin(PerunSession sess, User user, String loginNamespace, String login) throws InternalErrorException, PrivilegeException, UserNotExistsException, LoginExistsException;
+	void setLogin(PerunSession sess, User user, String loginNamespace, String login) throws InternalErrorException, PrivilegeException, UserNotExistsException, LoginExistsException, InvalidLoginException;
 
 	/**
 	 * Request change of user's preferred email address.
@@ -1134,7 +1142,7 @@ public interface UsersManager {
 	 * @throws InternalErrorException
 	 * @throws PrivilegeException
 	 */
-	Map<String,String> generateAccount(PerunSession session, String namespace, Map<String, String> parameters) throws InternalErrorException, PrivilegeException;
+	Map<String,String> generateAccount(PerunSession session, String namespace, Map<String, String> parameters) throws InternalErrorException, PrivilegeException, PasswordStrengthException;
 
 	/**
 	 * Gets list of users that sponsor the member, with attributes.
@@ -1161,7 +1169,7 @@ public interface UsersManager {
 	 * @param loginNamespace login namespace
 	 * @return String representing HTML with data about new generated password
 	 */
-	String changePasswordRandom(PerunSession sess, User user, String loginNamespace) throws InternalErrorException, PrivilegeException, PasswordOperationTimeoutException, LoginNotExistsException, PasswordChangeFailedException;
+	String changePasswordRandom(PerunSession sess, User user, String loginNamespace) throws InternalErrorException, PrivilegeException, PasswordOperationTimeoutException, LoginNotExistsException, PasswordChangeFailedException, InvalidLoginException, PasswordStrengthException;
 
 	/**
 	 * Return all groups where user is active (has VALID status in VO and Group together)

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/MembersManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/MembersManagerBl.java
@@ -23,6 +23,7 @@ import cz.metacentrum.perun.core.api.exceptions.ExtSourceNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ExtendMembershipException;
 import cz.metacentrum.perun.core.api.exceptions.GroupResourceMismatchException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.InvalidLoginException;
 import cz.metacentrum.perun.core.api.exceptions.LoginNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.MemberAlreadyRemovedException;
 import cz.metacentrum.perun.core.api.exceptions.MemberNotExistsException;
@@ -32,6 +33,7 @@ import cz.metacentrum.perun.core.api.exceptions.MemberResourceMismatchException;
 import cz.metacentrum.perun.core.api.exceptions.ParentGroupNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.PasswordCreationFailedException;
 import cz.metacentrum.perun.core.api.exceptions.PasswordOperationTimeoutException;
+import cz.metacentrum.perun.core.api.exceptions.PasswordStrengthException;
 import cz.metacentrum.perun.core.api.exceptions.PasswordStrengthFailedException;
 import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
 import cz.metacentrum.perun.core.api.exceptions.UserExtSourceNotExistsException;
@@ -359,7 +361,7 @@ public interface MembersManagerBl {
 	 * @deprecated replaced by {@link #createSponsoredMember(PerunSession, Vo, String, String, String, User, boolean)}
 	 */
 	@Deprecated
-	Member createSponsoredAccount(PerunSession sess, Map<String, String> params, String namespace, ExtSource extSource, String extSourcePostfix, User owner, Vo vo, int loa) throws InternalErrorException, PasswordCreationFailedException, PasswordOperationTimeoutException, PasswordStrengthFailedException, ExtendMembershipException, AlreadyMemberException, WrongReferenceAttributeValueException, WrongAttributeValueException, UserNotExistsException, ExtSourceNotExistsException, LoginNotExistsException;
+	Member createSponsoredAccount(PerunSession sess, Map<String, String> params, String namespace, ExtSource extSource, String extSourcePostfix, User owner, Vo vo, int loa) throws InternalErrorException, PasswordCreationFailedException, PasswordOperationTimeoutException, PasswordStrengthFailedException, ExtendMembershipException, AlreadyMemberException, WrongReferenceAttributeValueException, WrongAttributeValueException, UserNotExistsException, ExtSourceNotExistsException, LoginNotExistsException, PasswordStrengthException, InvalidLoginException;
 
 	/**
 	 * Creates member. Runs synchronously.
@@ -1483,7 +1485,7 @@ public interface MembersManagerBl {
 	 * @throws WrongReferenceAttributeValueException
 	 * @throws UserNotInRoleException if the member is not in required role
 	 */
-	Member createSponsoredMember(PerunSession session, Vo vo, String namespace, Map<String, String> name, String password, User sponsor, boolean asyncValidation) throws InternalErrorException, AlreadyMemberException, LoginNotExistsException, PasswordCreationFailedException, ExtendMembershipException, WrongAttributeValueException, ExtSourceNotExistsException, WrongReferenceAttributeValueException, UserNotInRoleException;
+	Member createSponsoredMember(PerunSession session, Vo vo, String namespace, Map<String, String> name, String password, User sponsor, boolean asyncValidation) throws InternalErrorException, AlreadyMemberException, LoginNotExistsException, PasswordCreationFailedException, ExtendMembershipException, WrongAttributeValueException, ExtSourceNotExistsException, WrongReferenceAttributeValueException, UserNotInRoleException, PasswordStrengthException, InvalidLoginException;
 
 	/**
 	 * Links sponsored member and sponsoring user.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ModulesUtilsBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ModulesUtilsBl.java
@@ -243,7 +243,7 @@ public interface ModulesUtilsBl {
 	 * Regex for each namespace can be defined in /etc/perun/perun-namespaces.properties
 	 * You can define login exceptions, which override these syntactically wrong login names in the same file.
 	 * It is to support historically wrong values or specific exception within existing namespaces.
-	 * @see #isLoginException(String, String)
+	 * @see #isLoginExceptionallyAllowed(String, String)
 	 *
 	 * @param namespace Namespace to perform check in
 	 * @param login Login to check
@@ -262,13 +262,13 @@ public interface ModulesUtilsBl {
 	 * You can define login exceptions, which override these reserved login names in the same file.
 	 * This method returns TRUE for such exceptions.
 	 * It is to support historically wrong values or specific exception within existing namespaces.
-	 * @see #isLoginException(String, String)
+	 * @see #isLoginExceptionallyAllowed(String, String)
 	 *
 	 * @param namespace Namespace to perform check in
 	 * @param login Login to check
 	 * @return TRUE if login value is permitted within the namespace / FALSE otherwise
 	 */
-	boolean checkIfUserLoginIsPermitted(String namespace, String login);
+	boolean isUserLoginPermitted(String namespace, String login);
 
 	/**
 	 * Return true, if login value is "exception" within its namespace rules.
@@ -280,7 +280,7 @@ public interface ModulesUtilsBl {
 	 * @param login Login to check
 	 * @return TRUE if login value is within exceptions / FALSE otherwise
 	 */
-	boolean isLoginException(String namespace, String login);
+	boolean isLoginExceptionallyAllowed(String namespace, String login);
 
 	/**
 	 * Get value of attribute A_F_Def_unixGroupName-Namespace

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
@@ -21,6 +21,7 @@ import cz.metacentrum.perun.core.api.exceptions.AlreadyReservedLoginException;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ExtSourceNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.InvalidLoginException;
 import cz.metacentrum.perun.core.api.exceptions.LoginNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.MemberAlreadyRemovedException;
 import cz.metacentrum.perun.core.api.exceptions.PasswordChangeFailedException;
@@ -28,6 +29,7 @@ import cz.metacentrum.perun.core.api.exceptions.PasswordCreationFailedException;
 import cz.metacentrum.perun.core.api.exceptions.PasswordDeletionFailedException;
 import cz.metacentrum.perun.core.api.exceptions.PasswordDoesntMatchException;
 import cz.metacentrum.perun.core.api.exceptions.PasswordOperationTimeoutException;
+import cz.metacentrum.perun.core.api.exceptions.PasswordStrengthException;
 import cz.metacentrum.perun.core.api.exceptions.PasswordStrengthFailedException;
 import cz.metacentrum.perun.core.api.exceptions.RelationExistsException;
 import cz.metacentrum.perun.core.api.exceptions.RelationNotExistsException;
@@ -794,15 +796,16 @@ public interface UsersManagerBl {
 	List<User> findUsersByExactName(PerunSession sess, String searchString) throws InternalErrorException;
 
 	/**
-	 * Checks if the login is available in the namespace.
+	 * Checks if the login is available in the namespace. Returns FALSE is is already occupied,
+	 * throws exception if value is not allowed.
 	 *
 	 * @param sess
 	 * @param loginNamespace in which the login will be checked (provide only the name of the namespace, not the whole attribute name)
-	 * @param login          to be checked
-	 * @return true if login available, false otherwise
-	 * @throws InternalErrorException
+	 * @param login to be checked
+	 * @return true if login is available, false otherwise
+	 * @throws InvalidLoginException When login to check has invalid syntax or is not allowed.
 	 */
-	boolean isLoginAvailable(PerunSession sess, String loginNamespace, String login) throws InternalErrorException;
+	boolean isLoginAvailable(PerunSession sess, String loginNamespace, String login) throws InvalidLoginException;
 
 	/**
 	 * Batch method which returns users by theirs ids.
@@ -913,12 +916,14 @@ public interface UsersManagerBl {
 	 * @param checkOldPassword
 	 * @param loginNamespace
 	 * @throws InternalErrorException
-	 * @throws LoginNotExistsException
 	 * @throws PasswordDoesntMatchException
 	 * @throws PasswordChangeFailedException
+	 * @throws LoginNotExistsException When user doesn't have login in specified namespace
+	 * @throws InvalidLoginException When When login of user has invalid syntax (is not allowed)
+	 * @throws PasswordStrengthException When password doesn't match expected strength by namespace configuration
 	 */
 	void changePassword(PerunSession sess, User user, String loginNamespace, String oldPassword, String newPassword, boolean checkOldPassword)
-			throws InternalErrorException, LoginNotExistsException, PasswordDoesntMatchException, PasswordChangeFailedException, PasswordOperationTimeoutException, PasswordStrengthFailedException;
+			throws InternalErrorException, LoginNotExistsException, PasswordDoesntMatchException, PasswordChangeFailedException, PasswordOperationTimeoutException, PasswordStrengthFailedException, InvalidLoginException, PasswordStrengthException;
 
 	/**
 	 * Reserves random password in external system. User must exists.
@@ -928,9 +933,10 @@ public interface UsersManagerBl {
 	 * @param loginNamespace
 	 * @throws InternalErrorException
 	 * @throws PasswordCreationFailedException
-	 * @throws LoginNotExistsException
+	 * @throws LoginNotExistsException When user doesn't have login in specified namespace
+	 * @throws InvalidLoginException When When login of user has invalid syntax (is not allowed)
 	 */
-	void reserveRandomPassword(PerunSession sess, User user, String loginNamespace) throws InternalErrorException, PasswordCreationFailedException, LoginNotExistsException, PasswordOperationTimeoutException, PasswordStrengthFailedException;
+	void reserveRandomPassword(PerunSession sess, User user, String loginNamespace) throws InternalErrorException, PasswordCreationFailedException, LoginNotExistsException, PasswordOperationTimeoutException, PasswordStrengthFailedException, InvalidLoginException;
 
 	/**
 	 * Reserves the password in external system. User must not exists.
@@ -941,9 +947,11 @@ public interface UsersManagerBl {
 	 * @param password
 	 * @throws InternalErrorException
 	 * @throws PasswordCreationFailedException
+	 * @throws InvalidLoginException When When login of user has invalid syntax (is not allowed)
+	 * @throws PasswordStrengthException When password doesn't match expected strength by namespace configuration
 	 */
 	void reservePassword(PerunSession sess, String userLogin, String loginNamespace, String password)
-			throws InternalErrorException, PasswordCreationFailedException, PasswordOperationTimeoutException, PasswordStrengthFailedException;
+			throws InternalErrorException, PasswordCreationFailedException, PasswordOperationTimeoutException, PasswordStrengthFailedException, InvalidLoginException, PasswordStrengthException;
 
 	/**
 	 * Reserves the password in external system. User must exists.
@@ -954,10 +962,12 @@ public interface UsersManagerBl {
 	 * @param password
 	 * @throws InternalErrorException
 	 * @throws PasswordCreationFailedException
-	 * @throws LoginNotExistsException
+	 * @throws LoginNotExistsException When user doesn't have login in specified namespace
+	 * @throws InvalidLoginException When When login of user has invalid syntax (is not allowed)
+	 * @throws PasswordStrengthException When password doesn't match expected strength by namespace configuration
 	 */
 	void reservePassword(PerunSession sess, User user, String loginNamespace, String password)
-			throws InternalErrorException, PasswordCreationFailedException, LoginNotExistsException, PasswordOperationTimeoutException, PasswordStrengthFailedException;
+			throws InternalErrorException, PasswordCreationFailedException, LoginNotExistsException, PasswordOperationTimeoutException, PasswordStrengthFailedException, InvalidLoginException, PasswordStrengthException;
 
 	/**
 	 * Validates the password in external system. User must not exists.
@@ -967,9 +977,10 @@ public interface UsersManagerBl {
 	 * @param loginNamespace
 	 * @throws InternalErrorException
 	 * @throws PasswordCreationFailedException
+	 * @throws InvalidLoginException When When login of user has invalid syntax (is not allowed)
 	 */
 	void validatePassword(PerunSession sess, String userLogin, String loginNamespace)
-			throws InternalErrorException, PasswordCreationFailedException;
+			throws InternalErrorException, PasswordCreationFailedException, InvalidLoginException;
 
 	/**
 	 * Validates the password in external system. User must exists.
@@ -979,10 +990,11 @@ public interface UsersManagerBl {
 	 * @param loginNamespace
 	 * @throws InternalErrorException
 	 * @throws PasswordCreationFailedException
-	 * @throws LoginNotExistsException
+	 * @throws LoginNotExistsException When user doesn't have login in specified namespace
+	 * @throws InvalidLoginException When When login of user has invalid syntax (is not allowed)
 	 */
 	void validatePassword(PerunSession sess, User user, String loginNamespace)
-			throws InternalErrorException, PasswordCreationFailedException, LoginNotExistsException;
+			throws InternalErrorException, PasswordCreationFailedException, LoginNotExistsException, InvalidLoginException;
 
 	/**
 	 * Validates the password in external system and set user extSources and extSource related attributes. User must exists.
@@ -993,12 +1005,13 @@ public interface UsersManagerBl {
 	 * @param loginNamespace
 	 * @throws InternalErrorException
 	 * @throws PasswordCreationFailedException
-	 * @throws LoginNotExistsException
 	 * @throws ExtSourceNotExistsException
 	 * @throws WrongAttributeValueException
 	 * @throws WrongReferenceAttributeValueException
+	 * @throws LoginNotExistsException When user doesn't have login in specified namespace
+	 * @throws InvalidLoginException When When login of user has invalid syntax (is not allowed)
 	 */
-	void validatePasswordAndSetExtSources(PerunSession sess, User user, String userLogin, String loginNamespace) throws InternalErrorException, PasswordCreationFailedException, LoginNotExistsException, ExtSourceNotExistsException, WrongAttributeValueException, WrongReferenceAttributeValueException;
+	void validatePasswordAndSetExtSources(PerunSession sess, User user, String userLogin, String loginNamespace) throws InternalErrorException, PasswordCreationFailedException, LoginNotExistsException, ExtSourceNotExistsException, WrongAttributeValueException, WrongReferenceAttributeValueException, InvalidLoginException;
 
 	/**
 	 * Deletes password in external system. User must not exists.
@@ -1008,10 +1021,11 @@ public interface UsersManagerBl {
 	 * @param loginNamespace
 	 * @throws InternalErrorException
 	 * @throws PasswordDeletionFailedException
-	 * @throws LoginNotExistsException
+	 * @throws LoginNotExistsException When user doesn't have login in specified namespace
+	 * @throws InvalidLoginException When When login of user has invalid syntax (is not allowed)
 	 */
 	void deletePassword(PerunSession sess, String userLogin, String loginNamespace)
-			throws InternalErrorException, PasswordDeletionFailedException, LoginNotExistsException, PasswordOperationTimeoutException;
+			throws InternalErrorException, PasswordDeletionFailedException, LoginNotExistsException, PasswordOperationTimeoutException, InvalidLoginException;
 
 	/**
 	 * Creates alternative password in external system.
@@ -1023,9 +1037,10 @@ public interface UsersManagerBl {
 	 * @param password string representation of password
 	 * @throws InternalErrorException
 	 * @throws PasswordCreationFailedException
-	 * @throws LoginNotExistsException
+	 * @throws LoginNotExistsException When user doesn't have login in specified namespace
+	 * @throws PasswordStrengthException When password doesn't match expected strength by namespace configuration
 	 */
-	void createAlternativePassword(PerunSession sess, User user, String description, String loginNamespace, String password) throws InternalErrorException, PasswordCreationFailedException, LoginNotExistsException;
+	void createAlternativePassword(PerunSession sess, User user, String description, String loginNamespace, String password) throws InternalErrorException, PasswordCreationFailedException, LoginNotExistsException, PasswordStrengthException;
 
 	/**
 	 * Deletes alternative password in external system.
@@ -1036,7 +1051,7 @@ public interface UsersManagerBl {
 	 * @throws InternalErrorException
 	 * @throws UserNotExistsException
 	 * @throws PasswordDeletionFailedException
-	 * @throws LoginNotExistsException
+	 * @throws LoginNotExistsException When user doesn't have login in specified namespace
 	 */
 	void deleteAlternativePassword(PerunSession sess, User user, String loginNamespace, String passwordId) throws InternalErrorException, PasswordDeletionFailedException, LoginNotExistsException;
 
@@ -1272,11 +1287,13 @@ public interface UsersManagerBl {
 	 * @param password password to set
 	 * @param lang Language to get notification in
 	 * @throws InternalErrorException
-	 * @throws LoginNotExistsException
 	 * @throws PasswordChangeFailedException
+	 * @throws LoginNotExistsException When user doesn't have login in specified namespace
+	 * @throws InvalidLoginException When When login of user has invalid syntax (is not allowed)
+	 * @throws PasswordStrengthException When password doesn't match expected strength by namespace configuration
 	 */
 	void changeNonAuthzPassword(PerunSession sess, User user, String m, String password, String lang)
-			throws InternalErrorException, LoginNotExistsException, PasswordChangeFailedException, PasswordOperationTimeoutException, PasswordStrengthFailedException;
+			throws InternalErrorException, LoginNotExistsException, PasswordChangeFailedException, PasswordOperationTimeoutException, PasswordStrengthFailedException, InvalidLoginException, PasswordStrengthException;
 
 	/**
 	 * Get count of all users.
@@ -1304,8 +1321,9 @@ public interface UsersManagerBl {
 	 * @param parameters Optional parameters
 	 * @return Map of data from backed response
 	 * @throws InternalErrorException
+	 * @throws PasswordStrengthException When password doesn't match expected strength by namespace configuration
 	 */
-	Map<String,String> generateAccount(PerunSession session, String namespace, Map<String, String> parameters) throws InternalErrorException;
+	Map<String,String> generateAccount(PerunSession session, String namespace, Map<String, String> parameters) throws InternalErrorException, PasswordStrengthException;
 
 	/**
 	 * Gets list of users that sponsor the member.
@@ -1362,11 +1380,13 @@ public interface UsersManagerBl {
 	 * @param loginNamespace login namespace
 	 * @return String representing HTML with data about new generated password
 	 * @throws PasswordOperationTimeoutException password change timed out
-	 * @throws LoginNotExistsException           there is no login for given namespace
 	 * @throws InternalErrorException            internal error
 	 * @throws PasswordChangeFailedException     password change failed
+	 * @throws LoginNotExistsException When user doesn't have login in specified namespace
+	 * @throws InvalidLoginException When When login of user has invalid syntax (is not allowed)
+	 * @throws PasswordStrengthException When password doesn't match expected strength by namespace configuration
 	 */
-	String changePasswordRandom(PerunSession session, User user, String loginNamespace) throws PasswordOperationTimeoutException, LoginNotExistsException, InternalErrorException, PasswordChangeFailedException;
+	String changePasswordRandom(PerunSession session, User user, String loginNamespace) throws PasswordOperationTimeoutException, LoginNotExistsException, InternalErrorException, PasswordChangeFailedException, InvalidLoginException, PasswordStrengthException;
 
 	/**
 	 * Return all groups where user is active (has VALID status in VO and Group together)

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
@@ -78,6 +78,7 @@ import cz.metacentrum.perun.core.api.exceptions.GroupResourceMismatchException;
 import cz.metacentrum.perun.core.api.exceptions.GroupStructureSynchronizationAlreadyRunningException;
 import cz.metacentrum.perun.core.api.exceptions.GroupSynchronizationAlreadyRunningException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.InvalidLoginException;
 import cz.metacentrum.perun.core.api.exceptions.LoginNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.MemberAlreadyRemovedException;
 import cz.metacentrum.perun.core.api.exceptions.MemberGroupMismatchException;
@@ -308,6 +309,8 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 					getPerunBl().getUsersManagerBl().deletePassword(sess, login.getRight(), login.getLeft());
 				} catch (LoginNotExistsException ex) {
 					log.error("Login: {} not exists in namespace: {} while deleting passwords.", login.getRight(), login.getLeft());
+				} catch (InvalidLoginException e) {
+					throw new InternalErrorException("We are deleting reserved login from group applications, but its syntax is not allowed by namespace configuration.", e);
 				} catch (PasswordDeletionFailedException | PasswordOperationTimeoutException ex) {
 					throw new InternalErrorException("Failed to delete reserved login "+login.getRight()+" from KDC.", ex);
 				}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
@@ -54,6 +54,7 @@ import cz.metacentrum.perun.core.api.exceptions.GroupNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.GroupResourceMismatchException;
 import cz.metacentrum.perun.core.api.exceptions.IllegalArgumentException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.InvalidLoginException;
 import cz.metacentrum.perun.core.api.exceptions.LoginNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.MemberAlreadyRemovedException;
 import cz.metacentrum.perun.core.api.exceptions.MemberGroupMismatchException;
@@ -65,6 +66,7 @@ import cz.metacentrum.perun.core.api.exceptions.NotGroupMemberException;
 import cz.metacentrum.perun.core.api.exceptions.ParentGroupNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.PasswordCreationFailedException;
 import cz.metacentrum.perun.core.api.exceptions.PasswordOperationTimeoutException;
+import cz.metacentrum.perun.core.api.exceptions.PasswordStrengthException;
 import cz.metacentrum.perun.core.api.exceptions.PasswordStrengthFailedException;
 import cz.metacentrum.perun.core.api.exceptions.RelationExistsException;
 import cz.metacentrum.perun.core.api.exceptions.SubjectNotExistsException;
@@ -348,7 +350,7 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 
 	@Override
 	@Deprecated
-	public Member createSponsoredAccount(PerunSession sess, Map<String, String> params, String namespace, ExtSource extSource, String extSourcePostfix, User owner, Vo vo, int loa) throws InternalErrorException, PasswordCreationFailedException, PasswordOperationTimeoutException, PasswordStrengthFailedException, ExtendMembershipException, AlreadyMemberException, WrongReferenceAttributeValueException, WrongAttributeValueException, UserNotExistsException, ExtSourceNotExistsException, LoginNotExistsException {
+	public Member createSponsoredAccount(PerunSession sess, Map<String, String> params, String namespace, ExtSource extSource, String extSourcePostfix, User owner, Vo vo, int loa) throws InternalErrorException, PasswordCreationFailedException, PasswordOperationTimeoutException, PasswordStrengthFailedException, ExtendMembershipException, AlreadyMemberException, WrongReferenceAttributeValueException, WrongAttributeValueException, UserNotExistsException, ExtSourceNotExistsException, LoginNotExistsException, PasswordStrengthException, InvalidLoginException {
 		String loginNamespaceUri = AttributesManager.NS_USER_ATTR_DEF + ":login-namespace:" + namespace;
 		boolean passwordPresent = params.get("password") != null;
 		if (params.get(loginNamespaceUri) == null) {
@@ -2350,7 +2352,7 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 	}
 
 	@Override
-	public Member createSponsoredMember(PerunSession session, Vo vo, String namespace, Map<String, String> name, String password, User sponsor, boolean asyncValidation) throws InternalErrorException, AlreadyMemberException, LoginNotExistsException, PasswordCreationFailedException, ExtendMembershipException, WrongAttributeValueException, ExtSourceNotExistsException, WrongReferenceAttributeValueException, UserNotInRoleException {
+	public Member createSponsoredMember(PerunSession session, Vo vo, String namespace, Map<String, String> name, String password, User sponsor, boolean asyncValidation) throws InternalErrorException, AlreadyMemberException, LoginNotExistsException, PasswordCreationFailedException, ExtendMembershipException, WrongAttributeValueException, ExtSourceNotExistsException, WrongReferenceAttributeValueException, UserNotInRoleException, PasswordStrengthException, InvalidLoginException {
 		//check that sponsoring user has role SPONSOR for the VO
 		if (!getPerunBl().getVosManagerBl().isUserInRoleForVo(session, sponsor, Role.SPONSOR, vo, true)) {
 			throw new UserNotInRoleException("user " + sponsor.getId() + " is not in role SPONSOR for VO " + vo.getId());

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ModulesUtilsBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ModulesUtilsBlImpl.java
@@ -556,14 +556,14 @@ public class ModulesUtilsBlImpl implements ModulesUtilsBl {
 				throw new InternalErrorException("Regex pattern \""+regex+"\" from \"login-namespace:"+namespace+":regex\" property of perun-namespaces.properties file is invalid.");
 			}
 			// check syntax or if its between exceptions
-			if(!login.matches(regex) && !isLoginException(namespace, login)) {
+			if(!login.matches(regex) && !isLoginExceptionallyAllowed(namespace, login)) {
 				log.warn("Login '{}' in {} namespace doesn't match regex: {}", login, namespace, regex);
 				throw new InvalidLoginException("Login doesn't matches expected regex: \"" + regex +"\"");
 			}
 		} else {
 			// Regex property not found in our attribute map, so use the default hardcoded regex
 			// check syntax or if its between exceptions
-			if (!defaultRegex.matcher(login).matches() && !isLoginException(namespace, login)) {
+			if (!defaultRegex.matcher(login).matches() && !isLoginExceptionallyAllowed(namespace, login)) {
 				log.warn("Login '{}' in {} namespace doesn't match regex: {}", login, namespace, regex);
 				throw new InvalidLoginException("Login doesn't matches expected regex: \"" + defaultRegex +"\"");
 			}
@@ -571,7 +571,7 @@ public class ModulesUtilsBlImpl implements ModulesUtilsBl {
 	}
 
 	@Override
-	public boolean checkIfUserLoginIsPermitted(String namespace, String login) {
+	public boolean isUserLoginPermitted(String namespace, String login) {
 		Utils.notNull(namespace, "namespace to check unpermited logins in");
 		if(login == null) return true;
 
@@ -580,15 +580,15 @@ public class ModulesUtilsBlImpl implements ModulesUtilsBl {
 		String prohibitedNames = perunNamespaces.get("login-namespace:" + namespace + ":reservedNames");
 		if (prohibitedNames != null) {
 			List<String> prohibitedNamesList = Arrays.asList(prohibitedNames.split("\\s*,\\s*"));
-			return !prohibitedNamesList.contains(login) || isLoginException(namespace, login);
+			return !prohibitedNamesList.contains(login) || isLoginExceptionallyAllowed(namespace, login);
 		} else {
 			//Property not found in our attribute map, so we will use the default hardcoded values instead
-			return !unpermittedNamesForUserLogins.contains(login) || isLoginException(namespace, login);
+			return !unpermittedNamesForUserLogins.contains(login) || isLoginExceptionallyAllowed(namespace, login);
 		}
 	}
 
 	@Override
-	public boolean isLoginException(String namespace, String login) {
+	public boolean isLoginExceptionallyAllowed(String namespace, String login) {
 		Utils.notNull(namespace, "namespace to check allowed exceptions for login in");
 		if(login == null) return false;
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
@@ -2083,6 +2083,7 @@ public class UsersManagerBlImpl implements UsersManagerBl {
 				false, possibleCharacters, new SecureRandom());
 
 		try {
+			// FIXME - we want to re-generate password if it was considered weak
 			changePassword(session, user, loginNamespace, null, newRandomPassword, false);
 		} catch (PasswordDoesntMatchException | PasswordStrengthFailedException e) {
 			// should not happen when we are not using the old password

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/MembersManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/MembersManagerEntry.java
@@ -1292,10 +1292,9 @@ public class MembersManagerEntry implements MembersManager {
 
 	@Override
 	public RichMember createSponsoredMember(PerunSession session, Vo vo, String namespace, Map<String, String> name, String password, User sponsor)
-			throws InternalErrorException, PrivilegeException, AlreadyMemberException,
-			LoginNotExistsException, PasswordCreationFailedException,
-			ExtendMembershipException,
-			WrongAttributeValueException, ExtSourceNotExistsException, WrongReferenceAttributeValueException, UserNotInRoleException, PasswordStrengthException, InvalidLoginException {
+			throws InternalErrorException, PrivilegeException, AlreadyMemberException, LoginNotExistsException, PasswordCreationFailedException,
+			ExtendMembershipException, WrongAttributeValueException, ExtSourceNotExistsException, WrongReferenceAttributeValueException,
+			UserNotInRoleException, PasswordStrengthException, InvalidLoginException {
 		Utils.checkPerunSession(session);
 		Utils.notNull(vo, "vo");
 		Utils.notNull(namespace, "namespace");

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/MembersManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/MembersManagerEntry.java
@@ -26,6 +26,7 @@ import cz.metacentrum.perun.core.api.exceptions.ExtendMembershipException;
 import cz.metacentrum.perun.core.api.exceptions.GroupNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.GroupResourceMismatchException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.InvalidLoginException;
 import cz.metacentrum.perun.core.api.exceptions.LoginNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.MemberAlreadyRemovedException;
 import cz.metacentrum.perun.core.api.exceptions.MemberNotExistsException;
@@ -35,6 +36,7 @@ import cz.metacentrum.perun.core.api.exceptions.MemberNotValidYetException;
 import cz.metacentrum.perun.core.api.exceptions.ParentGroupNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.PasswordCreationFailedException;
 import cz.metacentrum.perun.core.api.exceptions.PasswordOperationTimeoutException;
+import cz.metacentrum.perun.core.api.exceptions.PasswordStrengthException;
 import cz.metacentrum.perun.core.api.exceptions.PasswordStrengthFailedException;
 import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
 import cz.metacentrum.perun.core.api.exceptions.ResourceNotExistsException;
@@ -164,7 +166,7 @@ public class MembersManagerEntry implements MembersManager {
 
 	@Override
 	@Deprecated
-	public Member createSponsoredAccount(PerunSession sess, Map<String, String> params, String namespace, ExtSource extSource, String extSourcePostfix, Vo vo, int loa) throws InternalErrorException, PrivilegeException, UserNotExistsException, ExtSourceNotExistsException, UserExtSourceNotExistsException, WrongReferenceAttributeValueException, LoginNotExistsException, PasswordCreationFailedException, ExtendMembershipException, AlreadyMemberException, PasswordStrengthFailedException, PasswordOperationTimeoutException, WrongAttributeValueException {
+	public Member createSponsoredAccount(PerunSession sess, Map<String, String> params, String namespace, ExtSource extSource, String extSourcePostfix, Vo vo, int loa) throws InternalErrorException, PrivilegeException, UserNotExistsException, ExtSourceNotExistsException, UserExtSourceNotExistsException, WrongReferenceAttributeValueException, LoginNotExistsException, PasswordCreationFailedException, ExtendMembershipException, AlreadyMemberException, PasswordStrengthFailedException, PasswordOperationTimeoutException, WrongAttributeValueException, PasswordStrengthException, InvalidLoginException {
 		Utils.checkPerunSession(sess);
 		Utils.notNull(extSource, "extSource");
 		Utils.notNull(namespace, "namespace");
@@ -1292,8 +1294,8 @@ public class MembersManagerEntry implements MembersManager {
 	public RichMember createSponsoredMember(PerunSession session, Vo vo, String namespace, Map<String, String> name, String password, User sponsor)
 			throws InternalErrorException, PrivilegeException, AlreadyMemberException,
 			LoginNotExistsException, PasswordCreationFailedException,
-		ExtendMembershipException,
-			WrongAttributeValueException, ExtSourceNotExistsException, WrongReferenceAttributeValueException, UserNotInRoleException {
+			ExtendMembershipException,
+			WrongAttributeValueException, ExtSourceNotExistsException, WrongReferenceAttributeValueException, UserNotInRoleException, PasswordStrengthException, InvalidLoginException {
 		Utils.checkPerunSession(session);
 		Utils.notNull(vo, "vo");
 		Utils.notNull(namespace, "namespace");

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
@@ -25,6 +25,7 @@ import cz.metacentrum.perun.core.api.exceptions.ConsistencyErrorException;
 import cz.metacentrum.perun.core.api.exceptions.ExtSourceNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.FacilityNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.InvalidLoginException;
 import cz.metacentrum.perun.core.api.exceptions.LoginExistsException;
 import cz.metacentrum.perun.core.api.exceptions.LoginNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.MemberAlreadyRemovedException;
@@ -35,6 +36,7 @@ import cz.metacentrum.perun.core.api.exceptions.PasswordCreationFailedException;
 import cz.metacentrum.perun.core.api.exceptions.PasswordDeletionFailedException;
 import cz.metacentrum.perun.core.api.exceptions.PasswordDoesntMatchException;
 import cz.metacentrum.perun.core.api.exceptions.PasswordOperationTimeoutException;
+import cz.metacentrum.perun.core.api.exceptions.PasswordStrengthException;
 import cz.metacentrum.perun.core.api.exceptions.PasswordStrengthFailedException;
 import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
 import cz.metacentrum.perun.core.api.exceptions.RelationExistsException;
@@ -880,7 +882,7 @@ public class UsersManagerEntry implements UsersManager {
 	}
 
 	@Override
-	public boolean isLoginAvailable(PerunSession sess, String loginNamespace, String login) throws InternalErrorException {
+	public boolean isLoginAvailable(PerunSession sess, String loginNamespace, String login) throws InvalidLoginException {
 		Utils.checkPerunSession(sess);
 
 		// Authorization - must be public since it's used to check anonymous users input on registration form
@@ -928,7 +930,7 @@ public class UsersManagerEntry implements UsersManager {
 
 	@Override
 	public void changePassword(PerunSession sess, User user, String loginNamespace, String oldPassword, String newPassword, boolean checkOldPassword) throws InternalErrorException,
-			PrivilegeException, UserNotExistsException, LoginNotExistsException, PasswordDoesntMatchException, PasswordChangeFailedException, PasswordOperationTimeoutException, PasswordStrengthFailedException {
+			PrivilegeException, UserNotExistsException, LoginNotExistsException, PasswordDoesntMatchException, PasswordChangeFailedException, PasswordOperationTimeoutException, PasswordStrengthFailedException, InvalidLoginException, PasswordStrengthException {
 		Utils.checkPerunSession(sess);
 
 		getUsersManagerBl().checkUserExists(sess, user);
@@ -954,7 +956,7 @@ public class UsersManagerEntry implements UsersManager {
 
 	@Override
 	public void changePassword(PerunSession sess, String login , String loginNamespace, String oldPassword, String newPassword, boolean checkOldPassword) throws InternalErrorException,
-			PrivilegeException, LoginNotExistsException, PasswordDoesntMatchException, PasswordChangeFailedException, PasswordOperationTimeoutException, PasswordStrengthFailedException {
+			PrivilegeException, LoginNotExistsException, PasswordDoesntMatchException, PasswordChangeFailedException, PasswordOperationTimeoutException, PasswordStrengthFailedException, InvalidLoginException, PasswordStrengthException {
 		Utils.checkPerunSession(sess);
 
 		String attributeName = AttributesManager.NS_USER_ATTR_DEF + ":" + AttributesManager.LOGIN_NAMESPACE + ":" + loginNamespace;
@@ -980,7 +982,7 @@ public class UsersManagerEntry implements UsersManager {
 	}
 
 	@Override
-	public void reserveRandomPassword(PerunSession sess, User user, String loginNamespace) throws InternalErrorException, PasswordCreationFailedException, PrivilegeException, UserNotExistsException, LoginNotExistsException, PasswordOperationTimeoutException, PasswordStrengthFailedException {
+	public void reserveRandomPassword(PerunSession sess, User user, String loginNamespace) throws InternalErrorException, PasswordCreationFailedException, PrivilegeException, UserNotExistsException, LoginNotExistsException, PasswordOperationTimeoutException, PasswordStrengthFailedException, InvalidLoginException {
 		Utils.checkPerunSession(sess);
 
 		// Authorization
@@ -994,7 +996,7 @@ public class UsersManagerEntry implements UsersManager {
 
 	@Override
 	public void reservePassword(PerunSession sess, String userLogin, String loginNamespace, String password) throws InternalErrorException,
-			PrivilegeException, PasswordCreationFailedException, PasswordOperationTimeoutException, PasswordStrengthFailedException {
+			PrivilegeException, PasswordCreationFailedException, PasswordOperationTimeoutException, PasswordStrengthFailedException, InvalidLoginException, PasswordStrengthException {
 		Utils.checkPerunSession(sess);
 
 		// Authorization
@@ -1013,7 +1015,7 @@ public class UsersManagerEntry implements UsersManager {
 
 	@Override
 	public void reservePassword(PerunSession sess, User user, String loginNamespace, String password) throws InternalErrorException,
-			PrivilegeException, PasswordCreationFailedException, UserNotExistsException, LoginNotExistsException, PasswordOperationTimeoutException, PasswordStrengthFailedException {
+			PrivilegeException, PasswordCreationFailedException, UserNotExistsException, LoginNotExistsException, PasswordOperationTimeoutException, PasswordStrengthFailedException, InvalidLoginException, PasswordStrengthException {
 		Utils.checkPerunSession(sess);
 
 		// Authorization
@@ -1028,7 +1030,7 @@ public class UsersManagerEntry implements UsersManager {
 
 	@Override
 	public void validatePassword(PerunSession sess, String userLogin, String loginNamespace) throws InternalErrorException,
-			PrivilegeException, PasswordCreationFailedException {
+			PrivilegeException, PasswordCreationFailedException, InvalidLoginException {
 		Utils.checkPerunSession(sess);
 
 		// Authorization
@@ -1046,7 +1048,7 @@ public class UsersManagerEntry implements UsersManager {
 	}
 
 	@Override
-	public void validatePasswordAndSetExtSources(PerunSession sess, User user, String userLogin, String loginNamespace) throws PrivilegeException, InternalErrorException, PasswordCreationFailedException, LoginNotExistsException, ExtSourceNotExistsException, WrongAttributeValueException, WrongReferenceAttributeValueException {
+	public void validatePasswordAndSetExtSources(PerunSession sess, User user, String userLogin, String loginNamespace) throws PrivilegeException, InternalErrorException, PasswordCreationFailedException, LoginNotExistsException, ExtSourceNotExistsException, InvalidLoginException, WrongReferenceAttributeValueException, WrongAttributeValueException {
 		Utils.checkPerunSession(sess);
 
 		// Authorization
@@ -1065,7 +1067,7 @@ public class UsersManagerEntry implements UsersManager {
 
 	@Override
 	public void validatePassword(PerunSession sess, User user, String loginNamespace) throws InternalErrorException,
-			PrivilegeException, PasswordCreationFailedException, UserNotExistsException, LoginNotExistsException {
+			PrivilegeException, PasswordCreationFailedException, UserNotExistsException, LoginNotExistsException, InvalidLoginException {
 		Utils.checkPerunSession(sess);
 
 		// Authorization
@@ -1081,7 +1083,7 @@ public class UsersManagerEntry implements UsersManager {
 
 	@Override
 	public void deletePassword(PerunSession sess, String userLogin, String loginNamespace) throws InternalErrorException,
-			PrivilegeException, PasswordDeletionFailedException, LoginNotExistsException, PasswordOperationTimeoutException {
+			PrivilegeException, PasswordDeletionFailedException, LoginNotExistsException, PasswordOperationTimeoutException, InvalidLoginException {
 		Utils.checkPerunSession(sess);
 
 		// Authorization
@@ -1107,7 +1109,7 @@ public class UsersManagerEntry implements UsersManager {
 	}
 
 	@Override
-	public void createAlternativePassword(PerunSession sess, User user, String description, String loginNamespace, String password) throws InternalErrorException, PasswordCreationFailedException, PrivilegeException, UserNotExistsException, LoginNotExistsException {
+	public void createAlternativePassword(PerunSession sess, User user, String description, String loginNamespace, String password) throws InternalErrorException, PasswordCreationFailedException, PrivilegeException, UserNotExistsException, LoginNotExistsException, PasswordStrengthException {
 		Utils.checkPerunSession(sess);
 		Utils.notNull(description, "description");
 		Utils.notNull(loginNamespace, "loginNamespace");
@@ -1252,7 +1254,7 @@ public class UsersManagerEntry implements UsersManager {
 	}
 
 	@Override
-	public void setLogin(PerunSession sess, User user, String loginNamespace, String login) throws InternalErrorException, PrivilegeException, UserNotExistsException, LoginExistsException {
+	public void setLogin(PerunSession sess, User user, String loginNamespace, String login) throws InternalErrorException, PrivilegeException, UserNotExistsException, LoginExistsException, InvalidLoginException {
 
 		// checks
 		Utils.checkPerunSession(sess);
@@ -1326,7 +1328,7 @@ public class UsersManagerEntry implements UsersManager {
 	}
 
 	@Override
-	public void changeNonAuthzPassword(PerunSession sess, String i, String m, String password, String lang) throws InternalErrorException, UserNotExistsException, LoginNotExistsException, PasswordChangeFailedException, PasswordOperationTimeoutException, PasswordStrengthFailedException {
+	public void changeNonAuthzPassword(PerunSession sess, String i, String m, String password, String lang) throws InternalErrorException, UserNotExistsException, LoginNotExistsException, PasswordChangeFailedException, PasswordOperationTimeoutException, PasswordStrengthFailedException, InvalidLoginException, PasswordStrengthException {
 
 		Utils.checkPerunSession(sess);
 
@@ -1361,7 +1363,7 @@ public class UsersManagerEntry implements UsersManager {
 	}
 
 	@Override
-	public Map<String,String> generateAccount(PerunSession sess, String namespace, Map<String, String> parameters) throws InternalErrorException, PrivilegeException {
+	public Map<String,String> generateAccount(PerunSession sess, String namespace, Map<String, String> parameters) throws InternalErrorException, PrivilegeException, PasswordStrengthException {
 		Utils.checkPerunSession(sess);
 
 		// Authorization
@@ -1393,7 +1395,7 @@ public class UsersManagerEntry implements UsersManager {
 	}
 
 	@Override
-	public String changePasswordRandom(PerunSession sess, User user, String loginNamespace)	throws InternalErrorException, PrivilegeException, PasswordOperationTimeoutException, LoginNotExistsException, PasswordChangeFailedException {
+	public String changePasswordRandom(PerunSession sess, User user, String loginNamespace) throws InternalErrorException, PrivilegeException, PasswordOperationTimeoutException, LoginNotExistsException, PasswordChangeFailedException, InvalidLoginException, PasswordStrengthException {
 		Utils.checkPerunSession(sess);
 
 		// Authorization

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/DummyPasswordManagerModule.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/DummyPasswordManagerModule.java
@@ -2,6 +2,8 @@ package cz.metacentrum.perun.core.impl.modules.pwdmgr;
 
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.InvalidLoginException;
+import cz.metacentrum.perun.core.api.exceptions.PasswordStrengthException;
 import cz.metacentrum.perun.core.implApi.modules.pwdmgr.PasswordManagerModule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -21,7 +23,7 @@ public class DummyPasswordManagerModule implements PasswordManagerModule {
 
 	private static final Random RANDOM = new Random();
 	@Override
-	public Map<String, String> generateAccount(PerunSession session, Map<String, String> parameters) {
+	public Map<String, String> generateAccount(PerunSession sess, Map<String, String> parameters) {
 		log.debug("generateAccount(parameters={})",parameters);
 		Map<String, String> result = new HashMap<>();
 		result.put(LOGIN_PREFIX+"dummy", Integer.toString(9000000+RANDOM.nextInt(1000000)));
@@ -29,12 +31,12 @@ public class DummyPasswordManagerModule implements PasswordManagerModule {
 	}
 
 	@Override
-	public void reservePassword(PerunSession session, String userLogin, String password) {
+	public void reservePassword(PerunSession sess, String userLogin, String password) {
 		log.debug("reservePassword(userLogin={})",userLogin);
 	}
 
 	@Override
-	public void reserveRandomPassword(PerunSession session, String userLogin) {
+	public void reserveRandomPassword(PerunSession sess, String userLogin) {
 		log.debug("reserveRandomPassword(userLogin={})",userLogin);
 	}
 
@@ -66,6 +68,16 @@ public class DummyPasswordManagerModule implements PasswordManagerModule {
 	@Override
 	public void deleteAlternativePassword(PerunSession sess, User user, String passwordId) {
 		log.debug("deleteAlternativePassword(user={},passwordId={})", user, passwordId);
+	}
+
+	@Override
+	public void checkLoginFormat(PerunSession sess, String login) {
+		log.debug("checkLoginFormat(userLogin={})", login);
+	}
+
+	@Override
+	public void checkPasswordStrength(PerunSession sess, String login, String password) {
+		log.debug("checkPasswordStrength(userLogin={})", login);
 	}
 
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/EinfraPasswordManagerModule.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/EinfraPasswordManagerModule.java
@@ -24,7 +24,7 @@ import java.util.regex.Pattern;
 
 /**
  * Password manager for EINFRA login-namespace. It provides custom checks on login format
- * adn password strength. Also implementation for alternative passwords is customized.
+ * and password strength. Also implementation for alternative passwords is customized.
  *
  * It calls generic pwd manager script logic with ".einfra"
  *
@@ -121,7 +121,7 @@ public class EinfraPasswordManagerModule extends GenericPasswordManagerModule {
 		((PerunBl)sess.getPerun()).getModulesUtilsBl().checkLoginNamespaceRegex(actualLoginNamespace, login, einfraLoginPattern);
 
 		// check if login is permitted
-		if (!((PerunBl)sess.getPerun()).getModulesUtilsBl().checkIfUserLoginIsPermitted(actualLoginNamespace, login)) {
+		if (!((PerunBl)sess.getPerun()).getModulesUtilsBl().isUserLoginPermitted(actualLoginNamespace, login)) {
 			log.warn("Login '{}' is not allowed in {} namespace by configuration.", login, actualLoginNamespace);
 			throw new InvalidLoginException("Login '"+login+"' is not allowed in '"+actualLoginNamespace+"' namespace by configuration.");
 		}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/EinfraPasswordManagerModule.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/EinfraPasswordManagerModule.java
@@ -6,8 +6,9 @@ import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.InvalidLoginException;
+import cz.metacentrum.perun.core.api.exceptions.PasswordStrengthException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
-import cz.metacentrum.perun.core.api.exceptions.rt.EmptyPasswordRuntimeException;
 import cz.metacentrum.perun.core.api.exceptions.rt.LoginNotExistsRuntimeException;
 import cz.metacentrum.perun.core.api.exceptions.rt.PasswordCreationFailedRuntimeException;
 import cz.metacentrum.perun.core.api.exceptions.rt.PasswordDeletionFailedRuntimeException;
@@ -19,10 +20,11 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 /**
- * Password manager for EINFRA login-namespace. It performs custom checks
- * on password strength and login format.
+ * Password manager for EINFRA login-namespace. It provides custom checks on login format
+ * adn password strength. Also implementation for alternative passwords is customized.
  *
  * It calls generic pwd manager script logic with ".einfra"
  *
@@ -31,6 +33,13 @@ import java.util.Map;
 public class EinfraPasswordManagerModule extends GenericPasswordManagerModule {
 
 	private final static Logger log = LoggerFactory.getLogger(EinfraPasswordManagerModule.class);
+
+	protected final Pattern einfraLoginPattern = Pattern.compile("^[a-z][a-z0-9_-]{1,14}$");
+
+	protected final Pattern einfraPasswordContainsDigit = Pattern.compile(".*[0-9].*");
+	protected final Pattern einfraPasswordContainsLower = Pattern.compile(".*[a-z].*");
+	protected final Pattern einfraPasswordContainsUpper = Pattern.compile(".*[A-Z].*");
+	protected final Pattern einfraPasswordContainsSpec = Pattern.compile(".*[\\x20-\\x2F\\x3A-\\x40\\x5B-\\x60\\x7B-\\x7E].*");
 
 	public EinfraPasswordManagerModule() {
 
@@ -51,31 +60,14 @@ public class EinfraPasswordManagerModule extends GenericPasswordManagerModule {
 	}
 
 	@Override
-	public void reservePassword(PerunSession session, String userLogin, String password) throws InternalErrorException {
-		checkLoginFormat(userLogin);
-		checkPasswordStrength(password);
-		super.reservePassword(session, userLogin, password);
+	public void reserveRandomPassword(PerunSession sess, String userLogin) throws InvalidLoginException {
+		// FIXME - probably generate password for einfra here and perform standard reservation
+		super.reserveRandomPassword(sess, userLogin);
 	}
 
 	@Override
-	public void reserveRandomPassword(PerunSession session, String userLogin) throws InternalErrorException {
-		// FIXME - probably generate password here and perform standard reservation
-		checkLoginFormat(userLogin);
-		super.reserveRandomPassword(session, userLogin);
-	}
-
-	@Override
-	public void changePassword(PerunSession sess, String userLogin, String newPassword) throws InternalErrorException {
-		checkPasswordStrength(newPassword);
-		super.changePassword(sess, userLogin, newPassword);
-	}
-
-	@Override
-	public void createAlternativePassword(PerunSession sess, User user, String passwordId, String password) {
-		if (StringUtils.isBlank(password)) {
-			throw new EmptyPasswordRuntimeException("Password for " + actualLoginNamespace + ":" + passwordId + " cannot be empty.");
-		}
-		checkPasswordStrength(password);
+	public void createAlternativePassword(PerunSession sess, User user, String passwordId, String password) throws PasswordStrengthException {
+		checkPasswordStrength(sess, passwordId, password);
 
 		ProcessBuilder pb = new ProcessBuilder(altPasswordManagerProgram, PASSWORD_CREATE);
 		// pass variables as ENV
@@ -122,6 +114,66 @@ public class EinfraPasswordManagerModule extends GenericPasswordManagerModule {
 
 	}
 
+	@Override
+	public void checkLoginFormat(PerunSession sess, String login) throws InvalidLoginException {
+
+		// check login syntax/format
+		((PerunBl)sess.getPerun()).getModulesUtilsBl().checkLoginNamespaceRegex(actualLoginNamespace, login, einfraLoginPattern);
+
+		// check if login is permitted
+		if (!((PerunBl)sess.getPerun()).getModulesUtilsBl().checkIfUserLoginIsPermitted(actualLoginNamespace, login)) {
+			log.warn("Login '{}' is not allowed in {} namespace by configuration.", login, actualLoginNamespace);
+			throw new InvalidLoginException("Login '"+login+"' is not allowed in '"+actualLoginNamespace+"' namespace by configuration.");
+		}
+
+		// TODO - we will probably want to split regex checks on multiple conditions and let user know about all problems at once
+
+	}
+
+	@Override
+	public void checkPasswordStrength(PerunSession sess, String login, String password) throws PasswordStrengthException {
+
+		if (StringUtils.isBlank(password)) {
+			log.warn("Password for {}:{} cannot be empty.", actualLoginNamespace, login);
+			throw new PasswordStrengthException("Password for " + actualLoginNamespace + ":" + login + " cannot be empty.");
+		}
+
+		if (password.length() < 10) {
+			log.warn("Password for {}:{} is too short. At least 10 characters is required.", actualLoginNamespace, login);
+			throw new PasswordStrengthException("Password for " + actualLoginNamespace + ":" + login + " is too short. At least 10 characters is required.");
+		}
+
+		String backwardPassword = StringUtils.reverse(password);
+
+		if (password.equalsIgnoreCase(login) ||
+				backwardPassword.equalsIgnoreCase(login) ||
+				password.toLowerCase().contains(login.toLowerCase()) ||
+				backwardPassword.toLowerCase().contains(login.toLowerCase())) {
+			log.warn("Password for {}:{} must not match/contain login or backwards login.", actualLoginNamespace, login);
+			throw new PasswordStrengthException("Password for " + actualLoginNamespace + ":" + login + " must not match/contain login or backwards login.");
+		}
+
+		// TODO - fetch user and get names to make sure they are not part of password
+
+		if (!StringUtils.isAsciiPrintable(password)) {
+			log.warn("Password for {}:{} must contain only printable characters.", actualLoginNamespace, login);
+			throw new PasswordStrengthException("Password for " + actualLoginNamespace + ":" + login + " must contain only printable characters.");
+		}
+
+		// check that it contains at least 3 groups of 4
+		int groupsCounter = 0;
+		if (einfraPasswordContainsDigit.matcher(password).matches()) groupsCounter++;
+		if (einfraPasswordContainsUpper.matcher(password).matches()) groupsCounter++;
+		if (einfraPasswordContainsLower.matcher(password).matches()) groupsCounter++;
+		if (einfraPasswordContainsSpec.matcher(password).matches()) groupsCounter++;
+
+		if (groupsCounter < 3) {
+			log.warn("Password for {}:{} is two weak. It must consist of at least 3 kinds of characters from: lower-case letter, upper-case letter, digit, spec. character.", actualLoginNamespace, login);
+			throw new PasswordStrengthException("Password for " + actualLoginNamespace + ":" + login + " is two weak. It must consist of at least 3 kinds of characters from: lower-case letter, upper-case letter, digit, spec. character.");
+		}
+
+	}
+
 	private void handleAltPwdManagerExit(Process process, PerunRuntimeException exToThrow) {
 		try {
 			if (process.waitFor() != 0) {
@@ -135,16 +187,16 @@ public class EinfraPasswordManagerModule extends GenericPasswordManagerModule {
 	/**
 	 * Retrieve "einfra" login of the user, since its necessary for alternative password backend
 	 *
-	 * @param session session
+	 * @param sess Session
 	 * @param user user to get login for
 	 * @return einfra login
 	 * @throws LoginNotExistsRuntimeException if user doesn't have "einfra" login
 	 */
-	private String getEinfraLogin(PerunSession session, User user) {
+	private String getEinfraLogin(PerunSession sess, User user) {
 
 		String login = null;
 		try {
-			Attribute attribute = ((PerunBl)session.getPerun()).getAttributesManagerBl().getAttribute(session, user, AttributesManager.NS_USER_ATTR_DEF+":login-namespace:einfra");
+			Attribute attribute = ((PerunBl)sess.getPerun()).getAttributesManagerBl().getAttribute(sess, user, AttributesManager.NS_USER_ATTR_DEF+":login-namespace:einfra");
 			if (attribute.getValue() == null) {
 				log.warn("{} doesn't have login in namespace 'einfra', so the alternative password can't be set.", user);
 				throw new LoginNotExistsRuntimeException(user+" doesn't have login in namespace 'einfra', so the alternative password can't be set.");
@@ -162,14 +214,14 @@ public class EinfraPasswordManagerModule extends GenericPasswordManagerModule {
 	/**
 	 * Retrieve users preferred mail
 	 *
-	 * @param session session
+	 * @param sess session
 	 * @param user user to get mail for
 	 * @return users preferred mail
 	 */
-	private String getMail(PerunSession session, User user) {
+	private String getMail(PerunSession sess, User user) {
 
 		try {
-			Attribute attribute = ((PerunBl)session.getPerun()).getAttributesManagerBl().getAttribute(session, user, AttributesManager.NS_USER_ATTR_DEF+":preferredMail");
+			Attribute attribute = ((PerunBl)sess.getPerun()).getAttributesManagerBl().getAttribute(sess, user, AttributesManager.NS_USER_ATTR_DEF+":preferredMail");
 			return attribute.valueAsString();
 		} catch (WrongAttributeAssignmentException | AttributeNotExistsException e) {
 			// shouldn't happen
@@ -177,14 +229,6 @@ public class EinfraPasswordManagerModule extends GenericPasswordManagerModule {
 			throw new InternalErrorException("We couldn't retrieve mail for the "+user+" to create/delete alternative password.");
 		}
 
-	}
-
-	private void checkLoginFormat(String userLogin) {
-		// TODO
-	}
-
-	private void checkPasswordStrength(String password) {
-		// TODO
 	}
 
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/GenericPasswordManagerModule.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/GenericPasswordManagerModule.java
@@ -87,8 +87,8 @@ public class GenericPasswordManagerModule implements PasswordManagerModule {
 
 	@Override
 	public void checkPassword(PerunSession sess, String userLogin, String password) {
-		// use custom check instead of strength, since this is about empty input
-		// we must allow checks for old weaker passwords
+		// use custom check instead of checkPasswordStrength(), since this is only about empty input
+		// and we must allow checks for older (weaker) passwords
 		if (StringUtils.isBlank(password)) {
 			throw new InternalErrorException("Password for " + actualLoginNamespace + ":" + userLogin + " cannot be empty.");
 		}
@@ -141,7 +141,7 @@ public class GenericPasswordManagerModule implements PasswordManagerModule {
 		((PerunBl)sess.getPerun()).getModulesUtilsBl().checkLoginNamespaceRegex(actualLoginNamespace, login, defaultLoginPattern);
 
 		// check if login is permitted
-		if (!((PerunBl)sess.getPerun()).getModulesUtilsBl().checkIfUserLoginIsPermitted(actualLoginNamespace, login)) {
+		if (!((PerunBl)sess.getPerun()).getModulesUtilsBl().isUserLoginPermitted(actualLoginNamespace, login)) {
 			log.warn("Login '{}' is not allowed in {} namespace by configuration.", login, actualLoginNamespace);
 			throw new InvalidLoginException("Login '"+login+"' is not allowed in '"+actualLoginNamespace+"' namespace by configuration.");
 		}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/MuPasswordManagerModule.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/MuPasswordManagerModule.java
@@ -7,9 +7,12 @@ import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.UserExtSource;
 import cz.metacentrum.perun.core.api.exceptions.IllegalArgumentException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.InvalidLoginException;
+import cz.metacentrum.perun.core.api.exceptions.PasswordStrengthException;
 import cz.metacentrum.perun.core.bl.PerunBl;
 import cz.metacentrum.perun.core.implApi.modules.pwdmgr.PasswordManagerModule;
 import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.StringEscapeUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,6 +48,7 @@ import java.util.Random;
 
 /**
  * Password manager implementation for MU login-namespace.
+ * !! It doesn't reuse generic password manager !!
  *
  * @author Pavel Zlámal <zlamal@cesnet.cz>
  */
@@ -54,7 +58,13 @@ public class MuPasswordManagerModule implements PasswordManagerModule {
 	private final static String CRLF = "\r\n"; // Line separator required by multipart/form-data.
 
 	@Override
-	public Map<String, String> generateAccount(PerunSession session, Map<String, String> parameters) throws InternalErrorException {
+	public Map<String, String> generateAccount(PerunSession session, Map<String, String> parameters) throws PasswordStrengthException {
+
+		String password = null;
+		if (parameters.get(PASSWORD_KEY) != null && !parameters.get(PASSWORD_KEY).isEmpty()) {
+			password = parameters.get(PASSWORD_KEY);
+		}
+		checkPasswordStrength(session, "--not yet known--", password);
 
 		try {
 			int requestID = (new Random()).nextInt(1000000) + 1;
@@ -83,7 +93,8 @@ public class MuPasswordManagerModule implements PasswordManagerModule {
 	}
 
 	@Override
-	public void changePassword(PerunSession sess, String userLogin, String newPassword) throws InternalErrorException {
+	public void changePassword(PerunSession sess, String userLogin, String newPassword) throws PasswordStrengthException {
+		checkPasswordStrength(sess, userLogin, newPassword);
 
 		try {
 			int requestID = (new Random()).nextInt(1000000) + 1;
@@ -102,7 +113,7 @@ public class MuPasswordManagerModule implements PasswordManagerModule {
 	}
 
 	@Override
-	public void deletePassword(PerunSession sess, String userLogin) throws InternalErrorException {
+	public void deletePassword(PerunSession sess, String userLogin) {
 		throw new InternalErrorException("Deleting user/password in login namespace 'mu' is not supported.");
 	}
 
@@ -114,6 +125,32 @@ public class MuPasswordManagerModule implements PasswordManagerModule {
 	@Override
 	public void deleteAlternativePassword(PerunSession sess, User user, String passwordId) {
 		throw new InternalErrorException("Deleting alternative password in login namespace 'mu' is not supported.");
+	}
+
+	@Override
+	public void checkLoginFormat(PerunSession sess, String login) throws InvalidLoginException {
+
+		// check login syntax/format
+		((PerunBl)sess.getPerun()).getModulesUtilsBl().checkLoginNamespaceRegex("mu", login, GenericPasswordManagerModule.defaultLoginPattern);
+
+		// check if login is permitted
+		if (!((PerunBl)sess.getPerun()).getModulesUtilsBl().checkIfUserLoginIsPermitted("mu", login)) {
+			log.warn("Login '{}' is not allowed in {} namespace by configuration.", login, "mu");
+			throw new InvalidLoginException("Login '"+login+"' is not allowed in 'mu' namespace by configuration.");
+		}
+
+	}
+
+	@Override
+	public void checkPasswordStrength(PerunSession sess, String login, String password) throws PasswordStrengthException {
+
+		if (StringUtils.isBlank(password)) {
+			log.warn("Password for {}:{} cannot be empty.", "mu", login);
+			throw new PasswordStrengthException("Password for mu:" + login + " cannot be empty.");
+		}
+
+		// TODO - some more generic checks ???
+
 	}
 
 	/**

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/MuPasswordManagerModule.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/MuPasswordManagerModule.java
@@ -134,7 +134,7 @@ public class MuPasswordManagerModule implements PasswordManagerModule {
 		((PerunBl)sess.getPerun()).getModulesUtilsBl().checkLoginNamespaceRegex("mu", login, GenericPasswordManagerModule.defaultLoginPattern);
 
 		// check if login is permitted
-		if (!((PerunBl)sess.getPerun()).getModulesUtilsBl().checkIfUserLoginIsPermitted("mu", login)) {
+		if (!((PerunBl)sess.getPerun()).getModulesUtilsBl().isUserLoginPermitted("mu", login)) {
 			log.warn("Login '{}' is not allowed in {} namespace by configuration.", login, "mu");
 			throw new InvalidLoginException("Login '"+login+"' is not allowed in 'mu' namespace by configuration.");
 		}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/SambaduPasswordManagerModule.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/SambaduPasswordManagerModule.java
@@ -2,6 +2,7 @@ package cz.metacentrum.perun.core.impl.modules.pwdmgr;
 
 import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.BeansUtils;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
@@ -34,6 +35,10 @@ public class SambaduPasswordManagerModule extends EinfraPasswordManagerModule {
 
 		// set proper namespace
 		this.actualLoginNamespace = "samba-du";
+
+		// re-init config since Einfra pwd module already modified it
+		this.passwordManagerProgram = BeansUtils.getCoreConfig().getPasswordManagerProgram();
+		this.altPasswordManagerProgram = BeansUtils.getCoreConfig().getAlternativePasswordManagerProgram();
 
 		// if we are not faking password manager by using /bin/true value in the config,
 		// then append namespace to the script path to trigger correct password manager script.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/pwdmgr/PasswordManagerModule.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/pwdmgr/PasswordManagerModule.java
@@ -4,6 +4,8 @@ import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.InvalidLoginException;
+import cz.metacentrum.perun.core.api.exceptions.PasswordStrengthException;
 
 import java.util.Map;
 
@@ -28,22 +30,26 @@ public interface PasswordManagerModule {
 	String LOGIN_PREFIX = AttributesManager.NS_USER_ATTR_DEF + ":" + AttributesManager.LOGIN_NAMESPACE + ":";
 	String ALT_PASSWORD_PREFIX = AttributesManager.NS_USER_ATTR_DEF + ":altPasswords:";
 
-	Map<String,String> generateAccount(PerunSession session, Map<String, String> parameters) throws InternalErrorException;
+	Map<String,String> generateAccount(PerunSession sess, Map<String, String> parameters) throws PasswordStrengthException;
 
-	void reservePassword(PerunSession session, String userLogin, String password) throws InternalErrorException;
+	void reservePassword(PerunSession sess, String userLogin, String password) throws InvalidLoginException, PasswordStrengthException;
 
-	void reserveRandomPassword(PerunSession session, String userLogin) throws InternalErrorException;
+	void reserveRandomPassword(PerunSession sess, String userLogin) throws InvalidLoginException;
 
 	void checkPassword(PerunSession sess, String userLogin, String password);
 
-	void changePassword(PerunSession sess, String userLogin, String newPassword) throws InternalErrorException;
+	void changePassword(PerunSession sess, String userLogin, String newPassword) throws InvalidLoginException, PasswordStrengthException;
 
-	void validatePassword(PerunSession sess, String userLogin);
+	void validatePassword(PerunSession sess, String userLogin) throws InvalidLoginException;
 
-	void deletePassword(PerunSession sess, String userLogin) throws InternalErrorException;
+	void deletePassword(PerunSession sess, String userLogin) throws InvalidLoginException;
 
-	void createAlternativePassword(PerunSession sess, User user, String passwordId, String password);
+	void createAlternativePassword(PerunSession sess, User user, String passwordId, String password) throws PasswordStrengthException;
 
 	void deleteAlternativePassword(PerunSession sess, User user, String passwordId);
+
+	void checkLoginFormat(PerunSession sess, String login) throws InvalidLoginException;
+
+	void checkPasswordStrength(PerunSession sess, String login, String password) throws PasswordStrengthException;
 
 }

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace_ceitecTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace_ceitecTest.java
@@ -1,13 +1,21 @@
 package cz.metacentrum.perun.core.impl.modules.attributes;
 
 import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.BeansUtils;
+import cz.metacentrum.perun.core.api.CoreConfig;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.bl.ModulesUtilsBl;
 import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.bl.UsersManagerBl;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import cz.metacentrum.perun.core.impl.modules.pwdmgr.GenericPasswordManagerModule;
+import cz.metacentrum.perun.core.implApi.modules.pwdmgr.PasswordManagerModule;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.ArrayList;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -25,9 +33,15 @@ public class urn_perun_user_attribute_def_def_login_namespace_ceitecTest {
 		session = mock(PerunSessionImpl.class);
 		user = new User();
 		attributeToCheck = new Attribute();
+		attributeToCheck.setNamespace(AttributesManager.NS_USER_ATTR_DEF);
+		attributeToCheck.setFriendlyName("login-namespace:ceitec");
 
 		PerunBl perunBl = mock(PerunBl.class);
 		when(session.getPerunBl()).thenReturn(perunBl);
+		UsersManagerBl usersManagerBl = mock(UsersManagerBl.class);
+		when(session.getPerunBl().getUsersManagerBl()).thenReturn(usersManagerBl);
+		PasswordManagerModule module = mock(GenericPasswordManagerModule.class);
+		when(session.getPerunBl().getUsersManagerBl().getPasswordManagerModule(session, "ceitec")).thenReturn(module);
 
 		ModulesUtilsBl modulesUtilsBl = mock(ModulesUtilsBl.class);
 		when(perunBl.getModulesUtilsBl()).thenReturn(modulesUtilsBl);

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace_eduroam_vsupTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace_eduroam_vsupTest.java
@@ -10,6 +10,8 @@ import cz.metacentrum.perun.core.bl.ModulesUtilsBl;
 import cz.metacentrum.perun.core.bl.PerunBl;
 import cz.metacentrum.perun.core.bl.UsersManagerBl;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import cz.metacentrum.perun.core.impl.modules.pwdmgr.GenericPasswordManagerModule;
+import cz.metacentrum.perun.core.implApi.modules.pwdmgr.PasswordManagerModule;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -30,8 +32,11 @@ public class urn_perun_user_attribute_def_def_login_namespace_eduroam_vsupTest {
 		session = mock(PerunSessionImpl.class);
 		user = new User();
 		attributeToCheck = new Attribute();
-		attributeToCheck.setFriendlyName("friendly_name");
+		attributeToCheck.setNamespace(AttributesManager.NS_USER_ATTR_DEF);
+		attributeToCheck.setFriendlyName("login-namespace:eduroam-vsup");
 		attribute = new Attribute();
+		attribute.setNamespace(AttributesManager.NS_USER_ATTR_DEF);
+		attribute.setFriendlyName("login-namespace:eduroam-vsup");
 		attribute.setValue("same_value");
 
 		PerunBl perunBl = mock(PerunBl.class);
@@ -42,6 +47,9 @@ public class urn_perun_user_attribute_def_def_login_namespace_eduroam_vsupTest {
 
 		UsersManagerBl usersManagerBl = mock(UsersManagerBl.class);
 		when(perunBl.getUsersManagerBl()).thenReturn(usersManagerBl);
+
+		PasswordManagerModule module = mock(GenericPasswordManagerModule.class);
+		when(session.getPerunBl().getUsersManagerBl().getPasswordManagerModule(session, "eduroam-vsup")).thenReturn(module);
 
 		AttributesManagerBl attributesManagerBl = mock(AttributesManagerBl.class);
 		when(perunBl.getAttributesManagerBl()).thenReturn(attributesManagerBl);

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace_eduteams_acc_nicknameTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace_eduteams_acc_nicknameTest.java
@@ -1,11 +1,15 @@
 package cz.metacentrum.perun.core.impl.modules.attributes;
 
 import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.bl.ModulesUtilsBl;
 import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.bl.UsersManagerBl;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import cz.metacentrum.perun.core.impl.modules.pwdmgr.GenericPasswordManagerModule;
+import cz.metacentrum.perun.core.implApi.modules.pwdmgr.PasswordManagerModule;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -24,12 +28,21 @@ public class urn_perun_user_attribute_def_def_login_namespace_eduteams_acc_nickn
 		session = mock(PerunSessionImpl.class);
 		user = new User();
 		attributeToCheck = new Attribute();
+		attributeToCheck.setNamespace(AttributesManager.NS_USER_ATTR_DEF);
+		attributeToCheck.setFriendlyName("login-namespace:eduteams-acc-nickname");
 
 		PerunBl perunBl = mock(PerunBl.class);
 		when(session.getPerunBl()).thenReturn(perunBl);
 
 		ModulesUtilsBl modulesUtilsBl = mock(ModulesUtilsBl.class);
 		when(perunBl.getModulesUtilsBl()).thenReturn(modulesUtilsBl);
+
+		UsersManagerBl usersManagerBl = mock(UsersManagerBl.class);
+		when(perunBl.getUsersManagerBl()).thenReturn(usersManagerBl);
+
+		PasswordManagerModule module = mock(GenericPasswordManagerModule.class);
+		when(session.getPerunBl().getUsersManagerBl().getPasswordManagerModule(session, "eduteams-acc-nickname")).thenReturn(module);
+
 	}
 
 	@Test

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace_eduteams_nicknameTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace_eduteams_nicknameTest.java
@@ -1,11 +1,15 @@
 package cz.metacentrum.perun.core.impl.modules.attributes;
 
 import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.bl.ModulesUtilsBl;
 import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.bl.UsersManagerBl;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import cz.metacentrum.perun.core.impl.modules.pwdmgr.GenericPasswordManagerModule;
+import cz.metacentrum.perun.core.implApi.modules.pwdmgr.PasswordManagerModule;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -24,12 +28,22 @@ public class urn_perun_user_attribute_def_def_login_namespace_eduteams_nicknameT
 		session = mock(PerunSessionImpl.class);
 		user = new User();
 		attributeToCheck = new Attribute();
+		attributeToCheck.setNamespace(AttributesManager.NS_USER_ATTR_DEF);
+		attributeToCheck.setFriendlyName("login-namespace:eduteams-nickname");
 
 		PerunBl perunBl = mock(PerunBl.class);
 		when(session.getPerunBl()).thenReturn(perunBl);
 
 		ModulesUtilsBl modulesUtilsBl = mock(ModulesUtilsBl.class);
 		when(perunBl.getModulesUtilsBl()).thenReturn(modulesUtilsBl);
+
+		UsersManagerBl usersManagerBl = mock(UsersManagerBl.class);
+		when(perunBl.getUsersManagerBl()).thenReturn(usersManagerBl);
+
+		PasswordManagerModule module = mock(GenericPasswordManagerModule.class);
+		when(session.getPerunBl().getUsersManagerBl().getPasswordManagerModule(session, "eduteams-nickname")).thenReturn(module);
+
+
 	}
 
 	@Test

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace_fenix_nicknameTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace_fenix_nicknameTest.java
@@ -1,11 +1,15 @@
 package cz.metacentrum.perun.core.impl.modules.attributes;
 
 import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.bl.ModulesUtilsBl;
 import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.bl.UsersManagerBl;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import cz.metacentrum.perun.core.impl.modules.pwdmgr.GenericPasswordManagerModule;
+import cz.metacentrum.perun.core.implApi.modules.pwdmgr.PasswordManagerModule;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -24,12 +28,22 @@ public class urn_perun_user_attribute_def_def_login_namespace_fenix_nicknameTest
 		session = mock(PerunSessionImpl.class);
 		user = new User();
 		attributeToCheck = new Attribute();
+		attributeToCheck.setNamespace(AttributesManager.NS_USER_ATTR_DEF);
+		attributeToCheck.setFriendlyName("login-namespace:fenix-nickname");
 
 		PerunBl perunBl = mock(PerunBl.class);
 		when(session.getPerunBl()).thenReturn(perunBl);
 
 		ModulesUtilsBl modulesUtilsBl = mock(ModulesUtilsBl.class);
 		when(perunBl.getModulesUtilsBl()).thenReturn(modulesUtilsBl);
+
+		UsersManagerBl usersManagerBl = mock(UsersManagerBl.class);
+		when(perunBl.getUsersManagerBl()).thenReturn(usersManagerBl);
+
+		PasswordManagerModule module = mock(GenericPasswordManagerModule.class);
+		when(session.getPerunBl().getUsersManagerBl().getPasswordManagerModule(session, "fenix-nickname")).thenReturn(module);
+
+
 	}
 
 	@Test

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace_vsupTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace_vsupTest.java
@@ -1,11 +1,15 @@
 package cz.metacentrum.perun.core.impl.modules.attributes;
 
 import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.bl.ModulesUtilsBl;
 import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.bl.UsersManagerBl;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import cz.metacentrum.perun.core.impl.modules.pwdmgr.GenericPasswordManagerModule;
+import cz.metacentrum.perun.core.implApi.modules.pwdmgr.PasswordManagerModule;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -25,12 +29,21 @@ public class urn_perun_user_attribute_def_def_login_namespace_vsupTest {
 		session = mock(PerunSessionImpl.class);
 		user = new User();
 		attributeToCheck = new Attribute();
+		attributeToCheck.setNamespace(AttributesManager.NS_USER_ATTR_DEF);
+		attributeToCheck.setFriendlyName("login-namespace:vsup");
 
 		PerunBl perunBl = mock(PerunBl.class);
 		when(session.getPerunBl()).thenReturn(perunBl);
 
 		ModulesUtilsBl modulesUtilsBl = mock(ModulesUtilsBl.class);
 		when(perunBl.getModulesUtilsBl()).thenReturn(modulesUtilsBl);
+
+		UsersManagerBl usersManagerBl = mock(UsersManagerBl.class);
+		when(perunBl.getUsersManagerBl()).thenReturn(usersManagerBl);
+
+		PasswordManagerModule module = mock(GenericPasswordManagerModule.class);
+		when(session.getPerunBl().getUsersManagerBl().getPasswordManagerModule(session, "vsup")).thenReturn(module);
+
 	}
 
 	@Test

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/UsersManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/UsersManagerMethod.java
@@ -910,12 +910,13 @@ public enum UsersManagerMethod implements ManagerMethod {
 	},
 
 	/*#
-	 * Checks if the login is available in the namespace.
+	 * Checks if the login is available in the namespace. Return 1 if yes, 0 if no.
 	 *
 	 * @param loginNamespace String Namespace
 	 * @param login String Login
 	 * @exampleResponse 1
 	 * @return int 1: login available, 0: login not available
+	 * @throw InvalidLoginException When login to check has invalid syntax or is not allowed
 	 */
 	isLoginAvailable {
 
@@ -951,6 +952,8 @@ public enum UsersManagerMethod implements ManagerMethod {
 	 * @param newPassword String New password
 	 * @param oldPassword String Old password which will be checked. This parameter is required only if checkOldPassword is set to true.
 	 * @param checkOldPassword boolean True if the oldPassword have to be checked. When omitted it defaults to false.
+	 * @throw InvalidLoginException When login of user has invalid syntax (is not allowed)
+	 * @throw PasswordStrengthException When password doesn't match expected strength by namespace configuration
 	 */
 	/*#
 	 * Changes user password in defined login-namespace.
@@ -960,6 +963,9 @@ public enum UsersManagerMethod implements ManagerMethod {
 	 * @param newPassword String New password
 	 * @param oldPassword String Old password which will be checked. This parameter is required only if checkOldPassword is set to true.
 	 * @param checkOldPassword boolean True if the oldPassword have to be checked. When omitted it defaults to false.
+	 * @throw LoginNotExistsException When user doesn't have login in specified namespace
+	 * @throw InvalidLoginException When login of user has invalid syntax (is not allowed)
+	 * @throw PasswordStrengthException When password doesn't match expected strength by namespace configuration
 	 */
 	changePassword {
 		@Override
@@ -985,12 +991,15 @@ public enum UsersManagerMethod implements ManagerMethod {
 		}
 	},
 	/*#
-	 * Changes user's password in namespace based on encrypted parameters
+	 * Changes user's password in namespace based on encrypted input parameters.
 	 *
 	 * @param i String first encrypted parameter
 	 * @param m String second encrypted parameter
 	 * @param password String new password
 	 * @param lang String language to get notifications in (optional).
+	 * @throw LoginNotExistsException When user doesn't have login in specified namespace
+	 * @throw InvalidLoginException When login of user has invalid syntax (is not allowed)
+	 * @throw PasswordStrengthException When password doesn't match expected strength by namespace configuration
 	 */
 	changeNonAuthzPassword {
 		@Override
@@ -1008,6 +1017,8 @@ public enum UsersManagerMethod implements ManagerMethod {
 	 *
 	 * @param user int User <code>id</code>
 	 * @param namespace String Namespace
+	 * @throw LoginNotExistsException When user doesn't have login in specified namespace
+	 * @throw InvalidLoginException When login of user has invalid syntax (is not allowed)
 	 */
 	reserveRandomPassword {
 		@Override
@@ -1026,6 +1037,9 @@ public enum UsersManagerMethod implements ManagerMethod {
 	 * @param user int User <code>id</code>
 	 * @param namespace String Namespace
 	 * @param password String password
+	 * @throw LoginNotExistsException When user doesn't have login in specified namespace
+	 * @throw InvalidLoginException When login of user has invalid syntax (is not allowed)
+	 * @throw PasswordStrengthException When password doesn't match expected strength by namespace configuration
 	 */
 	/*#
 	 * Reserves password for a user in specified login-namespace.
@@ -1033,6 +1047,8 @@ public enum UsersManagerMethod implements ManagerMethod {
 	 * @param login String Login
 	 * @param namespace String Namespace
 	 * @param password String password
+	 * @throw InvalidLoginException When login has invalid syntax (is not allowed)
+	 * @throw PasswordStrengthException When password doesn't match expected strength by namespace configuration
 	 */
 	reservePassword {
 		@Override
@@ -1055,6 +1071,8 @@ public enum UsersManagerMethod implements ManagerMethod {
 	 *
 	 * @param user int User <code>id</code>
 	 * @param namespace String Namespace
+	 * @throw LoginNotExistsException When user doesn't have login in specified namespace
+	 * @throw InvalidLoginException When login of user has invalid syntax (is not allowed)
 	 */
 	/*#
 	 * Validates password for a user in specified login-namespace. After that, user should be able to log-in
@@ -1062,6 +1080,7 @@ public enum UsersManagerMethod implements ManagerMethod {
 	 *
 	 * @param login String Login
 	 * @param namespace String Namespace
+	 * @throw InvalidLoginException When login of user has invalid syntax (is not allowed)
 	 */
 	validatePassword {
 		@Override
@@ -1086,6 +1105,8 @@ public enum UsersManagerMethod implements ManagerMethod {
 	 * @param user int User <code>id</code>
 	 * @param login String Login
 	 * @param namespace String Namespace
+	 * @throw LoginNotExistsException When user doesn't have login in specified namespace
+	 * @throw InvalidLoginException When login of user has invalid syntax (is not allowed)
 	 */
 	validatePasswordAndSetExtSources {
 		@Override
@@ -1105,6 +1126,8 @@ public enum UsersManagerMethod implements ManagerMethod {
 	 * @param user int User <code>id</code>
 	 * @param login String Login
 	 * @param namespace String Namespace
+	 * @throw InvalidLoginException When login of user has invalid syntax (is not allowed)
+	 * @throw LoginExistsException When login is already taken by another user
 	 */
 	setLogin {
 		@Override
@@ -1282,7 +1305,7 @@ public enum UsersManagerMethod implements ManagerMethod {
 	 * @param parameters Map
 	 *
 	 * @return Map<String, String> Map of data from backed response
-	 * @throws InternalErrorException
+	 * @throw PasswordStrengthException When password doesn't match expected strength by namespace configuration
 	 */
 	generateAccount {
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/applicationresources/RegistrarFormItemGenerator.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/applicationresources/RegistrarFormItemGenerator.java
@@ -24,6 +24,7 @@ import cz.metacentrum.perun.webgui.model.ApplicationFormItem;
 import cz.metacentrum.perun.webgui.model.ApplicationFormItemWithPrefilledValue;
 import cz.metacentrum.perun.webgui.model.BasicOverlayType;
 import cz.metacentrum.perun.webgui.model.ItemTexts;
+import cz.metacentrum.perun.webgui.model.PerunError;
 import cz.metacentrum.perun.webgui.widgets.CustomButton;
 
 import java.util.*;
@@ -1321,6 +1322,26 @@ public class RegistrarFormItemGenerator {
 								}
 								validationTrigger.triggerValidation();
 							}
+
+							@Override
+							public void onError(PerunError error) {
+
+								if(!str.equals(strValueBox.getValue())){
+									// value changed before request finished, don't update the valid value
+									return;
+								}
+								if ("InvalidLoginException".equalsIgnoreCase(error.getType())) {
+									validMap.put(str,false);
+									statusCellWrapper.setWidget(new FormInputStatusWidget("Login has invalid syntax." + error.getErrorInfo(), Status.ERROR));
+								} else {
+									// generic error
+									statusCellWrapper.setWidget(new FormInputStatusWidget("Unable to check if login is available!", Status.ERROR));
+								}
+								validating = false;
+								validationTrigger.triggerValidation();
+
+							}
+
 						}).retrieveData();
 
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/applicationresources/RegistrarFormItemGenerator.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/applicationresources/RegistrarFormItemGenerator.java
@@ -1330,7 +1330,7 @@ public class RegistrarFormItemGenerator {
 									// value changed before request finished, don't update the valid value
 									return;
 								}
-								if ("InvalidLoginException".equalsIgnoreCase(error.getType())) {
+								if ("InvalidLoginException".equalsIgnoreCase(error.getName())) {
 									validMap.put(str,false);
 									statusCellWrapper.setWidget(new FormInputStatusWidget("Login has invalid syntax." + error.getErrorInfo(), Status.ERROR));
 								} else {

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/usersManager/IsLoginAvailable.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/usersManager/IsLoginAvailable.java
@@ -142,7 +142,7 @@ public class IsLoginAvailable implements JsonCallback {
 
 	public void onError(PerunError error) {
 
-		if (error != null && !"InvalidLoginException".equalsIgnoreCase(error.getType())) {
+		if (error != null && !"InvalidLoginException".equalsIgnoreCase(error.getName())) {
 			// creates a alert box
 			JsonErrorHandler.alertBox(error);
 		}

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/usersManager/IsLoginAvailable.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/usersManager/IsLoginAvailable.java
@@ -6,6 +6,7 @@ import com.google.gwt.json.client.JSONObject;
 import cz.metacentrum.perun.webgui.json.JsonCallback;
 import cz.metacentrum.perun.webgui.json.JsonCallbackEvents;
 import cz.metacentrum.perun.webgui.json.JsonClient;
+import cz.metacentrum.perun.webgui.json.JsonErrorHandler;
 import cz.metacentrum.perun.webgui.model.BasicOverlayType;
 import cz.metacentrum.perun.webgui.model.PerunError;
 
@@ -81,6 +82,7 @@ public class IsLoginAvailable implements JsonCallback {
 	private void isLoginAvailable(String namespace){
 		// sending data
 		JsonClient req = new JsonClient();
+		req.setHidden(true);
 		req.retrieveData(JSON_URL, "login=" + login + "&loginNamespace=" + namespace, this);
 	}
 
@@ -139,6 +141,12 @@ public class IsLoginAvailable implements JsonCallback {
 	}
 
 	public void onError(PerunError error) {
+
+		if (error != null && !"InvalidLoginException".equalsIgnoreCase(error.getType())) {
+			// creates a alert box
+			JsonErrorHandler.alertBox(error);
+		}
+
 		finalEvents.onError(error);
 	}
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/CreateServiceMemberInVoTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/CreateServiceMemberInVoTabItem.java
@@ -455,7 +455,8 @@ public class CreateServiceMemberInVoTabItem implements TabItem, TabItemWithUrl {
 								button.addClickHandler(new ClickHandler() {
 									public void onClick(ClickEvent clickEvent) {
 
-										if (!validator.validateTextBox() && !validator2.validateTextBox()) {
+										if (!validator.validateTextBox() || !validator2.validateTextBox()) {
+											// one of input boxes for passwords is wrong
 											return;
 										}
 
@@ -634,8 +635,11 @@ public class CreateServiceMemberInVoTabItem implements TabItem, TabItemWithUrl {
 								ft.setHTML(1, 0, "Re-type&nbsp;password:");
 								ft.setWidget(1, 1, serviceUserPassword2);
 								ft.getFlexCellFormatter().setStyleName(1, 0, "itemName");
-
-								ft.setHTML(2, 0, "Please <b>avoid using accented characters</b>. It might not be supported by all backend components and services.");
+								if ("einfra".equals(namespace.getSelectedValue())) {
+									ft.setHTML(2, 0, "Password must <ul><li>contain only printing (non-accented) characters<li>be at least 10 characters long<li>consist of at least 3 of 4 character groups<ul><li>lower-case letters<li>upper-case letters<li>digits<li>special characters</ul></ul>");
+								} else {
+									ft.setHTML(2, 0, "Please <b>avoid using accented characters</b>. It might not be supported by all backend components and services.");
+								}
 								ft.getFlexCellFormatter().setColSpan(2, 0, 2);
 								ft.getCellFormatter().setStyleName(2, 0,"inputFormInlineComment");
 
@@ -772,7 +776,7 @@ public class CreateServiceMemberInVoTabItem implements TabItem, TabItemWithUrl {
 						public void onError(PerunError error) {
 							// response is relevant to current value
 							if (serviceUserLogin.getTextBox().getValue().trim().equals(login)) {
-								if ("InvalidLoginException".equalsIgnoreCase(error.getType())) {
+								if ("InvalidLoginException".equalsIgnoreCase(error.getName())) {
 									serviceUserLogin.setProcessing(false);
 									String text = error.getErrorInfo();
 									text = text.split(":", 2)[1];
@@ -843,7 +847,7 @@ public class CreateServiceMemberInVoTabItem implements TabItem, TabItemWithUrl {
 							public void onError(PerunError error) {
 								// response is relevant to current value
 								if (serviceUserLogin.getTextBox().getValue().trim().equals(login)) {
-									if ("InvalidLoginException".equalsIgnoreCase(error.getType())) {
+									if ("InvalidLoginException".equalsIgnoreCase(error.getName())) {
 										serviceUserLogin.setProcessing(false);
 										String text = error.getErrorInfo();
 										text = text.split(":", 2)[1];

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/CreateServiceMemberInVoTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/CreateServiceMemberInVoTabItem.java
@@ -189,6 +189,80 @@ public class CreateServiceMemberInVoTabItem implements TabItem, TabItemWithUrl {
 		final ExtendedTextBox.TextBoxValidator validator = new ExtendedTextBox.TextBoxValidator() {
 			@Override
 			public boolean validateTextBox() {
+
+				if (serviceUserPassword.getTextBox().getValue().trim().equals("")) {
+					serviceUserPassword.setError("Password can't be empty!");
+					return false;
+				}
+
+				// einfra check
+				if ("einfra".equals(namespace.getSelectedValue())) {
+
+					RegExp regExp2 = RegExp.compile("^[\\x20-\\x7E]{1,}$");
+					if(regExp2.exec(serviceUserPassword.getTextBox().getValue()) == null){
+						serviceUserPassword.setError("Password <b>can`t contain accented characters (diacritics)</b> or non-printing and control characters!");
+						return false;
+					}
+
+					// Check that password contains at least 3 of 4 character groups
+
+					RegExp regExpDigit = RegExp.compile("^.*[0-9].*$");
+					RegExp regExpLower = RegExp.compile("^.*[a-z].*$");
+					RegExp regExpUpper = RegExp.compile("^.*[A-Z].*$");
+					RegExp regExpSpec = RegExp.compile("^.*[\\x20-\\x2F\\x3A-\\x40\\x5B-\\x60\\x7B-\\x7E].*$"); // FIXME - are those correct printable specific chars?
+
+					int matchCounter = 0;
+					if (regExpDigit.exec(serviceUserPassword.getTextBox().getValue()) != null) matchCounter++;
+					if (regExpLower.exec(serviceUserPassword.getTextBox().getValue()) != null) matchCounter++;
+					if (regExpUpper.exec(serviceUserPassword.getTextBox().getValue()) != null) matchCounter++;
+					if (regExpSpec.exec(serviceUserPassword.getTextBox().getValue()) != null) matchCounter++;
+
+					if(matchCounter < 3){
+						serviceUserPassword.setError("Password must consist of <b>at least 3 of 4</b> character groups<ul><li>lower-case letters</li><li>upper-case letters</li><li>digits</li><li>special characters</li></ul>");
+						return false;
+					}
+
+					// check length
+					if (serviceUserPassword.getTextBox().getValue().length() < 10) {
+						serviceUserPassword.setError("Password must be <b>at least 10 characters</b> long!");
+						return false;
+					}
+
+				}
+
+				if (!serviceUserPassword.getTextBox().getValue().equals(serviceUserPassword2.getTextBox().getValue())) {
+					serviceUserPassword.setOk();
+					serviceUserPassword2.setError("Password in both textboxes must be the same!");
+					return false;
+				}
+
+				serviceUserPassword.setOk();
+				return true;
+
+			}
+		};
+		serviceUserPassword.setValidator(validator);
+
+		final ExtendedTextBox.TextBoxValidator validator2 = new ExtendedTextBox.TextBoxValidator() {
+			@Override
+			public boolean validateTextBox() {
+
+				if (!serviceUserPassword2.getTextBox().getValue().equals(serviceUserPassword.getTextBox().getValue())) {
+					serviceUserPassword2.setError("Password in both textboxes must be the same!");
+					return false;
+				} else {
+					serviceUserPassword2.setOk();
+					return true;
+				}
+
+			}
+		};
+		serviceUserPassword2.setValidator(validator2);
+
+		/*
+		final ExtendedTextBox.TextBoxValidator validator = new ExtendedTextBox.TextBoxValidator() {
+			@Override
+			public boolean validateTextBox() {
 				if (serviceUserPassword.getTextBox().getValue().trim().isEmpty()) {
 					serviceUserPassword.setError("Password can't be empty !");
 					return false;
@@ -221,7 +295,7 @@ public class CreateServiceMemberInVoTabItem implements TabItem, TabItemWithUrl {
 			}
 		};
 		serviceUserPassword2.setValidator(validator2);
-
+		*/
 
 		final ExtendedTextBox.TextBoxValidator certDNValidator = new ExtendedTextBox.TextBoxValidator() {
 			@Override
@@ -696,9 +770,19 @@ public class CreateServiceMemberInVoTabItem implements TabItem, TabItemWithUrl {
 						}
 						@Override
 						public void onError(PerunError error) {
+							// response is relevant to current value
 							if (serviceUserLogin.getTextBox().getValue().trim().equals(login)) {
-								serviceUserLogin.setProcessing(false);
-								serviceUserLogin.setHardError("Unable to check if login is available!");
+								if ("InvalidLoginException".equalsIgnoreCase(error.getType())) {
+									serviceUserLogin.setProcessing(false);
+									String text = error.getErrorInfo();
+									text = text.split(":", 2)[1];
+									text = (text == null || text.isEmpty()) ? error.getErrorInfo() : text;
+									serviceUserLogin.setHardError(text);
+								} else {
+									// generic error
+									serviceUserLogin.setProcessing(false);
+									serviceUserLogin.setHardError("Unable to check if login is available!");
+								}
 							}
 						}
 					}).retrieveData();
@@ -714,6 +798,7 @@ public class CreateServiceMemberInVoTabItem implements TabItem, TabItemWithUrl {
 					// do not set login
 					serviceUserLogin.getTextBox().setEnabled(false);
 					serviceUserLogin.getTextBox().setValue(null);
+					loginValidator.validateTextBox();
 					label.setVisible(false);
 				} else if (namespace.getSelectedValue().equals("mu")) {
 					serviceUserLogin.getTextBox().setEnabled(false);
@@ -723,40 +808,57 @@ public class CreateServiceMemberInVoTabItem implements TabItem, TabItemWithUrl {
 					label.setVisible(false);
 				}
 
-				final String login = serviceUserLogin.getTextBox().getValue().trim();
-				final String loginNamespace = namespace.getValue(namespace.getSelectedIndex());
-				if ((!login.isEmpty() && RegExp.compile(Utils.LOGIN_VALUE_MATCHER).test(login)) || serviceUserLogin.isHardError()) {
-					new IsLoginAvailable(loginNamespace, login, new JsonCallbackEvents(){
-						@Override
-						public void onFinished(JavaScriptObject jso) {
-							// UPDATE RESULT ONLY IF CONTENT OF LOGIN BOX IS SAME AS ON CALLBACK START
-							if (serviceUserLogin.getTextBox().getValue().trim().equals(login)) {
-								serviceUserLogin.setProcessing(false);
-								BasicOverlayType bo = jso.cast();
-								if (!bo.getBoolean()) {
-									serviceUserLogin.setHardError("Login is already in use!");
-								} else {
+				if (namespace.getSelectedIndex() != 0) {
+					// do not check login if not desired to set
+
+					final String login = serviceUserLogin.getTextBox().getValue().trim();
+					final String loginNamespace = namespace.getValue(namespace.getSelectedIndex());
+					if ((!login.isEmpty() && RegExp.compile(Utils.LOGIN_VALUE_MATCHER).test(login)) || serviceUserLogin.isHardError()) {
+						new IsLoginAvailable(loginNamespace, login, new JsonCallbackEvents() {
+							@Override
+							public void onFinished(JavaScriptObject jso) {
+								// UPDATE RESULT ONLY IF CONTENT OF LOGIN BOX IS SAME AS ON CALLBACK START
+								if (serviceUserLogin.getTextBox().getValue().trim().equals(login)) {
+									serviceUserLogin.setProcessing(false);
+									BasicOverlayType bo = jso.cast();
+									if (!bo.getBoolean()) {
+										serviceUserLogin.setHardError("Login is already in use!");
+									} else {
+										serviceUserLogin.removeHardError();
+										loginValidator.validateTextBox();
+									}
+								}
+							}
+
+							@Override
+							public void onLoadingStart() {
+								if (serviceUserLogin.getTextBox().getValue().trim().equals(login)) {
 									serviceUserLogin.removeHardError();
+									serviceUserLogin.setProcessing(true);
 									loginValidator.validateTextBox();
 								}
 							}
-						}
-						@Override
-						public void onLoadingStart(){
-							if (serviceUserLogin.getTextBox().getValue().trim().equals(login)) {
-								serviceUserLogin.removeHardError();
-								serviceUserLogin.setProcessing(true);
-								loginValidator.validateTextBox();
+
+							@Override
+							public void onError(PerunError error) {
+								// response is relevant to current value
+								if (serviceUserLogin.getTextBox().getValue().trim().equals(login)) {
+									if ("InvalidLoginException".equalsIgnoreCase(error.getType())) {
+										serviceUserLogin.setProcessing(false);
+										String text = error.getErrorInfo();
+										text = text.split(":", 2)[1];
+										text = (text == null || text.isEmpty()) ? error.getErrorInfo() : text;
+										serviceUserLogin.setHardError(text);
+									} else {
+										// generic error
+										serviceUserLogin.setProcessing(false);
+										serviceUserLogin.setHardError("Unable to check if login is available!");
+									}
+								}
 							}
-						}
-						@Override
-						public void onError(PerunError error) {
-							if (serviceUserLogin.getTextBox().getValue().trim().equals(login)) {
-								serviceUserLogin.setProcessing(false);
-								serviceUserLogin.setHardError("Unable to check if login is available!");
-							}
-						}
-					}).retrieveData();
+						}).retrieveData();
+					}
+
 				}
 			}
 		});

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/AddLoginTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/AddLoginTabItem.java
@@ -170,6 +170,12 @@ public class AddLoginTabItem implements TabItem {
 		layout.setWidget(2, 0, notice);
 		layout.getFlexCellFormatter().addStyleName(2, 0, "inputFormInlineComment");
 
+		HTML help = new HTML("Login must<ul><li>start with lower-cased letter<li>be 2-15 characters long<li>consist only of<ul><li>lower-cased non-accented letters<li>digits<li>hyphens and underscores</ul></ul>");
+		help.setVisible(false);
+		layout.getFlexCellFormatter().setColSpan(3, 0, 2);
+		layout.setWidget(3, 0, help);
+		layout.getFlexCellFormatter().addStyleName(3, 0, "inputFormInlineComment");
+
 		TabMenu menu = new TabMenu();
 		menu.addWidget(createLogin);
 
@@ -224,8 +230,17 @@ public class AddLoginTabItem implements TabItem {
 						@Override
 						public void onError(PerunError error) {
 							if (value.equals(userLogin.getTextBox().getValue().trim())) {
-								userLogin.setProcessing(false);
-								userLogin.setHardError("Unable to check if login is available!");
+								if ("InvalidLoginException".equalsIgnoreCase(error.getType())) {
+									userLogin.setProcessing(false);
+									String text = error.getErrorInfo();
+									text = text.split(":", 2)[1];
+									text = (text == null || text.isEmpty()) ? error.getErrorInfo() : text;
+									userLogin.setHardError(text);
+								} else {
+									// generic error
+									userLogin.setProcessing(false);
+									userLogin.setHardError("Unable to check if login is available!");
+								}
 							}
 						}
 						}).retrieveData();
@@ -235,6 +250,12 @@ public class AddLoginTabItem implements TabItem {
 
 			namespace.addChangeHandler(new ChangeHandler() {
 				public void onChange(ChangeEvent changeEvent) {
+
+					if (namespace.getSelectedValue().equals("einfra")) {
+						help.setVisible(true);
+					} else {
+						help.setVisible(false);
+					}
 
 					if (namespace.getSelectedValue().equals("mu")) {
 
@@ -321,6 +342,8 @@ public class AddLoginTabItem implements TabItem {
 			userLogin.getTextBox().setEnabled(false);
 			notice.setVisible(true);
 
+		} else if (namespace.getSelectedValue().equals("einfra")) {
+			help.setVisible(true);
 		}
 
 		vp.add(menu);

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/AddLoginTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/AddLoginTabItem.java
@@ -230,7 +230,7 @@ public class AddLoginTabItem implements TabItem {
 						@Override
 						public void onError(PerunError error) {
 							if (value.equals(userLogin.getTextBox().getValue().trim())) {
-								if ("InvalidLoginException".equalsIgnoreCase(error.getType())) {
+								if ("InvalidLoginException".equalsIgnoreCase(error.getName())) {
 									userLogin.setProcessing(false);
 									String text = error.getErrorInfo();
 									text = text.split(":", 2)[1];


### PR DESCRIPTION
CORE
- Logic of attribute checks for login syntax was moved into
  tha password manager modules.
- Helping methods in ModulesUtilsBl were updated to work just with
  login and namespace (without Attribute object).
- New configuration option "login-namespace:[namespace]:allowedExceptions"
  in /etc/perun/perun-namespaces.properties can be used to allow
  otherwise invalid logins (syntactically or unpermitted).
  This is necessary to enforce correct checks on new logins, but
  leave out currently existing invalid logins.
- Added checked InvalidLoginException, which is thrown if login
  is invalid by syntax or is not permitted.
- isLoginAvailable() now also checks if login is syntactically
  correct and allowed within namespace before returning info about
  availability. This allows us to have input check in current
  forms.
- Updated generic user:def:login-namespace attribute module to wrap
  new logic and throw WrongAttributeValue as expected.

- Implemented password strength check in password manager modules.
- GenericPasswordManagerModule checks only emptiness, to conform
  previous behavior.
  EinfraPasswordManagerModule checks various password properties
  and its logic will be extended later. It is also applied to
  SambaduPasswordManagerModule.

- Various generic methods working with login/password now throws those
  two new exceptions, and usually also methods using them.
  Core and RPC javadoc for such methods was updated.

GUI
- Check for login availability can handle InvalidLoginException.
- Show einfra specific help and perform checks on password.