### PR TITLE
Synchronization of group structures by group login (not name)

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/CandidateGroup.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/CandidateGroup.java
@@ -3,7 +3,7 @@ package cz.metacentrum.perun.core.api;
 import java.util.Objects;
 
 /**
- * Group obtained from an extSource with the name of its parent in the external source.
+ * Group obtained from an extSource with the login and login of its parent in the external source.
  * It can be then created as a group of a virtual organization in Perun.
  *
  * @date 8/30/17.
@@ -12,7 +12,8 @@ import java.util.Objects;
 public class CandidateGroup extends Auditable {
 
 	private ExtSource extSource;
-	private String parentGroupName;
+	private String login;
+	private String parentGroupLogin;
 	private Group group;
 
 	public CandidateGroup() {
@@ -27,12 +28,20 @@ public class CandidateGroup extends Auditable {
 		this.extSource = extSource;
 	}
 
-	public String getParentGroupName() {
-		return parentGroupName;
+	public String getLogin() {
+		return login;
 	}
 
-	public void setParentGroupName(String parentGroupName) {
-		this.parentGroupName = parentGroupName;
+	public void setLogin(String login) {
+		this.login = login;
+	}
+
+	public String getParentGroupLogin() {
+		return parentGroupLogin;
+	}
+
+	public void setParentGroupLogin(String parentGroupLogin) {
+		this.parentGroupLogin = parentGroupLogin;
 	}
 
 	public Group asGroup() {
@@ -46,20 +55,22 @@ public class CandidateGroup extends Auditable {
 		if (!super.equals(o)) return false;
 		CandidateGroup that = (CandidateGroup) o;
 		return Objects.equals(getExtSource(), that.getExtSource()) &&
-				Objects.equals(getParentGroupName(), that.getParentGroupName()) &&
+				Objects.equals(getLogin(), that.getLogin()) &&
+				Objects.equals(getParentGroupLogin(), that.getParentGroupLogin()) &&
 				Objects.equals(asGroup(), that.asGroup());
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(super.hashCode(), getExtSource(), getParentGroupName(), asGroup());
+		return Objects.hash(super.hashCode(), getExtSource(), getLogin(), getParentGroupLogin(), asGroup());
 	}
 
 	@Override
 	public String toString() {
 		return "CandidateGroup{" +
 				"extSource=" + extSource +
-				", parentGroupName='" + parentGroupName + '\'' +
+				", login='" + login + + '\'' +
+				", parentGroupLogin='" + parentGroupLogin + '\'' +
 				", group=" + group +
 				'}';
 	}
@@ -71,8 +82,10 @@ public class CandidateGroup extends Auditable {
 		return str.append(this.getClass().getSimpleName())
 				.append(":[extSource=<")
 				.append(getExtSource() == null ? "\\0" : getExtSource().serializeToString())
-				.append(">, parentGroupName=<")
-				.append(getParentGroupName())
+				.append(">, login=<")
+				.append(getLogin())
+				.append(">, parentGroupLogin=<")
+				.append(getParentGroupLogin())
 				.append(">, group=<")
 				.append(asGroup() == null ? "\\0" : asGroup().serializeToString())
 				.append(">]").toString();

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/GroupsManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/GroupsManager.java
@@ -59,6 +59,8 @@ public interface GroupsManager {
 	String GROUPEXTSOURCE_ATTRNAME = AttributesManager.NS_GROUP_ATTR_DEF + ":groupExtSource";
 	// Define the external source used for accessing the data about the group members
 	String GROUPMEMBERSEXTSOURCE_ATTRNAME = AttributesManager.NS_GROUP_ATTR_DEF + ":groupMembersExtSource";
+	// Define name of attribute in Perun where logins are saved for a group structure
+	String GROUPS_STRUCTURE_LOGIN_ATTRNAME = AttributesManager.NS_GROUP_ATTR_DEF + ":groupStructureLogin";
 	// If the synchronization is enabled/disabled, value is true/false
 	String GROUPSYNCHROENABLED_ATTRNAME = AttributesManager.NS_GROUP_ATTR_DEF + ":synchronizationEnabled";
 	// If the group structure synchronization is enabled/disabled, value is true/false

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -7410,6 +7410,19 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		rights.add(new AttributeRights(-1, Role.GROUPADMIN, Collections.singletonList(ActionType.READ)));
 		attributes.put(attr, rights);
 
+		//urn:perun:group:attribute-def:def:groupStructureLogin
+		attr = new AttributeDefinition();
+		attr.setNamespace(AttributesManager.NS_GROUP_ATTR_DEF);
+		attr.setType(String.class.getName());
+		attr.setFriendlyName("groupStructureLogin");
+		attr.setDisplayName("Group structure login");
+		attr.setDescription("Name of attribute in perun used for identifying groups in a structure");
+		//set attribute rights (with dummy id of attribute - not known yet)
+		rights = new ArrayList<>();
+		rights.add(new AttributeRights(-1, Role.VOADMIN, Collections.singletonList(ActionType.READ)));
+		rights.add(new AttributeRights(-1, Role.GROUPADMIN, Collections.singletonList(ActionType.READ)));
+		attributes.put(attr, rights);
+
 		//urn:perun:group:attribute-def:def:groupsQuery
 		attr = new AttributeDefinition();
 		attr.setNamespace(AttributesManager.NS_GROUP_ATTR_DEF);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ExtSourcesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ExtSourcesManagerBlImpl.java
@@ -296,16 +296,21 @@ public class ExtSourcesManagerBlImpl implements ExtSourcesManagerBl {
 
 		candidateGroup.setExtSource(source);
 		candidateGroup.asGroup().setName(groupSubjectData.get(GroupsManagerBlImpl.GROUP_NAME));
+		candidateGroup.setLogin(groupSubjectData.get(GroupsManagerBlImpl.GROUP_LOGIN));
+
+		if(candidateGroup.getLogin() == null || candidateGroup.getLogin().isEmpty()) {
+			throw new InternalErrorException("Group subject data has to contain valid group login!");
+		}
 
 		// Check if the group name is not null and if it is in valid format.
 		if(candidateGroup.asGroup().getName() != null) {
 			Matcher name = groupNamePattern.matcher(candidateGroup.asGroup().getName());
-			if(!name.matches()) throw new InternalErrorException("Group subject data has to contains valid group name!");
+			if(!name.matches()) throw new InternalErrorException("Group subject data has to contain valid group name!");
 		} else {
 			throw new InternalErrorException("group name cannot be null in Group subject data!");
 		}
 
-		candidateGroup.setParentGroupName(groupSubjectData.get(GroupsManagerBlImpl.PARENT_GROUP_NAME));
+		candidateGroup.setParentGroupLogin(groupSubjectData.get(GroupsManagerBlImpl.PARENT_GROUP_LOGIN));
 		candidateGroup.asGroup().setDescription(groupSubjectData.get(GroupsManagerBlImpl.GROUP_DESCRIPTION));
 
 		return candidateGroup;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceSql.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceSql.java
@@ -323,16 +323,22 @@ public class ExtSourceSql extends ExtSource implements ExtSourceSimpleApi {
 					Map<String, String> map = new HashMap<>();
 
 					try {
+						map.put(GroupsManagerBlImpl.GROUP_LOGIN, rs.getString(GroupsManagerBlImpl.GROUP_LOGIN));
+					} catch (SQLException e) {
+						// If the column doesn't exists, ignore it
+						map.put(GroupsManagerBlImpl.GROUP_LOGIN, null);
+					}
+					try {
 						map.put(GroupsManagerBlImpl.GROUP_NAME, rs.getString(GroupsManagerBlImpl.GROUP_NAME));
 					} catch (SQLException e) {
 						// If the column doesn't exists, ignore it
 						map.put(GroupsManagerBlImpl.GROUP_NAME, null);
 					}
 					try {
-						map.put(GroupsManagerBlImpl.PARENT_GROUP_NAME, rs.getString(GroupsManagerBlImpl.PARENT_GROUP_NAME));
+						map.put(GroupsManagerBlImpl.PARENT_GROUP_LOGIN, rs.getString(GroupsManagerBlImpl.PARENT_GROUP_LOGIN));
 					} catch (SQLException e) {
 						// If the column doesn't exists, ignore it
-						map.put(GroupsManagerBlImpl.PARENT_GROUP_NAME, null);
+						map.put(GroupsManagerBlImpl.PARENT_GROUP_LOGIN, null);
 					}
 					try {
 						map.put(GroupsManagerBlImpl.GROUP_DESCRIPTION, rs.getString(GroupsManagerBlImpl.GROUP_DESCRIPTION));


### PR DESCRIPTION
 - change main attributes of class CandidateGroup to work with logins
 instead of names (parentGroupLogin instead of parentGroupName) and add
 group login too
 - add new group attribute groupStructureLogin to specify name of
 attribute where logins are saved for specific group structure (add this
 attribute to initialization, to be created when perun is started or
 restarted)
 - rework behavior in method sychronizeGroupStructure to work with
 logins
 - support of logins in SQL extSource (the only extSource supporting
 group structure synchronization)