### PR TITLE
Validate sponsored members after creating of sponsorship

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
@@ -2416,13 +2416,29 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 		if(!sponsoredMember.isSponsored()) {
 			throw new MemberNotSponsoredException("member "+sponsoredMember.getId()+" is not marked as sponsored");
 		}
+
 		// check whether the user is already sponsor
 		List<User> sponsors = getPerunBl().getUsersManagerBl().getSponsors(session, sponsoredMember);
 		if(sponsors.stream().map(PerunBean::getId).anyMatch(id -> id==sponsor.getId())) {
 			throw new AlreadySponsorException("member "+sponsoredMember.getId()+" is already sponsored by user "+sponsor.getId());
 		}
+
 		// add the sponsor
 		getMembersManagerImpl().addSponsor(session, sponsoredMember, sponsor);
+
+		//remove expiration and validate member
+		try {
+			AttributeDefinition expiration = getPerunBl().getAttributesManagerBl().getAttributeDefinition(session, EXPIRATION);
+			getPerunBl().getAttributesManagerBl().removeAttribute(session, sponsoredMember, expiration);
+		} catch (WrongAttributeAssignmentException | AttributeNotExistsException| WrongAttributeValueException | WrongReferenceAttributeValueException ex) {
+			throw new InternalErrorException("cannot remove expiration date for sponsored member " + sponsoredMember.getId(), ex);
+		}
+		try {
+			validateMember(session, sponsoredMember);
+		} catch (WrongReferenceAttributeValueException | WrongAttributeValueException ex) {
+			throw new InternalErrorException("cannot validate sponsored member " + sponsoredMember.getId(), ex);
+		}
+
 		getPerunBl().getAuditer().log(session, new SponsorshipEstablished(sponsoredMember, sponsor));
 
 		return sponsoredMember;


### PR DESCRIPTION
 - sponsored members could be expired (after first sponsorship ends), so
 we need to be sure that new sponsorship will validate them again (and
 also remove their expiration date)