### PR TITLE
New method to convert unique attribute to nonunique

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/AttributeNotMarkedUniqueException.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/AttributeNotMarkedUniqueException.java
@@ -1,0 +1,33 @@
+package cz.metacentrum.perun.core.api.exceptions;
+
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+
+/**
+ * Attribute is not marked as unique.
+ *
+ * @author Metodej Klang
+ */
+public class AttributeNotMarkedUniqueException extends PerunException {
+
+	private AttributeDefinition attribute;
+
+	/**
+	 *
+	 * @param message message with details about the cause
+	 * @param attributeDefinition attributeDefinition that has not been marked as unique
+	 */
+	public AttributeNotMarkedUniqueException(String message, AttributeDefinition attributeDefinition) {
+		super(message + " " + attributeDefinition.toString());
+		this.attribute = attributeDefinition;
+
+	}
+
+	/**
+	 * Getter for the attribute that has not been marked as unique
+	 * @return attributeDefinition that has not been marked as unique
+	 */
+	public AttributeDefinition getAttribute() {
+		return attribute;
+	}
+
+}

--- a/perun-base/src/main/resources/perun-roles.yml
+++ b/perun-base/src/main/resources/perun-roles.yml
@@ -158,6 +158,11 @@ perun_policies:
     include_policies:
       - default_policy
 
+  convertAttributeToNonunique_int_policy:
+    policy_roles: []
+    include_policies:
+      - default_policy
+
   getModulesDependenciesGraph_GraphTextFormat_policy:
     policy_roles:
       - PERUNOBSERVER:

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/AttributesManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/AttributesManager.java
@@ -3,6 +3,7 @@ package cz.metacentrum.perun.core.api;
 import cz.metacentrum.perun.core.api.exceptions.AttributeAlreadyMarkedUniqueException;
 import cz.metacentrum.perun.core.api.exceptions.AttributeDefinitionExistsException;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.AttributeNotMarkedUniqueException;
 import cz.metacentrum.perun.core.api.exceptions.FacilityNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.GroupNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.GroupResourceMismatchException;
@@ -4059,14 +4060,15 @@ public interface AttributesManager {
 	 * Converts attribute to non-unique.
 	 *
 	 * Unmarks unique flag from attribute definition, and deletes all values from a special table with unique constraint
-	 * that ensures that all values remain unique. Already non-unique attribute is skipped.
+	 * that ensures that all values remain unique.
 	 *
 	 * @param session perun session
 	 * @param attrId  attribute id
 	 * @throws PrivilegeException insufficient permissions
 	 * @throws AttributeNotExistsException when the attribute definition for attrId doesn't exist
+	 * @throws AttributeNotMarkedUniqueException when the attribute definition is not unique
 	 */
-	void convertAttributeToNonunique(PerunSession session, int attrId) throws PrivilegeException, AttributeNotExistsException;
+	void convertAttributeToNonunique(PerunSession session, int attrId) throws PrivilegeException, AttributeNotExistsException, AttributeNotMarkedUniqueException;
 
 	/**
 	 * Generates graph describing attribute modules dependencies.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/AttributesManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/AttributesManager.java
@@ -4056,6 +4056,19 @@ public interface AttributesManager {
 	void convertAttributeToUnique(PerunSession session, int attrId) throws PrivilegeException, AttributeNotExistsException, AttributeAlreadyMarkedUniqueException;
 
 	/**
+	 * Converts attribute to non-unique.
+	 *
+	 * Unmarks unique flag from attribute definition, and deletes all values from a special table with unique constraint
+	 * that ensures that all values remain unique. Already non-unique attribute is skipped.
+	 *
+	 * @param session perun session
+	 * @param attrId  attribute id
+	 * @throws PrivilegeException insufficient permissions
+	 * @throws AttributeNotExistsException when the attribute definition for attrId doesn't exist
+	 */
+	void convertAttributeToNonunique(PerunSession session, int attrId) throws PrivilegeException, AttributeNotExistsException;
+
+	/**
 	 * Generates graph describing attribute modules dependencies.
 	 * Text output format can be specified by {@link GraphTextFormat} format.
 	 *

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
@@ -4609,6 +4609,18 @@ public interface AttributesManagerBl {
 	void convertAttributeToUnique(PerunSession session, int attrId) throws AttributeNotExistsException, AttributeAlreadyMarkedUniqueException;
 
 	/**
+	 * Converts attribute to nonunique.
+	 *
+	 * Unmarks unique flag from attribute definition, and deletes all values from a special table with unique constraint
+	 * that ensures that all values remain unique. Already nonunique attribute is skipped.
+	 *
+	 * @param session perun session
+	 * @param attrId attribute id
+	 * @throws AttributeNotExistsException when the attribute definition for attrId doesn't exist
+	 */
+	void convertAttributeToNonunique(PerunSession session, int attrId) throws AttributeNotExistsException;
+
+	/**
 	 * Generates graph describing attribute modules dependencies.
 	 * Text output format can be specified by {@link GraphTextFormat} format.
 	 *

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
@@ -21,6 +21,7 @@ import cz.metacentrum.perun.core.api.exceptions.ActionTypeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.AttributeAlreadyMarkedUniqueException;
 import cz.metacentrum.perun.core.api.exceptions.AttributeDefinitionExistsException;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.AttributeNotMarkedUniqueException;
 import cz.metacentrum.perun.core.api.exceptions.GroupResourceMismatchException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.MemberGroupMismatchException;
@@ -4612,13 +4613,14 @@ public interface AttributesManagerBl {
 	 * Converts attribute to nonunique.
 	 *
 	 * Unmarks unique flag from attribute definition, and deletes all values from a special table with unique constraint
-	 * that ensures that all values remain unique. Already nonunique attribute is skipped.
+	 * that ensures that all values remain unique.
 	 *
 	 * @param session perun session
 	 * @param attrId attribute id
 	 * @throws AttributeNotExistsException when the attribute definition for attrId doesn't exist
+	 * @throws AttributeNotMarkedUniqueException when the attribute definition is not unique
 	 */
-	void convertAttributeToNonunique(PerunSession session, int attrId) throws AttributeNotExistsException;
+	int convertAttributeToNonunique(PerunSession session, int attrId) throws AttributeNotExistsException, AttributeNotMarkedUniqueException;
 
 	/**
 	 * Generates graph describing attribute modules dependencies.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -8116,10 +8116,19 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		log.info("converting attribute {} to unique",attrDef.getName());
 		attrDef.setUnique(true);
 		this.updateAttributeDefinition(session, attrDef);
-		long startTime = System.currentTimeMillis();
+
 		attributesManagerImpl.convertAttributeValuesToUnique(session, attrDef);
-		long endTime = System.currentTimeMillis();
-		log.debug("Attribute {} was converted to unique in {} ms",attrDef.getName(),(endTime-startTime));
+	}
+
+	@Override
+	public void convertAttributeToNonunique(PerunSession session, int attrId) throws AttributeNotExistsException {
+		AttributeDefinition attrDef = getAttributeDefinitionById(session, attrId);
+		if(!attrDef.isUnique()) return;
+		log.info("converting unique attribute {} to nonunique",attrDef.getName());
+		attrDef.setUnique(false);
+		this.updateAttributeDefinition(session, attrDef);
+
+		attributesManagerImpl.convertAttributeValuesToNonunique(session, attrDef);
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -8124,7 +8124,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	@Override
 	public int convertAttributeToNonunique(PerunSession session, int attrId) throws AttributeNotExistsException, AttributeNotMarkedUniqueException {
 		AttributeDefinition attrDef = getAttributeDefinitionById(session, attrId);
-		if(!attrDef.isUnique()) throw new AttributeNotMarkedUniqueException("Cannot convert attribute because it is already marked as unique", attrDef);
+		if(!attrDef.isUnique()) throw new AttributeNotMarkedUniqueException("Cannot convert attribute because it is already marked as nonunique", attrDef);
 		log.info("converting unique attribute {} to nonunique",attrDef.getName());
 		attrDef.setUnique(false);
 		this.updateAttributeDefinition(session, attrDef);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -75,6 +75,7 @@ import cz.metacentrum.perun.core.api.exceptions.ActionTypeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.AttributeAlreadyMarkedUniqueException;
 import cz.metacentrum.perun.core.api.exceptions.AttributeDefinitionExistsException;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.AttributeNotMarkedUniqueException;
 import cz.metacentrum.perun.core.api.exceptions.ConsistencyErrorException;
 import cz.metacentrum.perun.core.api.exceptions.FacilityNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.GroupResourceMismatchException;
@@ -8121,14 +8122,14 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	}
 
 	@Override
-	public void convertAttributeToNonunique(PerunSession session, int attrId) throws AttributeNotExistsException {
+	public int convertAttributeToNonunique(PerunSession session, int attrId) throws AttributeNotExistsException, AttributeNotMarkedUniqueException {
 		AttributeDefinition attrDef = getAttributeDefinitionById(session, attrId);
-		if(!attrDef.isUnique()) return;
+		if(!attrDef.isUnique()) throw new AttributeNotMarkedUniqueException("Cannot convert attribute because it is already marked as unique", attrDef);
 		log.info("converting unique attribute {} to nonunique",attrDef.getName());
 		attrDef.setUnique(false);
 		this.updateAttributeDefinition(session, attrDef);
 
-		attributesManagerImpl.convertAttributeValuesToNonunique(session, attrDef);
+		return attributesManagerImpl.convertAttributeValuesToNonunique(session, attrDef);
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/AttributesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/AttributesManagerEntry.java
@@ -21,6 +21,7 @@ import cz.metacentrum.perun.core.api.Vo;
 import cz.metacentrum.perun.core.api.exceptions.AttributeAlreadyMarkedUniqueException;
 import cz.metacentrum.perun.core.api.exceptions.AttributeDefinitionExistsException;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.AttributeNotMarkedUniqueException;
 import cz.metacentrum.perun.core.api.exceptions.ConsistencyErrorException;
 import cz.metacentrum.perun.core.api.exceptions.FacilityNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.GroupNotExistsException;
@@ -4516,19 +4517,19 @@ public class AttributesManagerEntry implements AttributesManager {
 
 		// Authorization
 		if(!AuthzResolver.authorizedInternal(session, "convertAttributeToUnique_int_policy")) {
-			throw new PrivilegeException("This operation can do only PerunAdmin.");
+			throw new PrivilegeException(session, "convertAttributeToUnique");
 		}
 
 		getAttributesManagerBl().convertAttributeToUnique(session, attrId);
 	}
 
 	@Override
-	public void convertAttributeToNonunique(PerunSession session, int attrId) throws PrivilegeException, AttributeNotExistsException {
+	public void convertAttributeToNonunique(PerunSession session, int attrId) throws PrivilegeException, AttributeNotExistsException, AttributeNotMarkedUniqueException {
 		Utils.checkPerunSession(session);
 
 		// Authorization
 		if(!AuthzResolver.authorizedInternal(session, "convertAttributeToNonunique_int_policy")) {
-			throw new PrivilegeException("This operation can do only PerunAdmin.");
+			throw new PrivilegeException(session, "convertAttributeToNonunique");
 		}
 
 		getAttributesManagerBl().convertAttributeToNonunique(session, attrId);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/AttributesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/AttributesManagerEntry.java
@@ -4523,6 +4523,18 @@ public class AttributesManagerEntry implements AttributesManager {
 	}
 
 	@Override
+	public void convertAttributeToNonunique(PerunSession session, int attrId) throws PrivilegeException, AttributeNotExistsException {
+		Utils.checkPerunSession(session);
+
+		// Authorization
+		if(!AuthzResolver.authorizedInternal(session, "convertAttributeToNonunique_int_policy")) {
+			throw new PrivilegeException("This operation can do only PerunAdmin.");
+		}
+
+		getAttributesManagerBl().convertAttributeToNonunique(session, attrId);
+	}
+
+	@Override
 	public GraphDTO getModulesDependenciesGraph(PerunSession session, GraphTextFormat format) throws PrivilegeException {
 
 		// Authorization

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
@@ -4516,10 +4516,10 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 	}
 
 	@Override
-	public void convertAttributeValuesToNonunique(PerunSession session, AttributeDefinition attrDef) {
+	public int convertAttributeValuesToNonunique(PerunSession session, AttributeDefinition attrDef) {
 		String tablePrefix = attributeToTablePrefix(attrDef);
 		try {
-			jdbc.update("DELETE FROM " + tablePrefix + "_attr_u_values WHERE attr_id=?", attrDef.getId());
+			return jdbc.update("DELETE FROM " + tablePrefix + "_attr_u_values WHERE attr_id=?", attrDef.getId());
 		} catch (RuntimeException e) {
 			throw new InternalErrorException(e);
 		}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
@@ -2601,4 +2601,9 @@ public interface AttributesManagerImplApi {
 	 * Copies all values of the attribute to table _attr_u_values which has unique constraint.
 	 */
 	void convertAttributeValuesToUnique(PerunSession session, AttributeDefinition attrDef);
+
+	/**
+	 * Deletes all values of the attribute from table _attr_u_values which has unique constraint.
+	 */
+	void convertAttributeValuesToNonunique(PerunSession session, AttributeDefinition attrDef);
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
@@ -2603,7 +2603,7 @@ public interface AttributesManagerImplApi {
 	void convertAttributeValuesToUnique(PerunSession session, AttributeDefinition attrDef);
 
 	/**
-	 * Deletes all values of the attribute from table _attr_u_values which has unique constraint.
+	 * Deletes all values of the attribute from table _attr_u_values which has unique constraint. And returns how many rows were deleted.
 	 */
-	void convertAttributeValuesToNonunique(PerunSession session, AttributeDefinition attrDef);
+	int convertAttributeValuesToNonunique(PerunSession session, AttributeDefinition attrDef);
 }

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/AttributesManagerEntryIntegrationTestAbstract.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/AttributesManagerEntryIntegrationTestAbstract.java
@@ -5500,6 +5500,129 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 	}
 
 	@Test
+	public void testConvertingToNonuniqAttribute() throws Exception {
+		System.out.println(CLASS_NAME + "testConvertingToNonuniqAttribute");
+		attributesManagerBl = getTargetObject(perun.getAttributesManagerBl());
+		int counter = 1;
+		for (String bean : AttributesManagerImpl.BEANS_TO_NAMESPACES_MAP.keySet()) {
+
+			//entityless attributes cannot be unique, no need for conversion
+			if (bean.equals("entityless")) continue;
+
+			for (String type : AttributesManagerImpl.ATTRIBUTE_TYPES) {
+				//large string and large array are unsupported types for uniqueness
+
+				log.debug("conversion to unique bean {} type {}", bean, type);
+				String namespace = AttributesManagerImpl.BEANS_TO_NAMESPACES_MAP.get(bean) + ":def";
+				String friendlyName = "test-conv-attr" + (counter++);
+				String description = "poznamka";
+				AttributeDefinition attrDef = new AttributeDefinition();
+				attrDef.setUnique(true);
+				attrDef.setFriendlyName(friendlyName);
+				attrDef.setNamespace(namespace);
+				attrDef.setDescription(description);
+				attrDef.setType(type);
+				attributesManager.createAttribute(sess, attrDef);
+				AttributeDefinition attributeDefinition = attributesManager.getAttributeDefinition(sess, namespace + ":" + friendlyName);
+				assertTrue("attribute is not marked unique", attributeDefinition.isUnique());
+				assertEquals("friendly name not loaded correctly", friendlyName, attributeDefinition.getFriendlyName());
+				assertEquals("namespace not loaded correctly", namespace, attributeDefinition.getNamespace());
+				assertEquals("description not loaded correctly", description, attributeDefinition.getDescription());
+
+				//create values
+				Attribute a = new Attribute(attributeDefinition);
+				Attribute b = new Attribute(attributeDefinition);
+				switch (type) {
+					case "java.lang.String":
+					case BeansUtils.largeStringClassName:
+						a.setValue("string1");
+						b.setValue("string2");
+						break;
+					case "java.lang.Integer":
+						a.setValue(Integer.MIN_VALUE);
+						b.setValue(Integer.MAX_VALUE);
+						break;
+					case "java.lang.Boolean":
+						a.setValue(Boolean.FALSE);
+						b.setValue(Boolean.TRUE);
+						break;
+					case "java.util.ArrayList":
+					case BeansUtils.largeArrayListClassName:
+						a.setValue(new ArrayList<>(Arrays.asList("value1","value2")));
+						b.setValue(new ArrayList<>(Arrays.asList("value3","value4")));
+						break;
+					case "java.util.LinkedHashMap":
+						LinkedHashMap<String,String> m1 = new LinkedHashMap<>();
+						m1.put("k1","v1");
+						m1.put("k2","v2");
+						LinkedHashMap<String,String> m2 = new LinkedHashMap<>();
+						m2.put("k4","v4");
+						m2.put("k3","v3");
+						a.setValue(m1);
+						b.setValue(m2);
+						break;
+					default:
+						throw new Exception("unknown type "+type);
+				}
+				switch (bean) {
+					case "user":
+						attributesManager.setAttribute(sess, user1, a);
+						attributesManager.setAttribute(sess, user2, b);
+						break;
+					case "member":
+						attributesManager.setAttribute(sess, member1OfUser1, a);
+						attributesManager.setAttribute(sess, member2OfUser1, b);
+						break;
+					case "facility":
+						attributesManager.setAttribute(sess, facility1, a);
+						attributesManager.setAttribute(sess, facility2, b);
+						break;
+					case "vo":
+						attributesManager.setAttribute(sess, vo1, a);
+						attributesManager.setAttribute(sess, vo2, b);
+						break;
+					case "host":
+						attributesManager.setAttribute(sess, host1OnFacility1, a);
+						attributesManager.setAttribute(sess, host2OnFacility2, b);
+						break;
+					case "group":
+						attributesManager.setAttribute(sess, group1InVo1, a);
+						attributesManager.setAttribute(sess, group2InVo2, b);
+						break;
+					case "resource":
+						attributesManager.setAttribute(sess, resource1InVo1, a);
+						attributesManager.setAttribute(sess, resource2InVo2, b);
+						break;
+					case "member_resource":
+						attributesManager.setAttribute(sess, member1OfUser1, resource1InVo1, a);
+						attributesManager.setAttribute(sess, member2OfUser2, resource2InVo1, b);
+						break;
+					case "member_group":
+						attributesManager.setAttribute(sess, member1OfUser1, group1InVo1, a);
+						attributesManager.setAttribute(sess, member2OfUser2, group2InVo1, b);
+						break;
+					case "user_facility":
+						attributesManager.setAttribute(sess, facility1, user1, a);
+						attributesManager.setAttribute(sess, facility2, user2, b);
+						break;
+					case "group_resource":
+						attributesManager.setAttribute(sess, resource1InVo1, group1InVo1, a);
+						attributesManager.setAttribute(sess, resource2InVo2, group2InVo2, b);
+						break;
+					case "user_ext_source":
+						attributesManager.setAttribute(sess, userExtSource1, a);
+						attributesManager.setAttribute(sess, userExtSource2, b);
+						break;
+					default:
+						throw new Exception("unknown entity "+bean);
+				}
+				attributesManager.convertAttributeToNonunique(sess, attributeDefinition.getId());
+				assertFalse(attributesManager.getAttributeDefinition(sess, attributeDefinition.getName()).isUnique());
+			}
+		}
+	}
+
+	@Test
 	public void testGetPerunBeanIdsForUniqueAttributeValue() throws Exception {
 		System.out.println(CLASS_NAME + "testGetPerunBeanIdsForUniqueAttributeValue");
 		attributesManagerBl = getTargetObject(perun.getAttributesManagerBl());

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/AttributesManagerEntryIntegrationTestAbstract.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/AttributesManagerEntryIntegrationTestAbstract.java
@@ -5616,10 +5616,39 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 					default:
 						throw new Exception("unknown entity "+bean);
 				}
-				attributesManager.convertAttributeToNonunique(sess, attributeDefinition.getId());
+				int rowsChanged = attributesManagerBl.convertAttributeToNonunique(sess, attributeDefinition.getId());
 				assertFalse(attributesManager.getAttributeDefinition(sess, attributeDefinition.getName()).isUnique());
+				assertTrue(rowsChanged > 0);
 			}
 		}
+	}
+
+	@Test
+	public void testConvertingToNonuniqAttributeExactlyRowsDeleted() throws Exception {
+		System.out.println(CLASS_NAME + "testConvertingToNonuniqAttributeExactlyRowsDeleted");
+		attributesManagerBl = getTargetObject(perun.getAttributesManagerBl());
+
+		String namespace = AttributesManager.NS_USER_ATTR_DEF;
+		String friendlyName = "test-conv-attr";
+		String description = "poznamka";
+		AttributeDefinition attrDef = new AttributeDefinition();
+		attrDef.setUnique(true);
+		attrDef.setFriendlyName(friendlyName);
+		attrDef.setNamespace(namespace);
+		attrDef.setDescription(description);
+		attrDef.setType(String.class.getName());
+		attributesManager.createAttribute(sess, attrDef);
+		attrDef = attributesManager.getAttributeDefinition(sess, namespace + ":" + friendlyName);
+
+		Attribute a = new Attribute(attrDef);
+		Attribute b = new Attribute(attrDef);
+		a.setValue("string1");
+		b.setValue("string2");
+		attributesManager.setAttribute(sess, user1, a);
+		attributesManager.setAttribute(sess, user2, b);
+
+		int rowsChanged = attributesManagerBl.convertAttributeToNonunique(sess, attrDef.getId());
+		assertEquals(2, rowsChanged);
 	}
 
 	@Test

--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -1743,6 +1743,14 @@ components:
       in: query
       required: true
 
+    attrDefId:
+      name: attributeDefinition
+      description: "id of AttributeDefinition"
+      schema:
+        type: integer
+      in: query
+      required: true
+
     attributes:
       name: "attributes[]"
       description: "list of attribute ids List<Integer>"
@@ -5946,7 +5954,7 @@ paths:
       summary: "Converts attribute to unique - marks its definition as unique and ensures that all its values are unique.
       Entityless attributes cannot be converted to unique, only attributes attached to PerunBeans or pairs of PerunBeans."
       parameters:
-        - $ref: '#/components/parameters/attributeInteger'
+        - $ref: '#/components/parameters/attrDefId'
       responses:
         '200':
           $ref: '#/components/responses/VoidResponse'
@@ -5961,7 +5969,7 @@ paths:
       summary: "Converts attribute to nonunique - unmarks unique flag from attribute definition, and deletes all values
       from a special table with unique constraint that ensures that all values remain unique."
       parameters:
-        - $ref: '#/components/parameters/attributeInteger'
+        - $ref: '#/components/parameters/attrDefId'
       responses:
         '200':
           $ref: '#/components/responses/VoidResponse'

--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -5959,7 +5959,7 @@ paths:
         - AttributesManager
       operationId: convertAttributeToNonunique
       summary: "Converts attribute to nonunique - unmarks unique flag from attribute definition, and deletes all values
-      from a special table with unique constraint that ensures that all values remain unique. Already nonunique attribute is skipped."
+      from a special table with unique constraint that ensures that all values remain unique."
       parameters:
         - $ref: '#/components/parameters/attributeInteger'
       responses:

--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -5938,7 +5938,35 @@ paths:
           $ref: '#/components/responses/ExceptionResponse'
 
 
-  #TODO convertAttributeToUnique
+  /urlinjsonout/attributesManager/convertAttributeToUnique:
+    post:
+      tags:
+        - AttributesManager
+      operationId: convertAttributeToUnique
+      summary: "Converts attribute to unique - marks its definition as unique and ensures that all its values are unique.
+      Entityless attributes cannot be converted to unique, only attributes attached to PerunBeans or pairs of PerunBeans."
+      parameters:
+        - $ref: '#/components/parameters/attributeInteger'
+      responses:
+        '200':
+          $ref: '#/components/responses/VoidResponse'
+        default:
+          $ref: '#/components/responses/ExceptionResponse'
+
+  /urlinjsonout/attributesManager/convertAttributeToNonunique:
+    post:
+      tags:
+        - AttributesManager
+      operationId: convertAttributeToNonunique
+      summary: "Converts attribute to nonunique - unmarks unique flag from attribute definition, and deletes all values
+      from a special table with unique constraint that ensures that all values remain unique. Already nonunique attribute is skipped."
+      parameters:
+        - $ref: '#/components/parameters/attributeInteger'
+      responses:
+        '200':
+          $ref: '#/components/responses/VoidResponse'
+        default:
+          $ref: '#/components/responses/ExceptionResponse'
 
   /json/attributesManager/getAttributeModulesDependenciesGraphText:
     get:

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/AttributesManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/AttributesManagerMethod.java
@@ -6,6 +6,7 @@ import java.util.List;
 import cz.metacentrum.perun.core.api.*;
 import cz.metacentrum.perun.core.api.exceptions.AttributeAlreadyMarkedUniqueException;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.AttributeNotMarkedUniqueException;
 import cz.metacentrum.perun.core.api.exceptions.PerunException;
 import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
 import cz.metacentrum.perun.utils.graphs.GraphTextFormat;
@@ -3980,11 +3981,13 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	 * Already nonunique attribute is skipped.
 	 *
 	 * @param attrDefId int AttributeDefinition <code>id</code>
+	 * @throw PrivilegeException Insufficient permissions.
 	 * @throw AttributeNotExistsException When Attribute with <code>id</code> doesn't exist.
+	 * @throw AttributeNotMarkedUniqueException When Attribute with <code>id</code> is not unique.
 	 */
 	convertAttributeToNonunique {
 		@Override
-		public Void call(ApiCaller ac, Deserializer parms) throws PrivilegeException, AttributeNotExistsException {
+		public Void call(ApiCaller ac, Deserializer parms) throws PrivilegeException, AttributeNotExistsException, AttributeNotMarkedUniqueException {
 			parms.stateChangingCheck();
 			ac.getAttributesManager().convertAttributeToNonunique(ac.getSession(), parms.readInt("attrDefId"));
 			return null;

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/AttributesManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/AttributesManagerMethod.java
@@ -3975,6 +3975,23 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	},
 
 	/*#
+	 * Converts attribute to nonunique - unmarks unique flag from attribute definition, and deletes all values
+	 * from a special table with unique constraint that ensures that all values remain unique.
+	 * Already nonunique attribute is skipped.
+	 *
+	 * @param attrDefId int AttributeDefinition <code>id</code>
+	 * @throw AttributeNotExistsException When Attribute with <code>id</code> doesn't exist.
+	 */
+	convertAttributeToNonunique {
+		@Override
+		public Void call(ApiCaller ac, Deserializer parms) throws PrivilegeException, AttributeNotExistsException {
+			parms.stateChangingCheck();
+			ac.getAttributesManager().convertAttributeToNonunique(ac.getSession(), parms.readInt("attrDefId"));
+			return null;
+		}
+	},
+
+	/*#
 	 * Generates text file describing dependencies between attribute modules.
 	 * The format of text file can be specified by parameter.
 	 * Modules that has no dependency relations are omitted.

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/AttributesManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/AttributesManagerMethod.java
@@ -3978,10 +3978,8 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	/*#
 	 * Converts attribute to nonunique - unmarks unique flag from attribute definition, and deletes all values
 	 * from a special table with unique constraint that ensures that all values remain unique.
-	 * Already nonunique attribute is skipped.
 	 *
 	 * @param attrDefId int AttributeDefinition <code>id</code>
-	 * @throw PrivilegeException Insufficient permissions.
 	 * @throw AttributeNotExistsException When Attribute with <code>id</code> doesn't exist.
 	 * @throw AttributeNotMarkedUniqueException When Attribute with <code>id</code> is not unique.
 	 */


### PR DESCRIPTION
- new method convertAttributeToNonunique converts unique attribute to nonunique by setting uniqueness flag in attribute definition to false and removing values of attribute from table _attr_u_values which has unique constraint
- convertAttributeToNonunique was added to all layers of Perun including rpc and openapi, also added test
- updateAttributeDefinition fixed to update uniqueness of attribute definition (and not just set it to true)
- method convertAttributeToUnique also added to openapi
- removed forgotten debugging of convertAttributeToUnique method