### PR TITLE
CORE: Move generating random password into PasswordManagerModule

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/DummyPasswordManagerModule.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/DummyPasswordManagerModule.java
@@ -80,4 +80,10 @@ public class DummyPasswordManagerModule implements PasswordManagerModule {
 		log.debug("checkPasswordStrength(userLogin={})", login);
 	}
 
+	@Override
+	public String generateRandomPassword(PerunSession sess, String login) {
+		log.debug("generateRandomPassword(userLogin={})", login);
+		return null;
+	}
+
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/GenericPasswordManagerModule.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/GenericPasswordManagerModule.java
@@ -16,6 +16,7 @@ import cz.metacentrum.perun.core.api.exceptions.rt.PasswordOperationTimeoutRunti
 import cz.metacentrum.perun.core.api.exceptions.rt.PasswordStrengthFailedRuntimeException;
 import cz.metacentrum.perun.core.bl.PerunBl;
 import cz.metacentrum.perun.core.implApi.modules.pwdmgr.PasswordManagerModule;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,6 +27,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.PrintWriter;
+import java.security.SecureRandom;
 import java.util.Map;
 import java.util.regex.Pattern;
 
@@ -54,6 +56,9 @@ public class GenericPasswordManagerModule implements PasswordManagerModule {
 	protected String actualLoginNamespace = "generic";
 	protected String passwordManagerProgram = BeansUtils.getCoreConfig().getPasswordManagerProgram();
 	protected String altPasswordManagerProgram = BeansUtils.getCoreConfig().getAlternativePasswordManagerProgram();
+
+	protected int randomPasswordLength = 12;
+	protected char[] randomPasswordCharacters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%&*()-_=+;:,<.>/?".toCharArray();
 
 	public String getActualLoginNamespace() {
 		return actualLoginNamespace;
@@ -157,6 +162,28 @@ public class GenericPasswordManagerModule implements PasswordManagerModule {
 		}
 
 		// TODO - some more generic checks ???
+
+	}
+
+	@Override
+	public String generateRandomPassword(PerunSession sess, String login) {
+
+		String randomPassword = null;
+		boolean strengthOk = false;
+		while (!strengthOk) {
+
+			randomPassword = RandomStringUtils.random(randomPasswordLength, 0, randomPasswordCharacters.length - 1,
+					false, false, randomPasswordCharacters, new SecureRandom());
+
+			try {
+				checkPasswordStrength(sess, login, randomPassword);
+				strengthOk = true;
+			} catch (PasswordStrengthException ex) {
+				strengthOk = false;
+			}
+		}
+
+		return randomPassword;
 
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/MuPasswordManagerModule.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/MuPasswordManagerModule.java
@@ -12,6 +12,7 @@ import cz.metacentrum.perun.core.api.exceptions.PasswordStrengthException;
 import cz.metacentrum.perun.core.bl.PerunBl;
 import cz.metacentrum.perun.core.implApi.modules.pwdmgr.PasswordManagerModule;
 import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.StringEscapeUtils;
 import org.slf4j.Logger;
@@ -41,6 +42,7 @@ import java.io.StringReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -56,6 +58,9 @@ public class MuPasswordManagerModule implements PasswordManagerModule {
 
 	private final static Logger log = LoggerFactory.getLogger(MuPasswordManagerModule.class);
 	private final static String CRLF = "\r\n"; // Line separator required by multipart/form-data.
+
+	protected int randomPasswordLength = 12;
+	protected char[] randomPasswordCharacters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%&*()-_=+;:,<.>/?".toCharArray();
 
 	@Override
 	public Map<String, String> generateAccount(PerunSession session, Map<String, String> parameters) throws PasswordStrengthException {
@@ -150,6 +155,28 @@ public class MuPasswordManagerModule implements PasswordManagerModule {
 		}
 
 		// TODO - some more generic checks ???
+
+	}
+
+	@Override
+	public String generateRandomPassword(PerunSession sess, String login) {
+
+		String randomPassword = null;
+		boolean strengthOk = false;
+		while (!strengthOk) {
+
+			randomPassword = RandomStringUtils.random(randomPasswordLength, 0, randomPasswordCharacters.length - 1,
+					false, false, randomPasswordCharacters, new SecureRandom());
+
+			try {
+				checkPasswordStrength(sess, login, randomPassword);
+				strengthOk = true;
+			} catch (PasswordStrengthException ex) {
+				strengthOk = false;
+			}
+		}
+
+		return randomPassword;
 
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/VsupPasswordManagerModule.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/VsupPasswordManagerModule.java
@@ -1,0 +1,15 @@
+package cz.metacentrum.perun.core.impl.modules.pwdmgr;
+
+public class VsupPasswordManagerModule extends GenericPasswordManagerModule {
+
+	public VsupPasswordManagerModule() {
+
+		// override random password generating params
+		this.randomPasswordLength = 14;
+
+		// omit chars that can be mistaken by users: yY, zZ, O, l, I and all spec chars.
+		this.randomPasswordCharacters = "ABCDEFGHJKLMNPQRSTUVWXabcdefghijkmnopqrstuvwx0123456789".toCharArray();
+
+	}
+
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/pwdmgr/PasswordManagerModule.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/pwdmgr/PasswordManagerModule.java
@@ -52,4 +52,6 @@ public interface PasswordManagerModule {
 
 	void checkPasswordStrength(PerunSession sess, String login, String password) throws PasswordStrengthException;
 
+	String generateRandomPassword(PerunSession sess, String login);
+
 }


### PR DESCRIPTION
- PasswordManagerModule can now generate own random password.
  It does it from defined chars in expected length and performs
  check on strength. Only passwords passing that check are returned.
  Null is returned on fail.
- Added module for 'vsup' namespace, which have specific requirements
  for random password generation. Eg. omit chars that user can mistake
  on keyboard: l vs I, yY<->zZ, special chars.