### PR TITLE
CORE: Fixed login-namespace for vsup

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/VsupPasswordManagerModule.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/VsupPasswordManagerModule.java
@@ -4,6 +4,9 @@ public class VsupPasswordManagerModule extends GenericPasswordManagerModule {
 
 	public VsupPasswordManagerModule() {
 
+		// set proper namespace
+		this.actualLoginNamespace = "vsup";
+
 		// override random password generating params
 		this.randomPasswordLength = 14;
 


### PR DESCRIPTION
- We must override actualLoginNamespaces value
  in classes extending GenericPasswordManagerModule.