### PR TITLE
separate logs for group sync

### DIFF
--- a/perun-base/src/main/resources/logback-default.xml
+++ b/perun-base/src/main/resources/logback-default.xml
@@ -106,19 +106,27 @@
 		<appender-ref ref="perun-cabinet"/>
 	</logger>
 
-
-	<appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="perun-core">
-		<file>${LOGDIR}perun-core.log</file>
-		<rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-			<fileNamePattern>${LOGDIR}perun-core.log.%d.%i</fileNamePattern>
-			<maxFileSize>100MB</maxFileSize>
-			<maxHistory>${MAXHISTORY}</maxHistory>
-			<totalSizeCap>1GB</totalSizeCap>
-		</rollingPolicy>
-		<encoder>
-			<pattern>${ENCODER_PATTERN}</pattern>
-		</encoder>
+	<appender name="perun-core" class="ch.qos.logback.classic.sift.SiftingAppender">
+		<discriminator>
+			<key>logFileName</key>
+			<defaultValue>perun-core</defaultValue>
+		</discriminator>
+		<sift>
+			<appender name="sift-${logFileName}" class="ch.qos.logback.core.rolling.RollingFileAppender">
+				<file>${LOGDIR}${logFileName}.log</file>
+				<rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+					<fileNamePattern>${LOGDIR}${logFileName}.log.%d.%i</fileNamePattern>
+					<maxFileSize>100MB</maxFileSize>
+					<maxHistory>${MAXHISTORY}</maxHistory>
+					<totalSizeCap>1GB</totalSizeCap>
+				</rollingPolicy>
+				<encoder>
+					<pattern>${ENCODER_PATTERN}</pattern>
+				</encoder>
+			</appender>
+		</sift>
 	</appender>
+
 	<logger name="cz.metacentrum.perun.core" level="info" additivity="false">
 		<appender-ref ref="perun-core"/>
 	</logger>

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
@@ -114,6 +114,7 @@ import cz.metacentrum.perun.core.implApi.GroupsManagerImplApi;
 import cz.metacentrum.perun.core.implApi.modules.attributes.AbstractMembershipExpirationRulesModule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 
 import java.sql.Timestamp;
 import java.text.ParseException;
@@ -156,6 +157,7 @@ import static cz.metacentrum.perun.core.impl.PerunLocksUtils.lockGroupMembership
 public class GroupsManagerBlImpl implements GroupsManagerBl {
 
 	private final static Logger log = LoggerFactory.getLogger(GroupsManagerBlImpl.class);
+	private static final String MDC_LOG_FILE_NAME = "logFileName";
 
 	private final GroupsManagerImplApi groupsManagerImpl;
 	private PerunBl perunBl;
@@ -1649,6 +1651,9 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 		ExtSource membersSource = null;
 
 		try {
+			//set Logback's Mapped Diagnostic Context key for the current thread
+			MDC.put(MDC_LOG_FILE_NAME, "groupsync-"+group.getName());
+
 			long startTime = System.nanoTime();
 			getPerunBl().getAuditer().log(sess,new GroupSyncStarted(group));
 			log.debug("Group synchronization for {} has been started.", group);
@@ -1701,6 +1706,7 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 			log.info("Group synchronization for {} has been finished.", group);
 		} finally {
 			closeExtSourcesAfterSynchronization(membersSource, source);
+			MDC.remove(MDC_LOG_FILE_NAME);
 		}
 
 		return skippedMembers;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
@@ -143,10 +143,10 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import static java.util.Collections.reverseOrder;
-import static java.util.Comparator.comparingInt;
 
 import static cz.metacentrum.perun.core.impl.PerunLocksUtils.lockGroupMembership;
+import static java.util.Collections.reverseOrder;
+import static java.util.Comparator.comparingInt;
 
 /**
  * GroupsManager business logic
@@ -1652,7 +1652,7 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 
 		try {
 			//set Logback's Mapped Diagnostic Context key for the current thread
-			MDC.put(MDC_LOG_FILE_NAME, "groupsync-"+group.getName());
+			MDC.put(MDC_LOG_FILE_NAME, "groupsync/group_" + group.getId());
 
 			long startTime = System.nanoTime();
 			getPerunBl().getAuditer().log(sess,new GroupSyncStarted(group));


### PR DESCRIPTION
- added putting a special value  in Logback's Mapped Diagnostic Context under the key "logFileName" for each group synchronization
- added an example into the logback-default.xml file how to use that value to log into separate files. If the value is not set, the default "perun-core" would be used as the file name