### PR TITLE
CORE: All attribute tables now have single attr_value column

### DIFF
--- a/perun-base/src/test/resources/test-schema.sql
+++ b/perun-base/src/test/resources/test-schema.sql
@@ -2,7 +2,7 @@ set database sql syntax PGS true;
 -- fix unique index on authz, since PGS compatibility doesn't allow coalesce call in index and treats nulls in columns as different values.
 SET DATABASE SQL UNIQUE NULLS FALSE;
 
--- database version 3.1.64 (don't forget to update insert statement at the end of file)
+-- database version 3.1.65 (don't forget to update insert statement at the end of file)
 
 -- VOS - virtual organizations
 create table vos (
@@ -336,7 +336,6 @@ create table host_attr_values (
 	created_by longvarchar default user not null,
 	modified_at timestamp default current_date not null,
 	modified_by longvarchar default user not null,
-	attr_value_text longvarchar,   --value of attribute if it is very long text
 	created_by_uid integer,
 	modified_by_uid integer,
 	constraint hostav_pk primary key (host_id,attr_id),
@@ -612,7 +611,6 @@ create table entityless_attr_values (
 	created_by longvarchar default user not null,
 	modified_at timestamp default current_date not null,
 	modified_by longvarchar default user not null,
-	attr_value_text longvarchar,           --attribute value in case it is very long text
 	created_by_uid integer,
 	modified_by_uid integer,
 	constraint entlatval_pk primary key(subject,attr_id),
@@ -628,7 +626,6 @@ create table facility_attr_values (
 	created_by longvarchar default user not null,
 	modified_at timestamp default current_date not null,
 	modified_by longvarchar default user not null,
-	attr_value_text longvarchar,           --attribute value in case it is very long text
 	created_by_uid integer,
 	modified_by_uid integer,
 	constraint facattval_pk primary key (facility_id,attr_id),
@@ -655,7 +652,6 @@ create table group_attr_values (
 	created_by longvarchar default user not null,
 	modified_at timestamp default current_date not null,
 	modified_by longvarchar default user not null,
-	attr_value_text longvarchar,          --attribute value in case it is very long text
 	created_by_uid integer,
 	modified_by_uid integer,
 	constraint grpattval_pk primary key (group_id,attr_id),
@@ -681,7 +677,6 @@ create table resource_attr_values (
 	created_by longvarchar default user not null,
 	modified_at timestamp default current_date not null,
 	modified_by longvarchar default user not null,
-	attr_value_text longvarchar,           --attribute value in case it is very long text
 	created_by_uid integer,
 	modified_by_uid integer,
 	constraint resatval_pk primary key (resource_id,attr_id),
@@ -708,7 +703,6 @@ create table group_resource_attr_values (
 	created_by longvarchar default user not null,
 	modified_at timestamp default current_date not null,
 	modified_by longvarchar default user not null,
-	attr_value_text longvarchar,          --attribute value in case it is very long text
 	created_by_uid integer,
 	modified_by_uid integer,
 	constraint grpresav_pk primary key (group_id,resource_id,attr_id),
@@ -770,7 +764,6 @@ create table member_attr_values (
 	created_by longvarchar default user not null,
 	modified_at timestamp default current_date not null,
 	modified_by longvarchar default user not null,
-	attr_value_text longvarchar,         --attribute value in case it is very long text
 	created_by_uid integer,
 	modified_by_uid integer,
 	constraint memattval_pk primary key (member_id,attr_id),
@@ -797,7 +790,6 @@ create table member_group_attr_values (
 	created_by longvarchar default user not null,
 	modified_at timestamp default current_date not null,
 	modified_by longvarchar default user not null,
-	attr_value_text longvarchar,         --attribute value in case it is very long text
 	created_by_uid integer,
 	modified_by_uid integer,
 	constraint memgav_pk primary key(member_id,group_id,attr_id),
@@ -826,7 +818,6 @@ create table member_resource_attr_values (
 	created_by longvarchar default user not null,
 	modified_at timestamp default current_date not null,
 	modified_by longvarchar default user not null,
-	attr_value_text longvarchar,         --attribute value in case it is very long text
 	created_by_uid integer,
 	modified_by_uid integer,
 	constraint memrav_pk primary key(member_id,resource_id,attr_id),
@@ -854,7 +845,6 @@ create table user_attr_values (
 	created_by longvarchar default user not null,
 	modified_at timestamp default current_date not null,
 	modified_by longvarchar default user not null,
-	attr_value_text longvarchar,      --attribute value in case it is very long text
 	created_by_uid integer,
 	modified_by_uid integer,
 	constraint usrav_pk primary key(user_id,attr_id),
@@ -881,7 +871,6 @@ create table user_facility_attr_values (
 	created_by longvarchar default user not null,
 	modified_at timestamp default current_date not null,
 	modified_by longvarchar default user not null,
-	attr_value_text longvarchar,         --attribute value in case it is very long text
 	created_by_uid integer,
 	modified_by_uid integer,
 	constraint usrfacav_u primary key(user_id,facility_id,attr_id),
@@ -909,7 +898,6 @@ create table vo_attr_values (
 	created_by longvarchar default user not null,
 	modified_at timestamp default current_date not null,
 	modified_by longvarchar default user not null,
-	attr_value_text longvarchar,      --attribute value in case it is very long text
 	created_by_uid integer,
 	modified_by_uid integer,
 	constraint voattval_pk primary key (vo_id,attr_id),
@@ -1370,7 +1358,6 @@ create table user_ext_source_attr_values (
 	created_by longvarchar default user not null,
 	modified_at timestamp default current_date not null,
 	modified_by longvarchar default user not null,
-	attr_value_text longvarchar,
 	created_by_uid integer,
 	modified_by_uid integer,
 	constraint uesattrval_pk primary key (user_ext_source_id, attr_id),
@@ -1632,7 +1619,7 @@ CREATE INDEX ufauv_idx ON user_facility_attr_u_values (user_id, facility_id, att
 CREATE INDEX vauv_idx ON vo_attr_u_values (vo_id, attr_id) ;
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.1.64');
+insert into configurations values ('DATABASE VERSION','3.1.65');
 insert into membership_types (id, membership_type, description) values (1, 'DIRECT', 'Member is directly added into group');
 insert into membership_types (id, membership_type, description) values (2, 'INDIRECT', 'Member is added indirectly through UNION relation');
 insert into action_types (id, action_type, description) values (nextval('action_types_seq'), 'read', 'Can read value.');

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -2439,10 +2439,6 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 			if (!Arrays.asList("def","opt").contains(attribute.getNamespace().split(":")[4])) {
 				throw new InternalErrorException("only 'def' and 'opt' attributes can be unique");
 			}
-			if(attribute.getType().equals(BeansUtils.largeStringClassName) ||
-					attribute.getType().equals(BeansUtils.largeArrayListClassName)) {
-				throw new InternalErrorException("large attributes cannot be marked unique");
-			}
 		}
 
 		attribute = getAttributesManagerImpl().createAttribute(sess, attribute);
@@ -8116,10 +8112,6 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		if(attrDef.getNamespace().startsWith(NS_ENTITYLESS_ATTR)) throw new InternalErrorException("entityless atributes cannot be converted to unique");
 		if(!Arrays.asList("def","opt").contains(attrDef.getNamespace().split(":")[4])) {
 			throw new InternalErrorException("only 'def' and 'opt' attributes can be converted to unique");
-		}
-		if(attrDef.getType().equals(BeansUtils.largeStringClassName) ||
-				attrDef.getType().equals(BeansUtils.largeArrayListClassName)) {
-			throw new InternalErrorException("large attributes cannot be marked unique");
 		}
 		log.info("converting attribute {} to unique",attrDef.getName());
 		attrDef.setUnique(true);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/FacilitiesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/FacilitiesManagerBlImpl.java
@@ -488,9 +488,6 @@ public class FacilitiesManagerBlImpl implements FacilitiesManagerBl {
 	public List<Facility> getFacilitiesByAttribute(PerunSession sess, String attributeName, String attributeValue) throws WrongAttributeAssignmentException {
 		try {
 			AttributeDefinition attributeDef = getPerunBl().getAttributesManagerBl().getAttributeDefinition(sess, attributeName);
-			if (Utils.isLargeAttribute(sess, attributeDef)) {
-				throw new InternalErrorException("Attribute " + attributeName + " is large attribute, which is not supported.");
-			}
 			Attribute attribute = new Attribute(attributeDef);
 			attribute.setValue(BeansUtils.stringToAttributeValue(attributeValue, attribute.getType()));
 			getPerunBl().getAttributesManagerBl().checkNamespace(sess, attribute, AttributesManager.NS_FACILITY_ATTR);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
@@ -209,7 +209,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 					"action_types.action_type as action_type";
 
 	static String getAttributeMappingSelectQuery(String nameOfValueTable) {
-		return attributeDefinitionMappingSelectQuery + ", attr_value, attr_value_text" +
+		return attributeDefinitionMappingSelectQuery + ", attr_value" +
 				", " + nameOfValueTable + ".created_at as attr_value_created_at" +
 				", " + nameOfValueTable + ".created_by as attr_value_created_by" +
 				", " + nameOfValueTable + ".modified_at as attr_value_modified_at" +
@@ -234,16 +234,6 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 		if (rs.getInt("attr_names_created_by_uid") == 0) attribute.setCreatedByUid(null);
 		else attribute.setCreatedByUid(rs.getInt("attr_names_created_by_uid"));
 		return attribute;
-	};
-
-	/*
-	 * This rowMapper is only for getting attribute values (value and valueText)
-	 */
-	private static final RowMapper<String> ATTRIBUTE_VALUES_MAPPER = (rs, i) -> {
-		String valueText = rs.getString("attr_value_text");
-		String value = rs.getString("attr_value");
-		if (valueText != null) return valueText;
-		return value;
 	};
 
 	static final RowMapper<Attribute> ATTRIBUTE_MAPPER = (rs, i) -> {
@@ -335,10 +325,8 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 				}
 			}
 
-			String stringValue = AttributesManagerImpl.readAttributeValue(sess, attribute, rs);
-
 			try {
-				attribute.setValue(BeansUtils.stringToAttributeValue(stringValue, attribute.getType()));
+				attribute.setValue(BeansUtils.stringToAttributeValue(rs.getString("attr_value"), attribute.getType()));
 			} catch (InternalErrorException ex) {
 				throw new InternalErrorException(ex);
 			}
@@ -637,30 +625,16 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 	}
 
 	private static class ValueRowMapper implements RowMapper<Object> {
-		private final PerunSession sess;
 		private final AttributeDefinition attributeDefinition;
 
-		/**
-		 * Constructor.
-		 */
-		ValueRowMapper(PerunSession sess, AttributeDefinition attributeDefinition) {
-			this.sess = sess;
+		ValueRowMapper(AttributeDefinition attributeDefinition) {
 			this.attributeDefinition = attributeDefinition;
 		}
 
 		@Override
 		public Object mapRow(ResultSet rs, int i) throws SQLException {
-			String stringValue;
-			if (Utils.isLargeAttribute(sess, attributeDefinition)) {
-				//large attributes
-				stringValue = rs.getString("attr_value_text");
-			} else {
-				//ordinary attributes
-				stringValue = rs.getString("attr_value");
-			}
-
 			try {
-				return BeansUtils.stringToAttributeValue(stringValue, attributeDefinition.getType());
+				return BeansUtils.stringToAttributeValue(rs.getString("attr_value"), attributeDefinition.getType());
 			} catch (InternalErrorException ex) {
 				throw new InternalErrorException(ex);
 			}
@@ -697,7 +671,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 		try {
 			return jdbc.query("select " + getAttributeMappingSelectQuery("fac") + " from attr_names " +
 							"left join facility_attr_values fac    on id=fac.attr_id and fac.facility_id=? " +
-							"where namespace=? or (namespace in (?,?) and (attr_value is not null or attr_value_text is not null))",
+							"where namespace=? or (namespace in (?,?) and attr_value is not null)",
 					new SingleBeanAttributeRowMapper<>(sess, this, facility), facility.getId(), AttributesManager.NS_FACILITY_ATTR_CORE, AttributesManager.NS_FACILITY_ATTR_DEF, AttributesManager.NS_FACILITY_ATTR_OPT);
 
 		} catch (EmptyResultDataAccessException ex) {
@@ -803,7 +777,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 		try {
 			return jdbc.query("select " + getAttributeMappingSelectQuery("voattr") + " from attr_names " +
 							"left join vo_attr_values voattr    on id=voattr.attr_id and voattr.vo_id=? " +
-							"where namespace=? or (namespace in (?,?) and (attr_value is not null or attr_value_text is not null))",
+							"where namespace=? or (namespace in (?,?) and attr_value is not null)",
 					new SingleBeanAttributeRowMapper<>(sess, this, vo), vo.getId(), AttributesManager.NS_VO_ATTR_CORE, AttributesManager.NS_VO_ATTR_DEF, AttributesManager.NS_VO_ATTR_OPT);
 		} catch (EmptyResultDataAccessException ex) {
 			return new ArrayList<>();
@@ -817,7 +791,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 		try {
 			return jdbc.query("select " + getAttributeMappingSelectQuery("groupattr") + " from attr_names " +
 							"left join group_attr_values groupattr    on id=groupattr.attr_id and groupattr.group_id=? " +
-							"where namespace=? or (namespace in (?,?) and (attr_value is not null or attr_value_text is not null))",
+							"where namespace=? or (namespace in (?,?) and attr_value is not null)",
 					new SingleBeanAttributeRowMapper<>(sess, this, group), group.getId(), AttributesManager.NS_GROUP_ATTR_CORE, AttributesManager.NS_GROUP_ATTR_DEF, AttributesManager.NS_GROUP_ATTR_OPT);
 		} catch (EmptyResultDataAccessException ex) {
 			return new ArrayList<>();
@@ -831,7 +805,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 		try {
 			return jdbc.query("select " + getAttributeMappingSelectQuery("host_attr_values") + " from attr_names " +
 							"left join host_attr_values on id=attr_id and host_id=? " +
-							"where namespace=? or (namespace in (?,?) and (attr_value is not null or attr_value_text is not null))",
+							"where namespace=? or (namespace in (?,?) and attr_value is not null)",
 					new SingleBeanAttributeRowMapper<>(sess, this, host), host.getId(), AttributesManager.NS_HOST_ATTR_CORE, AttributesManager.NS_HOST_ATTR_DEF, AttributesManager.NS_HOST_ATTR_OPT);
 		} catch (EmptyResultDataAccessException ex) {
 			log.debug("No attribute for host exists.");
@@ -868,7 +842,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 		try {
 			return jdbc.query("select " + getAttributeMappingSelectQuery("resource_attr_values") + " from attr_names " +
 							"left join resource_attr_values on id=attr_id and resource_id=? " +
-							"where namespace=? or (namespace in (?,?) and (attr_value is not null or attr_value_text is not null))",
+							"where namespace=? or (namespace in (?,?) and attr_value is not null)",
 					new SingleBeanAttributeRowMapper<>(sess, this, resource), resource.getId(), AttributesManager.NS_RESOURCE_ATTR_CORE, AttributesManager.NS_RESOURCE_ATTR_DEF, AttributesManager.NS_RESOURCE_ATTR_OPT);
 		} catch (EmptyResultDataAccessException ex) {
 			log.debug("No attribute for resource exists.");
@@ -885,7 +859,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 			//member-resource attributes, member core attributes
 			return jdbc.query("select " + getAttributeMappingSelectQuery("mem") + " from attr_names " +
 							"left join   member_resource_attr_values   mem        on attr_names.id=mem.attr_id and mem.resource_id=? and member_id=? " +
-							"where namespace in (?,?) and (mem.attr_value is not null or mem.attr_value_text is not null)",
+							"where namespace in (?,?) and mem.attr_value is not null",
 					new MemberResourceAttributeRowMapper(sess, this, member, resource),
 					resource.getId(), member.getId(),
 					AttributesManager.NS_MEMBER_RESOURCE_ATTR_DEF, AttributesManager.NS_MEMBER_RESOURCE_ATTR_OPT);
@@ -903,7 +877,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 			//member-group attributes, member core attributes
 			return jdbc.query("select " + getAttributeMappingSelectQuery("mem_gr") + " from attr_names " +
 							"left join member_group_attr_values mem_gr on attr_names.id=mem_gr.attr_id and mem_gr.group_id=? and member_id=? " +
-							"where namespace in (?,?) and (mem_gr.attr_value is not null or mem_gr.attr_value_text is not null)",
+							"where namespace in (?,?) and mem_gr.attr_value is not null",
 					new MemberGroupAttributeRowMapper(sess, this, member, group), group.getId(), member.getId(),
 					AttributesManager.NS_MEMBER_GROUP_ATTR_DEF, AttributesManager.NS_MEMBER_GROUP_ATTR_OPT);
 		} catch (EmptyResultDataAccessException ex) {
@@ -1007,7 +981,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 		try {
 			return jdbc.query("select " + getAttributeMappingSelectQuery("mem") + " from attr_names " +
 							"left join    member_attr_values     mem      on id=mem.attr_id     and    member_id=? " +
-							"where namespace=? or (namespace in (?,?) and (mem.attr_value is not null or mem.attr_value_text is not null))",
+							"where namespace=? or (namespace in (?,?) and mem.attr_value is not null)",
 					new SingleBeanAttributeRowMapper<>(sess, this, member), member.getId(),
 					AttributesManager.NS_MEMBER_ATTR_CORE, AttributesManager.NS_MEMBER_ATTR_OPT, AttributesManager.NS_MEMBER_ATTR_DEF);
 		} catch (EmptyResultDataAccessException ex) {
@@ -1153,7 +1127,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 		try {
 			return jdbc.query("select " + getAttributeMappingSelectQuery("usr_fac") + " from attr_names " +
 							"left join    user_facility_attr_values     usr_fac      on id=usr_fac.attr_id     and   facility_id=? and user_id=? " +
-							"where namespace in (?,?) and (usr_fac.attr_value is not null or usr_fac.attr_value_text is not null)",
+							"where namespace in (?,?) and usr_fac.attr_value is not null",
 					new UserFacilityAttributeRowMapper(sess, this, user, facility), facility.getId(), user.getId(),
 					AttributesManager.NS_USER_FACILITY_ATTR_DEF, AttributesManager.NS_USER_FACILITY_ATTR_OPT);
 		} catch (EmptyResultDataAccessException ex) {
@@ -1169,7 +1143,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 		try {
 			return jdbc.query("select " + getAttributeMappingSelectQuery("usr_fac") + " from attr_names " +
 							"left join    user_facility_attr_values     usr_fac      on id=usr_fac.attr_id     and   facility_id=? " +
-							"where namespace in (?,?) and (usr_fac.attr_value is not null or usr_fac.attr_value_text is not null)",
+							"where namespace in (?,?) and usr_fac.attr_value is not null",
 					new SingleBeanAttributeRowMapper<>(sess, this, facility), facility.getId(),
 					AttributesManager.NS_USER_FACILITY_ATTR_DEF, AttributesManager.NS_USER_FACILITY_ATTR_OPT);
 		} catch (EmptyResultDataAccessException ex) {
@@ -1186,7 +1160,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 		try {
 			return jdbc.query("select " + getAttributeMappingSelectQuery("usr") + " from attr_names " +
 							"left join      user_attr_values    usr    on      id=usr.attr_id    and   user_id=? " +
-							"where namespace=? or (namespace in (?,?) and (attr_value is not null or attr_value_text is not null))",
+							"where namespace=? or (namespace in (?,?) and attr_value is not null)",
 					new SingleBeanAttributeRowMapper<>(sess, this, user), user.getId(),
 					AttributesManager.NS_USER_ATTR_CORE, AttributesManager.NS_USER_ATTR_DEF, AttributesManager.NS_USER_ATTR_OPT);
 		} catch (EmptyResultDataAccessException ex) {
@@ -1249,7 +1223,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 		try {
 			return jdbc.query("select " + getAttributeMappingSelectQuery("grp_res") + " from attr_names " +
 							"left join    group_resource_attr_values     grp_res      on id=grp_res.attr_id     and   resource_id=? and group_id=? " +
-							"where namespace in (?,?) and (grp_res.attr_value is not null or grp_res.attr_value_text is not null)",
+							"where namespace in (?,?) and grp_res.attr_value is not null",
 					new GroupResourceAttributeRowMapper(sess, this, group, resource), resource.getId(), group.getId(),
 					AttributesManager.NS_GROUP_RESOURCE_ATTR_DEF, AttributesManager.NS_GROUP_RESOURCE_ATTR_OPT);
 		} catch (EmptyResultDataAccessException ex) {
@@ -1265,7 +1239,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 		try {
 			return jdbc.query("select " + getAttributeMappingSelectQuery("enattr") + " from attr_names " +
 							"left join entityless_attr_values enattr on id=enattr.attr_id and enattr.subject=? " +
-							"where namespace in (?,?) and (enattr.attr_value is not null or enattr.attr_value_text is not null)",
+							"where namespace in (?,?) and enattr.attr_value is not null",
 					new SingleBeanAttributeRowMapper<>(sess, this, null), key, AttributesManager.NS_ENTITYLESS_ATTR_DEF, AttributesManager.NS_ENTITYLESS_ATTR_OPT);
 		} catch (EmptyResultDataAccessException ex) {
 			return new ArrayList<>();
@@ -1279,7 +1253,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 		try {
 			return jdbc.query("select " + getAttributeMappingSelectQuery("ues") + " from attr_names " +
 							"left join user_ext_source_attr_values ues on id=ues.attr_id and user_ext_source_id=? " +
-							"where namespace=? or (namespace in (?,?) and (ues.attr_value is not null or ues.attr_value_text is not null))",
+							"where namespace=? or (namespace in (?,?) and ues.attr_value is not null)",
 					new SingleBeanAttributeRowMapper<>(sess, this, ues), ues.getId(),
 					AttributesManager.NS_UES_ATTR_CORE, AttributesManager.NS_UES_ATTR_DEF, AttributesManager.NS_UES_ATTR_OPT);
 		} catch (EmptyResultDataAccessException ex) {
@@ -1293,7 +1267,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 	@Override
 	public String getEntitylessAttrValueForUpdate(PerunSession sess, int attrId, String key) throws AttributeNotExistsException {
 		try {
-			return jdbc.queryForObject("SELECT attr_value, attr_value_text FROM entityless_attr_values WHERE subject=? AND attr_id=? FOR UPDATE", ATTRIBUTE_VALUES_MAPPER, key, attrId);
+			return jdbc.queryForObject("SELECT attr_value FROM entityless_attr_values WHERE subject=? AND attr_id=? FOR UPDATE", String.class, key, attrId);
 		} catch (EmptyResultDataAccessException ex) {
 			//If there is no such entityless attribute, create new one with null value and return null (insert is for transaction same like select for update)
 			Attribute attr = new Attribute(this.getAttributeDefinitionById(sess, attrId));
@@ -1310,7 +1284,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 		try {
 			return jdbc.query("select " + getAttributeMappingSelectQuery("enattr") + " from attr_names " +
 							"left join entityless_attr_values enattr on id=enattr.attr_id " +
-							"where attr_name=? and namespace in (?,?) and (enattr.attr_value is not null or enattr.attr_value_text is not null)",
+							"where attr_name=? and namespace in (?,?) and enattr.attr_value is not null",
 					new SingleBeanAttributeRowMapper<>(sess, this, null), attrName, AttributesManager.NS_ENTITYLESS_ATTR_DEF, AttributesManager.NS_ENTITYLESS_ATTR_OPT);
 		} catch (EmptyResultDataAccessException ex) {
 			return new ArrayList<>();
@@ -1350,7 +1324,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 							"left join    user_facility_attr_values     usr_fac      on attr_names.id=usr_fac.attr_id     and   usr_fac.user_id=? " +
 							"join users on users.id = usr_fac.user_id " +
 							"join facilities on facilities.id = usr_fac.facility_id " +
-							"where namespace in (?,?) and (usr_fac.attr_value is not null or usr_fac.attr_value_text is not null)",
+							"where namespace in (?,?) and usr_fac.attr_value is not null",
 					new RichAttributeRowMapper<>(new SingleBeanAttributeRowMapper<>(sess, this, user), UsersManagerImpl.USER_MAPPER, FacilitiesManagerImpl.FACILITY_MAPPER),
 					user.getId(),
 					AttributesManager.NS_USER_FACILITY_ATTR_DEF, AttributesManager.NS_USER_FACILITY_ATTR_OPT);
@@ -1931,13 +1905,9 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 				return numAffected == 1;
 			}
 
-			// set the column name according to the size of the attribute
-			boolean largeAttribute = Utils.isLargeAttribute(sess, attribute);
-			String valueColName = (largeAttribute ? "attr_value_text" : "attr_value");
-
 			// if the DB value is the same as parameter, return
 			try {
-				Object value = BeansUtils.stringToAttributeValue(jdbc.queryForObject("select "+valueColName+" from " + tableName + " where " + buildParameters(columnNames, "=?", " and "), String.class, columnValues.toArray()), attribute.getType());
+				Object value = BeansUtils.stringToAttributeValue(jdbc.queryForObject("select attr_value from " + tableName + " where " + buildParameters(columnNames, "=?", " and "), String.class, columnValues.toArray()), attribute.getType());
 				if (attribute.getValue().equals(value)) {
 					return false;
 				}
@@ -1953,7 +1923,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 					case 0: {
 						// value doesn't exist -> insert
 						try {
-							return self.insertAttribute(sess, valueColName, attribute, tableName, columnNames, columnValues);
+							return self.insertAttribute(sess, attribute, tableName, columnNames, columnValues);
 						} catch (DataAccessException ex) {
 							// unsuccessful insert, do it again in while loop
 							if (++repetatCounter > MERGE_TRY_CNT) {
@@ -1969,7 +1939,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 					case 1: {
 						// value exists -> update
 						try {
-							return self.updateAttribute(sess, valueColName, attribute, tableName, columnNames, columnValues);
+							return self.updateAttribute(sess, attribute, tableName, columnNames, columnValues);
 						} catch (DataAccessException ex) {
 							// unsuccessful insert, do it again in while loop
 							if (++repetatCounter > MERGE_TRY_CNT) {
@@ -2012,7 +1982,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 	}
 
 	@Override
-	public boolean insertAttribute(PerunSession sess, String valueColName, Attribute attribute, String tableName, List<String> columnNames, List<Object> columnValues) {
+	public boolean insertAttribute(PerunSession sess, Attribute attribute, String tableName, List<String> columnNames, List<Object> columnValues) {
 		// add additional SQL values to the list
 		List<Object> values = new ArrayList<>(columnValues);
 		values.add(BeansUtils.attributeValueToString(attribute)); // valueColName
@@ -2027,20 +1997,20 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 		}
 		String questionMarks = sb.toString();
 
-		int changed = jdbc.update("insert into " + tableName + " (" + buildParameters(columnNames, "", ", ") + ", " + valueColName + ", created_by, modified_by, created_by_uid, modified_by_uid, modified_at, created_at) "
+		int changed = jdbc.update("insert into " + tableName + " (" + buildParameters(columnNames, "", ", ") + ", attr_value, created_by, modified_by, created_by_uid, modified_by_uid, modified_at, created_at) "
 				+ "values (" + questionMarks + Compatibility.getSysdate() + ", " + Compatibility.getSysdate() + " )", values.toArray());
 		return changed > 0;
 	}
 
 	@Override
-	public boolean updateAttribute(PerunSession sess, String valueColName, Attribute attribute, String tableName, List<String> columnNames, List<Object> columnValues) {
+	public boolean updateAttribute(PerunSession sess, Attribute attribute, String tableName, List<String> columnNames, List<Object> columnValues) {
 		// add additional SQL values to the list
 		List<Object> values = new ArrayList<>();
 		values.add(BeansUtils.attributeValueToString(attribute)); // valueColName
 		values.add(sess.getPerunPrincipal().getActor()); // modified_by
 		values.add(sess.getPerunPrincipal().getUserId()); // modified_by_uid
 		values.addAll(columnValues);
-		int changed = jdbc.update("update " + tableName + " set " + valueColName + "=?, modified_by=?, modified_by_uid=?, modified_at=" +
+		int changed = jdbc.update("update " + tableName + " set attr_value=?, modified_by=?, modified_by_uid=?, modified_at=" +
 				Compatibility.getSysdate() + " where " + buildParameters(columnNames, "=?", " and "), values.toArray());
 		return changed > 0;
 	}
@@ -2048,8 +2018,8 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 	@Override
 	public boolean setAttributeWithNullValue(final PerunSession sess, final String key, final Attribute attribute) {
 		try {
-			jdbc.update("insert into entityless_attr_values (attr_id, subject, attr_value, attr_value_text, created_by, modified_by, created_at, modified_at, created_by_uid, modified_by_uid) "
-							+ "values (?,?,?,?,?,?," + Compatibility.getSysdate() + "," + Compatibility.getSysdate() + ",?,?)", attribute.getId(), key, null, null,
+			jdbc.update("insert into entityless_attr_values (attr_id, subject, attr_value, created_by, modified_by, created_at, modified_at, created_by_uid, modified_by_uid) "
+							+ "values (?,?,?,?,?," + Compatibility.getSysdate() + "," + Compatibility.getSysdate() + ",?,?)", attribute.getId(), key, null,
 					sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getUserId(), sess.getPerunPrincipal().getUserId());
 			return true;
 		} catch (RuntimeException ex) {
@@ -3846,7 +3816,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 	@Override
 	public List<Object> getAllResourceValues(PerunSession sess, AttributeDefinition attributeDefinition) {
 		try {
-			return jdbc.query("SELECT attr_value FROM resource_attr_values WHERE attr_id=?", new ValueRowMapper(sess, attributeDefinition), attributeDefinition.getId());
+			return jdbc.query("SELECT attr_value FROM resource_attr_values WHERE attr_id=?", new ValueRowMapper(attributeDefinition), attributeDefinition.getId());
 		} catch (EmptyResultDataAccessException ex) {
 			return new ArrayList<>();
 		} catch (RuntimeException ex) {
@@ -3857,7 +3827,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 	@Override
 	public List<Object> getAllGroupResourceValues(PerunSession sess, AttributeDefinition attributeDefinition) {
 		try {
-			return jdbc.query("SELECT attr_value FROM group_resource_attr_values WHERE attr_id=?", new ValueRowMapper(sess, attributeDefinition), attributeDefinition.getId());
+			return jdbc.query("SELECT attr_value FROM group_resource_attr_values WHERE attr_id=?", new ValueRowMapper(attributeDefinition), attributeDefinition.getId());
 		} catch (EmptyResultDataAccessException ex) {
 			return new ArrayList<>();
 		} catch (RuntimeException ex) {
@@ -3868,7 +3838,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 	@Override
 	public List<Object> getAllGroupValues(PerunSession sess, AttributeDefinition attributeDefinition) {
 		try {
-			return jdbc.query("SELECT attr_value FROM group_attr_values WHERE attr_id=?", new ValueRowMapper(sess, attributeDefinition), attributeDefinition.getId());
+			return jdbc.query("SELECT attr_value FROM group_attr_values WHERE attr_id=?", new ValueRowMapper(attributeDefinition), attributeDefinition.getId());
 		} catch (EmptyResultDataAccessException ex) {
 			return new ArrayList<>();
 		} catch (RuntimeException ex) {
@@ -3879,7 +3849,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 	@Override
 	public List<Object> getAllUserValues(PerunSession sess, AttributeDefinition attributeDefinition) {
 		try {
-			return jdbc.query("SELECT attr_value FROM user_attr_values WHERE attr_id=?", new ValueRowMapper(sess, attributeDefinition), attributeDefinition.getId());
+			return jdbc.query("SELECT attr_value FROM user_attr_values WHERE attr_id=?", new ValueRowMapper(attributeDefinition), attributeDefinition.getId());
 		} catch (EmptyResultDataAccessException ex) {
 			return new ArrayList<>();
 		} catch (RuntimeException ex) {
@@ -4473,11 +4443,11 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 				@SuppressWarnings("UnnecessaryLocalVariable")
 				String bean = tablePrefix;
 				final AtomicInteger counter = new AtomicInteger(0);
-				jdbc.query("SELECT " + bean + "_id,attr_value,attr_value_text FROM " + tablePrefix + "_attr_values WHERE attr_id=?", rs -> {
+				jdbc.query("SELECT " + bean + "_id,attr_value FROM " + tablePrefix + "_attr_values WHERE attr_id=?", rs -> {
 					int beanId = rs.getInt(1);
 					Object value = null;
 					try {
-						value = BeansUtils.stringToAttributeValue(readAttributeValue(session, attrDef, rs), attrDef.getType());
+						value = BeansUtils.stringToAttributeValue(rs.getString("attr_value"), attrDef.getType());
 						Utils.notNull(value, "value");
 						switch (attrDef.getType()) {
 							case "java.lang.String":
@@ -4515,12 +4485,12 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 				String[] ss = tablePrefix.split("_");
 				String bean1 = ss[0];
 				String bean2 = ss[1];
-				jdbc.query("SELECT " + bean1 + "_id," + bean2 + "_id,attr_value,attr_value_text FROM " + tablePrefix + "_attr_values WHERE attr_id=?", rs -> {
+				jdbc.query("SELECT " + bean1 + "_id," + bean2 + "_id,attr_value FROM " + tablePrefix + "_attr_values WHERE attr_id=?", rs -> {
 					int bean1Id = rs.getInt(1);
 					int bean2Id = rs.getInt(2);
 					Object value = null;
 					try {
-						value = BeansUtils.stringToAttributeValue(readAttributeValue(session, attrDef, rs), attrDef.getType());
+						value = BeansUtils.stringToAttributeValue(rs.getString("attr_value"), attrDef.getType());
 						Utils.notNull(value, "value");
 						switch (attrDef.getType()) {
 							case "java.lang.String":
@@ -4552,15 +4522,6 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 			}
 		} catch (InternalErrorException ex) {
 			throw new InternalErrorException(ex);
-		}
-	}
-
-
-	private static String readAttributeValue(PerunSession session, AttributeDefinition attrDef, ResultSet rs) throws SQLException {
-		if (Utils.isLargeAttribute(session, attrDef)) {
-			return rs.getString("attr_value_text");
-		} else {
-			return rs.getString("attr_value");
 		}
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
@@ -3795,12 +3795,6 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 		return attribute.getNamespace().startsWith(namespace + ":") || attribute.getNamespace().equals(namespace);
 	}
 
-	public boolean isLargeAttribute(PerunSession sess, AttributeDefinition attribute) {
-		return (attribute.getType().equals(LinkedHashMap.class.getName()) ||
-				attribute.getType().equals(BeansUtils.largeStringClassName) ||
-				attribute.getType().equals(BeansUtils.largeArrayListClassName));
-	}
-
 	@Override
 	public void checkNamespace(PerunSession sess, AttributeDefinition attribute, String namespace) throws WrongAttributeAssignmentException {
 		if (!isFromNamespace(attribute, namespace)) throw new WrongAttributeAssignmentException(attribute);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Utils.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Utils.java
@@ -2,7 +2,6 @@ package cz.metacentrum.perun.core.impl;
 
 import com.zaxxer.hikari.HikariDataSource;
 import cz.metacentrum.perun.core.api.Attribute;
-import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.BeansUtils;
 import cz.metacentrum.perun.core.api.Destination;
 import cz.metacentrum.perun.core.api.ExtSource;
@@ -1475,19 +1474,6 @@ public class Utils {
 		}
 		return normalizedOutput;
 
-	}
-
-	/**
-	 * Determine if attribute is large (can contain value over 4kb).
-	 *
-	 * @param sess perun session
-	 * @param attribute attribute to be checked
-	 * @return true if the attribute is large
-	 */
-	public static boolean isLargeAttribute(PerunSession sess, AttributeDefinition attribute) {
-		return (attribute.getType().equals(LinkedHashMap.class.getName()) ||
-				attribute.getType().equals(BeansUtils.largeStringClassName) ||
-				attribute.getType().equals(BeansUtils.largeArrayListClassName));
 	}
 
 	/**

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
@@ -883,31 +883,27 @@ public interface AttributesManagerImplApi {
 	 * Insert attribute value in DB.
 	 *
 	 * @param sess perun session
-	 * @param valueColName column, where the data will be stored, usually one of value or attr_value or attr_value_text
 	 * @param attribute that will be stored in the DB
 	 * @param tableName in the database in which the attribute will be inserted
 	 * @param columnNames of the database table in which the attribute will be written
 	 * @param columnValues of the objects, for which the attribute will be written, corresponding to the columnNames
 	 * @return true if new value differs from old value (i.e. values changed)
 	 *         false otherwise (value do not change)
-	 * @throws InternalErrorException
 	 */
-	boolean insertAttribute(PerunSession sess, String valueColName, Attribute attribute, String tableName, List<String> columnNames, List<Object> columnValues);
+	boolean insertAttribute(PerunSession sess, Attribute attribute, String tableName, List<String> columnNames, List<Object> columnValues);
 
 	/**
 	 * Update attribute value in DB.
 	 *
 	 * @param sess perun session
-	 * @param valueColName column, where the data will be stored, usually one of value or attr_value or attr_value_text
 	 * @param attribute that will be stored in the DB
 	 * @param tableName in the database for updating
 	 * @param columnNames of the database table in which the attribute will be written
 	 * @param columnValues of the objects, for which the attribute will be written, corresponding to the columnNames
 	 * @return true if new value differs from old value (i.e. values changed)
 	 *         false otherwise (value do not change)
-	 * @throws InternalErrorException
 	 */
-	boolean updateAttribute(PerunSession sess, String valueColName, Attribute attribute, String tableName, List<String> columnNames, List<Object> columnValues);
+	boolean updateAttribute(PerunSession sess, Attribute attribute, String tableName, List<String> columnNames, List<Object> columnValues);
 
 	/**
 	 * Set entityless attribute with null value (for key and attribute). Shouldn't be called from upper layer !!!

--- a/perun-core/src/main/resources/hsqldbChangelog.txt
+++ b/perun-core/src/main/resources/hsqldbChangelog.txt
@@ -3,6 +3,9 @@
 
 -- this update is not supported on hsql since its used only as in-memory db
 
+3.1.65
+update configurations set value='3.1.65' where property='DATABASE VERSION';
+
 3.1.64
 update configurations set value='3.1.64' where property='DATABASE VERSION';
 

--- a/perun-core/src/main/resources/postgresChangelog.txt
+++ b/perun-core/src/main/resources/postgresChangelog.txt
@@ -6,6 +6,61 @@
 -- Directly under version number should be version commands. They will be executed in the order they are written here.
 -- Comments are prefixed with -- and can be written only between version blocks, that means not in the lines with commands. They have to be at the start of the line.
 
+3.1.65
+ALTER TABLE host_attr_values ALTER COLUMN attr_value TYPE text;
+UPDATE host_attr_values set attr_value=attr_value_text where attr_value is null and attr_value_text is not null;
+ALTER TABLE host_attr_values DROP COLUMN attr_value_text;
+ALTER TABLE host_attr_u_values ALTER COLUMN attr_value TYPE text;
+ALTER TABLE entityless_attr_values ALTER COLUMN attr_value TYPE text;
+UPDATE entityless_attr_values set attr_value=attr_value_text where attr_value is null and attr_value_text is not null;
+ALTER TABLE entityless_attr_values DROP COLUMN attr_value_text;
+ALTER TABLE facility_attr_values ALTER COLUMN attr_value TYPE text;
+UPDATE facility_attr_values set attr_value=attr_value_text where attr_value is null and attr_value_text is not null;
+ALTER TABLE facility_attr_values DROP COLUMN attr_value_text;
+ALTER TABLE facility_attr_u_values ALTER COLUMN attr_value TYPE text;
+ALTER TABLE group_attr_values ALTER COLUMN attr_value TYPE text;
+UPDATE group_attr_values set attr_value=attr_value_text where attr_value is null and attr_value_text is not null;
+ALTER TABLE group_attr_values DROP COLUMN attr_value_text;
+ALTER TABLE group_attr_u_values ALTER COLUMN attr_value TYPE text;
+ALTER TABLE resource_attr_values ALTER COLUMN attr_value TYPE text;
+UPDATE resource_attr_values set attr_value=attr_value_text where attr_value is null and attr_value_text is not null;
+ALTER TABLE resource_attr_values DROP COLUMN attr_value_text;
+ALTER TABLE resource_attr_u_values ALTER COLUMN attr_value TYPE text;
+ALTER TABLE group_resource_attr_values ALTER COLUMN attr_value TYPE text;
+UPDATE group_resource_attr_values set attr_value=attr_value_text where attr_value is null and attr_value_text is not null;
+ALTER TABLE group_resource_attr_values DROP COLUMN attr_value_text;
+ALTER TABLE group_resource_attr_u_values ALTER COLUMN attr_value TYPE text;
+ALTER TABLE member_attr_values ALTER COLUMN attr_value TYPE text;
+UPDATE member_attr_values set attr_value=attr_value_text where attr_value is null and attr_value_text is not null;
+ALTER TABLE member_attr_values DROP COLUMN attr_value_text;
+ALTER TABLE member_attr_u_values ALTER COLUMN attr_value TYPE text;
+ALTER TABLE member_group_attr_values ALTER COLUMN attr_value TYPE text;
+UPDATE member_group_attr_values set attr_value=attr_value_text where attr_value is null and attr_value_text is not null;
+ALTER TABLE member_group_attr_values DROP COLUMN attr_value_text;
+ALTER TABLE member_group_attr_u_values ALTER COLUMN attr_value TYPE text;
+ALTER TABLE member_resource_attr_values ALTER COLUMN attr_value TYPE text;
+UPDATE member_resource_attr_values set attr_value=attr_value_text where attr_value is null and attr_value_text is not null;
+ALTER TABLE member_resource_attr_values DROP COLUMN attr_value_text;
+ALTER TABLE member_resource_attr_u_values ALTER COLUMN attr_value TYPE text;
+ALTER TABLE user_attr_values ALTER COLUMN attr_value TYPE text;
+UPDATE user_attr_values set attr_value=attr_value_text where attr_value is null and attr_value_text is not null;
+ALTER TABLE user_attr_values DROP COLUMN attr_value_text;
+ALTER TABLE user_attr_u_values ALTER COLUMN attr_value TYPE text;
+ALTER TABLE user_facility_attr_values ALTER COLUMN attr_value TYPE text;
+UPDATE user_facility_attr_values set attr_value=attr_value_text where attr_value is null and attr_value_text is not null;
+ALTER TABLE user_facility_attr_values DROP COLUMN attr_value_text;
+ALTER TABLE user_facility_attr_u_values ALTER COLUMN attr_value TYPE text;
+ALTER TABLE vo_attr_values ALTER COLUMN attr_value TYPE text;
+UPDATE vo_attr_values set attr_value=attr_value_text where attr_value is null and attr_value_text is not null;
+ALTER TABLE vo_attr_values DROP COLUMN attr_value_text;
+ALTER TABLE vo_attr_u_values ALTER COLUMN attr_value TYPE text;
+ALTER TABLE user_ext_source_attr_values ALTER COLUMN attr_value TYPE text;
+UPDATE user_ext_source_attr_values set attr_value=attr_value_text where attr_value is null and attr_value_text is not null;
+ALTER TABLE user_ext_source_attr_values DROP COLUMN attr_value_text;
+ALTER TABLE user_ext_source_attr_u_values ALTER COLUMN attr_value TYPE text;
+ALTER TABLE ext_sources_attributes ALTER COLUMN attr_value TYPE text;
+update configurations set value='3.1.65' where property='DATABASE VERSION';
+
 3.1.64
 ALTER TABLE vos DROP COLUMN status;
 ALTER TABLE users DROP COLUMN status;

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/AttributesManagerEntryIntegrationTestAbstract.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/AttributesManagerEntryIntegrationTestAbstract.java
@@ -5389,9 +5389,6 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 
 			for (String type : AttributesManagerImpl.ATTRIBUTE_TYPES) {
 				//large string and large array are unsupported types for uniqueness
-				if(type.equals(BeansUtils.largeStringClassName) || type.equals(BeansUtils.largeArrayListClassName)) {
-					continue;
-				}
 
 				log.debug("conversion to unique bean {} type {}", bean, type);
 				String namespace = AttributesManagerImpl.BEANS_TO_NAMESPACES_MAP.get(bean) + ":def";
@@ -5415,6 +5412,7 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 				Attribute b = new Attribute(attributeDefinition);
 				switch (type) {
 					case "java.lang.String":
+					case BeansUtils.largeStringClassName:
 						a.setValue("string1");
 						b.setValue("string2");
 						break;
@@ -5427,6 +5425,7 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 						b.setValue(Boolean.TRUE);
 						break;
 					case "java.util.ArrayList":
+					case BeansUtils.largeArrayListClassName:
 						a.setValue(new ArrayList<>(Arrays.asList("value1","value2")));
 						b.setValue(new ArrayList<>(Arrays.asList("value3","value4")));
 						break;
@@ -5542,10 +5541,6 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 			if (bean.equals("entityless")) continue;
 
 			for(String type: AttributesManagerImpl.ATTRIBUTE_TYPES) {
-				//large string and large array are unsupported types for uniqueness
-				if(type.equals(BeansUtils.largeStringClassName) || type.equals(BeansUtils.largeArrayListClassName)) {
-					continue;
-				}
 
 				log.debug(" uniqueness check bean {} type {}", bean, type);
 				String namespace = AttributesManagerImpl.BEANS_TO_NAMESPACES_MAP.get(bean) + ":def";
@@ -5568,6 +5563,7 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 				Attribute b = new Attribute(attributeDefinition);
 				switch (type) {
 					case "java.lang.String":
+					case BeansUtils.largeStringClassName:
 						a.setValue("samestring");
 						b.setValue("samestring");
 						break;
@@ -5580,6 +5576,7 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 						b.setValue(Boolean.TRUE);
 						break;
 					case "java.util.ArrayList":
+					case BeansUtils.largeArrayListClassName:
 						a.setValue(Lists.newArrayList("value1","value2"));
 						b.setValue(Lists.newArrayList("value3","value2"));
 						break;

--- a/perun-db/postgres.sql
+++ b/perun-db/postgres.sql
@@ -327,7 +327,7 @@ create table hosts (
 create table host_attr_values (
 	host_id integer not null,  --identifier of host (hosts.id)
 	attr_id integer not null,  --identifier of attributes (attr_names.id)
-	attr_value varchar,  --value of attribute
+	attr_value text,  --value of attribute
 	created_at timestamp default statement_timestamp() not null,
 	created_by varchar default user not null,
 	modified_at timestamp default statement_timestamp() not null,

--- a/perun-db/postgres.sql
+++ b/perun-db/postgres.sql
@@ -1,4 +1,4 @@
--- database version 3.1.64 (don't forget to update insert statement at the end of file)
+-- database version 3.1.65 (don't forget to update insert statement at the end of file)
 
 -- VOS - virtual organizations
 create table vos (
@@ -332,7 +332,6 @@ create table host_attr_values (
 	created_by varchar default user not null,
 	modified_at timestamp default statement_timestamp() not null,
 	modified_by varchar default user not null,
-	attr_value_text text,   --value of attribute if it is very long text
 	created_by_uid integer,
 	modified_by_uid integer,
 	constraint hostav_pk primary key (host_id,attr_id),
@@ -344,7 +343,7 @@ create table host_attr_values (
 CREATE TABLE host_attr_u_values (
 	host_id INT NOT NULL,
 	attr_id INT NOT NULL,
-	attr_value varchar,
+	attr_value text,
 	UNIQUE (attr_id, attr_value),
 	FOREIGN KEY (host_id,attr_id) REFERENCES host_attr_values ON DELETE CASCADE
 );
@@ -603,12 +602,11 @@ create table facility_service_destinations (
 create table entityless_attr_values (
 	subject varchar not null,  --indicator of subject assigned with attribute
 	attr_id integer not null,       --identifier of attribute (attr_names.id)
-	attr_value varchar,       --attribute value
+	attr_value text,       --attribute value
 	created_at timestamp default statement_timestamp() not null,
 	created_by varchar default user not null,
 	modified_at timestamp default statement_timestamp() not null,
 	modified_by varchar default user not null,
-	attr_value_text text,           --attribute value in case it is very long text
 	created_by_uid integer,
 	modified_by_uid integer,
 	constraint entlatval_pk primary key(subject,attr_id),
@@ -619,12 +617,11 @@ create table entityless_attr_values (
 create table facility_attr_values (
 	facility_id integer not null,   --identifier of facility (facilities.id)
 	attr_id integer not null,       --identifier of attribute (attr_names.id)
-	attr_value varchar,       --attribute value
+	attr_value text,       --attribute value
 	created_at timestamp default statement_timestamp() not null,
 	created_by varchar default user not null,
 	modified_at timestamp default statement_timestamp() not null,
 	modified_by varchar default user not null,
-	attr_value_text text,           --attribute value in case it is very long text
 	created_by_uid integer,
 	modified_by_uid integer,
 	constraint facattval_pk primary key (facility_id,attr_id),
@@ -636,7 +633,7 @@ create table facility_attr_values (
 CREATE TABLE facility_attr_u_values (
 	facility_id INT NOT NULL,
 	attr_id INT NOT NULL,
-	attr_value varchar,
+	attr_value text,
 	UNIQUE (attr_id, attr_value),
 	FOREIGN KEY (facility_id,attr_id) REFERENCES facility_attr_values ON DELETE CASCADE
 );
@@ -646,12 +643,11 @@ CREATE TABLE facility_attr_u_values (
 create table group_attr_values (
 	group_id integer not null,     --identifier of group (groups.id)
 	attr_id integer not null,      --identifier of attribute (attr_names.id)
-	attr_value varchar,      --attribute value
+	attr_value text,      --attribute value
 	created_at timestamp default statement_timestamp() not null,
 	created_by varchar default user not null,
 	modified_at timestamp default statement_timestamp() not null,
 	modified_by varchar default user not null,
-	attr_value_text text,          --attribute value in case it is very long text
 	created_by_uid integer,
 	modified_by_uid integer,
 	constraint grpattval_pk primary key (group_id,attr_id),
@@ -663,7 +659,7 @@ create table group_attr_values (
 CREATE TABLE group_attr_u_values (
 	group_id INT NOT NULL,
 	attr_id INT NOT NULL,
-	attr_value varchar,
+	attr_value text,
 	UNIQUE (attr_id, attr_value),
 	FOREIGN KEY (group_id,attr_id) REFERENCES group_attr_values ON DELETE CASCADE
 );
@@ -672,12 +668,11 @@ CREATE TABLE group_attr_u_values (
 create table resource_attr_values (
 	resource_id integer not null,   --identifier of resource (resources.id)
 	attr_id integer not null,       --identifier of attribute (attr_names.id)
-	attr_value varchar,       --attribute value
+	attr_value text,       --attribute value
 	created_at timestamp default statement_timestamp() not null,
 	created_by varchar default user not null,
 	modified_at timestamp default statement_timestamp() not null,
 	modified_by varchar default user not null,
-	attr_value_text text,           --attribute value in case it is very long text
 	created_by_uid integer,
 	modified_by_uid integer,
 	constraint resatval_pk primary key (resource_id,attr_id),
@@ -689,7 +684,7 @@ create table resource_attr_values (
 CREATE TABLE resource_attr_u_values (
 	resource_id INT NOT NULL,
 	attr_id INT NOT NULL,
-	attr_value varchar,
+	attr_value text,
 	UNIQUE (attr_id, attr_value),
 	FOREIGN KEY (resource_id,attr_id) REFERENCES resource_attr_values ON DELETE CASCADE
 );
@@ -699,12 +694,11 @@ create table group_resource_attr_values (
 	group_id integer not null,     --identifier of group (groups.id)
 	resource_id integer not null,  --identifier of resource (resources.id)
 	attr_id integer not null,      --identifier of attribute (attr_names.id)
-	attr_value varchar,      --attribute value
+	attr_value text,      --attribute value
 	created_at timestamp default statement_timestamp() not null,
 	created_by varchar default user not null,
 	modified_at timestamp default statement_timestamp() not null,
 	modified_by varchar default user not null,
-	attr_value_text text,          --attribute value in case it is very long text
 	created_by_uid integer,
 	modified_by_uid integer,
 	constraint grpresav_pk primary key (group_id,resource_id,attr_id),
@@ -718,7 +712,7 @@ CREATE TABLE group_resource_attr_u_values (
 	group_id INT NOT NULL,
 	resource_id INT NOT NULL,
 	attr_id INT NOT NULL,
-	attr_value varchar,
+	attr_value text,
 	UNIQUE (attr_id, attr_value),
 	FOREIGN KEY (group_id,resource_id,attr_id) REFERENCES group_resource_attr_values ON DELETE CASCADE
 );
@@ -761,12 +755,11 @@ create table groups_resources (
 create table member_attr_values (
 	member_id integer not null,   --identifier of member (members.id)
 	attr_id integer not null,     --identifier of attribute (attr_names.id)
-	attr_value varchar,     --attribute value
+	attr_value text,     --attribute value
 	created_at timestamp default statement_timestamp() not null,
 	created_by varchar default user not null,
 	modified_at timestamp default statement_timestamp() not null,
 	modified_by varchar default user not null,
-	attr_value_text text,         --attribute value in case it is very long text
 	created_by_uid integer,
 	modified_by_uid integer,
 	constraint memattval_pk primary key (member_id,attr_id),
@@ -778,7 +771,7 @@ create table member_attr_values (
 CREATE TABLE member_attr_u_values (
 	member_id INT NOT NULL,
 	attr_id INT NOT NULL,
-	attr_value varchar,
+	attr_value text,
 	UNIQUE (attr_id, attr_value),
 	FOREIGN KEY (member_id,attr_id) REFERENCES member_attr_values ON DELETE CASCADE
 );
@@ -788,12 +781,11 @@ create table member_group_attr_values (
 	member_id integer not null,   --identifier of member (members.id)
 	group_id integer not null, --identifier of group (groups.id)
 	attr_id integer not null,     --identifier of attribute (attr_names.id)
-	attr_value varchar,     --attribute value
+	attr_value text,     --attribute value
 	created_at timestamp default statement_timestamp() not null,
 	created_by varchar default user not null,
 	modified_at timestamp default statement_timestamp() not null,
 	modified_by varchar default user not null,
-	attr_value_text text,         --attribute value in case it is very long text
 	created_by_uid integer,
 	modified_by_uid integer,
 	constraint memgav_pk primary key(member_id,group_id,attr_id),
@@ -807,7 +799,7 @@ CREATE TABLE member_group_attr_u_values (
 	member_id INT NOT NULL,
 	group_id INT NOT NULL,
 	attr_id INT NOT NULL,
-	attr_value varchar,
+	attr_value text,
 	UNIQUE (attr_id, attr_value),
 	FOREIGN KEY (member_id,group_id,attr_id) REFERENCES member_group_attr_values ON DELETE CASCADE
 );
@@ -817,12 +809,11 @@ create table member_resource_attr_values (
 	member_id integer not null,   --identifier of member (members.id)
 	resource_id integer not null, --identifier of resource (resources.id)
 	attr_id integer not null,     --identifier of attribute (attr_names.id)
-	attr_value varchar,     --attribute value
+	attr_value text,     --attribute value
 	created_at timestamp default statement_timestamp() not null,
 	created_by varchar default user not null,
 	modified_at timestamp default statement_timestamp() not null,
 	modified_by varchar default user not null,
-	attr_value_text text,         --attribute value in case it is very long text
 	created_by_uid integer,
 	modified_by_uid integer,
 	constraint memrav_pk primary key(member_id,resource_id,attr_id),
@@ -836,7 +827,7 @@ CREATE TABLE member_resource_attr_u_values (
 	member_id INT NOT NULL,
 	resource_id INT NOT NULL,
 	attr_id INT NOT NULL,
-	attr_value varchar,
+	attr_value text,
 	UNIQUE (attr_id, attr_value),
 	FOREIGN KEY (member_id,resource_id,attr_id) REFERENCES member_resource_attr_values ON DELETE CASCADE
 );
@@ -845,12 +836,11 @@ CREATE TABLE member_resource_attr_u_values (
 create table user_attr_values (
 	user_id integer not null,  --identifier of user (users.id)
 	attr_id integer not null,  --identifier of attribute (attr_names.id)
-	attr_value varchar,  --attribute value
+	attr_value text,  --attribute value
 	created_at timestamp default statement_timestamp() not null,
 	created_by varchar default user not null,
 	modified_at timestamp default statement_timestamp() not null,
 	modified_by varchar default user not null,
-	attr_value_text text,      --attribute value in case it is very long text
 	created_by_uid integer,
 	modified_by_uid integer,
 	constraint usrav_pk primary key(user_id,attr_id),
@@ -862,7 +852,7 @@ create table user_attr_values (
 CREATE TABLE user_attr_u_values (
 	user_id  INT NOT NULL,
 	attr_id  INT NOT NULL,
-	attr_value varchar,
+	attr_value text,
 	UNIQUE (attr_id, attr_value),
 	FOREIGN KEY (user_id,attr_id) REFERENCES user_attr_values ON DELETE CASCADE
 );
@@ -872,12 +862,11 @@ create table user_facility_attr_values (
 	user_id integer not null,     --identifier of user (users.id)
 	facility_id integer not null, --identifier of facility (facilities.id)
 	attr_id integer not null,     --identifier of attribute (attr_names.id)
-	attr_value varchar,     --attribute value
+	attr_value text,     --attribute value
 	created_at timestamp default statement_timestamp() not null,
 	created_by varchar default user not null,
 	modified_at timestamp default statement_timestamp() not null,
 	modified_by varchar default user not null,
-	attr_value_text text,         --attribute value in case it is very long text
 	created_by_uid integer,
 	modified_by_uid integer,
 	constraint usrfacav_u primary key(user_id,facility_id,attr_id),
@@ -891,7 +880,7 @@ CREATE TABLE user_facility_attr_u_values (
 	user_id INT NOT NULL,
 	facility_id INT NOT NULL,
 	attr_id INT NOT NULL,
-	attr_value varchar,
+	attr_value text,
 	UNIQUE (attr_id, attr_value),
 	FOREIGN KEY (user_id,facility_id,attr_id) REFERENCES user_facility_attr_values ON DELETE CASCADE
 );
@@ -900,12 +889,11 @@ CREATE TABLE user_facility_attr_u_values (
 create table vo_attr_values (
 	vo_id integer not null,    --identifier of VO (vos.id)
 	attr_id integer not null,  --identifier of attribute (attr_names.id)
-	attr_value varchar,  --attribute value
+	attr_value text,  --attribute value
 	created_at timestamp default statement_timestamp() not null,
 	created_by varchar default user not null,
 	modified_at timestamp default statement_timestamp() not null,
 	modified_by varchar default user not null,
-	attr_value_text text,      --attribute value in case it is very long text
 	created_by_uid integer,
 	modified_by_uid integer,
 	constraint voattval_pk primary key (vo_id,attr_id),
@@ -917,7 +905,7 @@ create table vo_attr_values (
 CREATE TABLE vo_attr_u_values (
 	vo_id INT NOT NULL,
 	attr_id INT NOT NULL,
-	attr_value varchar,
+	attr_value text,
 	UNIQUE (attr_id, attr_value),
 	FOREIGN KEY (vo_id,attr_id) REFERENCES vo_attr_values ON DELETE CASCADE
 );
@@ -941,7 +929,7 @@ create table ext_sources (
 create table ext_sources_attributes (
 	ext_sources_id integer not null,   --identifier of ext. source (ext_sources.id)
 	attr_name varchar not null,   --name of attribute at ext. source
-	attr_value varchar,          --value of attribute
+	attr_value text,          --value of attribute
 	created_at timestamp default statement_timestamp() not null,
 	created_by varchar default user not null,
 	modified_at timestamp default statement_timestamp() not null,
@@ -1360,12 +1348,11 @@ create table facilities_bans (
 create table user_ext_source_attr_values (
 	user_ext_source_id integer not null,
 	attr_id integer not null,
-	attr_value varchar,
+	attr_value text,
 	created_at timestamp default statement_timestamp() not null,
 	created_by varchar default user not null,
 	modified_at timestamp default statement_timestamp() not null,
 	modified_by varchar default user not null,
-	attr_value_text text,
 	created_by_uid integer,
 	modified_by_uid integer,
 	constraint uesattrval_pk primary key (user_ext_source_id, attr_id),
@@ -1377,7 +1364,7 @@ create table user_ext_source_attr_values (
 CREATE TABLE user_ext_source_attr_u_values (
 	user_ext_source_id INT NOT NULL,
 	attr_id    INT NOT NULL,
-	attr_value varchar,
+	attr_value text,
 	UNIQUE (attr_id, attr_value),
 	FOREIGN KEY (user_ext_source_id,attr_id) REFERENCES user_ext_source_attr_values ON DELETE CASCADE
 );
@@ -1725,7 +1712,7 @@ grant all on user_ext_source_attr_u_values to perun;
 grant all on members_sponsored to perun;
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.1.64');
+insert into configurations values ('DATABASE VERSION','3.1.65');
 
 -- insert membership types
 insert into membership_types (id, membership_type, description) values (1, 'DIRECT', 'Member is directly added into group');

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
@@ -3033,10 +3033,10 @@ public class RegistrarManagerImpl implements RegistrarManager {
 
 				// if attribute exists
 				if (a != null) {
-					if (a.getType().equalsIgnoreCase("java.util.LinkedHashMap")) {
+					if (a.getType().equalsIgnoreCase(LinkedHashMap.class.getName())) {
 						// FIXME do not set hash map attributes - not supported in GUI and registrar
 						continue;
-					} else if (a.getType().equalsIgnoreCase("java.util.ArrayList") || a.getType().equalsIgnoreCase(BeansUtils.largeArrayListClassName)) {
+					} else if (a.getType().equalsIgnoreCase(ArrayList.class.getName()) || a.getType().equalsIgnoreCase(BeansUtils.largeArrayListClassName)) {
 						// we expects that list contains strings
 						ArrayList<String> value = a.valueAsList();
 						// if value not present in list => add

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/attributestabs/AttributeDefinitionDetailTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/attributestabs/AttributeDefinitionDetailTabItem.java
@@ -153,7 +153,7 @@ public class AttributeDefinitionDetailTabItem implements TabItem {
 				public void onValueChange(ValueChangeEvent<Boolean> valueChangeEvent) {
 
 					if (valueChangeEvent.getValue()) {
-						UiElements.generateAlert("Change confirmation", "Changing attribute to UNIQUE might take a lot of time if there is large number of entities with set values. Perun will check uniqueness during the process. If values are not unique, conversion will be stopped.<p style=\"color:red;\">We strongly recommend to refresh whole browser window after conversion is DONE to prevent errors when modyfying attributes from GUI.", new ClickHandler() {
+						UiElements.generateAlert("Change confirmation", "Changing attribute to UNIQUE might take a lot of time if there is large number of entities with set values. Perun will check uniqueness during the process. If values are not unique, conversion will be stopped.<p style=\"color:red;\">We strongly recommend to refresh whole browser window after conversion is DONE to prevent errors when modifying attributes from GUI.", new ClickHandler() {
 							@Override
 							public void onClick(ClickEvent clickEvent) {
 								ConvertAttributeToUnique convert = new ConvertAttributeToUnique(new JsonCallbackEvents() {


### PR DESCRIPTION
- All values of large attributes from "attr_value_text" column
  were moved to the standard "attr_value" column.
  Default column type changed to "text" to contain large values.
- Updated DB schema and changelog 3.1.65.
- Simplified attribute value reading where possible.

- We expect to remove "large" attribute types from the API/logic
  in the future.