### PR TITLE
Fix invalid entry calls

### DIFF
--- a/perun-base/src/main/resources/perun-roles.yml
+++ b/perun-base/src/main/resources/perun-roles.yml
@@ -364,6 +364,7 @@ perun_policies:
 
   getExtSourceById_int_policy:
     policy_roles:
+      - SELF:
       - RPC:
       - PERUNOBSERVER:
     include_policies:
@@ -1061,6 +1062,8 @@ perun_policies:
 
   getGroupById_int_policy:
     policy_roles:
+#      Temporary fix until a new MEMBERSHIP role is created
+      - SELF:
       - RESOURCEADMIN: Vo
       - PERUNOBSERVER:
       - RPC:
@@ -1787,6 +1790,7 @@ perun_policies:
 
   getMemberById_int_policy:
     policy_roles:
+      - SELF: User
       - RPC:
       - PERUNOBSERVER:
       - VOOBSERVER: Vo
@@ -2341,6 +2345,7 @@ perun_policies:
   #ResourcesManagerEntry
   getResourceById_int_policy:
     policy_roles:
+      - FACILITYADMIN: Facility
       - RESOURCESELFSERVICE: Resource
       - RESOURCEADMIN: Resource
       - RPC:
@@ -3348,6 +3353,7 @@ perun_policies:
 
   getServiceById_int_policy:
     policy_roles:
+      - FACILITYADMIN:
       - VOADMIN:
       - VOOBSERVER:
       - ENGINE:
@@ -3358,6 +3364,7 @@ perun_policies:
 
   getServiceByName_String_policy:
     policy_roles:
+      - FACILITYADMIN:
       - VOADMIN:
       - VOOBSERVER:
       - ENGINE:
@@ -3448,6 +3455,7 @@ perun_policies:
 
   getServicesPackages_policy:
     policy_roles:
+      - FACILITYADMIN:
       - VOADMIN:
       - VOOBSERVER:
       - PERUNOBSERVER:
@@ -3456,6 +3464,7 @@ perun_policies:
 
   getServicesPackageById_int_policy:
     policy_roles:
+      - FACILITYADMIN:
       - RPC:
       - VOADMIN:
       - VOOBSERVER:
@@ -3465,6 +3474,7 @@ perun_policies:
 
   getServicesPackageByName_String_policy:
     policy_roles:
+      - FACILITYADMIN:
       - VOADMIN:
       - VOOBSERVER:
       - PERUNOBSERVER:
@@ -3498,6 +3508,7 @@ perun_policies:
 
   getServicesFromServicesPackage_ServicesPackage_policy:
     policy_roles:
+      - FACILITYADMIN:
       - VOADMIN:
       - VOOBSERVER:
       - PERUNOBSERVER:

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/AttributesManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/AttributesManagerMethod.java
@@ -1141,7 +1141,7 @@ public enum AttributesManagerMethod implements ManagerMethod {
 
 		@Override
 		public AttributeDefinition call(ApiCaller ac, Deserializer parms) throws PerunException {
-			return ac.getAttributeDefinitionById(parms.readInt("id"));
+			return ac.getAttributesManager().getAttributeDefinitionById(ac.getSession(), parms.readInt("id"));
 		}
 	},
 

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/ExtSourcesManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/ExtSourcesManagerMethod.java
@@ -62,7 +62,7 @@ public enum ExtSourcesManagerMethod implements ManagerMethod {
 
 		@Override
 		public ExtSource call(ApiCaller ac, Deserializer parms) throws PerunException {
-			return ac.getExtSourceById(parms.readInt("id"));
+			return ac.getExtSourcesManager().getExtSourceById(ac.getSession(), parms.readInt("id"));
 		}
 	},
 

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/FacilitiesManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/FacilitiesManagerMethod.java
@@ -24,7 +24,7 @@ public enum FacilitiesManagerMethod implements ManagerMethod {
 
 		@Override
 		public Facility call(ApiCaller ac, Deserializer parms) throws PerunException {
-			return ac.getFacilityById(parms.readInt("id"));
+			return ac.getFacilitiesManager().getFacilityById(ac.getSession(), parms.readInt("id"));
 		}
 	},
 
@@ -38,7 +38,7 @@ public enum FacilitiesManagerMethod implements ManagerMethod {
 
 		@Override
 		public Facility call(ApiCaller ac, Deserializer parms) throws PerunException {
-			return ac.getFacilityByName(parms.readString("name"));
+			return ac.getFacilitiesManager().getFacilityByName(ac.getSession(), parms.readString("name"));
 		}
 	},
 

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/GroupsManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/GroupsManagerMethod.java
@@ -338,7 +338,7 @@ public enum GroupsManagerMethod implements ManagerMethod {
 
 		@Override
 		public Group call(ApiCaller ac, Deserializer parms) throws PerunException {
-			return ac.getGroupById(parms.readInt("id"));
+			return ac.getGroupsManager().getGroupById(ac.getSession(), parms.readInt("id"));
 		}
 	},
 

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/MembersManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/MembersManagerMethod.java
@@ -501,7 +501,7 @@ public enum MembersManagerMethod implements ManagerMethod {
 	getMemberById {
 		@Override
 		public Member call(ApiCaller ac, Deserializer parms) throws PerunException {
-			return ac.getMemberById(parms.readInt("id"));
+			return ac.getMembersManager().getMemberById(ac.getSession(), parms.readInt("id"));
 		}
 	},
 

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/OwnersManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/OwnersManagerMethod.java
@@ -79,7 +79,7 @@ public enum OwnersManagerMethod implements ManagerMethod {
 	getOwnerById {
 		@Override
 		public Owner call(ApiCaller ac, Deserializer parms) throws PerunException {
-			return ac.getOwnerById(parms.readInt("id"));
+			return ac.getOwnersManager().getOwnerById(ac.getSession(), parms.readInt("id"));
 		}
 	},
 
@@ -92,7 +92,7 @@ public enum OwnersManagerMethod implements ManagerMethod {
 	getOwnerByName {
 		@Override
 		public Owner call(ApiCaller ac, Deserializer parms) throws PerunException {
-			return ac.getOwnerByName(parms.readString("name"));
+			return ac.getOwnersManager().getOwnerByName(ac.getSession(), parms.readString("name"));
 		}
 	},
 

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/ResourcesManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/ResourcesManagerMethod.java
@@ -24,7 +24,7 @@ public enum ResourcesManagerMethod implements ManagerMethod {
 
 		@Override
 		public Resource call(ApiCaller ac, Deserializer parms) throws PerunException {
-			return ac.getResourceById(parms.readInt("id"));
+			return ac.getResourcesManager().getResourceById(ac.getSession(), parms.readInt("id"));
 		}
 	},
 

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/ServicesManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/ServicesManagerMethod.java
@@ -403,7 +403,7 @@ public enum ServicesManagerMethod implements ManagerMethod {
 
 		@Override
 		public Service call(ApiCaller ac, Deserializer parms) throws PerunException {
-			return ac.getServiceById(parms.readInt("id"));
+			return ac.getServicesManager().getServiceById(ac.getSession(), parms.readInt("id"));
 		}
 	},
 
@@ -1184,7 +1184,7 @@ public enum ServicesManagerMethod implements ManagerMethod {
 
 		@Override
 		public ServicesPackage call(ApiCaller ac, Deserializer parms) throws PerunException {
-			return ac.getServicesPackageById(parms.readInt("servicesPackageId"));
+			return ac.getServicesManager().getServicesPackageById(ac.getSession(), parms.readInt("servicesPackageId"));
 		}
 	},
 

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/UsersManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/UsersManagerMethod.java
@@ -57,7 +57,7 @@ public enum UsersManagerMethod implements ManagerMethod {
 
 		@Override
 		public User call(ApiCaller ac, Deserializer parms) throws PerunException {
-			return ac.getUserById(parms.readInt("id"));
+			return ac.getUsersManager().getUserById(ac.getSession(), parms.readInt("id"));
 		}
 	},
 


### PR DESCRIPTION
* There were some methods that didn't call directly entry layer but
instead, they called methods from ApiCaller which are for a different
purpose. Because of that in the entry layer, there was an invalid
Principal.
* Added role SELF to policy for the `getGroupById` method because after
this fix, group members would not be able to call this method.