### PR TITLE
Implementation of independent propagation task scheduling

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/taskslib/model/Task.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/taskslib/model/Task.java
@@ -39,7 +39,8 @@ public class Task implements Serializable {
 	private TaskStatus status;
 	private boolean sourceUpdated;
 	private boolean propagationForced;
-
+	private String scheduleExpr;
+	
 	@Override
 	public int hashCode() {
 		final int prime = 31;
@@ -122,7 +123,7 @@ public class Task implements Serializable {
 		this.schedule = schedule;
 	}
 
-	public void setSchdule(Long schedule) {
+	public void setSchedule(Long schedule) {
 		if (schedule != null) {
 			this.schedule = Instant.ofEpochMilli(schedule).atZone(ZoneId.systemDefault()).toLocalDateTime();
 		} else {
@@ -323,6 +324,7 @@ public class Task implements Serializable {
 				.append("', service='").append(service)
 				.append("', facility='").append(facility)
 				.append("', destinations='").append(destinations)
+				.append("', scheduleExpr='").append(scheduleExpr)
 				.append("']").toString();
 	}
 
@@ -341,4 +343,12 @@ public class Task implements Serializable {
 	public void setPropagationForced(boolean propagationForced) {
 		this.propagationForced = propagationForced;
 	}
+	public String getScheduleExpr() {
+		return scheduleExpr;
+	}
+
+	public void setScheduleExpr(String scheduleExpr) {
+		this.scheduleExpr = scheduleExpr;
+	}
+
 }

--- a/perun-base/src/test/resources/test-schema.sql
+++ b/perun-base/src/test/resources/test-schema.sql
@@ -1156,6 +1156,7 @@ create table tasks (
 	start_time timestamp,
 	end_time timestamp,
 	engine_id integer,
+	schedule_expr varchar(256),
 	created_at timestamp default current_date not null,
 	err_message varchar(4000),
 	created_by_uid integer,

--- a/perun-base/src/test/resources/test-schema.sql
+++ b/perun-base/src/test/resources/test-schema.sql
@@ -1753,7 +1753,7 @@ CREATE INDEX ufauv_idx ON user_facility_attr_u_values (user_id, facility_id, att
 CREATE INDEX vauv_idx ON vo_attr_u_values (vo_id, attr_id) ;
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.1.59');
+insert into configurations values ('DATABASE VERSION','3.1.60');
 insert into membership_types (id, membership_type, description) values (1, 'DIRECT', 'Member is directly added into group');
 insert into membership_types (id, membership_type, description) values (2, 'INDIRECT', 'Member is added indirectly through UNION relation');
 insert into action_types (id, action_type, description) values (nextval('action_types_seq'), 'read', 'Can read value.');

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/TasksManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/TasksManager.java
@@ -37,6 +37,8 @@ public interface TasksManager {
 
 	List<Task> listAllTasksInState(PerunSession perunSession, Task.TaskStatus state) throws PrivilegeException;
 
+	List<Task> listAllSchedulableTasks() throws PrivilegeException;
+	
 	boolean isThereSuchTask(PerunSession session, Service service, Facility facility) throws PrivilegeException;
 
 	int countTasks();

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/TasksManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/TasksManagerBl.java
@@ -167,6 +167,8 @@ public interface TasksManagerBl {
 
 	List<Task> listAllTasksNotInState(Task.TaskStatus state);
 
+	List<Task> listAllSchedulableTasks();
+
 	/**
 	 * List newest TaskResults tied to a certain task
 	 *

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/TasksManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/TasksManagerBlImpl.java
@@ -126,6 +126,11 @@ public class TasksManagerBlImpl implements TasksManagerBl {
 	}
 
 	@Override
+	public List<Task>listAllSchedulableTasks() {
+		return getTasksManagerImpl().listAllSchedulableTasks();
+	}
+
+	@Override
 	public void updateTask(Task task) {
 		getTasksManagerImpl().updateTask(task);
 	}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/TasksManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/TasksManagerEntry.java
@@ -74,9 +74,16 @@ public class TasksManagerEntry implements TasksManager {
 
 	@Override
 	public List<Task> listAllTasksInState(PerunSession perunSession, Task.TaskStatus state) throws PrivilegeException {
+		// TODO: authorization check
 		return tasksManagerBl.listAllTasksInState(perunSession, state);
 	}
 
+	@Override
+	public List<Task> listAllSchedulableTasks() throws PrivilegeException {
+		// TODO: authorization check
+		return tasksManagerBl.listAllSchedulableTasks();
+	}
+	
 	@Override
 	public boolean isThereSuchTask(PerunSession session, Service service, Facility facility) throws PrivilegeException {
 		if (!AuthzResolver.isAuthorized(session, Role.FACILITYADMIN, facility) &&

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/TasksManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/TasksManagerImpl.java
@@ -549,6 +549,14 @@ public class TasksManagerImpl implements TasksManagerImplApi {
 	}
 
 	@Override
+	public List<Task> listAllSchedulableTasks() {
+		return getMyJdbcTemplate().query("select " + taskMappingSelectQuery + ", " + FacilitiesManagerImpl.facilityMappingSelectQuery +
+				", " + ServicesManagerImpl.serviceMappingSelectQuery  + " from tasks left join services on tasks.service_id = services.id " +
+				"left join facilities on facilities.id = tasks.facility_id where tasks.schedule_expr is not null ",
+			    TASK_ROWMAPPER);
+	}
+	
+	@Override
 	public void updateTask(Task task) {
 		String scheduled = null;
 		if (task.getSchedule() != null) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/TasksManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/TasksManagerImplApi.java
@@ -116,4 +116,6 @@ public interface TasksManagerImplApi {
 	 */
 	List<TaskResult> getTaskResultsForDestinations(List<String> destinationsNames) throws InternalErrorException;
 
+	List<Task> listAllSchedulableTasks();
+
 }

--- a/perun-core/src/main/resources/hsqldbChangelog.txt
+++ b/perun-core/src/main/resources/hsqldbChangelog.txt
@@ -8,6 +8,10 @@
 
 -- this update is not supported on hsql since its used only as in-memory db
 
+3.1.60
+ALTER TABLE tasks ADD schedule_expr VARCHAR(256);
+update configurations set value='3.1.60' where property='DATABASE VERSION';
+
 3.1.59
 ALTER TABLE ext_sources_attributes ALTER COLUMN attr_value TYPE longvarchar;
 update configurations set value='3.1.59' where property='DATABASE VERSION';

--- a/perun-core/src/main/resources/oracleChangelog.txt
+++ b/perun-core/src/main/resources/oracleChangelog.txt
@@ -6,6 +6,10 @@
 -- Directly under version number should be version commands. They will be executed in the order they are written here.
 -- Comments are prefixed with -- and can be written only between version blocks, that means not in the lines with commands. They have to be at the start of the line.
 
+3.1.60
+ALTER TABLE tasks ADD schedule_expr NVARCHAR2(256);
+update configurations set value='3.1.60' where property='DATABASE VERSION';
+
 3.1.59
 ALTER TABLE EXT_SOURCES_ATTRIBUTES ADD (tmpcolumn CLOB);
 UPDATE EXT_SOURCES_ATTRIBUTES SET tmpcolumn=attr_value;

--- a/perun-core/src/main/resources/postgresChangelog.txt
+++ b/perun-core/src/main/resources/postgresChangelog.txt
@@ -6,6 +6,10 @@
 -- Directly under version number should be version commands. They will be executed in the order they are written here.
 -- Comments are prefixed with -- and can be written only between version blocks, that means not in the lines with commands. They have to be at the start of the line.
 
+3.1.60
+ALTER TABLE tasks ADD schedule_expr VARCHAR(256);
+update configurations set value='3.1.60' where property='DATABASE VERSION';
+
 3.1.59
 ALTER TABLE ext_sources_attributes ALTER COLUMN attr_value TYPE varchar;
 update configurations set value='3.1.59' where property='DATABASE VERSION';

--- a/perun-db/oracle.sql
+++ b/perun-db/oracle.sql
@@ -1,4 +1,4 @@
--- database version 3.1.59 (don't forget to update insert statement at the end of file)
+-- database version 3.1.60 (don't forget to update insert statement at the end of file)
 
 create user perunv3 identified by password;
 grant create session to perunv3;
@@ -1162,6 +1162,7 @@ create table tasks (
 	start_time date,                    --real start time of task
 	end_time date,                      --real end time of task
 	engine_id integer, --identifier of engine which executing the task (engines.id)
+	schedule_expr nvarchar2(256),	-- cron scheduling expression
 	created_at date default sysdate not null,
 	err_message nvarchar2(4000),          --return message in case of error
 	created_by_uid integer,
@@ -1754,7 +1755,7 @@ CREATE INDEX ufauv_idx ON user_facility_attr_u_values (user_id, facility_id, att
 CREATE INDEX vauv_idx ON vo_attr_u_values (vo_id, attr_id) ;
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.1.59');
+insert into configurations values ('DATABASE VERSION','3.1.60');
 
 -- insert membership types
 insert into membership_types (id, membership_type, description) values (1, 'DIRECT', 'Member is directly added into group');

--- a/perun-db/postgres.sql
+++ b/perun-db/postgres.sql
@@ -1153,7 +1153,7 @@ create table tasks (
 	start_time timestamp,                    --real start time of task
 	end_time timestamp,                      --real end time of task
 	engine_id integer, --identifier of engine which executing the task (engines.id)
-    schedule_expr varchar(256), -- cron scheduling expr
+	schedule_expr varchar(256), -- cron scheduling expr
 	created_at timestamp default statement_timestamp() not null,
 	err_message varchar(4000),          --return message in case of error
 	created_by_uid integer,

--- a/perun-db/postgres.sql
+++ b/perun-db/postgres.sql
@@ -1,4 +1,4 @@
--- database version 3.1.59 (don't forget to update insert statement at the end of file)
+-- database version 3.1.60 (don't forget to update insert statement at the end of file)
 
 -- VOS - virtual organizations
 create table vos (
@@ -1153,6 +1153,7 @@ create table tasks (
 	start_time timestamp,                    --real start time of task
 	end_time timestamp,                      --real end time of task
 	engine_id integer, --identifier of engine which executing the task (engines.id)
+    schedule_expr varchar(256), -- cron scheduling expr
 	created_at timestamp default statement_timestamp() not null,
 	err_message varchar(4000),          --return message in case of error
 	created_by_uid integer,
@@ -1851,7 +1852,7 @@ grant all on user_ext_source_attr_u_values to perun;
 grant all on members_sponsored to perun;
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.1.59');
+insert into configurations values ('DATABASE VERSION','3.1.60');
 
 -- insert membership types
 insert into membership_types (id, membership_type, description) values (1, 'DIRECT', 'Member is directly added into group');

--- a/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/scheduling/PropagationMaintainer.java
+++ b/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/scheduling/PropagationMaintainer.java
@@ -122,6 +122,8 @@ public class PropagationMaintainer extends AbstractRunner {
 	}
 	
 	/**
+	 * Create triggers for all periodically scheduled tasks (as indicated by tasks.schedule_expr column)
+	 * and register schedules with the perunScheduler bean.
 	 * 
 	 */
 	public void createIndependentTaskSchedules() {

--- a/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/scheduling/SchedulingPool.java
+++ b/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/scheduling/SchedulingPool.java
@@ -78,6 +78,13 @@ public interface SchedulingPool extends TaskStore {
 	String getReport();
 
 	/**
+	 * Get all tasks with periodic schedule
+	 * 
+	 *  @return list of Tasks
+	 */
+	List<Task> listAllSchedulableTasks();
+	
+	/**
 	 * Switch all processing Tasks to ERROR if engine was restarted.
 	 *
 	 */

--- a/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/scheduling/TaskScheduler.java
+++ b/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/scheduling/TaskScheduler.java
@@ -1,5 +1,26 @@
 package cz.metacentrum.perun.dispatcher.scheduling;
 
+import static cz.metacentrum.perun.dispatcher.scheduling.impl.TaskScheduled.DB_ERROR;
+import static cz.metacentrum.perun.dispatcher.scheduling.impl.TaskScheduled.DENIED;
+import static cz.metacentrum.perun.dispatcher.scheduling.impl.TaskScheduled.ERROR;
+import static cz.metacentrum.perun.dispatcher.scheduling.impl.TaskScheduled.QUEUE_ERROR;
+import static cz.metacentrum.perun.dispatcher.scheduling.impl.TaskScheduled.SUCCESS;
+
+import java.time.LocalDateTime;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.DelayQueue;
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.Resource;
+
+import org.apache.commons.codec.binary.Base64;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
 import cz.metacentrum.perun.core.api.Destination;
 import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.Perun;
@@ -22,23 +43,6 @@ import cz.metacentrum.perun.taskslib.model.TaskResult;
 import cz.metacentrum.perun.taskslib.model.TaskSchedule;
 import cz.metacentrum.perun.taskslib.runners.impl.AbstractRunner;
 
-import org.apache.commons.codec.binary.Base64;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-
-import java.time.LocalDateTime;
-import java.util.Date;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Properties;
-import java.util.concurrent.DelayQueue;
-import java.util.concurrent.TimeUnit;
-
-import javax.annotation.Resource;
-
-import static cz.metacentrum.perun.dispatcher.scheduling.impl.TaskScheduled.*;
-
 /**
  * Schedule Tasks, which are WAITING in DelayQueue and send them to Engine and switch it to PLANNED.
  *
@@ -60,7 +64,7 @@ public class TaskScheduler extends AbstractRunner {
 	private DelayQueue<TaskSchedule> waitingTasksQueue;
 	private DelayQueue<TaskSchedule> waitingForcedTasksQueue;
 	private TasksManagerBl tasksManagerBl;
-
+	 
 	// ----- setters -------------------------------------
 
 	public SchedulingPool getSchedulingPool() {
@@ -126,6 +130,7 @@ public class TaskScheduler extends AbstractRunner {
 		this.tasksManagerBl = tasksManagerBl;
 	}
 
+	
 	// ----- methods -------------------------------------
 
 

--- a/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/scheduling/impl/SchedulingPoolImpl.java
+++ b/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/scheduling/impl/SchedulingPoolImpl.java
@@ -387,6 +387,11 @@ public class SchedulingPoolImpl implements SchedulingPool {
 	}
 
 	@Override
+	public List<Task> listAllSchedulableTasks() {
+		return tasksManagerBl.listAllSchedulableTasks();
+	}
+	
+	@Override
 	public String getReport() {
 		int waiting = getTasksWithStatus(TaskStatus.WAITING).size();
 		int planned = getTasksWithStatus(TaskStatus.PLANNED).size();


### PR DESCRIPTION
Implementation of independent scheduling of propagations:
  * adds "schedule_expr" column to tasks table
  * value of this column can be:
     - "rate=LONG" - propagations will be scheduled every LONG seconds
     - "cron=EXPR" - propagations will be scheduled according to the EXPR cron expression 