### PR TITLE
RPC: Bumped tomcat and cargo plugin to latest version

### DIFF
--- a/perun-rpc/pom.xml
+++ b/perun-rpc/pom.xml
@@ -34,7 +34,7 @@
 			<plugin>
 				<groupId>org.codehaus.cargo</groupId>
 				<artifactId>cargo-maven2-plugin</artifactId>
-				<version>1.6.8</version>
+				<version>1.7.15</version>
 				<configuration>
 					<container>
 						<containerId>tomcat8x</containerId>

--- a/perun-rpc/tomcat.xml
+++ b/perun-rpc/tomcat.xml
@@ -5,6 +5,7 @@
 
 	<!-- must be kept, since Cargo plugin check "cargocpc" app on 8080 port -->
 	<Connector port="8080"
+	           address="127.0.0.1"
 	           maxThreads="150"
 	           minSpareThreads="25"
 	           enableLookups="false"
@@ -22,7 +23,9 @@
 	           tomcatAuthentication="false"
 	           URIEncoding="UTF-8"
 	           packetSize="36000"
-	           redirectPort="8080"/>
+	           redirectPort="8080"
+	           secretRequired="false"
+	           allowedRequestAttributesPattern=".*"/>
 
 	<Engine name="Catalina" defaultHost="localhost" debug="FINE">
 

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
 		<spring.profiles.default>default</spring.profiles.default>
 
 		<!-- redefine versions of some libraries defined by Spring Boot Starter Parent -->
-		<tomcat.version>8.5.34</tomcat.version>
+		<tomcat.version>8.5.57</tomcat.version>
 		<oracle-database.version>19.6.0.0</oracle-database.version>
 
 		<!-- versions of libraries not defined by the Spring Boot Starter Parent -->


### PR DESCRIPTION
- Use latest cargo plugin used to locally run perun.
- Specify latest tomcat8 version to use.
- Updated tomcat.xml with new required properties.