### PR TITLE
New method in Core - get policies

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/AuthzResolver.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/AuthzResolver.java
@@ -1020,4 +1020,13 @@ public class AuthzResolver {
 		if (!isAuthorized(sess, Role.PERUNADMIN)) throw new PrivilegeException(sess, "loadAuthorizationComponents");
 		AuthzResolverBlImpl.loadAuthorizationComponents();
 	}
+
+	/**
+	 * Return all loaded perun policies.
+	 *
+	 * @return all loaded policies
+	 */
+	public static List<PerunPolicy> getAllPolicies() {
+		return AuthzResolverBlImpl.getAllPolicies();
+	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
@@ -1411,6 +1411,15 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 		}
 	}
 
+	/**
+	 * Return all loaded perun policies.
+	 *
+	 * @return all loaded policies
+	 */
+	public static List<PerunPolicy> getAllPolicies() {
+		return AuthzResolverImpl.getAllPolicies();
+	}
+
 	public String toString() {
 		return getClass().getSimpleName() + ":[]";
 	}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AuthzResolverImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AuthzResolverImpl.java
@@ -770,4 +770,13 @@ public class AuthzResolverImpl implements AuthzResolverImplApi {
 	public static List<PerunPolicy> fetchPolicyWithAllIncludedPolicies(String policyName) throws PolicyNotExistsException {
 		return perunPoliciesContainer.fetchPolicyWithAllIncludedPolicies(policyName);
 	}
+
+	/**
+	 * Return all loaded perun policies.
+	 *
+	 * @return all loaded policies
+	 */
+	public static List<PerunPolicy> getAllPolicies() {
+		return perunPoliciesContainer.getAllPolicies();
+	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/PerunPoliciesContainer.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/PerunPoliciesContainer.java
@@ -6,6 +6,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -55,5 +56,14 @@ public class PerunPoliciesContainer {
 			policiesToCheck.addAll(policyToCheck.getIncludePolicies());
 		}
 		return new ArrayList<>(allIncludedPolicies.values());
+	}
+
+	/**
+	 * Return all loaded perun policies.
+	 *
+	 * @return all loaded policies
+	 */
+	public List<PerunPolicy> getAllPolicies() {
+		return Collections.unmodifiableList(perunPolicies);
 	}
 }

--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -380,6 +380,22 @@ components:
       discriminator:
         propertyName: beanName
 
+    PerunPolicy:
+      type: object
+      properties:
+        policyName: { type: string }
+        includePolicies: { type: array, items: { type: string } }
+        perunRoles:
+          type: array
+          items:
+            type: object
+            additionalProperties:
+              type: string
+      required:
+        - policyName
+        - includePolicies
+        - perunRoles
+
     Group:
       allOf:
         - $ref: '#/components/schemas/Auditable'
@@ -1214,6 +1230,15 @@ components:
             type: array
             items:
               $ref: "#/components/schemas/Group"
+
+    ListOfPerunPoliciesResponse:
+      description: "returns List<PerunPolicy>"
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/PerunPolicy"
 
     ListOfRichGroupsResponse:
       description: "returns List<RichGroup>"
@@ -2751,6 +2776,18 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/StringResponse'
+        default:
+          $ref: '#/components/responses/ExceptionResponse'
+
+  /json/authzResolver/getAllPolicies:
+    get:
+      tags:
+        - AuthzResolver
+      operationId: getAllPolicies
+      summary: Return all loaded perun policies.
+      responses:
+        '200':
+          $ref: '#/components/responses/ListOfPerunPoliciesResponse'
         default:
           $ref: '#/components/responses/ExceptionResponse'
 

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/AuthzResolverMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/AuthzResolverMethod.java
@@ -1,10 +1,12 @@
 package cz.metacentrum.perun.rpc.methods;
 
+import cz.metacentrum.perun.core.api.AuthzResolver;
 import cz.metacentrum.perun.core.api.Group;
 
 import java.util.ArrayList;
 import java.util.List;
 
+import cz.metacentrum.perun.core.api.PerunPolicy;
 import cz.metacentrum.perun.core.api.PerunPrincipal;
 import cz.metacentrum.perun.core.api.RichUser;
 import cz.metacentrum.perun.core.api.Role;
@@ -610,6 +612,18 @@ public enum AuthzResolverMethod implements ManagerMethod {
 		@Override
 		public String call(ApiCaller ac, Deserializer parms) throws PerunException {
 			return "OK";
+		}
+	},
+
+	/*#
+	 * Return all loaded perun policies.
+	 *
+	 * @return List<PerunPolicy> all loaded policies
+	 */
+	getAllPolicies {
+		@Override
+		public List<PerunPolicy> call(ApiCaller ac, Deserializer parms) throws PerunException {
+			return AuthzResolver.getAllPolicies();
 		}
 	},
 


### PR DESCRIPTION
* Created a new method which can be used to retrieve all of the loaded
perun policies in the AuthzResolver. This method will be used in the
NGUI for authorization.
* The new method `getPolicies` has been added to the openApi
specification as well.