### PR TITLE
DISPATCHER: Reintroduced configurable re-schedule interval

### DIFF
--- a/perun-dispatcher/src/main/resources/perun-dispatcher.xml
+++ b/perun-dispatcher/src/main/resources/perun-dispatcher.xml
@@ -66,6 +66,7 @@ http://www.springframework.org/schema/tx http://www.springframework.org/schema/t
 				<prop key="dispatcher.task.delay.count">4</prop>
 				<prop key="dispatcher.datadir">/tmp/perun-dispatcher-data</prop>
 				<prop key="dispatcher.propagation.timeout">190</prop>
+				<prop key="dispatcher.rescheduleInterval">48</prop>
 			</props>
 		</property>
 	</bean>


### PR DESCRIPTION
- If Tasks are DONE or ERROR for too many hours, they will
  be re-scheduled, even if source data hasn't changed. 
  It was previously configurable, then we
  switched to fixed "two days" period.
  Now, it is configurable again, defaulting to two days
  (setting is in hours in perun-dispatcher.properties).