### PR TITLE
CORE,RPC,GUI: Support for TaskResults deletion from GUI

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/TasksManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/TasksManager.java
@@ -139,4 +139,23 @@ public interface TasksManager {
 	 */
 	void deleteTask(PerunSession sess, Task task) throws PrivilegeException;
 
+	/**
+	 * Delete TaskResult by its ID
+	 *
+	 * @param sess PerunSession
+	 * @param taskResultId Id of TaskResults to be deleted
+	 * @throws PrivilegeException
+	 */
+	void deleteTaskResultById(PerunSession sess, int taskResultId) throws PrivilegeException;
+
+	/**
+	 * Delete all TaskResults related to specified Task and Destination
+	 *
+	 * @param sess PerunSession
+	 * @param task Task to have TaskResults deleted
+	 * @param destination Destination to have TasksResults deleted
+	 * @throws PrivilegeException
+	 */
+	void deleteTaskResults(PerunSession sess, Task task, Destination destination) throws PrivilegeException;
+
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/TasksManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/TasksManagerBl.java
@@ -180,25 +180,46 @@ public interface TasksManagerBl {
 	 */
 	List<TaskResult> getTaskResultsByTaskAndDestination(int taskId, int destinationId);
 
+	/**
+	 * Delete TaskResults by its ID
+	 *
+	 * @param taskResultId ID of TaskResult to delete
+	 */
+	void deleteTaskResultById(int taskResultId);
 
 	/**
-	 * Clear all results tied to a particular Task
+	 * Delete all TaskResults for the particular Task
 	 *
-	 * @param taskId
+	 * @param taskId ID of Task to delete TaskResults
 	 * @return number of deleted TaskResults
 	 */
-	int clearByTask(int taskId);
+	int deleteTaskResults(int taskId);
 
 	/**
-	 * Clear all results
+	 * Delete all TaskResults for the particular Task and Destination.
+	 *
+	 * @param taskId ID of Task to delete TaskResults
+	 * @param destinationId ID of Destination to delete TaskResults
+	 * @return number of deleted TaskResults
+	 */
+	int deleteTaskResults(int taskId, int destinationId);
+
+	/**
+	 * Delete all TaskResults older than specified number of days
+	 *
+	 * @param numDays Number of days to keep
+	 * @return number of deleted TaskResults
+	 */
+	int deleteOldTaskResults(int numDays);
+
+	/**
+	 * Delete all TaskResults
 	 *
 	 * @return number of deleted TaskResults
 	 */
-	int clearAll();
+	int deleteAllTaskResults();
 
 	int insertNewTaskResult(TaskResult taskResult);
-
-	int clearOld(int numDays);
 
 	/**
 	 * Returns list of tasks results for defined destinations (string representation).

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/FacilitiesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/FacilitiesManagerBlImpl.java
@@ -308,7 +308,7 @@ public class FacilitiesManagerBlImpl implements FacilitiesManagerBl {
 			}
 			List<Task> tasks = perunBl.getTasksManagerBl().listAllTasksForFacility(facility.getId());
 			for (Task task : tasks) {
-				perunBl.getTasksManagerBl().clearByTask(task.getId());
+				perunBl.getTasksManagerBl().deleteTaskResults(task.getId());
 				perunBl.getTasksManagerBl().removeTask(task.getId());
 			}
 		} else {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/TasksManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/TasksManagerBlImpl.java
@@ -12,7 +12,6 @@ import cz.metacentrum.perun.core.api.RichResource;
 import cz.metacentrum.perun.core.api.Service;
 import cz.metacentrum.perun.core.api.Vo;
 import cz.metacentrum.perun.core.api.exceptions.FacilityNotExistsException;
-import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.VoNotExistsException;
 import cz.metacentrum.perun.core.bl.PerunBl;
 import cz.metacentrum.perun.core.bl.ServicesManagerBl;
@@ -51,18 +50,28 @@ public class TasksManagerBlImpl implements TasksManagerBl {
 	}
 
 	@Override
-	public int clearByTask(int taskId) {
-		return getTasksManagerImpl().clearByTask(taskId);
+	public void deleteTaskResultById(int taskResultId) {
+		getTasksManagerImpl().deleteTaskResultById(taskResultId);
 	}
 
 	@Override
-	public int clearAll() {
-		return getTasksManagerImpl().clearAll();
+	public int deleteTaskResults(int taskId) {
+		return getTasksManagerImpl().deleteTaskResults(taskId);
 	}
 
 	@Override
-	public int clearOld(int numDays) {
-		return getTasksManagerImpl().clearOld(numDays);
+	public int deleteTaskResults(int taskId, int destinationId) {
+		return getTasksManagerImpl().deleteTaskResults(taskId, destinationId);
+	}
+
+	@Override
+	public int deleteAllTaskResults() {
+		return getTasksManagerImpl().deleteAllTaskResults();
+	}
+
+	@Override
+	public int deleteOldTaskResults(int numDays) {
+		return getTasksManagerImpl().deleteOldTaskResults(numDays);
 	}
 
 	@Override
@@ -396,7 +405,7 @@ public class TasksManagerBlImpl implements TasksManagerBl {
 		Service service = task.getService();
 
 		// clear all task results
-		getTasksManagerImpl().clearByTask(task.getId());
+		getTasksManagerImpl().deleteTaskResults(task.getId());
 
 		// remove task itself
 		getTasksManagerImpl().removeTask(service, facility);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/TasksManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/TasksManagerEntry.java
@@ -13,13 +13,11 @@ import cz.metacentrum.perun.core.api.TasksManager;
 import cz.metacentrum.perun.core.api.Vo;
 import cz.metacentrum.perun.core.api.exceptions.DestinationNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.FacilityNotExistsException;
-import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
 import cz.metacentrum.perun.core.api.exceptions.ServiceNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.VoNotExistsException;
 import cz.metacentrum.perun.core.bl.PerunBl;
 import cz.metacentrum.perun.core.bl.TasksManagerBl;
-import cz.metacentrum.perun.core.blImpl.PerunBlImpl;
 import cz.metacentrum.perun.core.impl.Utils;
 import cz.metacentrum.perun.taskslib.model.Task;
 import cz.metacentrum.perun.taskslib.model.TaskResult;
@@ -270,6 +268,26 @@ public class TasksManagerEntry implements TasksManager {
 		}
 
 		tasksManagerBl.deleteTask(sess, task);
+	}
+
+	@Override
+	public void deleteTaskResultById(PerunSession sess, int taskResultId) throws PrivilegeException {
+		TaskResult result = tasksManagerBl.getTaskResultById(taskResultId);
+		Task task = tasksManagerBl.getTaskById(result.getTaskId());
+		Facility facility = task.getFacility();
+		if (!AuthzResolver.isAuthorized(sess, Role.FACILITYADMIN, facility)) {
+			throw new PrivilegeException(sess, "deleteTaskResults");
+		}
+		tasksManagerBl.deleteTaskResultById(result.getId());
+	}
+
+	@Override
+	public void deleteTaskResults(PerunSession sess, Task task, Destination destination) throws PrivilegeException {
+		Facility facility = task.getFacility();
+		if (!AuthzResolver.isAuthorized(sess, Role.FACILITYADMIN, facility)) {
+			throw new PrivilegeException(sess, "deleteTaskResults");
+		}
+		tasksManagerBl.deleteTaskResults(task.getId(), destination.getId());
 	}
 
 	public void setPerunBl(PerunBl perunBl) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/TasksManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/TasksManagerImplApi.java
@@ -86,23 +86,45 @@ public interface TasksManagerImplApi {
 	TaskResult getTaskResultById(int taskResultId);
 
 	/**
-	 * Clear all results tied to a particular Task
+	 * Delete TaskResult by its ID
 	 *
-	 * @param taskId
-	 * @return number of deleted TaskResults
+	 * @param taskResultId ID of TaskResult to delete
 	 */
-	int clearByTask(int taskId);
+	void deleteTaskResultById(int taskResultId);
 
 	/**
-	 * Clear all results
+	 * Delete all TaskResults for the particular Task
+	 *
+	 * @param taskId ID of Task to delete TaskResults
+	 * @return number of deleted TaskResults
+	 */
+	int deleteTaskResults(int taskId);
+
+	/**
+	 * Delete all TaskResults for the particular Task and Destination.
+	 *
+	 * @param taskId ID of Task to delete TaskResults
+	 * @param destinationId ID of Destination to delete TaskResults
+	 * @return number of deleted TaskResults
+	 */
+	int deleteTaskResults(int taskId, int destinationId);
+
+	/**
+	 * Delete all TaskResults older than specified number of days
+	 *
+	 * @param numDays Number of days to keep
+	 * @return number of deleted TaskResults
+	 */
+	int deleteOldTaskResults(int numDays);
+
+	/**
+	 * Delete all TaskResults
 	 *
 	 * @return number of deleted TaskResults
 	 */
-	int clearAll();
+	int deleteAllTaskResults();
 
 	int insertNewTaskResult(TaskResult taskResult);
-
-	int clearOld(int numDays);
 
 	/**
 	 * Returns list of tasks results for defined destinations (string representation).

--- a/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/service/impl/DispatcherManagerImpl.java
+++ b/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/service/impl/DispatcherManagerImpl.java
@@ -248,7 +248,7 @@ public class DispatcherManagerImpl implements DispatcherManager {
 	public void cleanOldTaskResults() {
 		if (cleanTaskResultsJobEnabled) {
 			try {
-				int numRows = tasksManagerBl.clearOld(3);
+				int numRows = tasksManagerBl.deleteOldTaskResults(3);
 				log.debug("Cleaned {} old task results for engine", numRows);
 			} catch (Throwable e) {
 				log.error("Error cleaning old task results for engine: {}", e);

--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -13394,6 +13394,84 @@ paths:
               properties:
                 task:  { type: integer, description: "task id", nullable: false }
 
+  /json/tasksManager/deleteTaskResultById:
+    post:
+      tags:
+        - TasksManager
+      operationId: deleteTaskResultById
+      summary:  Delete TaskResult by its ID.
+      responses:
+        '200':
+          $ref: '#/components/responses/VoidResponse'
+        default:
+          $ref: '#/components/responses/ExceptionResponse'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              title: taskResultIdObject
+              description: "input to deleteTaskResultObject"
+              type: object
+              required:
+                - taskResultId
+              properties:
+                taskResultId:  { type: integer, description: "task result id", nullable: false }
+
+  /json/tasksManager/deleteTaskResults/id:
+    post:
+      tags:
+        - TasksManager
+      operationId: deleteTaskResultsIds
+      summary: Delete all TaskResults for specified Task and Destination.
+      responses:
+        '200':
+          $ref: '#/components/responses/VoidResponse'
+        default:
+          $ref: '#/components/responses/ExceptionResponse'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              title: taskAndDestinationIdObject
+              description: "input to deleteTaskResultsIds"
+              type: object
+              required:
+                - taskId
+                - destinationId
+              properties:
+                taskId:  { type: integer, description: "task id", nullable: false }
+                destinationId:  { type: integer, description: "destination id", nullable: false }
+
+  /json/tasksManager/deleteTaskResults/name:
+    post:
+      tags:
+        - TasksManager
+      operationId: deleteTaskResultsNames
+      summary: Delete all TaskResults for specified Task and Destination.
+      responses:
+        '200':
+          $ref: '#/components/responses/VoidResponse'
+        default:
+          $ref: '#/components/responses/ExceptionResponse'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              title: taskAndDestinationNameObject
+              description: "input to deleteTaskResultsNames"
+              type: object
+              required:
+                - taskId
+                - destinationName
+                - destinationType
+              properties:
+                taskId:  { type: integer, description: "task id", nullable: false }
+                destinationName:  { type: string, description: "destination name", nullable: false }
+                destinationType:  { type: string, description: "destination type", nullable: false }
+
   #################################################
   #                                               #
   # RTMessagesManager                               #

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/TasksManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/TasksManagerMethod.java
@@ -7,7 +7,6 @@ import cz.metacentrum.perun.controller.model.ResourceState;
 import cz.metacentrum.perun.controller.model.ServiceState;
 import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.Service;
-import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.PerunException;
 import cz.metacentrum.perun.rpc.ApiCaller;
 import cz.metacentrum.perun.rpc.ManagerMethod;
@@ -245,7 +244,55 @@ public enum TasksManagerMethod implements ManagerMethod {
 	 */
 	deleteTask {
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
+			parms.stateChangingCheck();
 			ac.getTasksManager().deleteTask(ac.getSession(), ac.getTasksManager().getTaskById(ac.getSession(), parms.readInt("task")));
+			return null;
+		}
+	},
+
+	/*#
+	 * Delete TaskResult by its ID
+	 *
+	 * @param taskResultId int ID of TaskResult to deleted
+	 */
+	deleteTaskResultById {
+		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
+			parms.stateChangingCheck();
+			ac.getTasksManager().deleteTaskResultById(ac.getSession(), parms.readInt("taskResultId"));
+			return null;
+		}
+	},
+
+	/*#
+	 * Delete TaskResults for specified Task and Destination.
+	 *
+	 * @param taskId int ID of Task to delete TaskResults for
+	 * @param destinationId int ID of Destination to delete TaskResults for
+	 */
+	/*#
+	 * Delete TaskResults for specified Task and Destination.
+	 *
+	 * @param taskId int ID of Task to delete TaskResults for
+	 * @param destinationName String Name of Destination to delete TaskResults for
+	 * @param destinationType String Type of Destination to delete TaskResults for
+	 */
+	deleteTaskResults {
+		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
+			parms.stateChangingCheck();
+			if (parms.contains("destinationId")) {
+				ac.getTasksManager().deleteTaskResults(ac.getSession(),
+						ac.getTasksManager().getTaskById(ac.getSession(), parms.readInt("taskId")),
+						ac.getServicesManager().getDestinationById(ac.getSession(), parms.readInt("destinationId")));
+			} else {
+				ac.getTasksManager().deleteTaskResults(ac.getSession(),
+						ac.getTasksManager().getTaskById(ac.getSession(), parms.readInt("taskId")),
+						ac.getServicesManager().getDestinationById(ac.getSession(),
+								ac.getServicesManager().getDestinationIdByName(
+										ac.getSession(),
+										parms.readString("destinationName"),
+										parms.readString("destinationType")
+								)));
+			}
 			return null;
 		}
 	};

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/UiElements.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/UiElements.java
@@ -557,6 +557,9 @@ public class UiElements {
 				} else if (go.getObjectType().equalsIgnoreCase("ResourceTag")) {
 					ResourceTag tag = go.cast();
 					items = items.concat("<li>" + SafeHtmlUtils.fromString((tag.getName()!=null) ? tag.getName() : "").asString() + "</li>");
+				} else if (go.getObjectType().equalsIgnoreCase("TaskResult")) {
+					TaskResult result = go.cast();
+					items = items.concat("<li>" + SafeHtmlUtils.fromString((result.getDestination()!=null) ? (result.getDestination().getDestination() + " / " + result.getId()) : "").asString() + "</li>");
 				} else {
 					items = items.concat("<li>" + SafeHtmlUtils.fromString((go.getName()!=null) ? go.getName() : "").asString() + "</li>");
 				}

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/tasksManager/DeleteTaskResults.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/tasksManager/DeleteTaskResults.java
@@ -1,0 +1,114 @@
+package cz.metacentrum.perun.webgui.json.tasksManager;
+
+import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.json.client.JSONNumber;
+import com.google.gwt.json.client.JSONObject;
+import cz.metacentrum.perun.webgui.client.PerunWebSession;
+import cz.metacentrum.perun.webgui.json.JsonCallbackEvents;
+import cz.metacentrum.perun.webgui.json.JsonPostClient;
+import cz.metacentrum.perun.webgui.model.PerunError;
+
+/**
+ * Ajax query to delete TaskResults
+ *
+ * @author Pavel Zlamal <zlamal@cesnet.cz>
+ */
+public class DeleteTaskResults {
+
+	// Session
+	private PerunWebSession session = PerunWebSession.getInstance();
+	// External events
+	private JsonCallbackEvents events = new JsonCallbackEvents();
+	// Json URL
+	static private final String JSON_URL = "tasksManager/deleteTaskResultById";
+	static private final String JSON_URL_MULTIPLE = "tasksManager/deleteTaskResults";
+
+	/**
+	 * New instance of DeleteTask
+	 */
+	public DeleteTaskResults() {}
+
+	/**
+	 * New instance of DeleteTask with external events
+	 *
+	 * @param events external events
+	 */
+	public DeleteTaskResults(JsonCallbackEvents events) {
+		this.events = events;
+	}
+
+	/**
+	 * Deletes Task from DB
+	 *
+	 * @param taskId id of Task to be deleted
+	 */
+	public void deleteTaskResults(final int taskId, final int destinationId) {
+
+		// whole JSON query
+		JSONObject jsonQuery = new JSONObject();
+		jsonQuery.put("taskId", new JSONNumber(taskId));
+		jsonQuery.put("destinationId", new JSONNumber(destinationId));
+
+		// new events
+		JsonCallbackEvents newEvents = new JsonCallbackEvents(){
+			public void onError(PerunError error) {
+				session.getUiElements().setLogErrorText("Deleting of TaskResults for Task: "+taskId+" failed.");
+				events.onError(error);
+			};
+
+			public void onFinished(JavaScriptObject jso) {
+				session.getUiElements().setLogSuccessText("TaskResults of Task: "+taskId+" deleted successfully.");
+				events.onFinished(jso);
+			};
+
+			public void onLoadingStart() {
+				events.onLoadingStart();
+			};
+		};
+
+		// sending data
+		JsonPostClient jspc = new JsonPostClient(newEvents);
+		jspc.sendData(JSON_URL_MULTIPLE, jsonQuery);
+
+
+	}
+
+	/**
+	 * Deletes TaskResult from DB
+	 *
+	 * @param taskResultId ID of TaskResult to be deleted
+	 */
+	public void deleteTaskResult(final int taskResultId) {
+
+		// whole JSON query
+		JSONObject jsonQuery = new JSONObject();
+		jsonQuery.put("taskResultId", new JSONNumber(taskResultId));
+
+		// new events
+		JsonCallbackEvents newEvents = new JsonCallbackEvents(){
+			public void onError(PerunError error) {
+				session.getUiElements().setLogErrorText("Deleting of TaskResult: "+taskResultId+" failed.");
+				events.onError(error);
+			};
+
+			public void onFinished(JavaScriptObject jso) {
+				session.getUiElements().setLogSuccessText("TaskResult: "+taskResultId+" deleted successfully.");
+				events.onFinished(jso);
+			};
+
+			public void onLoadingStart() {
+				events.onLoadingStart();
+			};
+		};
+
+		// sending data
+		JsonPostClient jspc = new JsonPostClient(newEvents);
+		jspc.sendData(JSON_URL, jsonQuery);
+
+	}
+
+	public void setEvents(JsonCallbackEvents events) {
+		this.events = events;
+	}
+
+}

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/tasksManager/GetRichTaskResultsByTask.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/tasksManager/GetRichTaskResultsByTask.java
@@ -123,6 +123,8 @@ public class GetRichTaskResultsByTask implements JsonCallback, JsonCallbackTable
 		table.setEmptyTableWidget(loaderImage);
 		loaderImage.setEmptyResultMessage("No propagation results found.");
 
+		table.addCheckBoxColumn();
+
 		table.addIdColumn("Result Id", fieldUpdater, 85);
 
 		// destination column

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/tasksManager/GetRichTaskResultsByTaskAndDestination.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/tasksManager/GetRichTaskResultsByTaskAndDestination.java
@@ -112,6 +112,8 @@ public class GetRichTaskResultsByTaskAndDestination implements JsonCallback, Jso
 		table.setEmptyTableWidget(loaderImage);
 		loaderImage.setEmptyResultMessage("No propagation results found.");
 
+		table.addCheckBoxColumn();
+
 		table.addIdColumn("Result Id", null, 85);
 
 		// destination column

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/TaskResult.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/TaskResult.java
@@ -31,6 +31,10 @@ public class TaskResult extends JavaScriptObject {
 		return this.service;
 	}-*/;
 
+	public final native int getTaskId() /*-{
+		return this.taskId;
+	}-*/;
+
 	public final native String getStandardMessage() /*-{
 		if (!this.standardMessage) { return ""; }
 		return this.standardMessage;

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/TaskResultsForDestinationTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/TaskResultsForDestinationTabItem.java
@@ -1,6 +1,8 @@
 package cz.metacentrum.perun.webgui.tabs.facilitiestabs;
 
 import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.user.cellview.client.CellTable;
 import com.google.gwt.user.client.ui.Label;
@@ -11,10 +13,13 @@ import com.google.gwt.user.client.ui.Widget;
 import cz.metacentrum.perun.webgui.client.PerunWebSession;
 import cz.metacentrum.perun.webgui.client.UiElements;
 import cz.metacentrum.perun.webgui.client.mainmenu.MainMenu;
+import cz.metacentrum.perun.webgui.client.resources.ButtonType;
 import cz.metacentrum.perun.webgui.client.resources.PerunEntity;
 import cz.metacentrum.perun.webgui.client.resources.SmallIcons;
 import cz.metacentrum.perun.webgui.json.GetEntityById;
 import cz.metacentrum.perun.webgui.json.JsonCallbackEvents;
+import cz.metacentrum.perun.webgui.json.JsonUtils;
+import cz.metacentrum.perun.webgui.json.tasksManager.DeleteTaskResults;
 import cz.metacentrum.perun.webgui.json.tasksManager.GetRichTaskResultsByTaskAndDestination;
 import cz.metacentrum.perun.webgui.model.Destination;
 import cz.metacentrum.perun.webgui.model.Task;
@@ -23,8 +28,10 @@ import cz.metacentrum.perun.webgui.tabs.FacilitiesTabs;
 import cz.metacentrum.perun.webgui.tabs.TabItem;
 import cz.metacentrum.perun.webgui.tabs.TabItemWithUrl;
 import cz.metacentrum.perun.webgui.tabs.UrlMapper;
+import cz.metacentrum.perun.webgui.widgets.CustomButton;
 import cz.metacentrum.perun.webgui.widgets.TabMenu;
 
+import java.util.ArrayList;
 import java.util.Map;
 import java.util.Objects;
 
@@ -97,11 +104,37 @@ public class TaskResultsForDestinationTabItem implements TabItem, TabItemWithUrl
 		VerticalPanel vp = new VerticalPanel();
 		vp.setSize("100%", "100%");
 
-		final GetRichTaskResultsByTaskAndDestination callback =
-				new GetRichTaskResultsByTaskAndDestination(task.getId(), destinationId);
+		final GetRichTaskResultsByTaskAndDestination callback = new GetRichTaskResultsByTaskAndDestination(task.getId(), destinationId);
+
+		// refresh table events
+		final JsonCallbackEvents events = JsonCallbackEvents.refreshTableEvents(callback);
 
 		TabMenu menu = new TabMenu();
 		menu.addWidget(UiElements.getRefreshButton(this));
+
+		final CustomButton removeButton = TabMenu.getPredefinedButton(ButtonType.REMOVE, "Remove all TaskResults");
+		removeButton.addClickHandler(new ClickHandler() {
+			@Override
+			public void onClick(ClickEvent event) {
+				final ArrayList<TaskResult> tasksResultsToDelete = callback.getTableSelectedList();
+				String text = "Following TaskResults will be deleted.";
+				UiElements.showDeleteConfirm(tasksResultsToDelete, text, new ClickHandler() {
+					@Override
+					public void onClick(ClickEvent clickEvent) {
+						// TODO - SHOULD HAVE ONLY ONE CALLBACK TO CORE !!
+						for (int i = 0; i < tasksResultsToDelete.size(); i++) {
+							if (i == tasksResultsToDelete.size()-1) {
+								DeleteTaskResults request = new DeleteTaskResults(JsonCallbackEvents.disableButtonEvents(removeButton, events));
+								request.deleteTaskResult(tasksResultsToDelete.get(i).getId());
+							} else {
+								DeleteTaskResults request = new DeleteTaskResults(JsonCallbackEvents.disableButtonEvents(removeButton));
+								request.deleteTaskResult(tasksResultsToDelete.get(i).getId());
+							}
+						}
+					}});
+			}
+		});
+		menu.addWidget(removeButton);
 
 		CellTable<TaskResult> table = callback.getTable();
 
@@ -114,6 +147,9 @@ public class TaskResultsForDestinationTabItem implements TabItem, TabItemWithUrl
 		vp.add(sp);
 
 		session.getUiElements().resizePerunTable(sp, 350, this);
+
+		removeButton.setEnabled(false);
+		JsonUtils.addTableManagedButton(callback, table, removeButton);
 
 		this.contentWidget.setWidget(vp);
 


### PR DESCRIPTION
- Sometimes we want to manually delete TaskResults, it is now possible
  to delete either all TaskResults for Task/Destination or
  each TaskResult by its ID.
- New delete methods added to the core and RPC API.
  It uses old authz in order to ease on cherry-picking to production.
  It will be fixed in own (following) pull-request.
- Impl layer of other delete methods was fixed, method names unified,
  uses try/catch on runtime exceptions etc.
- Require POST when calling API.
- Added RPC docs, fixed core API docs.
- We can delete TaskResults on its detail page in GUI (facility admin section).
- Methods added to OpenAPI.