### PR TITLE
CORE: Entityless attributes must be marked as writable

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/AttributesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/AttributesManagerEntry.java
@@ -756,7 +756,13 @@ public class AttributesManagerEntry implements AttributesManager {
 			throw new PrivilegeException(sess, "getEntitylessAttributesWithKeys");
 		}
 
-		return attributesManagerBl.getEntitylessAttributesWithKeys(sess, attrName);
+		Map<String, Attribute> result = attributesManagerBl.getEntitylessAttributesWithKeys(sess, attrName);
+		result.entrySet().removeIf(entry ->
+				!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.READ, new AttributeDefinition(entry.getValue()), entry.getKey()));
+		result.forEach((s, attribute) -> {
+			attribute.setWritable(AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attribute, s));
+		});
+		return result;
 	}
 
 	@Override
@@ -773,7 +779,13 @@ public class AttributesManagerEntry implements AttributesManager {
 			throw new PrivilegeException(sess, "getEntitylessAttributesWithKeys");
 		}
 
-		return attributesManagerBl.getEntitylessAttributesWithKeys(sess, attrName, keys);
+		Map<String, Attribute> result = attributesManagerBl.getEntitylessAttributesWithKeys(sess, attrName, keys);
+		result.entrySet().removeIf(entry ->
+				!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.READ, new AttributeDefinition(entry.getValue()), entry.getKey()));
+		result.forEach((s, attribute) -> {
+			attribute.setWritable(AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attribute, s));
+		});
+		return result;
 	}
 
 	@Override


### PR DESCRIPTION
- In order to edit attributes in GUI we must mark them as editable.
  It was used in old methods, but was missing in new methods.