### PR TITLE
CORE: Do not double "name" param in serialized AuditEvent

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/audit/events/AuditEvent.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/audit/events/AuditEvent.java
@@ -12,7 +12,7 @@ import java.util.Set;
 /**
  * @author Vojtech Sassmann <vojtech.sassmann@gmail.com>
  */
-@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "name")
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "name")
 public abstract class AuditEvent {
 
 	protected String name = getClass().getName();

--- a/perun-base/src/main/java/cz/metacentrum/perun/audit/events/GroupManagerEvents/GroupMoved.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/audit/events/GroupManagerEvents/GroupMoved.java
@@ -26,10 +26,6 @@ public class GroupMoved extends AuditEvent {
 		return group;
 	}
 
-	public String getName() {
-		return name;
-	}
-
 	@Override
 	public String toString() {
 		return message;

--- a/perun-base/src/main/java/cz/metacentrum/perun/audit/events/VoManagerEvents/VoUpdated.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/audit/events/VoManagerEvents/VoUpdated.java
@@ -26,10 +26,6 @@ public class VoUpdated extends AuditEvent {
 		return vo;
 	}
 
-	public String getName() {
-		return name;
-	}
-
 	@Override
 	public String toString() {
 		return message;


### PR DESCRIPTION
- Since we used "name" for both json type info property and object property,
  it was serialized twice (by coincidence having same value).
  Now we instruct serializer to use own "name" property to define java type.
- We have getName() in parent object AuditEvent. There is no need to override
  it with the same implementation.