### PR TITLE
UTILS: Changed tools for NRPE commands to use local definition

### DIFF
--- a/perun-utils/checkLastTaskResult.sh
+++ b/perun-utils/checkLastTaskResult.sh
@@ -1,8 +1,13 @@
 #!/bin/bash
 
-# source ENGINE identity and API URL
-. /etc/perun/perun-engine
-# overwrite cookie to ours
+# define connection to Perun
+export PERUN_URL=
+export PERUN_USER=
 export PERUN_COOKIE=/var/lib/nagios/.perun-nagios-cookie.txt
+# export perl libs
+PERL5LIB="/opt/perun-cli/lib/${PERL5LIB+:}${PERL5LIB}";
+export PERL5LIB;
+export PERL5LIB=$PERL5LIB":."
+
 # run tool
 /opt/perun-cli/bin/checkLastTaskResult "$@" 2>&1 || exit 2


### PR DESCRIPTION
- Do not source perun-engine identity, allow local
  definition of API url and user.
- Also properly export perl5libs.