### PR TITLE
Core - sendValidationEmail custom URL path

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/UsersManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/UsersManager.java
@@ -1052,12 +1052,13 @@ public interface UsersManager {
 	 * @param user User to request preferred email change for
 	 * @param email new email address
 	 * @param lang Language to get confirmation mail in (optional)
+	 * @param path path that is appended to the url of the verification link (optional)
 	 *
 	 * @throws InternalErrorException
 	 * @throws PrivilegeException
 	 * @throws UserNotExistsException
 	 */
-	void requestPreferredEmailChange(PerunSession sess, String url, User user, String email, String lang) throws PrivilegeException, UserNotExistsException;
+	void requestPreferredEmailChange(PerunSession sess, String url, User user, String email, String lang, String path) throws PrivilegeException, UserNotExistsException;
 
 	/**
 	 * Validate change of user's preferred email address.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
@@ -1221,9 +1221,10 @@ public interface UsersManagerBl {
 	 * @param user  User to request preferred email change for
 	 * @param email new email address
 	 * @param lang language to get confirmation mail in (optional)
+	 * @param path path that is appended to the url of the verification link (optional)
 	 * @throws InternalErrorException
 	 */
-	void requestPreferredEmailChange(PerunSession sess, String url, User user, String email, String lang);
+	void requestPreferredEmailChange(PerunSession sess, String url, User user, String email, String lang, String path);
 
 	/**
 	 * * Validate change of user's preferred email address.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
@@ -1817,7 +1817,7 @@ public class UsersManagerBlImpl implements UsersManagerBl {
 	}
 
 	@Override
-	public void requestPreferredEmailChange(PerunSession sess, String url, User user, String email, String lang) {
+	public void requestPreferredEmailChange(PerunSession sess, String url, User user, String email, String lang, String path) {
 
 		int changeId = getUsersManagerImpl().requestPreferredEmailChange(sess, user, email);
 
@@ -1851,7 +1851,7 @@ public class UsersManagerBlImpl implements UsersManagerBl {
 			throw new InternalErrorException(ex);
 		}
 
-		Utils.sendValidationEmail(user, url, email, changeId, subject, message);
+		Utils.sendValidationEmail(user, url, email, changeId, subject, message, path);
 
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
@@ -1276,7 +1276,7 @@ public class UsersManagerEntry implements UsersManager {
 	}
 
 	@Override
-	public void requestPreferredEmailChange(PerunSession sess, String url, User user, String email, String lang) throws PrivilegeException, UserNotExistsException {
+	public void requestPreferredEmailChange(PerunSession sess, String url, User user, String email, String lang, String path) throws PrivilegeException, UserNotExistsException {
 
 		Utils.checkPerunSession(sess);
 		getPerunBl().getUsersManagerBl().checkUserExists(sess, user);
@@ -1286,7 +1286,7 @@ public class UsersManagerEntry implements UsersManager {
 			throw new PrivilegeException(sess, "requestPreferredEmailChange");
 		}
 
-		getPerunBl().getUsersManagerBl().requestPreferredEmailChange(sess, url, user, email, lang);
+		getPerunBl().getUsersManagerBl().requestPreferredEmailChange(sess, url, user, email, lang, path);
 
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Utils.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Utils.java
@@ -891,7 +891,7 @@ public class Utils {
 	 * @param content Template message or null
 	 * @throws InternalErrorException
 	 */
-	public static void sendValidationEmail(User user, String url, String email, int changeId, String subject, String content) {
+	public static void sendValidationEmail(User user, String url, String email, int changeId, String subject, String content, String customUrlPath) {
 
 		// create mail sender
 		JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
@@ -925,7 +925,9 @@ public class Utils {
 			// use default if unknown rpc path
 			String path = "/gui/";
 
-			if (urlObject.getPath().contains("/krb/")) {
+			if (customUrlPath != null) {
+				path = customUrlPath;
+			} else if (urlObject.getPath().contains("/krb/")) {
 				path = "/krb/gui/";
 			} else if (urlObject.getPath().contains("/fed/")) {
 				path = "/fed/gui/";

--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -7130,6 +7130,7 @@ paths:
         - $ref: '#/components/parameters/userId'
         - {name: email, description: "new email address to set", schema: {type: string}, in: query, required: true}
         - {name: lang, description: "language to get confirmation mail in (optional)", schema: {type: string}, in: query, required: false}
+        - {name: linkPath, description: "path that is appended to the url of the verification link (optional)", schema: {type: string}, in: query, required: false}
       responses:
         '200':
           $ref: '#/components/responses/VoidResponse'

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/UsersManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/UsersManagerMethod.java
@@ -1151,6 +1151,7 @@ public enum UsersManagerMethod implements ManagerMethod {
 	 * @param user int User <code>id</code>
 	 * @param email String new email address to set
 	 * @param lang String language to get confirmation mail in (optional)
+	 * @param linkPath path that is appended to the url of the verification link (optional)
 	 */
 	requestPreferredEmailChange {
 		@Override
@@ -1166,7 +1167,8 @@ public enum UsersManagerMethod implements ManagerMethod {
 					referer,
 					ac.getUserById(parms.readInt("user")),
 					parms.readString("email"),
-					parms.contains("lang") ? parms.readString("lang") : null);
+					parms.contains("lang") ? parms.readString("lang") : null,
+					parms.contains("linkPath") ? parms.readString("linkPath") : null);
 
 			return null;
 


### PR DESCRIPTION
* Some frontend applications are located on a different domain and also,
they might use a different url path. The old implementation of the
sendValidationEmail method had hardcoded some path values that works
only with the old applications.
* I have added a new optional parameter `path` that can be used to
specify the path in the url verification link send to the user.