### PR TITLE
Fix wrong behavior for unixGID when adding group to resource

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_virt_unixGID.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_virt_unixGID.java
@@ -67,12 +67,12 @@ public class urn_perun_group_resource_attribute_def_virt_unixGID extends GroupRe
 			attribute.setValue(gidAttribute.getValue());
 			return attribute;
 		} catch(WrongAttributeValueException ex) {
+			return attribute;
+		} catch(WrongReferenceAttributeValueException ex) {
 			//Physical attribute have wrong value, let's find a new one
 			gidAttribute.setValue(null);
 			gidAttribute = sess.getPerunBl().getAttributesManagerBl().fillAttribute(sess, group, gidAttribute);
 			attribute.setValue(gidAttribute.getValue());
-			return attribute;
-		} catch(WrongReferenceAttributeValueException ex) {
 			return attribute;
 		}
 	}


### PR DESCRIPTION
- Unix GID wasn't filled for groups, which already had unixGroupName set,
during their assignment to the resource (where both attributes were required).
- The problem was in group-resource:virt:unixGID module, which didn't react
on correct exception (WrongRefferenceAttributeValueException), but rather on
former WrongAttributeValue (which is now thrown only for the wrong syntax, but
empty values are allowed -> hence attribute was not filled).
- Now we react on the correct exception and fill unixGID for the groups, which
already have unix group name in the namespace defined by the resource.