### PR TITLE
Core - secondary regex for group name

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/CoreConfig.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/CoreConfig.java
@@ -79,6 +79,8 @@ public class CoreConfig {
 	private String smtpUser;
 	private String smtpPass;
 	private List<String> autocreatedNamespaces;
+	private String groupNameSecondaryRegex;
+	private String groupFullNameSecondaryRegex;
 
 	public int getGroupMaxConcurentGroupsToSynchronize() {
 		return groupMaxConcurentGroupsToSynchronize;
@@ -653,5 +655,20 @@ public class CoreConfig {
 
 	public String getDefaultLoaIdP() {
 		return defaultLoaIdP;
+	}
+
+	public String getGroupNameSecondaryRegex() {
+		return groupNameSecondaryRegex;
+	}
+
+	public void setGroupNameSecondaryRegex(String groupNameSecondaryRegex) {
+		this.groupNameSecondaryRegex = groupNameSecondaryRegex;
+	}
+	public String getGroupFullNameSecondaryRegex() {
+		return groupFullNameSecondaryRegex;
+	}
+
+	public void setGroupFullNameSecondaryRegex(String groupFullNameSecondaryRegex) {
+		this.groupFullNameSecondaryRegex = groupFullNameSecondaryRegex;
 	}
 }

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/InvalidGroupNameException.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/InvalidGroupNameException.java
@@ -1,0 +1,26 @@
+package cz.metacentrum.perun.core.api.exceptions;
+
+
+/**
+ * This exception is thrown when there is an attempt to create a group with
+ * an invalid name.
+ *
+ * @author Vojtech Sassmann <vojtech.sassmann@gmail.com>
+ */
+public class InvalidGroupNameException extends PerunException {
+	public InvalidGroupNameException() {
+		super();
+	}
+
+	public InvalidGroupNameException(String message) {
+		super(message);
+	}
+
+	public InvalidGroupNameException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public InvalidGroupNameException(Throwable cause) {
+		super(cause);
+	}
+}

--- a/perun-base/src/main/resources/perun-base.xml
+++ b/perun-base/src/main/resources/perun-base.xml
@@ -23,6 +23,8 @@
 		<property name="groupStructureSynchronizationTimeout" value="${perun.group.structure.synchronization.timeout}"/>
 		<property name="groupMaxConcurentGroupsToSynchronize" value="${perun.group.maxConcurentGroupsToSynchronize}"/>
 		<property name="groupMaxConcurrentGroupsStructuresToSynchronize" value="${perun.group.structure.maxConcurrentGroupsStructuresToSynchronize}"/>
+		<property name="groupNameSecondaryRegex" value="${perun.group.nameSecondaryRegex}"/>
+		<property name="groupFullNameSecondaryRegex" value="${perun.group.fullNameSecondaryRegex}"/>
 		<property name="instanceId" value="${perun.instanceId}"/>
 		<property name="instanceName" value="${perun.instanceName}"/>
 		<property name="mailchangeBackupFrom" value="${perun.mailchange.backupFrom}"/>
@@ -93,6 +95,8 @@
 				<prop key="perun.group.structure.synchronization.timeout">10</prop>
 				<prop key="perun.group.maxConcurentGroupsToSynchronize">10</prop>
 				<prop key="perun.group.structure.maxConcurrentGroupsStructuresToSynchronize">10</prop>
+				<prop key="perun.group.nameSecondaryRegex"/>
+				<prop key="perun.group.fullNameSecondaryRegex"/>
 				<prop key="perun.rpc.powerusers"/>
 				<prop key="perun.perun.db.name">perun</prop>
 				<prop key="perun.rt.url">https://rt3.cesnet.cz/rt/REST/1.0/ticket/new</prop>

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/GroupsManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/GroupsManager.java
@@ -19,6 +19,7 @@ import cz.metacentrum.perun.core.api.exceptions.GroupStructureSynchronizationAlr
 import cz.metacentrum.perun.core.api.exceptions.GroupSynchronizationAlreadyRunningException;
 import cz.metacentrum.perun.core.api.exceptions.GroupSynchronizationNotEnabledException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.InvalidGroupNameException;
 import cz.metacentrum.perun.core.api.exceptions.MemberNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.NotGroupMemberException;
 import cz.metacentrum.perun.core.api.exceptions.ParentGroupNotExistsException;
@@ -102,8 +103,9 @@ public interface GroupsManager {
 	 * @throws GroupExistsException
 	 * @throws PrivilegeException
 	 * @throws VoNotExistsException
+	 * @throws InvalidGroupNameException when the given group name is invalid
 	 */
-	Group createGroup(PerunSession perunSession, Vo vo, Group group) throws GroupExistsException, PrivilegeException, VoNotExistsException;
+	Group createGroup(PerunSession perunSession, Vo vo, Group group) throws GroupExistsException, PrivilegeException, VoNotExistsException, InvalidGroupNameException;
 
 	/**
 	 * Creates a new subgroup of the existing group.
@@ -121,8 +123,9 @@ public interface GroupsManager {
 	 * @throws PrivilegeException
 	 * @throws GroupRelationNotAllowed
 	 * @throws GroupRelationAlreadyExists
+	 * @throws InvalidGroupNameException when the given group name is invalid
 	 */
-	Group createGroup(PerunSession perunSession, Group parentGroup, Group group) throws GroupNotExistsException, GroupExistsException, PrivilegeException, GroupRelationNotAllowed, GroupRelationAlreadyExists, ExternallyManagedException;
+	Group createGroup(PerunSession perunSession, Group parentGroup, Group group) throws GroupNotExistsException, GroupExistsException, PrivilegeException, GroupRelationNotAllowed, GroupRelationAlreadyExists, ExternallyManagedException, InvalidGroupNameException;
 
 	/**
 	 * If forceDelete is false, delete only group and if this group has members or subgroups, throw an exception.
@@ -219,8 +222,9 @@ public interface GroupsManager {
 	 * @throws GroupNotExistsException
 	 * @throws GroupExistsException if group with same name already exists in the same VO
 	 * @throws PrivilegeException
+	 * @throws InvalidGroupNameException when the given group name is invalid
 	 */
-	Group updateGroup(PerunSession perunSession, Group group) throws GroupNotExistsException, GroupExistsException, PrivilegeException;
+	Group updateGroup(PerunSession perunSession, Group group) throws GroupNotExistsException, GroupExistsException, PrivilegeException, InvalidGroupNameException;
 
 	/**
 	 * Search for the group with specified id in all VOs.
@@ -250,8 +254,9 @@ public interface GroupsManager {
 	 * @throws GroupNotExistsException
 	 * @throws InternalErrorException
 	 * @throws PrivilegeException
+	 * @throws InvalidGroupNameException when the given group name is invalid
 	 */
-	Group getGroupByName(PerunSession perunSession, Vo vo, String name) throws GroupNotExistsException, PrivilegeException, VoNotExistsException;
+	Group getGroupByName(PerunSession perunSession, Vo vo, String name) throws GroupNotExistsException, PrivilegeException, VoNotExistsException, InvalidGroupNameException;
 
 	/**
 	 * Adds member of the VO to the group in the same VO.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ExtSourcesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ExtSourcesManagerBlImpl.java
@@ -25,6 +25,7 @@ import cz.metacentrum.perun.core.api.exceptions.ExtSourceNotAssignedException;
 import cz.metacentrum.perun.core.api.exceptions.ExtSourceNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ExtSourceUnsupportedOperationException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.InvalidGroupNameException;
 import cz.metacentrum.perun.core.api.exceptions.SubjectNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.VoNotExistsException;
 
@@ -50,7 +51,6 @@ public class ExtSourcesManagerBlImpl implements ExtSourcesManagerBl {
 	final static Logger log = LoggerFactory.getLogger(ExtSourcesManagerBlImpl.class);
 	// \\p{L} means any unicode char
 	private static final Pattern namePattern = Pattern.compile("^[\\p{L} ,.0-9_'-]+$");
-	private static final Pattern groupNamePattern = Pattern.compile(GroupsManager.GROUP_SHORT_NAME_REGEXP);
 
 	private final ExtSourcesManagerImplApi extSourcesManagerImpl;
 	private PerunBl perunBl;
@@ -306,8 +306,11 @@ public class ExtSourcesManagerBlImpl implements ExtSourcesManagerBl {
 
 		// Check if the group name is not null and if it is in valid format.
 		if(candidateGroup.asGroup().getName() != null) {
-			Matcher name = groupNamePattern.matcher(candidateGroup.asGroup().getName());
-			if(!name.matches()) throw new InternalErrorException("Group subject data has to contain valid group name!");
+			try {
+				Utils.validateGroupName(candidateGroup.asGroup().getName());
+			} catch (InvalidGroupNameException e) {
+				throw new InternalErrorException("Group subject data has to contain valid group name!", e);
+			}
 		} else {
 			throw new InternalErrorException("group name cannot be null in Group subject data!");
 		}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/GroupsManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/GroupsManagerEntry.java
@@ -40,6 +40,7 @@ import cz.metacentrum.perun.core.api.exceptions.GroupSynchronizationAlreadyRunni
 import cz.metacentrum.perun.core.api.exceptions.GroupSynchronizationNotEnabledException;
 import cz.metacentrum.perun.core.api.exceptions.IllegalArgumentException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.InvalidGroupNameException;
 import cz.metacentrum.perun.core.api.exceptions.MemberNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.MembershipMismatchException;
 import cz.metacentrum.perun.core.api.exceptions.NotGroupMemberException;
@@ -90,16 +91,14 @@ public class GroupsManagerEntry implements GroupsManager {
 	}
 
 	@Override
-	public Group createGroup(PerunSession sess, Vo vo, Group group) throws GroupExistsException, PrivilegeException, VoNotExistsException {
+	public Group createGroup(PerunSession sess, Vo vo, Group group) throws GroupExistsException, PrivilegeException, VoNotExistsException, InvalidGroupNameException {
 		Utils.checkPerunSession(sess);
 		Utils.notNull(group, "group");
 		Utils.notNull(group.getName(), "group.name");
 
 		getPerunBl().getVosManagerBl().checkVoExists(sess, vo);
 
-		if (!group.getName().matches(GroupsManager.GROUP_SHORT_NAME_REGEXP)) {
-			throw new IllegalArgumentException("Wrong group name, group name must matches " + GroupsManager.GROUP_SHORT_NAME_REGEXP);
-		}
+		Utils.validateGroupName(group.getName());
 
 		if (group.getParentGroupId() != null) throw new InternalErrorException("Top-level groups can't have parentGroupId set!");
 
@@ -116,16 +115,13 @@ public class GroupsManagerEntry implements GroupsManager {
 	}
 
 	@Override
-	public Group createGroup(PerunSession sess, Group parentGroup, Group group) throws GroupNotExistsException, GroupExistsException, PrivilegeException, GroupRelationNotAllowed, GroupRelationAlreadyExists, ExternallyManagedException {
+	public Group createGroup(PerunSession sess, Group parentGroup, Group group) throws GroupNotExistsException, GroupExistsException, PrivilegeException, GroupRelationNotAllowed, GroupRelationAlreadyExists, ExternallyManagedException, InvalidGroupNameException {
 		Utils.checkPerunSession(sess);
 		getGroupsManagerBl().checkGroupExists(sess, parentGroup);
 		Utils.notNull(group, "group");
 		Utils.notNull(group.getName(), "group.name");
 
-
-		if (!group.getName().matches(GroupsManager.GROUP_SHORT_NAME_REGEXP)) {
-			throw new IllegalArgumentException("Wrong group name, group name must matches " + GroupsManager.GROUP_SHORT_NAME_REGEXP);
-		}
+		Utils.validateGroupName(group.getName());
 
 		// Authorization
 		if (!AuthzResolver.authorizedInternal(sess, "createGroup_Group_Group_policy", Collections.singletonList(parentGroup))) {
@@ -201,15 +197,13 @@ public class GroupsManagerEntry implements GroupsManager {
 	}
 
 	@Override
-	public Group updateGroup(PerunSession sess, Group group) throws GroupNotExistsException, GroupExistsException, PrivilegeException {
+	public Group updateGroup(PerunSession sess, Group group) throws GroupNotExistsException, GroupExistsException, PrivilegeException, InvalidGroupNameException {
 		Utils.checkPerunSession(sess);
 		getGroupsManagerBl().checkGroupExists(sess, group);
 		Utils.notNull(group, "group");
 		Utils.notNull(group.getName(), "group.name");
 
-		if (!group.getShortName().matches(GroupsManager.GROUP_SHORT_NAME_REGEXP)) {
-			throw new IllegalArgumentException("Wrong group shortName, group shortName must matches " + GroupsManager.GROUP_SHORT_NAME_REGEXP);
-		}
+		Utils.validateGroupName(group.getShortName());
 
 		// Authorization
 		if (!AuthzResolver.authorizedInternal(sess, "updateGroup_Group_policy", Collections.singletonList(group))) {
@@ -266,14 +260,12 @@ public class GroupsManagerEntry implements GroupsManager {
 	}
 
 	@Override
-	public Group getGroupByName(PerunSession sess, Vo vo, String name) throws GroupNotExistsException, PrivilegeException, VoNotExistsException {
+	public Group getGroupByName(PerunSession sess, Vo vo, String name) throws GroupNotExistsException, PrivilegeException, VoNotExistsException, InvalidGroupNameException {
 		Utils.checkPerunSession(sess);
 		getPerunBl().getVosManagerBl().checkVoExists(sess, vo);
 		Utils.notNull(name, "name");
 
-		if (!name.matches(GroupsManager.GROUP_FULL_NAME_REGEXP)) {
-			throw new IllegalArgumentException("Wrong group name, group name must matches " + GroupsManager.GROUP_FULL_NAME_REGEXP);
-		}
+		Utils.validateFullGroupName(name);
 
 		Group group = getGroupsManagerBl().getGroupByName(sess, vo, name);
 

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/GroupsManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/GroupsManagerEntryIntegrationTest.java
@@ -4,6 +4,7 @@ import cz.metacentrum.perun.core.AbstractPerunIntegrationTest;
 import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.BeansUtils;
 import cz.metacentrum.perun.core.api.Candidate;
 import cz.metacentrum.perun.core.api.ExtSource;
 import cz.metacentrum.perun.core.api.ExtSourcesManager;
@@ -33,6 +34,7 @@ import cz.metacentrum.perun.core.api.exceptions.GroupRelationCannotBeRemoved;
 import cz.metacentrum.perun.core.api.exceptions.GroupRelationDoesNotExist;
 import cz.metacentrum.perun.core.api.exceptions.GroupRelationNotAllowed;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.InvalidGroupNameException;
 import cz.metacentrum.perun.core.api.exceptions.MemberNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.NotGroupMemberException;
 import cz.metacentrum.perun.core.api.exceptions.RelationExistsException;
@@ -59,6 +61,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -4934,6 +4937,25 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 		assertEquals("Year must match", requiredDate.getYear(), expectedDate.getYear());
 		assertEquals("Month must match", requiredDate.getMonthValue(), expectedDate.getMonthValue());
 		assertEquals("Day must match", requiredDate.getDayOfMonth(), expectedDate.getDayOfMonth());
+	}
+
+	@Test
+	public void createGroupFailsOnInvalidNameForSecondaryRegex() throws Exception {
+		System.out.println(CLASS_NAME + "createGroupFailsOnInvalidNameForSecondaryRegex");
+		Vo vo = setUpVo();
+
+		String previousValue = BeansUtils.getCoreConfig().getGroupNameSecondaryRegex();
+		String secondaryRegex = "^[\\d]*";
+		BeansUtils.getCoreConfig().setGroupNameSecondaryRegex(secondaryRegex);
+
+		String invalidName = "invalid";
+		Group invalidGroup = new Group(invalidName, "");
+
+		assertThatExceptionOfType(InvalidGroupNameException.class)
+				.isThrownBy(() -> groupsManager.createGroup(sess, vo, invalidGroup));
+
+		// cleanup
+		BeansUtils.getCoreConfig().setGroupNameSecondaryRegex(previousValue);
 	}
 
 	// PRIVATE METHODS -------------------------------------------------------------

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/SecurityTeamsManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/SecurityTeamsManagerEntryIntegrationTest.java
@@ -961,7 +961,7 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 	}
 
 
-	private Group setUpGroup(User u0, User u1) throws PrivilegeException, UserNotExistsException, VoExistsException, GroupExistsException, VoNotExistsException, GroupNotExistsException, AlreadyMemberException, MemberNotExistsException, WrongReferenceAttributeValueException, WrongAttributeValueException, ExtendMembershipException, WrongAttributeAssignmentException, AttributeNotExistsException, ExternallyManagedException {
+	private Group setUpGroup(User u0, User u1) throws Exception {
 		Vo vo = new Vo();
 		vo.setShortName("testVo");
 		vo.setName("Test VO");

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/UtilsIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/UtilsIntegrationTest.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -230,6 +231,15 @@ public class UtilsIntegrationTest extends AbstractPerunIntegrationTest {
 		assertEquals(list.size(), 2);
 		assertTrue(list.contains(userExtSource2));
 		assertTrue(list.contains(userExtSource));
+	}
+
+	@Test
+	public void validateGroupNameThrowsACorrectExceptionForInvalidRegex() {
+		System.out.println("Utils.validateGroupNameThrowsACorrectExceptionForInvalidRegex");
+
+		String invalidPattern = "[a-";
+		assertThatExceptionOfType(InternalErrorException.class)
+				.isThrownBy(() -> Utils.validateGroupName("members", invalidPattern));
 	}
 
 	private Vo setUpVo() throws Exception {

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/EduGain.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/EduGain.java
@@ -4,6 +4,7 @@ import cz.metacentrum.perun.core.api.*;
 import cz.metacentrum.perun.core.api.exceptions.AlreadyAdminException;
 import cz.metacentrum.perun.core.api.exceptions.GroupNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.InvalidGroupNameException;
 import cz.metacentrum.perun.core.api.exceptions.PerunException;
 import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
@@ -34,7 +35,13 @@ public class EduGain extends DefaultRegistrarModule {
 
 			AuthzResolver.setRole(session, user, vo, Role.TOPGROUPCREATOR);
 
-			Group membersGroup = session.getPerun().getGroupsManager().getGroupByName(session, vo, "members");
+			Group membersGroup = null;
+			try {
+				membersGroup = session.getPerun().getGroupsManager().getGroupByName(session, vo, "members");
+			} catch (InvalidGroupNameException e) {
+				// shouldn't happen, "members" is a valid name
+				throw new InternalErrorException(e);
+			}
 			AuthzResolver.setRole(session, user, membersGroup, Role.GROUPADMIN);
 
 		}

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/GroupsManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/GroupsManagerMethod.java
@@ -81,6 +81,7 @@ public enum GroupsManagerMethod implements ManagerMethod {
 	 * @throw GroupRelationNotAllowed When the group relation cannot be created, because it's not allowed
 	 * @throw GroupRelationAlreadyExists When the group relation already exists
 	 * @throw VoNotExistsException When Vo doesn't exist
+	 * @throw InvalidGroupNameException when the given group name is invalid
 	 *
 	 * @param vo int Parent VO <code>id</code>
 	 * @param name String name of a group
@@ -269,6 +270,7 @@ public enum GroupsManagerMethod implements ManagerMethod {
 	 *
 	 * @throw GroupNotExistsException When the group doesn't exist
 	 * @throw GroupExistsException when the group with the same name already exists in the same vo
+	 * @throw InvalidGroupNameException when the given group name is invalid
 	 *
 	 * @param group Group JSON Group class
 	 * @return Group Updated group
@@ -346,6 +348,7 @@ public enum GroupsManagerMethod implements ManagerMethod {
 	 * IMPORTANT: need to use full name of group (ex. 'toplevel:a:b', not the shortname which is in this example 'b')
 	 *
 	 * @throw GroupNotExistsException When the group doesn't exist
+	 * @throw InvalidGroupNameException when the given group name is invalid
 	 *
 	 * @param vo int VO <code>id</code>
 	 * @param name String Group name


### PR DESCRIPTION
* On some instances, we need to be able to restrict the group names
even more. For this purpose, I have added an implementation of
validation against a secondary regexes. If the secondary regex is not
specified, it is skipped during the validation.
* Secondary regex for short name can be specified with the
`perun.group.nameSecondaryRegex` core property.
* Secondary regex for full name can be specified with the
`perun.group.fullNameSecondaryRegex` core property.
* One should define both, or none of this properties to ensure a correct
behaviour of the whole system.