### PR TITLE
Edit of findUsers

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/CoreConfig.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/CoreConfig.java
@@ -81,6 +81,7 @@ public class CoreConfig {
 	private List<String> autocreatedNamespaces;
 	private String groupNameSecondaryRegex;
 	private String groupFullNameSecondaryRegex;
+	private List<String> attributesToSearchUsersAndMembersBy;
 
 	public int getGroupMaxConcurentGroupsToSynchronize() {
 		return groupMaxConcurentGroupsToSynchronize;
@@ -670,5 +671,13 @@ public class CoreConfig {
 
 	public void setGroupFullNameSecondaryRegex(String groupFullNameSecondaryRegex) {
 		this.groupFullNameSecondaryRegex = groupFullNameSecondaryRegex;
+	}
+
+	public List<String> getAttributesToSearchUsersAndMembersBy() {
+		return attributesToSearchUsersAndMembersBy;
+	}
+
+	public void setAttributesToSearchUsersAndMembersBy(List<String> attributesToSearchUsersAndMembersBy) {
+		this.attributesToSearchUsersAndMembersBy = attributesToSearchUsersAndMembersBy;
 	}
 }

--- a/perun-base/src/main/resources/perun-base.xml
+++ b/perun-base/src/main/resources/perun-base.xml
@@ -64,6 +64,7 @@
 		<property name="rtSendToMail" value="${perun.rt.sendToMail}" />
 		<property name="queryTimeout" value="${perun.queryTimeout}" />
 		<property name="defaultLoaIdP" value="${perun.defaultLoa.idp}"/>
+		<property name="attributesToSearchUsersAndMembersBy" value="#{'${perun.attributesToSearchUsersAndMembersBy}'.split('\s*,\s*')}"/>
 	</bean>
 
 
@@ -127,6 +128,7 @@
 				<prop key="perun.allowedCorsDomains"></prop>
 				<prop key="perun.queryTimeout">-1</prop>
 				<prop key="perun.defaultLoa.idp">2</prop>
+				<prop key="perun.attributesToSearchUsersAndMembersBy">urn:perun:user:attribute-def:def:preferredMail, urn:perun:member:attribute-def:def:mail</prop>
 				<!--
 				   this creates a map from OIDC issuer to user extsources that are used for looking up a user identified by "sub" claim
 				-->

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/MembersManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/MembersManagerImpl.java
@@ -508,14 +508,7 @@ public class MembersManagerImpl implements MembersManagerImplApi {
 			sponsoredQueryString+=" members.sponsored=1 and ";
 		}
 
-		String userNameQueryString;
-		if (Compatibility.isPostgreSql()) {
-			userNameQueryString= " strpos(lower("+Compatibility.convertToAscii("COALESCE(users.first_name,'') || COALESCE(users.middle_name,'') || COALESCE(users.last_name,'')")+"),:nameString) > 0 ";
-		} else if (Compatibility.isHSQLDB()) {
-			userNameQueryString=" lower("+Compatibility.convertToAscii("COALESCE(users.first_name,'') || COALESCE(users.middle_name,'') || COALESCE(users.last_name,'')")+") like '%' || :nameString || '%' ";
-		} else {
-			throw new InternalErrorException("Unsupported db type");
-		}
+		String userNameQueryString = Utils.prepareUserSearchQuerySimilarMatch();
 
 		String idQueryString = "";
 		try {
@@ -526,39 +519,12 @@ public class MembersManagerImpl implements MembersManagerImplApi {
 		}
 
 		// Divide attributes received from CoreConfig into member, user and userExtSource attributes
-		List<String> allAttributes = BeansUtils.getCoreConfig().getAttributesToSearchUsersAndMembersBy();
-		List<String> memberAttributes = new ArrayList<>();
-		List<String> userAttributes = new ArrayList<>();
-		List<String> uesAttributes = new ArrayList<>();
-		for (String attribute : allAttributes) {
-			if (attribute.startsWith(AttributesManager.NS_MEMBER_ATTR)) {
-				memberAttributes.add(attribute);
-			} else if (attribute.startsWith(AttributesManager.NS_USER_ATTR)) {
-				userAttributes.add(attribute);
-			} else if (attribute.startsWith(AttributesManager.NS_UES_ATTR)) {
-				uesAttributes.add(attribute);
-			}
-		}
+		Map<String, List<String>> attributesToSearchBy = Utils.getDividedAttributes();
 
-		Pair<String, String> memberAttributesQueryString = new Pair<>("", "");
-		if (!memberAttributes.isEmpty()) {
-			memberAttributesQueryString.put(" left join member_attr_values mav on members.id=mav.member_id and mav.attr_id in (select id from attr_names where attr_name in (:memberAttributes))", " lower(mav.attr_value)=lower(:searchString) or " );
-		}
-		Pair<String, String> userAttributesQueryString = new Pair<>("", "");
-		if (!userAttributes.isEmpty()) {
-			userAttributesQueryString.put(" left join user_attr_values uav on users.id=uav.user_id and uav.attr_id in (select id from attr_names where attr_name in (:userAttributes))" , " lower(uav.attr_value)=lower(:searchString) or ");
-		}
-		Pair<String, String> uesAttributesQueryString = new Pair<>("", "");
-		if (!uesAttributes.isEmpty()) {
-			uesAttributesQueryString.put(" left join user_ext_source_attr_values uesav on uesav.user_ext_source_id=ues.id and uesav.attr_id in (select id from attr_names where attr_name in (:uesAttributes))", " lower(uesav.attr_value)=lower(:searchString) or ");
-		}
+		// Parts of query to search by attributes
+		Map<String, Pair<String, String>> attributesToSearchByQueries = Utils.getAttributesQuery(attributesToSearchBy.get("memberAttributes"), attributesToSearchBy.get("userAttributes"), attributesToSearchBy.get("uesAttributes"));
 
-		MapSqlParameterSource namedParams = new MapSqlParameterSource();
-		namedParams.addValue("searchString", searchString);
-		namedParams.addValue("nameString", Utils.utftoasci(searchString.toLowerCase()));
-		namedParams.addValue("memberAttributes", memberAttributes);
-		namedParams.addValue("userAttributes", userAttributes);
-		namedParams.addValue("uesAttributes", uesAttributes);
+		MapSqlParameterSource namedParams = Utils.getMapSqlParameterSourceToSearchUsersOrMembers(searchString, attributesToSearchBy);
 
 		//searching by member attributes
 		//searching by user attributes
@@ -570,17 +536,17 @@ public class MembersManagerImpl implements MembersManagerImplApi {
 				" from members " +
 				" left join users on members.user_id=users.id " +
 				" left join user_ext_sources ues on ues.user_id=users.id " +
-				memberAttributesQueryString.getLeft() +
-				userAttributesQueryString.getLeft() +
-				uesAttributesQueryString.getLeft() +
+				attributesToSearchByQueries.get("memberAttributesQuery").getLeft() +
+				attributesToSearchByQueries.get("userAttributesQuery").getLeft() +
+				attributesToSearchByQueries.get("uesAttributesQuery").getLeft() +
 				" where " +
 				voIdQueryString +
 				sponsoredQueryString +
 				" ( " +
 				" lower(ues.login_ext)=lower(:searchString) or " +
-				memberAttributesQueryString.getRight() +
-				userAttributesQueryString.getRight() +
-				uesAttributesQueryString.getRight() +
+				attributesToSearchByQueries.get("memberAttributesQuery").getRight() +
+				attributesToSearchByQueries.get("userAttributesQuery").getRight() +
+				attributesToSearchByQueries.get("uesAttributesQuery").getRight() +
 				idQueryString +
 				userNameQueryString +
 				" ) ", namedParams, MEMBER_MAPPER));

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/UsersManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/UsersManagerImpl.java
@@ -816,18 +816,18 @@ public class UsersManagerImpl implements UsersManagerImplApi {
 		if (exactMatch) {
 			// Part of query to search by user name (exact)
 			if (Compatibility.isPostgreSql()) {
-				userNameQueryString= " strpos(lower("+Compatibility.convertToAscii("COALESCE(users.first_name,'') || COALESCE(users.middle_name,'') || COALESCE(users.last_name,'')") + ")=?";
+				userNameQueryString= " strpos(lower("+Compatibility.convertToAscii("COALESCE(users.first_name,'') || COALESCE(users.middle_name,'') || COALESCE(users.last_name,'')") + ")=:nameString";
 			} else if (Compatibility.isHSQLDB()) {
-				userNameQueryString=" lower("+Compatibility.convertToAscii("COALESCE(users.first_name,'') || COALESCE(users.middle_name,'') || COALESCE(users.last_name,'')")+")=?";
+				userNameQueryString=" lower("+Compatibility.convertToAscii("COALESCE(users.first_name,'') || COALESCE(users.middle_name,'') || COALESCE(users.last_name,'')")+")=:nameString";
 			} else {
 				throw new InternalErrorException("Unsupported db type");
 			}
 		} else {
 			// Part of query to search by user name (not exact)
 			if (Compatibility.isPostgreSql()) {
-				userNameQueryString = " strpos(lower(" + Compatibility.convertToAscii("COALESCE(users.first_name,'') || COALESCE(users.middle_name,'') || COALESCE(users.last_name,'')") + "),?) > 0 ";
+				userNameQueryString = " strpos(lower(" + Compatibility.convertToAscii("COALESCE(users.first_name,'') || COALESCE(users.middle_name,'') || COALESCE(users.last_name,'')") + "),:nameString) > 0 ";
 			} else if (Compatibility.isHSQLDB()) {
-				userNameQueryString = " lower(" + Compatibility.convertToAscii("COALESCE(users.first_name,'') || COALESCE(users.middle_name,'') || COALESCE(users.last_name,'')") + ") like '%' || ? || '%' ";
+				userNameQueryString = " lower(" + Compatibility.convertToAscii("COALESCE(users.first_name,'') || COALESCE(users.middle_name,'') || COALESCE(users.last_name,'')") + ") like '%' || :nameString || '%' ";
 			} else {
 				throw new InternalErrorException("Unsupported db type");
 			}
@@ -844,18 +844,38 @@ public class UsersManagerImpl implements UsersManagerImplApi {
 
 		// Divide attributes received from CoreConfig into member, user and userExtSource attributes
 		List<String> allAttributes = BeansUtils.getCoreConfig().getAttributesToSearchUsersAndMembersBy();
-		StringBuilder memberAttributes = new StringBuilder("''");
-		StringBuilder userAttributes = new StringBuilder("''");
-		StringBuilder uesAttributes = new StringBuilder("''");
+		List<String> memberAttributes = new ArrayList<>();
+		List<String> userAttributes = new ArrayList<>();
+		List<String> uesAttributes = new ArrayList<>();
 		for (String attribute : allAttributes) {
 			if (attribute.startsWith(AttributesManager.NS_MEMBER_ATTR)) {
-				memberAttributes.append(",'").append(attribute).append("'");
+				memberAttributes.add(attribute);
 			} else if (attribute.startsWith(AttributesManager.NS_USER_ATTR)) {
-				userAttributes.append(",'").append(attribute).append("'");
+				userAttributes.add(attribute);
 			} else if (attribute.startsWith(AttributesManager.NS_UES_ATTR)) {
-				uesAttributes.append(",'").append(attribute).append("'");
+				uesAttributes.add(attribute);
 			}
 		}
+
+		Pair<String, String> memberAttributesQueryString = new Pair<>("", "");
+		if (!memberAttributes.isEmpty()) {
+			memberAttributesQueryString.put(" left join member_attr_values mav on members.id=mav.member_id and mav.attr_id in (select id from attr_names where attr_name in (:memberAttributes))", " lower(mav.attr_value)=lower(:searchString) or " );
+		}
+		Pair<String, String> userAttributesQueryString = new Pair<>("", "");
+		if (!userAttributes.isEmpty()) {
+			userAttributesQueryString.put(" left join user_attr_values uav on users.id=uav.user_id and uav.attr_id in (select id from attr_names where attr_name in (:userAttributes))" , " lower(uav.attr_value)=lower(:searchString) or ");
+		}
+		Pair<String, String> uesAttributesQueryString = new Pair<>("", "");
+		if (!uesAttributes.isEmpty()) {
+			uesAttributesQueryString.put(" left join user_ext_source_attr_values uesav on uesav.user_ext_source_id=ues.id and uesav.attr_id in (select id from attr_names where attr_name in (:uesAttributes))", " lower(uesav.attr_value)=lower(:searchString) or ");
+		}
+
+		MapSqlParameterSource namedParams = new MapSqlParameterSource();
+		namedParams.addValue("searchString", searchString);
+		namedParams.addValue("nameString", Utils.utftoasci(searchString.toLowerCase()));
+		namedParams.addValue("memberAttributes", memberAttributes);
+		namedParams.addValue("userAttributes", userAttributes);
+		namedParams.addValue("uesAttributes", uesAttributes);
 
 		// Search by member attributes
 		// Search by user attributes
@@ -863,22 +883,22 @@ public class UsersManagerImpl implements UsersManagerImplApi {
 		// Search by userExtSource attributes
 		// Search by user id
 		// Search by name for user
-		Set<User> users = new HashSet<>(jdbc.query("select distinct " + userMappingSelectQuery +
+		Set<User> users = new HashSet<>(namedParameterJdbcTemplate.query("select distinct " + userMappingSelectQuery +
 			" from users " +
-			" left join members m on users.id=m.user_id " +
-			" left join member_attr_values mav on m.id=mav.member_id and mav.attr_id in (select id from attr_names where attr_name in (" + memberAttributes.toString() + "))" +
-			" left join user_attr_values uav on users.id=uav.user_id and uav.attr_id in (select id from attr_names where attr_name in (" + userAttributes.toString() + "))" +
+			" left join members on users.id=members.user_id " +
 			" left join user_ext_sources ues on ues.user_id=users.id " +
-			" left join user_ext_source_attr_values uesav on uesav.user_ext_source_id=ues.id and uesav.attr_id in (select id from attr_names where attr_name in (" + uesAttributes.toString() + "))" +
+			memberAttributesQueryString.getLeft() +
+			userAttributesQueryString.getLeft() +
+			uesAttributesQueryString.getLeft() +
 			" where " +
 			" ( " +
-			" lower(mav.attr_value)=lower(?) or " +
-			" lower(uav.attr_value)=lower(?) or " +
-			" lower(ues.login_ext)=lower(?) or " +
-			" lower(uesav.attr_value)=lower(?) or " +
+			" lower(ues.login_ext)=lower(:searchString) or " +
+			memberAttributesQueryString.getRight() +
+			userAttributesQueryString.getRight() +
+			uesAttributesQueryString.getRight() +
 			idQueryString +
 			userNameQueryString +
-			" ) ", USER_MAPPER, searchString, searchString, searchString, searchString, Utils.utftoasci(searchString.toLowerCase())));
+			" ) ", namedParams, USER_MAPPER));
 
 		log.debug("Searching for users using searchString '{}'", searchString);
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Utils.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Utils.java
@@ -2,6 +2,7 @@ package cz.metacentrum.perun.core.impl;
 
 import com.zaxxer.hikari.HikariDataSource;
 import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.BeansUtils;
 import cz.metacentrum.perun.core.api.Destination;
 import cz.metacentrum.perun.core.api.ExtSource;
@@ -39,6 +40,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.mail.MailException;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
@@ -1637,5 +1639,125 @@ public class Utils {
 		} catch (PatternSyntaxException e) {
 			throw new InternalErrorException("Invalid group name regex defined: " + regex, e);
 		}
+	}
+
+	/**
+	 * Returns search query to search by user name (exact match) based on databased in use.
+	 *
+	 * @return search query
+	 */
+	public static String prepareUserSearchQueryExactMatch() {
+		if (Compatibility.isPostgreSql()) {
+			return " strpos(lower("+Compatibility.convertToAscii("COALESCE(users.first_name,'') || COALESCE(users.middle_name,'') || COALESCE(users.last_name,'')") + ")=:nameString";
+		} else if (Compatibility.isHSQLDB()) {
+			return " lower("+Compatibility.convertToAscii("COALESCE(users.first_name,'') || COALESCE(users.middle_name,'') || COALESCE(users.last_name,'')")+")=:nameString";
+		} else {
+			throw new InternalErrorException("Unsupported db type");
+		}
+	}
+
+	/**
+	 * Returns search query to search by user name (similar match) based on databased in use.
+	 *
+	 * @return search query
+	 */
+	public static String prepareUserSearchQuerySimilarMatch() {
+		if (Compatibility.isPostgreSql()) {
+			return " strpos(lower(" + Compatibility.convertToAscii("COALESCE(users.first_name,'') || COALESCE(users.middle_name,'') || COALESCE(users.last_name,'')") + "),:nameString) > 0 ";
+		} else if (Compatibility.isHSQLDB()) {
+			return " lower(" + Compatibility.convertToAscii("COALESCE(users.first_name,'') || COALESCE(users.middle_name,'') || COALESCE(users.last_name,'')") + ") like '%' || :nameString || '%' ";
+		} else {
+			throw new InternalErrorException("Unsupported db type");
+		}
+	}
+
+	/**
+	 * Takes attributes from CoreConfig used in users or members search and divides them into correct categories based
+	 * on attribute type (member, user, userExtSource).
+	 *
+	 * Then returns map: memberAttributes -> list of member attributes
+	 *                   userAttributes -> list of user attributes
+	 *                   uesAttributes -> list of userExtSource attributes
+	 *
+	 * @return map of attributes
+	 */
+	public static Map<String, List<String>> getDividedAttributes() {
+		Map<String, List<String>> result = new HashMap<>();
+
+		List<String> allAttributes = BeansUtils.getCoreConfig().getAttributesToSearchUsersAndMembersBy();
+		List<String> memberAttributes = new ArrayList<>();
+		List<String> userAttributes = new ArrayList<>();
+		List<String> uesAttributes = new ArrayList<>();
+		for (String attribute : allAttributes) {
+			if (attribute.startsWith(AttributesManager.NS_MEMBER_ATTR)) {
+				memberAttributes.add(attribute);
+			} else if (attribute.startsWith(AttributesManager.NS_USER_ATTR)) {
+				userAttributes.add(attribute);
+			} else if (attribute.startsWith(AttributesManager.NS_UES_ATTR)) {
+				uesAttributes.add(attribute);
+			}
+		}
+
+		result.put("memberAttributes", memberAttributes);
+		result.put("userAttributes", userAttributes);
+		result.put("uesAttributes", uesAttributes);
+
+		return result;
+	}
+
+	/**
+	 * Prepares query to search users or members by attributes if received attribute list is not empty.
+	 *
+	 * Returns map: memberAttributesQueryString -> pair of parts of query to search by member attributes
+	 * 	            userAttributesQueryString -> pair of parts of query to search by user attributes
+	 * 	            uesAttributesQueryString -> pair of parts of query to search by userExtSource attributes
+	 *
+	 * @param memberAttributes member attributes
+	 * @param userAttributes user attributes
+	 * @param uesAttributes userExtSource attributes
+	 *
+	 * @return map of parts of query
+	 */
+	public static Map<String, Pair<String, String>> getAttributesQuery(List<String> memberAttributes, List<String> userAttributes, List<String> uesAttributes) {
+		Map<String, Pair<String, String>> result = new HashMap<>();
+
+		Pair<String, String> memberAttributesQueryString = new Pair<>("", "");
+		if (!memberAttributes.isEmpty()) {
+			memberAttributesQueryString.put(" left join member_attr_values mav on members.id=mav.member_id and mav.attr_id in (select id from attr_names where attr_name in (:memberAttributes))", " lower(mav.attr_value)=lower(:searchString) or " );
+		}
+		result.put("memberAttributesQuery", memberAttributesQueryString);
+
+		Pair<String, String> userAttributesQueryString = new Pair<>("", "");
+		if (!userAttributes.isEmpty()) {
+			userAttributesQueryString.put(" left join user_attr_values uav on users.id=uav.user_id and uav.attr_id in (select id from attr_names where attr_name in (:userAttributes))" , " lower(uav.attr_value)=lower(:searchString) or ");
+		}
+		result.put("userAttributesQuery", userAttributesQueryString);
+
+		Pair<String, String> uesAttributesQueryString = new Pair<>("", "");
+		if (!uesAttributes.isEmpty()) {
+			uesAttributesQueryString.put(" left join user_ext_source_attr_values uesav on uesav.user_ext_source_id=ues.id and uesav.attr_id in (select id from attr_names where attr_name in (:uesAttributes))", " lower(uesav.attr_value)=lower(:searchString) or ");
+		}
+		result.put("uesAttributesQuery", uesAttributesQueryString);
+
+		return result;
+	}
+
+	/**
+	 * Returns MapSqlParameterSource with values added to search members or users.
+	 *
+	 * @param searchString string used to search by
+	 * @param attributesToSearchBy map of attributes used to search for users or members
+	 *
+	 * @return filled MapSqlParameterSource
+	 */
+	public static MapSqlParameterSource getMapSqlParameterSourceToSearchUsersOrMembers(String searchString, Map<String, List<String>> attributesToSearchBy) {
+		MapSqlParameterSource namedParams = new MapSqlParameterSource();
+		namedParams.addValue("searchString", searchString);
+		namedParams.addValue("nameString", Utils.utftoasci(searchString.toLowerCase()));
+		namedParams.addValue("memberAttributes", attributesToSearchBy.get("memberAttributes"));
+		namedParams.addValue("userAttributes", attributesToSearchBy.get("userAttributes"));
+		namedParams.addValue("uesAttributes", attributesToSearchBy.get("uesAttributes"));
+
+		return namedParams;
 	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/MembersManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/MembersManagerImplApi.java
@@ -342,7 +342,7 @@ public interface MembersManagerImplApi {
 
 	/**
 	 * Return list of members by specific string.
-	 * Looking for searchString in member mail, user preferredMail, logins, name and IDs (user and member).
+	 * Looking for searchString in user name, member and user id, member, users and userExtSource attributes specified by perun.properties.
 	 * All searches are case insensitive.
 	 * If parameter onlySponsored is true, it will return only sponsored members by searchString.
 	 * If vo is null, looking for any members in whole Perun. If vo is not null, looking only in specific VO.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/UsersManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/UsersManagerImplApi.java
@@ -506,22 +506,22 @@ public interface UsersManagerImplApi {
 	List<Vo> getVosWhereUserIsMember(PerunSession sess, User user);
 
 	/**
-	 * Returns list of users who matches the searchString, searching name, email and logins.
+	 * Returns list of users who matches the searchString, searching name, id, member attributes, user attributes
+	 * and userExtSource attributes (listed in perun.properties).
 	 *
-	 * @param sess
-	 * @param searchString
+	 * @param sess perun session
+	 * @param searchString it will be looking for this search string in the specific parameters in DB
 	 * @return list of users
-	 * @throws InternalErrorException
 	 */
 	List<User> findUsers(PerunSession sess, String searchString);
 
 	/**
-	 * Returns list of users who matches the searchString, searching name, email and logins.
+	 * Returns list of users who matches the searchString, searching name (exact match), id, member attributes, user attributes
+	 * and userExtSource attributes (listed in perun.properties).
 	 *
-	 * @param sess
-	 * @param searchString
+	 * @param sess perun session
+	 * @param searchString it will be looking for this search string in the specific parameters in DB
 	 * @return list of users
-	 * @throws InternalErrorException
 	 */
 	List<User> findUsersByExactMatch(PerunSession sess, String searchString);
 

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/MembersManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/MembersManagerEntryIntegrationTest.java
@@ -1345,6 +1345,11 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 		groupsManagerEntry.addMember(sess, createdGroup, member);
 		groupsManagerEntry.addMember(sess, createdGroup, member2);
 
+		// add user attribute to CoreConfig
+		List<String> attributes = BeansUtils.getCoreConfig().getAttributesToSearchUsersAndMembersBy();
+		attributes.add("urn:perun:user:attribute-def:def:login-namespace:testMichal");
+		BeansUtils.getCoreConfig().setAttributesToSearchUsersAndMembersBy(attributes);
+
 		List<Member> foundMembers = membersManagerEntry.findMembersInGroup(sess, createdGroup, "FirstTest");
 		assertTrue(foundMembers.contains(member));
 		foundMembers.remove(member);
@@ -1362,6 +1367,10 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 		assertTrue(foundMembers.contains(member));
 		foundMembers.remove(member);
 		assertTrue(foundMembers.isEmpty());
+
+		// reset CoreConfig to previous state
+		attributes.remove("urn:perun:user:attribute-def:def:login-namespace:testMichal");
+		BeansUtils.getCoreConfig().setAttributesToSearchUsersAndMembersBy(attributes);
 	}
 
 	@Ignore

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/UsersManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/UsersManagerEntryIntegrationTest.java
@@ -1327,8 +1327,8 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 	}
 
 	@Test
-	public void findUserByMemberMail() throws Exception {
-		System.out.println(CLASS_NAME + "findUserByMemberMail");
+	public void findUserByMemberAttribute() throws Exception {
+		System.out.println(CLASS_NAME + "findUserByMemberAttribute");
 
 		Member member = setUpMember(vo);
 

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/UsersManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/UsersManagerEntryIntegrationTest.java
@@ -6,6 +6,7 @@ import cz.metacentrum.perun.core.AbstractPerunIntegrationTest;
 import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.BeansUtils;
 import cz.metacentrum.perun.core.api.Candidate;
 import cz.metacentrum.perun.core.api.ExtSource;
 import cz.metacentrum.perun.core.api.ExtSourcesManager;
@@ -1301,6 +1302,124 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 			},
 			ATTR_UES_O
 		);
+	}
+
+	@Test
+	public void findUserById() {
+		System.out.println(CLASS_NAME + "findUserById");
+
+		List<User> users = perun.getUsersManagerBl().findUsers(sess, String.valueOf(user.getId()));
+		assertEquals(1, users.size());
+		assertEquals(user, users.get(0));
+	}
+
+	@Test
+	public void findUserByNames() {
+		System.out.println(CLASS_NAME + "findUserByNames");
+
+		List<User> users = perun.getUsersManagerBl().findUsers(sess, user.getFirstName());
+		assertEquals(1, users.size());
+		assertEquals(user, users.get(0));
+
+		users = perun.getUsersManagerBl().findUsers(sess, user.getLastName());
+		assertEquals(1, users.size());
+		assertEquals(user, users.get(0));
+	}
+
+	@Test
+	public void findUserByMemberMail() throws Exception {
+		System.out.println(CLASS_NAME + "findUserByMemberMail");
+
+		Member member = setUpMember(vo);
+
+		User user = perun.getUsersManagerBl().getUserByMember(sess, member);
+
+		// add member attribute to CoreConfig
+		List<String> attributes = BeansUtils.getCoreConfig().getAttributesToSearchUsersAndMembersBy();
+		attributes.add("urn:perun:member:attribute-def:def:test");
+		BeansUtils.getCoreConfig().setAttributesToSearchUsersAndMembersBy(attributes);
+
+		AttributeDefinition attrDef = new AttributeDefinition();
+		attrDef.setNamespace("urn:perun:member:attribute-def:def");
+		attrDef.setFriendlyName("test");
+		attrDef.setType(String.class.getName());
+		attrDef = perun.getAttributesManagerBl().createAttribute(sess, attrDef);
+		Attribute attribute = new Attribute(attrDef);
+		attribute.setValue("login");
+		perun.getAttributesManagerBl().setAttribute(sess, member, attribute);
+
+		List<User> users = perun.getUsersManagerBl().findUsers(sess, "login");
+		assertEquals(1, users.size());
+		assertEquals(user, users.get(0));
+
+		// reset CoreConfig to previous state
+		attributes.remove("urn:perun:member:attribute-def:def:test");
+		BeansUtils.getCoreConfig().setAttributesToSearchUsersAndMembersBy(attributes);
+	}
+
+	@Test
+	public void findUserByUserAttribute() throws Exception {
+		System.out.println(CLASS_NAME + "findUserByUserAttribute");
+
+		// add user attribute to CoreConfig
+		List<String> attributes = BeansUtils.getCoreConfig().getAttributesToSearchUsersAndMembersBy();
+		attributes.add("urn:perun:user:attribute-def:def:test");
+		BeansUtils.getCoreConfig().setAttributesToSearchUsersAndMembersBy(attributes);
+
+		AttributeDefinition attrDef = new AttributeDefinition();
+		attrDef.setNamespace("urn:perun:user:attribute-def:def");
+		attrDef.setFriendlyName("test");
+		attrDef.setType(String.class.getName());
+		attrDef = perun.getAttributesManagerBl().createAttribute(sess, attrDef);
+		Attribute attribute = new Attribute(attrDef);
+		attribute.setValue("login");
+
+		perun.getAttributesManagerBl().setAttribute(sess, user, attribute);
+
+		List<User> users = perun.getUsersManagerBl().findUsers(sess, "login");
+		assertEquals(1, users.size());
+		assertEquals(user, users.get(0));
+
+		// reset CoreConfig to previous state
+		attributes.remove("urn:perun:user:attribute-def:def:test");
+		BeansUtils.getCoreConfig().setAttributesToSearchUsersAndMembersBy(attributes);
+	}
+
+	@Test
+	public void findUserByUserExtSourceAttribute() throws Exception {
+		System.out.println(CLASS_NAME + "findUserByUserExtSourceAttribute");
+
+		// add userExtSource attribute to CoreConfig
+		List<String> attributes = BeansUtils.getCoreConfig().getAttributesToSearchUsersAndMembersBy();
+		attributes.add("urn:perun:ues:attribute-def:def:test");
+		BeansUtils.getCoreConfig().setAttributesToSearchUsersAndMembersBy(attributes);
+
+		AttributeDefinition attrDef = new AttributeDefinition();
+		attrDef.setNamespace("urn:perun:ues:attribute-def:def");
+		attrDef.setFriendlyName("test");
+		attrDef.setType(String.class.getName());
+		attrDef = perun.getAttributesManagerBl().createAttribute(sess, attrDef);
+		Attribute attribute = new Attribute(attrDef);
+		attribute.setValue("login");
+
+		perun.getAttributesManagerBl().setAttribute(sess, userExtSource, attribute);
+
+		List<User> users = perun.getUsersManagerBl().findUsers(sess, "login");
+		assertEquals(1, users.size());
+		assertEquals(user, users.get(0));
+
+		// reset CoreConfig to previous state
+		attributes.remove("urn:perun:ues:attribute-def:def:test");
+		BeansUtils.getCoreConfig().setAttributesToSearchUsersAndMembersBy(attributes);
+	}
+
+	@Test
+	public void findUserByUserExtSourceLogin() {
+		System.out.println(CLASS_NAME + "findUserByUserExtSourceLogin");
+
+		List<User> users = perun.getUsersManagerBl().findUsers(sess, extLogin);
+		assertEquals(1, users.size());
+		assertEquals(user, users.get(0));
 	}
 
 	// PRIVATE METHODS -------------------------------------------------------------


### PR DESCRIPTION
- findUsers now uses only one query with multiple joins and conditions
- the attributes to search users or members by are now stored in perun.properties and loaded by CoreConfig (it supports only full names of attributes)
- these changes were also applied to findMembers
- findUsers and findUsersByExactMatch now use private method with switch which selects whether name should be search only by exact match or not
- also added tests for this method and fixed existing tests that were affected