### PR TITLE
Modification of group structure synchronization

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/GroupsManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/GroupsManager.java
@@ -61,6 +61,8 @@ public interface GroupsManager {
 	String GROUPMEMBERSEXTSOURCE_ATTRNAME = AttributesManager.NS_GROUP_ATTR_DEF + ":groupMembersExtSource";
 	// Define name of attribute in Perun where logins are saved for a group structure
 	String GROUPS_STRUCTURE_LOGIN_ATTRNAME = AttributesManager.NS_GROUP_ATTR_DEF + ":groupStructureLogin";
+	//Define prefix of group's login in the structure
+	String GROUPS_STRUCTURE_LOGIN_PREFIX_ATTRNAME = AttributesManager.NS_GROUP_ATTR_DEF + ":groupStructureLoginPrefix";
 	// If the synchronization is enabled/disabled, value is true/false
 	String GROUPSYNCHROENABLED_ATTRNAME = AttributesManager.NS_GROUP_ATTR_DEF + ":synchronizationEnabled";
 	// If the group structure synchronization is enabled/disabled, value is true/false

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ExtSourcesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ExtSourcesManagerBl.java
@@ -225,11 +225,11 @@ public interface ExtSourcesManagerBl {
 
 	/**
 	 * Check if extSource is assigned to vo or not. Throw exception if not.
-	 * 
+	 *
 	 * @param sess
 	 * @param extSource
 	 * @param voId
-	 * 
+	 *
 	 * @throws InternalErrorException
 	 * @throws ExtSourceNotAssignedException
 	 * @throws VoNotExistsException
@@ -260,11 +260,12 @@ public interface ExtSourcesManagerBl {
 	 * @param perunSession
 	 * @param groupSubjectData
 	 * @param source
+	 * @param loginPrefix login prefix to change group login and parent group login by it
 	 *
 	 * @return Candidate group object
 	 * @throws InternalErrorException
 	 */
-	CandidateGroup generateCandidateGroup(PerunSession perunSession, Map<String,String> groupSubjectData, ExtSource source);
+	CandidateGroup generateCandidateGroup(PerunSession perunSession, Map<String,String> groupSubjectData, ExtSource source, String loginPrefix);
 
 	/**
 	 * Generate candidate groups from a group subject data.
@@ -274,10 +275,11 @@ public interface ExtSourcesManagerBl {
 	 * @param perunSession
 	 * @param groupSubjectsData
 	 * @param source
+	 * @param loginPrefix login prefix to change group login and parent group login by it
 	 *
 	 * @return Candidate group objects
 	 * @throws InternalErrorException
 	 */
-	List<CandidateGroup> generateCandidateGroups(PerunSession perunSession, List<Map<String,String>> groupSubjectsData, ExtSource source);
+	List<CandidateGroup> generateCandidateGroups(PerunSession perunSession, List<Map<String,String>> groupSubjectsData, ExtSource source, String loginPrefix);
 
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -7450,6 +7450,19 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		rights.add(new AttributeRights(-1, Role.GROUPADMIN, Collections.singletonList(ActionType.READ)));
 		attributes.put(attr, rights);
 
+		//urn:perun:group:attribute-def:def:groupStructureLoginPrefix
+		attr = new AttributeDefinition();
+		attr.setNamespace(AttributesManager.NS_GROUP_ATTR_DEF);
+		attr.setType(String.class.getName());
+		attr.setFriendlyName("groupStructureLoginPrefix");
+		attr.setDisplayName("Group structure login prefix");
+		attr.setDescription("Prefix which will be used to set groups login as 'prefix'+'login'.");
+		//set attribute rights (with dummy id of attribute - not known yet)
+		rights = new ArrayList<>();
+		rights.add(new AttributeRights(-1, Role.VOADMIN, Collections.singletonList(ActionType.READ)));
+		rights.add(new AttributeRights(-1, Role.GROUPADMIN, Collections.singletonList(ActionType.READ)));
+		attributes.put(attr, rights);
+
 		//urn:perun:group:attribute-def:def:groupsQuery
 		attr = new AttributeDefinition();
 		attr.setNamespace(AttributesManager.NS_GROUP_ATTR_DEF);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ExtSourcesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ExtSourcesManagerBlImpl.java
@@ -289,7 +289,7 @@ public class ExtSourcesManagerBlImpl implements ExtSourcesManagerBl {
 	}
 
 	@Override
-	public CandidateGroup generateCandidateGroup(PerunSession perunSession, Map<String,String> groupSubjectData, ExtSource source) {
+	public CandidateGroup generateCandidateGroup(PerunSession perunSession, Map<String,String> groupSubjectData, ExtSource source, String loginPrefix) {
 		if(groupSubjectData == null) throw new InternalErrorException("Group subject data cannot be null.");
 		if(groupSubjectData.isEmpty()) throw new InternalErrorException("Group subject data cannot be empty, at least group name has to exists.");
 		if(source == null) throw new InternalErrorException("ExtSource cannot be null while generating CandidateGroup");
@@ -298,7 +298,7 @@ public class ExtSourcesManagerBlImpl implements ExtSourcesManagerBl {
 
 		candidateGroup.setExtSource(source);
 		candidateGroup.asGroup().setName(groupSubjectData.get(GroupsManagerBlImpl.GROUP_NAME));
-		candidateGroup.setLogin(groupSubjectData.get(GroupsManagerBlImpl.GROUP_LOGIN));
+		candidateGroup.setLogin(loginPrefix + groupSubjectData.get(GroupsManagerBlImpl.GROUP_LOGIN));
 
 		if(candidateGroup.getLogin() == null || candidateGroup.getLogin().isEmpty()) {
 			throw new InternalErrorException("Group subject data has to contain valid group login!");
@@ -312,7 +312,9 @@ public class ExtSourcesManagerBlImpl implements ExtSourcesManagerBl {
 			throw new InternalErrorException("group name cannot be null in Group subject data!");
 		}
 
-		candidateGroup.setParentGroupLogin(groupSubjectData.get(GroupsManagerBlImpl.PARENT_GROUP_LOGIN));
+		if(groupSubjectData.get(GroupsManagerBlImpl.PARENT_GROUP_LOGIN) != null) {
+			candidateGroup.setParentGroupLogin(loginPrefix + groupSubjectData.get(GroupsManagerBlImpl.PARENT_GROUP_LOGIN));
+		}
 		candidateGroup.asGroup().setDescription(groupSubjectData.get(GroupsManagerBlImpl.GROUP_DESCRIPTION));
 
 		groupSubjectData.entrySet().stream()
@@ -323,11 +325,11 @@ public class ExtSourcesManagerBlImpl implements ExtSourcesManagerBl {
 	}
 
 	@Override
-	public List<CandidateGroup> generateCandidateGroups(PerunSession perunSession, List<Map<String,String>> subjectsData, ExtSource source) {
+	public List<CandidateGroup> generateCandidateGroups(PerunSession perunSession, List<Map<String,String>> subjectsData, ExtSource source, String loginPrefix) {
 		List<CandidateGroup> candidateGroups= new ArrayList<>();
 
 		for (Map<String, String> subjectData : subjectsData) {
-			candidateGroups.add(generateCandidateGroup(perunSession, subjectData, source));
+			candidateGroups.add(generateCandidateGroup(perunSession, subjectData, source, loginPrefix));
 		}
 
 		return candidateGroups;


### PR DESCRIPTION
 - order of operations was change from (add,update,remove) to
 (remove,add,update) to be able to change login of groups. Without it we
 can't create two groups with same name but different login
 - to be able to correctly work with group structure after changing of
 operations order, filtering of non-existent parent groups must be done
 in updating
 - for better efficiency the removing is starting from leaves if
 possible (groups for removing were sorted by names from longest to
 shortest)
 - login prefix for one group structure tree can be now set on base
 group and all newly synchronized groups will be updated to have this
 prefix. Prefix is optional and extSource don't need to prepare any data
 for using it
 - test of newly added prefixes was created