### PR TITLE
RPC - getEntitylessAttributesWithKeys

### DIFF
--- a/perun-base/src/test/resources/perun-roles.yml
+++ b/perun-base/src/test/resources/perun-roles.yml
@@ -3727,6 +3727,17 @@ perun_policies:
     include_policies:
       - default_policy
 
+  #AttributesManagerEntry
+  getEntitylessAttributesWithKeys_String_policy:
+    policy_roles: []
+    include_policies:
+      - default_policy
+
+  getEntitylessAttributesWithKeys_String_List<String>_policy:
+    policy_roles: []
+    include_policies:
+      - default_policy
+
 # A list of Perun management rules that are loaded to the PerunPoliciesContainer.
 perun_roles_management:
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/AttributesManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/AttributesManager.java
@@ -26,6 +26,7 @@ import cz.metacentrum.perun.utils.graphs.GraphDTO;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * @author Michal Prochazka <michalp@ics.muni.cz>
@@ -298,6 +299,34 @@ public interface AttributesManager {
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 */
 	List<Attribute> getEntitylessAttributes(PerunSession sess, String attrName) throws PrivilegeException;
+
+	/**
+	 * Get entityless attributes mapped by their keys.
+	 *
+	 * @param sess session
+	 * @param attrName attribute name
+	 * @return Map of entityless attributes mapped by their keys
+	 * @throws PrivilegeException insufficient permissions
+	 * @throws AttributeNotExistsException when the attribute definition for attrName doesn't exist
+	 * @throws WrongAttributeAssignmentException when passed non-entityless attribute
+	 */
+	Map<String, Attribute> getEntitylessAttributesWithKeys(PerunSession sess, String attrName)
+			throws PrivilegeException, AttributeNotExistsException, WrongAttributeAssignmentException;
+
+	/**
+	 * Get entityless attributes mapped by their keys.
+	 * Returns only attributes for specified keys.
+	 *
+	 * @param sess session
+	 * @param attrName attribute name
+	 * @return Map of entityless attributes mapped by their keys
+	 * @throws PrivilegeException insufficient permissions
+	 * @throws AttributeNotExistsException when the attribute definition for attrName doesn't exist, or
+	 *                                     when there is no such attribute for one of the specified keys
+	 * @throws WrongAttributeAssignmentException when passed non-entityless attribute
+	 */
+	Map<String, Attribute> getEntitylessAttributesWithKeys(PerunSession sess, String attrName, List<String> keys)
+			throws PrivilegeException, AttributeNotExistsException, WrongAttributeAssignmentException;
 
 	/**
 	 * Get all <b>non-empty</b> member, user, member-resource and user-facility attributes.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
@@ -577,6 +577,32 @@ public interface AttributesManagerBl {
 	List<Attribute> getEntitylessAttributes(PerunSession sess, String attrName);
 
 	/**
+	 * Get entityless attributes mapped by their keys.
+	 *
+	 * @param sess session
+	 * @param attrName attribute name
+	 * @return Map of entityless attributes mapped by their keys
+	 * @throws AttributeNotExistsException when the attribute definition for attrName doesn't exist
+	 * @throws WrongAttributeAssignmentException when passed non-entityless attribute
+	 */
+	Map<String, Attribute> getEntitylessAttributesWithKeys(PerunSession sess, String attrName)
+			throws AttributeNotExistsException, WrongAttributeAssignmentException;
+
+	/**
+	 * Get entityless attributes mapped by their keys.
+	 * Returns only attributes for specified keys.
+	 *
+	 * @param sess session
+	 * @param attrName attribute name
+	 * @return Map of entityless attributes mapped by their keys
+	 * @throws AttributeNotExistsException when the attribute definition for attrName doesn't exist, or
+	 *                                     when there is no such attribute for one of the specified keys
+	 * @throws WrongAttributeAssignmentException when passed non-entityless attribute
+	 */
+	Map<String, Attribute> getEntitylessAttributesWithKeys(PerunSession sess, String attrName, List<String> keys)
+			throws AttributeNotExistsException, WrongAttributeAssignmentException;
+
+	/**
 	 * Returns list of Keys which fits the attributeDefinition.
 	 * @param sess
 	 * @param attributeDefinition

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -557,6 +557,26 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	}
 
 	@Override
+	public Map<String, Attribute> getEntitylessAttributesWithKeys(PerunSession sess, String attrName)
+			throws AttributeNotExistsException, WrongAttributeAssignmentException {
+		AttributeDefinition definition = getAttributeDefinition(sess, attrName);
+		List<String> keys = getEntitylessKeys(sess, definition);
+		return getEntitylessAttributesWithKeys(sess, attrName, keys);
+	}
+
+	@Override
+	public Map<String, Attribute> getEntitylessAttributesWithKeys(PerunSession sess, String attrName, List<String> keys)
+			throws AttributeNotExistsException, WrongAttributeAssignmentException {
+		AttributeDefinition definition = getAttributeDefinition(sess, attrName);
+
+		Map<String, Attribute> attributesByKeys = new HashMap<>();
+		for (String key : keys) {
+			attributesByKeys.put(key, getAttribute(sess, key, attrName));
+		}
+		return attributesByKeys;
+	}
+
+	@Override
 	public List<String> getEntitylessKeys(PerunSession sess, AttributeDefinition attributeDefinition) {
 		return getAttributesManagerImpl().getEntitylessKeys(sess, attributeDefinition);
 	}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/AttributesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/AttributesManagerEntry.java
@@ -48,10 +48,12 @@ import cz.metacentrum.perun.utils.graphs.GraphTextFormat;
 import cz.metacentrum.perun.utils.graphs.GraphDTO;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -739,6 +741,38 @@ public class AttributesManagerEntry implements AttributesManager {
 		}
 
 		return getAttributesManagerBl().setWritableTrue(sess, getAttributesManagerBl().getEntitylessAttributes(sess, attrName));
+	}
+
+	@Override
+	public Map<String, Attribute> getEntitylessAttributesWithKeys(PerunSession sess, String attrName)
+			throws PrivilegeException, AttributeNotExistsException, WrongAttributeAssignmentException {
+		Utils.checkPerunSession(sess);
+		Utils.notNull(attrName, "name of entityless attributes");
+		if (attrName.isEmpty()) {
+			throw new InternalErrorException("name for entityless attribute can't be empty");
+		}
+		if (!AuthzResolver.authorizedInternal(sess, "getEntitylessAttributesWithKeys_String_policy")) {
+			throw new PrivilegeException(sess, "getEntitylessAttributesWithKeys");
+		}
+
+		return attributesManagerBl.getEntitylessAttributesWithKeys(sess, attrName);
+	}
+
+	@Override
+	public Map<String, Attribute> getEntitylessAttributesWithKeys(PerunSession sess, String attrName, List<String> keys)
+			throws PrivilegeException, AttributeNotExistsException, WrongAttributeAssignmentException {
+		Utils.checkPerunSession(sess);
+		Utils.notNull(attrName, "name of entityless attributes");
+		Utils.notNull(keys, "keys");
+
+		if (attrName.isEmpty()) {
+			throw new InternalErrorException("name for entityless attribute can't be empty");
+		}
+		if (!AuthzResolver.authorizedInternal(sess, "getEntitylessAttributesWithKeys_String_List<String>_policy")) {
+			throw new PrivilegeException(sess, "getEntitylessAttributesWithKeys");
+		}
+
+		return attributesManagerBl.getEntitylessAttributesWithKeys(sess, attrName, keys);
 	}
 
 	@Override

--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -895,6 +895,11 @@ components:
         memberPreferredEmail: { type: string }
         ticketNumber: { type: integer }
 
+    EntitylessAttributesByKeys:
+      type: object
+      additionalProperties:
+        $ref: '#/components/schemas/Attribute'
+
   #################################################
   #                                               #
   # RESPONSES - type definitions of return values #
@@ -1214,6 +1219,13 @@ components:
             type: array
             items:
               $ref: "#/components/schemas/Attribute"
+
+    EntitylessAttributesByKeysResponse:
+      description: "Entityless attributes by keys"
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/EntitylessAttributesByKeys"
 
     GroupResponse:
       description: "returns Group"
@@ -3426,6 +3438,22 @@ paths:
           $ref: '#/components/responses/ListOfStringsResponse'
         default:
           $ref: '#/components/responses/ExceptionResponse'
+
+  /json/attributesManager/getEntitylessAttributesWithKeys:
+    get:
+      tags:
+        - AttributesManager
+      operationId: getEntitylessAttributesWithKeys
+      summary: Get entityless attributes mapped by their keys.
+      parameters:
+        - $ref: '#/components/parameters/attrName'
+        - { name: "keys[]", description: "key for entityless attribute", schema: { type: array, items: { type: string } },  in: query, required: false }
+      responses:
+        '200':
+          $ref: '#/components/responses/EntitylessAttributesByKeysResponse'
+        default:
+          $ref: '#/components/responses/ExceptionResponse'
+
 
   /json/attributesManager/setAttributes/f-r-g-u-m:
     post:

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/AttributesManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/AttributesManagerMethod.java
@@ -470,6 +470,41 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	},
 
 	/*#
+	 * Get entityless attributes mapped by their keys.
+	 *
+	 * @param attrName String Attribute name
+	 * @return Map<String,Attribute> of entityless attributes mapped by their keys
+	 * @throw PrivilegeException insufficient permissions
+	 * @throw AttributeNotExistsException when the attribute definition for attrName doesn't exist
+	 * @throw WrongAttributeAssignmentException when passed non-entityless attribute
+	 */
+	/*#
+	 * Get entityless attributes mapped by their keys.
+	 * Returns only attributes for specified keys.
+	 *
+	 * @param attrName String Attribute name
+	 * @param keys List<String> keys
+	 * @return Map<String,Attribute> of entityless attributes mapped by their keys
+	 * @throw PrivilegeException insufficient permissions
+	 * @throw AttributeNotExistsException when the attribute definition for attrName doesn't exist, or
+	 *                                    when there is no such attribute for one of the specified keys
+	 * @throw WrongAttributeAssignmentException when passed non-entityless attribute
+	 */
+	getEntitylessAttributesWithKeys {
+		@Override
+		public Object call(ApiCaller ac, Deserializer parms) throws PerunException {
+			if (parms.contains("keys")) {
+				return ac.getAttributesManager()
+						.getEntitylessAttributesWithKeys(ac.getSession(), parms.readString("attrName"),
+								parms.readList("keys", String.class));
+			} else {
+				return ac.getAttributesManager()
+						.getEntitylessAttributesWithKeys(ac.getSession(), parms.readString("attrName"));
+			}
+		}
+	},
+
+	/*#
 	 * Returns all entityless attributes with <code>attrName</code> (for all namespaces of same attribute).
 	 *
 	 * @param attrName String Attribute name


### PR DESCRIPTION
* To be able to easily work with entityless attributes, we need a new
better methods. Until now, there have been only methods that were able
to retrieve entityless attributes keys and then attributes but without
the information to which keys these attributes belong.
* Created new method `getEntitylessAttributesWithKeys` which returns a
map of attributes which are mapped by their keys.
* Method specification added to openApi.