### PR TITLE
GUI - secondary group name regex

### DIFF
--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/CreateGroupTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/CreateGroupTabItem.java
@@ -195,10 +195,18 @@ public class CreateGroupTabItem implements TabItem {
 		final ExtendedTextBox.TextBoxValidator validator = new ExtendedTextBox.TextBoxValidator() {
 			@Override
 			public boolean validateTextBox() {
-				if (groupNameTextBox.getTextBox().getText().trim().isEmpty()) {
+				String groupName = groupNameTextBox.getTextBox().getText().trim();
+				String secondaryNameRegex = session.getConfiguration().getCustomProperty("groupNameSecondaryRegex");
+				if (groupName.isEmpty()) {
 					groupNameTextBox.setError("Name can't be empty.");
-				} else if (!groupNameTextBox.getTextBox().getText().trim().matches(Utils.GROUP_SHORT_NAME_MATCHER)) {
-					groupNameTextBox.setError("Name can contain only a-z, A-Z, numbers, spaces, dots, '_' and '-'.");
+				} else if (!groupName.matches(Utils.GROUP_SHORT_NAME_MATCHER) ||
+				          (!secondaryNameRegex.isEmpty() && !groupName.matches(secondaryNameRegex))) {
+					String customErrorMessage = session.getConfiguration().getCustomProperty("groupNameErrorMessage");
+					if (!customErrorMessage.isEmpty()) {
+						groupNameTextBox.setError(customErrorMessage);
+					} else {
+						groupNameTextBox.setError("Name can contain only a-z, A-Z, numbers, spaces, dots, '_' and '-'.");
+					}
 				} else {
 					groupNameTextBox.setOk();
 					return true;

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/EditGroupDetailsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/EditGroupDetailsTabItem.java
@@ -106,10 +106,18 @@ public class EditGroupDetailsTabItem implements TabItem {
 		final ExtendedTextBox.TextBoxValidator validator = new ExtendedTextBox.TextBoxValidator() {
 			@Override
 			public boolean validateTextBox() {
-				if (nameTextBox.getTextBox().getText().trim().isEmpty()) {
+				String groupName = nameTextBox.getTextBox().getText().trim();
+				String secondaryNameRegex = session.getConfiguration().getCustomProperty("groupNameSecondaryRegex");
+				if (groupName.isEmpty()) {
 					nameTextBox.setError("Name can't be empty.");
-				} else if (!nameTextBox.getTextBox().getText().trim().matches(Utils.GROUP_SHORT_NAME_MATCHER)) {
-					nameTextBox.setError("Name can contain only a-z, A-Z, numbers, spaces, dots, '_' and '-'.");
+				} else if (!groupName.matches(Utils.GROUP_SHORT_NAME_MATCHER) ||
+						(!secondaryNameRegex.isEmpty() && !groupName.matches(secondaryNameRegex))) {
+					String customErrorMessage = session.getConfiguration().getCustomProperty("groupNameErrorMessage");
+					if (!customErrorMessage.isEmpty()) {
+						nameTextBox.setError(customErrorMessage);
+					} else {
+						nameTextBox.setError("Name can contain only a-z, A-Z, numbers, spaces, dots, '_' and '-'.");
+					}
 				} else {
 					nameTextBox.setOk();
 					return true;


### PR DESCRIPTION
* Gui can now work with a secondary group name regex. This regex has to
be defined as a perun-web-gui property with a name
`groupNameSecondaryRegex`.
* Also added an option to specify a custom error message, when the group
name is invalid. This text can be specified using the
`groupNameErrorMessage` perun-web-gui property.
* If the `groupNameErrorMessage` is not specified, a default message
is shown.
* If the secondary regex is not specified, its validation is skipped.