### PR TITLE
UTILS: Changed tools for NRPE commands to use basic auth

### DIFF
--- a/perun-utils/checkLastTaskResult.sh
+++ b/perun-utils/checkLastTaskResult.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
-source /etc/perun/perun-engine
-KRB5CCNAME=/tmp/krb5cc_perun-engine-nagios
-/opt/perun-cli/bin/checkLastTaskResult $* 2>&1 || exit 2
+# source ENGINE identity and API URL
+. /etc/perun/perun-engine
+# overwrite cookie to ours
+export PERUN_COOKIE=/var/lib/nagios/.perun-nagios-cookie.txt
+# run tool
+/opt/perun-cli/bin/checkLastTaskResult "$@" 2>&1 || exit 2

--- a/perun-utils/listOfNRPECommands
+++ b/perun-utils/listOfNRPECommands
@@ -19,7 +19,7 @@ my $CHECK_COMMAND = '/opt/perun-utils/checkLastTaskResult.sh';
 sub help {
 	return qq{
 	Returns list of commands for NRPE server in format:
-	"command[SERVICE+DESTINATION]=PATH/CHECK_COMMAND -S SERVICE 
+	"command[SERVICE+DESTINATION]=PATH/CHECK_COMMAND -S SERVICE
 	-D DESTINATION" per line where '+' is needed separator,
 	PATH is where CLI scripts are and CHECK_COMMAND is command for checking
 	if the newest task_result for combination SERVICE and DESTINATION (names)


### PR DESCRIPTION
- Do not relay on kerberos, use engines basic auth.
- checkLastTaskResult.sh now defines cookie file to prevent
  clutter in nagios home folder
- Applied IDEA suggestion $* -> "$@" to better handle whitespace.
- Whitespace changes.