### PR TITLE
Group structure sync - resources

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -93,6 +93,7 @@ import cz.metacentrum.perun.core.impl.AttributesManagerImpl;
 import cz.metacentrum.perun.core.impl.Utils;
 import cz.metacentrum.perun.core.impl.modules.attributes.urn_perun_entityless_attribute_def_def_namespace_GIDRanges;
 import cz.metacentrum.perun.core.impl.modules.attributes.urn_perun_facility_attribute_def_virt_GIDRanges;
+import cz.metacentrum.perun.core.impl.modules.attributes.urn_perun_group_attribute_def_def_groupStructureResources;
 import cz.metacentrum.perun.core.impl.modules.attributes.urn_perun_member_attribute_def_def_suspensionInfo;
 import cz.metacentrum.perun.core.implApi.AttributesManagerImplApi;
 import cz.metacentrum.perun.core.implApi.modules.attributes.AttributesModuleImplApi;
@@ -7483,6 +7484,14 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		attr.setFriendlyName("authoritativeGroup");
 		attr.setDisplayName("Authoritative Group");
 		attr.setDescription("If group is authoritative for member. (for synchronization)");
+		//set attribute rights (with dummy id of attribute - not known yet)
+		rights = new ArrayList<>();
+		rights.add(new AttributeRights(-1, Role.VOADMIN, Arrays.asList(ActionType.READ, ActionType.WRITE)));
+		rights.add(new AttributeRights(-1, Role.GROUPADMIN, Collections.singletonList(ActionType.READ)));
+		attributes.put(attr, rights);
+
+		//urn:perun:group:attribute-def:def:groupStructureResources
+		attr = new urn_perun_group_attribute_def_def_groupStructureResources().getAttributeDefinition();
 		//set attribute rights (with dummy id of attribute - not known yet)
 		rights = new ArrayList<>();
 		rights.add(new AttributeRights(-1, Role.VOADMIN, Arrays.asList(ActionType.READ, ActionType.WRITE)));

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_groupStructureResources.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_groupStructureResources.java
@@ -1,0 +1,104 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.Vo;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.VoNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import cz.metacentrum.perun.core.implApi.modules.attributes.GroupAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.GroupAttributesModuleImplApi;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * @author Vojtech Sassmann <vojtech.sassmann@gmail.com>
+ */
+public class urn_perun_group_attribute_def_def_groupStructureResources extends GroupAttributesModuleAbstract implements GroupAttributesModuleImplApi {
+
+	private static final Pattern resourceIdPattern = Pattern.compile("^[1-9][0-9]*$");
+    private static final Pattern invalidEscapePattern =
+      Pattern.compile("(" + "([^\\\\]|^)(\\\\\\\\)*)\\\\([^,\\\\]|$)");
+
+	@Override
+	public void checkAttributeSyntax(PerunSessionImpl sess, Group group, Attribute attribute) throws WrongAttributeValueException {
+		//Null value is ok, means no settings for group
+		if(attribute.getValue() == null) return;
+
+		LinkedHashMap<String, String> attrValues = attribute.valueAsMap();
+
+		boolean hasInvalidResourceName = attrValues.keySet().stream()
+				.anyMatch(this::invalidResourceName);
+
+		if (hasInvalidResourceName) {
+			throw new WrongAttributeValueException(attribute, group, "Some of the specified resource ids has an invalid format.");
+		}
+		for (String rawGroupLogins : attrValues.values()) {
+			// null or empty value means the whole group tree
+			if (rawGroupLogins == null || rawGroupLogins.isEmpty()) {
+				continue;
+			}
+			Matcher m = invalidEscapePattern.matcher(rawGroupLogins);
+			if (m.find()) {
+				throw new WrongAttributeValueException(attribute, group, "Group logins format contains invalid escape sequence.");
+			}
+			if (!rawGroupLogins.endsWith(",")) {
+				throw new WrongAttributeValueException(attribute, group, "Each group login has to end with a comma ','.");
+			}
+		}
+	}
+
+	@Override
+	public void checkAttributeSemantics(PerunSessionImpl sess, Group group, Attribute attribute) throws WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+		//Null value is ok, means no settings for group
+		if(attribute.getValue() == null) return;
+
+		LinkedHashMap<String, String> attrValues = attribute.valueAsMap();
+		Vo vo;
+		try {
+			vo = sess.getPerunBl().getVosManagerBl().getVoById(sess, group.getVoId());
+		} catch (VoNotExistsException e) {
+			throw new InternalErrorException("Failed to find group's vo.", e);
+		}
+		List<Resource> voResources = sess.getPerunBl().getResourcesManagerBl().getResources(sess, vo);
+		Set<Integer> voResourceIds = voResources.stream()
+			.map(Resource::getId)
+			.collect(Collectors.toSet());
+
+		for (String rawId : attrValues.keySet()) {
+			int id = Integer.parseInt(rawId);
+			if (!voResourceIds.contains(id)) {
+				throw new WrongReferenceAttributeValueException(attribute, "There is no resource with id '" + id + "' assigned to the groups vo: " + vo);
+			}
+		}
+	}
+
+	private boolean invalidResourceName(String value) {
+		return !resourceIdPattern.matcher(value).matches();
+	}
+
+	@Override
+	public AttributeDefinition getAttributeDefinition() {
+		AttributeDefinition attr = new AttributeDefinition();
+		attr.setNamespace(AttributesManager.NS_GROUP_ATTR_DEF);
+		attr.setType(LinkedHashMap.class.getName());
+		attr.setFriendlyName("groupStructureResources");
+		attr.setDisplayName("Group structure synchronization resources");
+		attr.setDescription("Defines, which resources (map keys) should be auto assigned, and to which groups " +
+			"(map values). Each group login should end with the `,` character (even the last one, eg: " +
+			"`login1,login2,`). If some of the group logins contains a comma ',' or backslash '\\', you have to " +
+			"escape it with the backslash '\\' character.");
+		return attr;
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_groupStructureResourcesTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_groupStructureResourcesTest.java
@@ -1,0 +1,307 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.Vo;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Vojtech Sassmann <vojtech.sassmann@gmail.com>
+ */
+public class urn_perun_group_attribute_def_def_groupStructureResourcesTest {
+
+	private static final String CLASS_NAME = urn_perun_group_attribute_def_def_groupStructureResources.class.getName() + ".";
+	private urn_perun_group_attribute_def_def_groupStructureResources classInstance;
+	private Attribute attribute;
+	private PerunSessionImpl sess;
+	private Group group;
+	private Resource validResource;
+	private Vo vo;
+
+	@Before
+	public void setUp() throws Exception {
+		group = new Group("group", "description");
+		vo = new Vo(10, "vo", "vo");
+		group.setVoId(vo.getId());
+		classInstance = new urn_perun_group_attribute_def_def_groupStructureResources();
+		attribute = new Attribute(classInstance.getAttributeDefinition());
+		sess = mock(PerunSessionImpl.class, RETURNS_DEEP_STUBS);
+
+		validResource = new Resource(19, "resource", "", -1);
+		validResource.setVoId(vo.getId());
+
+		when(sess.getPerunBl().getVosManagerBl().getVoById(sess, vo.getId()))
+			.thenReturn(vo);
+
+		when(sess.getPerunBl().getResourcesManagerBl().getResources(sess, vo))
+			.thenReturn(Collections.singletonList(validResource));
+	}
+
+	// ---- Syntax ---- //
+
+	@Test
+	public void testGroupLoginsInvalidSingleEscape() throws Exception {
+		System.out.println(CLASS_NAME + "testGroupLoginsInvalidSingleEscape");
+		testInvalidGroupLoginsSyntax("\\");
+	}
+
+	@Test
+	public void testGroupLoginsInvalidEndEscape() throws Exception {
+		System.out.println(CLASS_NAME + "testGroupLoginsInvalidEndEscape");
+		testInvalidGroupLoginsSyntax("login1,\\");
+	}
+
+	@Test
+	public void testGroupLoginsInvalidStartEscape() throws Exception {
+		System.out.println(CLASS_NAME + "testGroupLoginsInvalidStartEscape");
+		testInvalidGroupLoginsSyntax("\\login1,");
+	}
+
+	@Test
+	public void testGroupLoginsInvalidEscape() throws Exception {
+		System.out.println(CLASS_NAME + "testGroupLoginsInvalidEscape");
+		testInvalidGroupLoginsSyntax("lo\\gin1,");
+	}
+
+	@Test
+	public void testGroupLoginsInvalidEscapeAfterCorrectBackslashEscape() throws Exception {
+		System.out.println(CLASS_NAME + "testGroupLoginsInvalidEscapeAfterCorrectBackslashEscape");
+		testInvalidGroupLoginsSyntax("lo\\\\\\gin1,");
+	}
+
+	@Test
+	public void testGroupLoginsInvalidEscapeAfterCorrectCommaEscape() throws Exception {
+		System.out.println(CLASS_NAME + "testGroupLoginsInvalidEscapeAfterCorrectCommaEscape");
+		testInvalidGroupLoginsSyntax("lo\\,\\gin1,");
+	}
+
+	@Test
+	public void testGroupLoginsNoCommaAtTheEnd() throws Exception {
+		System.out.println(CLASS_NAME + "testGroupLoginsNoCommaAtTheEnd");
+		testInvalidGroupLoginsSyntax("login1,login2");
+	}
+
+	@Test
+	public void testGroupLoginsValidCommaAfterBackSlash() throws Exception {
+		System.out.println(CLASS_NAME + "testGroupLoginsValidCommaAfterBackSlash");
+		testValidGroupLoginsSyntax("login1\\\\\\,login2,");
+	}
+
+	@Test
+	public void testGroupLoginsValidCommaAfterTwoBackSlashes() throws Exception {
+		System.out.println(CLASS_NAME + "testGroupLoginsValidCommaAfterTwoBackSlashes");
+		testValidGroupLoginsSyntax("login1\\\\\\\\,login2,");
+	}
+
+	@Test
+	public void testGroupLoginsValidBackslashEscape() throws Exception {
+		System.out.println(CLASS_NAME + "testGroupLoginsValidBackslashEscape");
+		testValidGroupLoginsSyntax("lo\\\\gin1,");
+	}
+
+	@Test
+	public void testGroupLoginsValidCommaEscape() throws Exception {
+		System.out.println(CLASS_NAME + "testGroupLoginsValidCommaEscape");
+		testValidGroupLoginsSyntax("lo\\,gin1,");
+	}
+
+	@Test
+	public void testGroupLoginsValidCommaAfterEscapeCommaEscape() throws Exception {
+		System.out.println(CLASS_NAME + "testGroupLoginsValidCommaAfterEscapeCommaEscape");
+		testValidGroupLoginsSyntax("lo\\,,gin1,");
+	}
+
+	@Test
+	public void testGroupLoginsValidMultipleLogins() throws Exception {
+		System.out.println(CLASS_NAME + "testGroupLoginsValidMultipleLogins");
+		testValidGroupLoginsSyntax("gro\\,up1,group2,group3,group4,");
+	}
+
+	@Test
+	public void testGroupLoginsValidEmptyValue() throws Exception {
+		System.out.println(CLASS_NAME + "testGroupLoginsValidEmptyValue");
+		testValidGroupLoginsSyntax("");
+	}
+
+	@Test
+	public void testInvalidGroupLoginAfterValidOne() throws Exception {
+		System.out.println(CLASS_NAME + "testInvalidGroupLoginAfterValidOne");
+		testInvalidMultipleGroupLoginsSyntax("", "missingComma");
+	}
+
+	@Test
+	public void testValidMultipleGroupLogins() throws Exception {
+		System.out.println(CLASS_NAME + "testValidMultipleGroupLogins");
+		testValidMultipleGroupLoginsSyntax("", "valid,");
+	}
+
+	@Test
+	public void testNullValueIsValidInSyntax() throws Exception {
+		System.out.println(CLASS_NAME + "testNullValueIsValidInSyntax");
+		attribute.setValue(null);
+		classInstance.checkAttributeSyntax(sess, group, attribute);
+	}
+
+	@Test
+	public void testValidResourceIdSyntax() throws Exception {
+		System.out.println(CLASS_NAME + "testValidResourceIdSyntax");
+		testValidResourceIdsSyntax("123");
+	}
+
+	@Test
+	public void testMultipleValidResourceIdSyntax() throws Exception {
+		System.out.println(CLASS_NAME + "testMultipleValidResourceIdSyntax");
+		testValidResourceIdsSyntax("123", "23");
+	}
+
+	@Test
+	public void testInValidCharInResourceIdSyntax() throws Exception {
+		System.out.println(CLASS_NAME + "testInValidCharInResourceIdSyntax");
+		testInValidResourceIdsSyntax("#123");
+	}
+
+	@Test
+	public void testInValidResourceIdWithValidSyntax() throws Exception {
+		System.out.println(CLASS_NAME + "testInValidResourceIdWithValidSyntax");
+		testInValidResourceIdsSyntax("123", "#123");
+	}
+
+	@Test
+	public void testInValidResourceIdEmptySyntax() throws Exception {
+		System.out.println(CLASS_NAME + "testInValidResourceIdEmptySyntax");
+		testInValidResourceIdsSyntax("");
+	}
+
+
+	// ---- Semantics ---- //
+
+
+	@Test
+	public void testNullValueIsValidInSemantics() throws Exception {
+		System.out.println(CLASS_NAME + "testNullValueIsValidInSemantics");
+		attribute.setValue(null);
+		classInstance.checkAttributeSemantics(sess, group, attribute);
+	}
+
+	@Test
+	public void testValidResourceIdInSemantics() throws Exception {
+		System.out.println(CLASS_NAME + "testValidResourceIdInSemantics");
+		testValidResourceSemantics(String.valueOf(validResource.getId()));
+	}
+
+	@Test
+	public void testInValidResourceIdInSemantics() throws Exception {
+		System.out.println(CLASS_NAME + "testInValidResourceIdInSemantics");
+		testInValidResourceSemantics("2344");
+	}
+
+	@Test
+	public void testInValidResourceIdWithValidInSemantics() throws Exception {
+		System.out.println(CLASS_NAME + "testInValidResourceIdWithValidInSemantics");
+		testInValidResourceSemantics(String.valueOf(validResource.getId()), "2344");
+	}
+
+
+
+	// ---- Private methods ---- //
+
+
+
+	private void testValidResourceSemantics(String... values) throws Exception {
+		HashMap<String, String> attrValue = new LinkedHashMap<>();
+		for (String value : values) {
+			attrValue.put(value, "login,");
+		}
+		attribute.setValue(attrValue);
+
+		classInstance.checkAttributeSemantics(sess, group, attribute);
+	}
+
+	private void testInValidResourceSemantics(String... values) throws Exception {
+		HashMap<String, String> attrValue = new LinkedHashMap<>();
+		for (String value : values) {
+			attrValue.put(value, "login,");
+		}
+		attribute.setValue(attrValue);
+
+		assertThatExceptionOfType(WrongReferenceAttributeValueException.class)
+				.isThrownBy(() -> classInstance.checkAttributeSemantics(sess, group, attribute));
+	}
+
+	private void testValidResourceIdsSyntax(String... values) throws Exception {
+		HashMap<String, String> attrValue = new LinkedHashMap<>();
+		for (String value : values) {
+			attrValue.put(value, "login,");
+		}
+		attribute.setValue(attrValue);
+
+		classInstance.checkAttributeSyntax(sess, group, attribute);
+	}
+
+	private void testInValidResourceIdsSyntax(String... values) throws Exception {
+		HashMap<String, String> attrValue = new LinkedHashMap<>();
+		for (String value : values) {
+			attrValue.put(value, "login,");
+		}
+		attribute.setValue(attrValue);
+
+		assertThatExceptionOfType(WrongAttributeValueException.class)
+				.isThrownBy(() -> classInstance.checkAttributeSyntax(sess, group, attribute));
+	}
+
+	private void testValidGroupLoginsSyntax(String value) throws Exception {
+		HashMap<String, String> attrValue = new LinkedHashMap<>();
+		attrValue.put("1", value);
+		attribute.setValue(attrValue);
+
+		classInstance.checkAttributeSyntax(sess, group, attribute);
+	}
+
+	private void testInvalidGroupLoginsSyntax(String value) {
+		HashMap<String, String> attrValue = new LinkedHashMap<>();
+		attrValue.put("1", value);
+		attribute.setValue(attrValue);
+
+		assertThatExceptionOfType(WrongAttributeValueException.class)
+			.isThrownBy(() -> classInstance.checkAttributeSyntax(sess, group, attribute));
+	}
+
+	private void testInvalidMultipleGroupLoginsSyntax(String... values) {
+		HashMap<String, String> attrValue = new LinkedHashMap<>();
+		int resourceId = 1;
+
+		for (String value : values) {
+			attrValue.put(String.valueOf(resourceId++), value);
+			attribute.setValue(attrValue);
+		}
+
+		assertThatExceptionOfType(WrongAttributeValueException.class)
+			.isThrownBy(() -> classInstance.checkAttributeSyntax(sess, group, attribute));
+	}
+
+	private void testValidMultipleGroupLoginsSyntax(String... values) throws WrongAttributeValueException {
+		HashMap<String, String> attrValue = new LinkedHashMap<>();
+		int resourceId = 1;
+
+		for (String value : values) {
+			attrValue.put(String.valueOf(resourceId), value);
+			attribute.setValue(attrValue);
+		}
+
+		classInstance.checkAttributeSyntax(sess, group, attribute);
+	}
+}


### PR DESCRIPTION
* Implemented login responsible for automatic assignment of resources
for certain group trees in the group structure synchronization.
* Created a new attribute for group structure synchronization named
groupStructureResources. This attribute is of the map type and keys
represents id of a resource which should be assigned, and values are
group logins, seperated with commas. The resource is assigned to group
with the login and also to all of its subgroups.