### PR TITLE
CORE: Use case insensitive comparing in attribute tcsMails:mu

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_tcsMails_mu.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_tcsMails_mu.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.function.Function;
@@ -53,7 +54,10 @@ public class urn_perun_user_attribute_def_virt_tcsMails_mu extends UserVirtualAt
 
 		Attribute attribute = new Attribute(attributeDefinition);
 
+		// to keep actual mails in order
 		SortedSet<String> tcsMailsValue = new TreeSet<>();
+		// to filter out case insensitive duplicates
+		Set<String> compareSet = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
 
 		List<String> namesOfAttributes = Arrays.asList(A_U_D_preferredMail, A_U_D_ISMail, A_U_D_o365EmailAddressesMU, A_U_D_publicAliasMails, A_U_D_privateAliasMails);
 
@@ -66,10 +70,22 @@ public class urn_perun_user_attribute_def_virt_tcsMails_mu extends UserVirtualAt
 			if (sourceAttribute != null) {
 				// gather values of all attributes
 				if (sourceAttribute.getType().equals(String.class.getName())) {
-					if (sourceAttribute.getValue() != null) tcsMailsValue.add(sourceAttribute.valueAsString().trim());
+					if (sourceAttribute.getValue() != null) {
+						if (!compareSet.contains(sourceAttribute.valueAsString().trim())) {
+							// add only case-insensitive unique values
+							compareSet.add(sourceAttribute.valueAsString().trim());
+							tcsMailsValue.add(sourceAttribute.valueAsString().trim());
+						}
+					}
 				} else if (sourceAttribute.getType().equals(ArrayList.class.getName())) {
 					if (sourceAttribute.getValue() != null) {
-						tcsMailsValue.addAll(sourceAttribute.valueAsList().stream().map(String::trim).collect(Collectors.toList()));
+						sourceAttribute.valueAsList().stream().map(String::trim).collect(Collectors.toList()).forEach(s -> {
+							if (!compareSet.contains(s)) {
+								// add only case-insensitive unique values
+								compareSet.add(s);
+								tcsMailsValue.add(s);
+							}
+						});
 					}
 				} else {
 					//unexpected type of value, log it and skip the attribute

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_tcsMails_muTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_tcsMails_muTest.java
@@ -44,7 +44,7 @@ public class urn_perun_user_attribute_def_virt_tcsMails_muTest {
 	private final String email3 = "email3@mail.cz";
 	private final String email4 = "email4@mail.cz";
 	private final String email5 = "email5@mail.cz";
-	private final String email6 = " email5@mail.cz"; // to check for the trim() and uniqueness
+	private final String email6 = " Email5@mail.cz"; // to check for the trim() and uniqueness
 
 	Attribute preferredMailAttr = setUpUserAttribute(1, "preferredMail", String.class.getName(), email1);
 	Attribute isMailAttr = setUpUserAttribute(2, "ISMail", String.class.getName(), email2);
@@ -89,12 +89,12 @@ public class urn_perun_user_attribute_def_virt_tcsMails_muTest {
 		ArrayList<String> attributeValue = classInstance.getAttributeValue(sess, user, tcsMailsAttrDef).valueAsList();
 		assertNotNull(attributeValue);
 		//we want to be sure, that preferredEmail is first (defined by sorting in module)
-		assertEquals(attributeValue.get(0), email1);
-		assertEquals(attributeValue.get(1), email2.trim()); // check if was trimmed
-		assertEquals(attributeValue.get(2), email3);
-		assertEquals(attributeValue.get(3), email4);
-		assertEquals(attributeValue.get(4), email5);
-		assertEquals(attributeValue.get(4), email6.trim()); // check if was trimmed and then equals "email5"
+		assertEquals(email1, attributeValue.get(0));
+		assertEquals(email2.trim(), attributeValue.get(1)); // check if was trimmed
+		assertEquals(email3, attributeValue.get(2));
+		assertEquals(email4, attributeValue.get(3));
+		assertEquals(email5, attributeValue.get(4));
+		assertEquals(email6.trim().toLowerCase(), attributeValue.get(4)); // check if was trimmed and then equals "email5"
 		assertEquals(5, attributeValue.size());
 
 	}


### PR DESCRIPTION
- Compare values ignoring case when making unique set of tcs mail
  addresses, since mails generally ignore case and same is true
  for the LDAP attribute, which stores them and prevents duplicates.