### PR TITLE
New method forceAllSubGroupsSynchronization

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/GroupSynchronizationNotEnabledException.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/GroupSynchronizationNotEnabledException.java
@@ -1,0 +1,55 @@
+package cz.metacentrum.perun.core.api.exceptions;
+
+import cz.metacentrum.perun.core.api.Group;
+
+/**
+ * This exception is thrown when the synchronization for the group is not enabled
+ *
+ * @author Michal Stava stavamichal@gmail.com
+ */
+public class GroupSynchronizationNotEnabledException extends PerunException {
+
+	private Group group;
+
+	/**
+	 * Simple constructor with a message
+	 * @param message message with details about the cause
+	 */
+	public GroupSynchronizationNotEnabledException(String message) {
+		super(message);
+	}
+
+	/**
+	 * Constructor with a message and Throwable object
+	 * @param message message with details about the cause
+	 * @param cause Throwable that caused throwing of this exception
+	 */
+	public GroupSynchronizationNotEnabledException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	/**
+	 * Constructor with a Throwable object
+	 * @param cause Throwable that caused throwing of this exception
+	 */
+	public GroupSynchronizationNotEnabledException(Throwable cause) {
+		super(cause);
+	}
+
+	/**
+	 * Constructor with the group
+	 * @param group group for which the synchronization was not enabled
+	 */
+	public GroupSynchronizationNotEnabledException(Group group) {
+		super(group.toString());
+		this.group = group;
+	}
+
+	/**
+	 * Getter for the group
+	 * @return group for which the synchronization was not enabled
+	 */
+	public Group getGroup() {
+		return this.group;
+	}
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/GroupsManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/GroupsManager.java
@@ -17,6 +17,7 @@ import cz.metacentrum.perun.core.api.exceptions.GroupRelationDoesNotExist;
 import cz.metacentrum.perun.core.api.exceptions.GroupRelationNotAllowed;
 import cz.metacentrum.perun.core.api.exceptions.GroupStructureSynchronizationAlreadyRunningException;
 import cz.metacentrum.perun.core.api.exceptions.GroupSynchronizationAlreadyRunningException;
+import cz.metacentrum.perun.core.api.exceptions.GroupSynchronizationNotEnabledException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.MemberNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.NotGroupMemberException;
@@ -960,9 +961,21 @@ public interface GroupsManager {
 	 * @throws InternalErrorException
 	 * @throws GroupNotExistsException
 	 * @throws PrivilegeException
-	 * @throws GroupSynchronizationAlreadyRunningException
+	 * @throws GroupSynchronizationAlreadyRunningException when synchronization for the group is already running
+	 * @throws GroupSynchronizationNotEnabledException when group doesn't have synchronization enabled
 	 */
-	void forceGroupSynchronization(PerunSession sess, Group group) throws GroupNotExistsException, PrivilegeException, GroupSynchronizationAlreadyRunningException;
+	void forceGroupSynchronization(PerunSession sess, Group group) throws GroupNotExistsException, PrivilegeException, GroupSynchronizationAlreadyRunningException, GroupSynchronizationNotEnabledException;
+
+	/**
+	 * Force synchronization for all subgroups (recursively - whole tree) of the group (useful for group structure)
+	 *
+	 * @param sess
+	 * @param group the group where all its subgroups will be forced to synchronize
+	 *
+	 * @throws PrivilegeException user is not privileged to call this method
+	 * @throws GroupNotExistsException when group not exists in Perun
+	 */
+	void forceAllSubGroupsSynchronization(PerunSession sess, Group group) throws GroupNotExistsException, PrivilegeException;
 
     /**
      * Puts the group on the first place to the queue of groups waiting for group structure synchronization.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/GroupsManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/GroupsManagerBl.java
@@ -33,6 +33,7 @@ import cz.metacentrum.perun.core.api.exceptions.GroupRelationNotAllowed;
 import cz.metacentrum.perun.core.api.exceptions.GroupResourceMismatchException;
 import cz.metacentrum.perun.core.api.exceptions.GroupStructureSynchronizationAlreadyRunningException;
 import cz.metacentrum.perun.core.api.exceptions.GroupSynchronizationAlreadyRunningException;
+import cz.metacentrum.perun.core.api.exceptions.GroupSynchronizationNotEnabledException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.MemberGroupMismatchException;
 import cz.metacentrum.perun.core.api.exceptions.MemberNotExistsException;
@@ -960,9 +961,10 @@ public interface GroupsManagerBl {
 	 * @param sess
 	 * @param group
 	 * @throws InternalErrorException
-	 * @throws GroupSynchronizationAlreadyRunningException
+	 * @throws GroupSynchronizationAlreadyRunningException when synchronization for the group is already running
+	 * @throws GroupSynchronizationNotEnabledException when group doesn't have synchronization enabled
 	 */
-	void forceGroupSynchronization(PerunSession sess, Group group) throws GroupSynchronizationAlreadyRunningException;
+	void forceGroupSynchronization(PerunSession sess, Group group) throws GroupSynchronizationAlreadyRunningException, GroupSynchronizationNotEnabledException;
 
 	/**
 	 * Synchronize the group structure with an external group structure. It checks if the synchronization of the same group is already in progress.
@@ -972,6 +974,14 @@ public interface GroupsManagerBl {
 	 * @throws GroupStructureSynchronizationAlreadyRunningException
 	 */
 	void forceGroupStructureSynchronization(PerunSession sess, Group group) throws GroupStructureSynchronizationAlreadyRunningException;
+
+	/**
+	 * Force synchronization for all subgroups (recursively - whole tree) of the group (useful for group structure)
+	 *
+	 * @param sess
+	 * @param group the group where all its subgroups will be forced to synchronize
+	 */
+	void forceAllSubGroupsSynchronization(PerunSession sess, Group group);
 
 	/**
 	 * Synchronize all groups which have enabled synchronization. This method is run by the scheduler every 5 minutes.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
@@ -78,6 +78,7 @@ import cz.metacentrum.perun.core.api.exceptions.GroupRelationNotAllowed;
 import cz.metacentrum.perun.core.api.exceptions.GroupResourceMismatchException;
 import cz.metacentrum.perun.core.api.exceptions.GroupStructureSynchronizationAlreadyRunningException;
 import cz.metacentrum.perun.core.api.exceptions.GroupSynchronizationAlreadyRunningException;
+import cz.metacentrum.perun.core.api.exceptions.GroupSynchronizationNotEnabledException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.InvalidLoginException;
 import cz.metacentrum.perun.core.api.exceptions.LoginNotExistsException;
@@ -1739,20 +1740,27 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 		return skippedGroups;
 	}
 
-	/**
-	 * Adds the group on the first place to the queue of groups waiting for synchronization.
-	 *
-	 * @param group the group to be forced this way
-	 *
-	 * @throws GroupSynchronizationAlreadyRunningException when group synchronization is already running at this moment
-	 */
 	@Override
-	public void forceGroupSynchronization(PerunSession sess, Group group) throws GroupSynchronizationAlreadyRunningException {
-		//Check if the group is not currently in synchronization process
-		if(poolOfSynchronizations.putGroupToPoolOfWaitingGroups(group, true)) {
-			log.debug("Scheduling synchronization for the group {} by force!", group);
+	public void forceGroupSynchronization(PerunSession sess, Group group) throws GroupSynchronizationAlreadyRunningException, GroupSynchronizationNotEnabledException {
+		//Check if the group should be synchronized (attribute synchronizationEnabled is set to 'true')
+		Boolean syncEnabled = false;
+		try {
+			Attribute syncEnabledAttr = getPerunBl().getAttributesManagerBl().getAttribute(sess, group, GroupsManager.GROUPSYNCHROENABLED_ATTRNAME);
+			if(syncEnabledAttr.getValue() != null) syncEnabled = "true".equals(syncEnabledAttr.valueAsString());
+		} catch (WrongAttributeAssignmentException | AttributeNotExistsException ex) {
+			//attribute is wrongly set in database
+			throw new InternalErrorException("Can't force " + group + " because we can't find ", ex);
+		}
+
+		if(syncEnabled) {
+			//Check if the group is not currently in synchronization process
+			if (poolOfSynchronizations.putGroupToPoolOfWaitingGroups(group, true)) {
+				log.debug("Scheduling synchronization for the group {} by force!", group);
+			} else {
+				throw new GroupSynchronizationAlreadyRunningException(group);
+			}
 		} else {
-			throw new GroupSynchronizationAlreadyRunningException(group);
+			throw new GroupSynchronizationNotEnabledException(group);
 		}
 	}
 
@@ -1954,6 +1962,18 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 			log.info("Scheduling synchronization for the group structure {} by force!", group);
 		} else {
 			throw new GroupStructureSynchronizationAlreadyRunningException(group);
+		}
+	}
+
+	@Override
+	public void forceAllSubGroupsSynchronization(PerunSession sess, Group group) {
+		List<Group> subGroups = perunBl.getGroupsManagerBl().getAllSubGroups(sess, group);
+		for(Group subGroup: subGroups) {
+			try {
+				forceGroupSynchronization(sess, subGroup);
+			} catch (GroupSynchronizationAlreadyRunningException | GroupSynchronizationNotEnabledException ex) {
+				//in bulk force this is not important, just skip it
+			}
 		}
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/GroupsManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/GroupsManagerEntry.java
@@ -36,6 +36,7 @@ import cz.metacentrum.perun.core.api.exceptions.GroupRelationDoesNotExist;
 import cz.metacentrum.perun.core.api.exceptions.GroupRelationNotAllowed;
 import cz.metacentrum.perun.core.api.exceptions.GroupStructureSynchronizationAlreadyRunningException;
 import cz.metacentrum.perun.core.api.exceptions.GroupSynchronizationAlreadyRunningException;
+import cz.metacentrum.perun.core.api.exceptions.GroupSynchronizationNotEnabledException;
 import cz.metacentrum.perun.core.api.exceptions.IllegalArgumentException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.MemberNotExistsException;
@@ -1167,7 +1168,7 @@ public class GroupsManagerEntry implements GroupsManager {
 	}
 
 	@Override
-	public void forceGroupSynchronization(PerunSession sess, Group group) throws GroupNotExistsException, PrivilegeException, GroupSynchronizationAlreadyRunningException {
+	public void forceGroupSynchronization(PerunSession sess, Group group) throws GroupNotExistsException, PrivilegeException, GroupSynchronizationAlreadyRunningException, GroupSynchronizationNotEnabledException {
 		Utils.checkPerunSession(sess);
 		getGroupsManagerBl().checkGroupExists(sess, group);
 
@@ -1178,6 +1179,20 @@ public class GroupsManagerEntry implements GroupsManager {
 		}
 
 		getGroupsManagerBl().forceGroupSynchronization(sess, group);
+	}
+
+	@Override
+	public void forceAllSubGroupsSynchronization(PerunSession sess, Group group) throws GroupNotExistsException, PrivilegeException {
+		Utils.checkPerunSession(sess);
+		getGroupsManagerBl().checkGroupExists(sess, group);
+
+		// Authorization
+		if (!AuthzResolver.isAuthorized(sess, Role.VOADMIN, group)
+			&& !AuthzResolver.isAuthorized(sess, Role.GROUPADMIN, group))  {
+			throw new PrivilegeException(sess, "forceAllSubGroupsSynchronization");
+		}
+
+		getGroupsManagerBl().forceAllSubGroupsSynchronization(sess, group);
 	}
 
 	@Override

--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -8754,6 +8754,20 @@ paths:
         default:
           $ref: '#/components/responses/ExceptionResponse'
 
+  /urlinjsonout/groupsManager/forceAllSubGroupsSynchronization:
+    post:
+      tags:
+        - GroupsManager
+      operationId: forceAllSubGroupsSynchronization
+      summary: Force synchronization for all subgroups (recursively - whole tree) of the group (useful for group structure).
+      parameters:
+        - $ref: '#/components/parameters/groupId'
+      responses:
+        '200':
+          $ref: '#/components/responses/VoidResponse'
+        default:
+          $ref: '#/components/responses/ExceptionResponse'
+
 
   #################################################
   #                                               #

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/GroupsManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/GroupsManagerMethod.java
@@ -1184,6 +1184,7 @@ public enum GroupsManagerMethod implements ManagerMethod {
 	 *
 	 * @throw GroupNotExistsException When the group doesn't exist
 	 * @throw GroupSynchronizationAlreadyRunningException When the group synchronization has already been running
+	 * @throw GroupSynchronizationNotEnabledException When group doesn't have synchronization enabled
 	 *
 	 * @param group int Group <code>id</code>
 	 */
@@ -1193,6 +1194,24 @@ public enum GroupsManagerMethod implements ManagerMethod {
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
 
 			ac.getGroupsManager().forceGroupSynchronization(ac.getSession(),
+					ac.getGroupById(parms.readInt("group")));
+			return null;
+		}
+	},
+
+	/*#
+	 * Force synchronization for all subgroups (recursively - whole tree) of the group (useful for group structure)
+	 *
+	 * @throw GroupNotExistsException When the group doesn't exist
+	 *
+	 * @param group int Group <code>id</code>
+	 */
+	forceAllSubGroupsSynchronization {
+
+		@Override
+		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
+
+			ac.getGroupsManager().forceAllSubGroupsSynchronization(ac.getSession(),
 					ac.getGroupById(parms.readInt("group")));
 			return null;
 		}


### PR DESCRIPTION
 - to be able to force synchronization of all subgroups (whole tree) of
 any base group, we need to add new method for it
 - in forcing group process we need to also check if group is enabled to
 be synchronized, if not, new exception should be thrown. For this
 reason GroupSynchronizationNotEnabledException was created
 - add new method also to rpc and openapi