### PR TITLE
Perun core - removed SUSPEND status

### DIFF
--- a/perun-auditparser/src/main/java/cz/metacentrum/perun/auditparser/AuditParser.java
+++ b/perun-auditparser/src/main/java/cz/metacentrum/perun/auditparser/AuditParser.java
@@ -402,11 +402,6 @@ public class AuditParser {
 		member.setStatus(BeansUtils.eraseEscaping(beanAttr.get("status")));
 		member.setMembershipType(BeansUtils.eraseEscaping(beanAttr.get("type")));
 		member.setSourceGroupId(beanAttr.get("sourceGroupId").equals("\\0") ? null : Integer.valueOf(beanAttr.get("sourceGroupId")));
-		try {
-			member.setSuspendedTo(beanAttr.get("suspendedTo").equals("\\0") ? null : BeansUtils.getDateFormatter().parse(BeansUtils.eraseEscaping(beanAttr.get("suspendedTo"))));
-		} catch (ParseException ex) {
-			throw new InternalErrorException("Can't parse date for member suspendedTo from the string representation!" , ex);
-		}
 		member.setSponsored(Boolean.valueOf(beanAttr.get("sponsored")));
 		return member;
 	}

--- a/perun-auditparser/src/test/java/cz/metacentrum/perun/auditparser/AuditParserTest.java
+++ b/perun-auditparser/src/test/java/cz/metacentrum/perun/auditparser/AuditParserTest.java
@@ -72,7 +72,6 @@ public class AuditParserTest {
 	public void setUp() throws Exception {
 		member.setMembershipType(MembershipType.DIRECT);
 		member.setSourceGroupId(5);
-		member.setSuspendedTo(Date.from(Instant.now()));
 		facility.setDescription(textMismatch);
 		Map<String, String> attributesMap = new HashMap<String, String>();
 		attributesMap.put("test1", textMismatch);

--- a/perun-base/src/main/java/cz/metacentrum/perun/audit/events/MembersManagerEvents/MemberUnsuspended.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/audit/events/MembersManagerEvents/MemberUnsuspended.java
@@ -4,18 +4,21 @@ import cz.metacentrum.perun.audit.events.AuditEvent;
 import cz.metacentrum.perun.audit.events.EngineForceEvent;
 import cz.metacentrum.perun.core.api.Member;
 
-public class MemberSuspended extends AuditEvent implements EngineForceEvent {
+
+/**
+ * @author Vojtech Sassmann <vojtech.sassmann@gmail.com>
+ */
+public class MemberUnsuspended extends AuditEvent implements EngineForceEvent {
 
 	private Member member;
 	private String message;
 
 	@SuppressWarnings("unused") // used by jackson mapper
-	public MemberSuspended() {
-	}
+	public MemberUnsuspended() { }
 
-	public MemberSuspended(Member member) {
+	public MemberUnsuspended(Member member) {
 		this.member = member;
-		this.message = formatMessage("%s suspended.", member);
+		this.message = formatMessage("%s unsuspended.", member);
 	}
 
 	@Override

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/BanOnVo.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/BanOnVo.java
@@ -1,0 +1,64 @@
+package cz.metacentrum.perun.core.api;
+
+import java.util.Date;
+
+/**
+ * @author Vojtech Sassmann <vojtech.sassmann@gmail.com>
+ */
+public class BanOnVo extends Ban {
+	private int memberId;
+	private int voId;
+
+	public BanOnVo() { }
+
+	public BanOnVo(int id,  int memberId, int voId, Date validityTo, String description) {
+		super(id, validityTo, description);
+		this.memberId = memberId;
+		this.voId = voId;
+	}
+
+	@Override
+	public String getType() {
+		return this.getClass().getSimpleName();
+	}
+
+	@Override
+	public int getSubjectId() {
+		return memberId;
+	}
+
+	@Override
+	public int getTargetId() {
+		return voId;
+	}
+
+	public int getMemberId() {
+		return memberId;
+	}
+
+	public void setMemberId(int memberId) {
+		this.memberId = memberId;
+	}
+
+	public int getVoId() {
+		return voId;
+	}
+
+	public void setVoId(int voId) {
+		this.voId = voId;
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder str = new StringBuilder();
+
+		Long validityInMiliseconds = null;
+		if(getValidityTo() != null) validityInMiliseconds = getValidityTo().getTime();
+
+		return str.append(getClass().getSimpleName()).append(":[id='").append(getId()
+		).append("', memberId='").append(memberId
+		).append("', voId='").append(voId
+		).append("', validityTo='").append(validityInMiliseconds
+		).append("', description='").append(getDescription()).append("']").toString();
+	}
+}

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/Member.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/Member.java
@@ -20,7 +20,6 @@ public class Member extends Auditable {
 	private MembershipType membershipType;
 	private Integer sourceGroupId;
 	private boolean sponsored = false;
-	private Date suspendedTo;
 	private Map<Integer, MemberGroupStatus> groupsStatuses = new HashMap<>();
 
 	public Member() {
@@ -123,20 +122,6 @@ public class Member extends Auditable {
 		this.sponsored = sponsored;
 	}
 
-	public Date getSuspendedTo() {
-		return suspendedTo;
-	}
-
-	public void setSuspendedTo(Date suspendedTo) { this.suspendedTo = suspendedTo; }
-
-	public boolean isSuspended() {
-		if(getSuspendedTo() != null) {
-			return suspendedTo.after(Date.from(LocalDate.now().atStartOfDay(ZoneId.systemDefault()).toInstant()));
-		}
-
-		return false;
-	}
-
 	/**
 	 * Adds member's status for given group. If member already had a VALID status
 	 * for given group, nothing is changed.
@@ -230,7 +215,6 @@ public class Member extends Auditable {
 				", type=<" + (getMembershipType() == null ? "\\0" : BeansUtils.createEscaping(getMembershipType().toString())) + ">" +
 				", sourceGroupId=<" + (getSourceGroupId() == null ? "\\0" : getSourceGroupId().toString()) + ">" +
 				", sponsored=<" + sponsored + ">" +
-				", suspendedTo=<" + (getSuspendedTo() == null ? "\\0" : BeansUtils.createEscaping(BeansUtils.getDateFormatter().format(getSuspendedTo()))) + ">" +
 				']';
 	}
 
@@ -243,7 +227,6 @@ public class Member extends Auditable {
 			"', type='" + membershipType +
 			"', sourceGroupId='" + sourceGroupId +
 			"', sponsored='" + sponsored +
-			"', suspendedTo='" + (getSuspendedTo() == null ? "null" : BeansUtils.getDateFormatter().format(getSuspendedTo())) +
 			"']";
 	}
 }

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/RichMember.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/RichMember.java
@@ -24,7 +24,6 @@ public class RichMember extends Member implements Comparable<PerunBean> {
 		setMembershipType(member.getMembershipType());
 		setSponsored(member.isSponsored());
 		this.setGroupsStatuses(member.getGroupStatuses());
-		this.setSuspendedTo(member.getSuspendedTo());
 		this.user = user;
 		this.userExtSources = userExtSources;
 		this.userAttributes = null;
@@ -113,7 +112,6 @@ public class RichMember extends Member implements Comparable<PerunBean> {
 			", type=<").append(getMembershipType()== null ? "\\0" : BeansUtils.createEscaping(getMembershipType().toString())).append(">").append(
 			", sourceGroupId=<").append(getSourceGroupId()== null ? "\\0" : getSourceGroupId().toString()).append(">").append(
 			", sponsored=<").append(isSponsored()).append(">").append(
-			", suspendedTo=<").append(getSuspendedTo() == null ? "\\0" : BeansUtils.createEscaping(BeansUtils.getDateFormatter().format(getSuspendedTo()))).append(">").append(
 			", user=<").append(getUser() == null ? "\\0" : getUser().serializeToString()).append(">").append(
 			", userExtSources=<").append(sUserESNew).append(">").append(
 			", userAttributes=<").append(sUserAttrNew).append(">").append(
@@ -132,7 +130,6 @@ public class RichMember extends Member implements Comparable<PerunBean> {
 			"', type='").append(getMembershipType()).append(
 			"', sourceGroupId='").append(getSourceGroupId()).append(
 			"', sponsored='").append(isSponsored()).append(
-			"', suspendedTo='").append(getSuspendedTo() == null ? "null" : BeansUtils.getDateFormatter().format(getSuspendedTo())).append(
 			"', user='").append(user).append(
 			"', userExtSources='").append(userExtSources).append(
 			"', userAttributes='").append(userAttributes).append(

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/Status.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/Status.java
@@ -7,7 +7,7 @@ import java.util.Map;
 public enum Status {
 	VALID  (0),
 	INVALID (1),    //just created object, where some information (e.g. attribute)  is missing
-	SUSPENDED (2),  //security issue
+//	SUSPENDED (2),  //security issue
 	EXPIRED (3),
 	DISABLED (4);   //use this status instead of deleting the entity
 

--- a/perun-base/src/main/resources/perun-roles.yml
+++ b/perun-base/src/main/resources/perun-roles.yml
@@ -4698,6 +4698,53 @@ perun_policies:
     include_policies:
       - default_policy
 
+  setBan_BanOnVo_policy:
+    policy_roles:
+      - VOADMIN: Vo
+    include_policies:
+      - default_policy
+
+  vo-removeBan_int_policy:
+    policy_roles:
+      - VOADMIN: Vo
+    include_policies:
+      - default_policy
+
+  vo-removeBanForMember_member_policy:
+    policy_roles:
+      - VOADMIN: Vo
+    include_policies:
+      - default_policy
+
+  vo-getBanById_int_policy:
+    policy_roles:
+      - PERUNOBSERVER:
+      - GROUPADMIN: Vo
+      - SELF: Member
+      - VOADMIN: Vo
+      - VOOBSERVER: Vo
+    include_policies:
+      - default_policy
+
+  vo-getBanForMember_member_policy:
+    policy_roles:
+      - PERUNOBSERVER:
+      - GROUPADMIN: Vo
+      - SELF: Member
+      - VOADMIN: Vo
+      - VOOBSERVER: Vo
+    include_policies:
+      - default_policy
+
+  getBansForVo_int_policy:
+    policy_roles:
+      - PERUNOBSERVER:
+      - GROUPADMIN: Vo
+      - VOADMIN: Vo
+      - VOOBSERVER: Vo
+    include_policies:
+      - default_policy
+
   #PerunNotifNotificationManagerImpl
   getPerunNotifReceiverById_int_policy:
     policy_roles:

--- a/perun-cli/Perun/beans/Member.pm
+++ b/perun-cli/Perun/beans/Member.pm
@@ -35,14 +35,7 @@ sub TO_JSON
 		$sponsored = undef;
 	}
 
-	my $suspendedTo;
-	if (defined($self->{_suspendedTo})) {
-		$suspendedTo = $self->{_suspendedTo};
-	} else {
-		$suspendedTo = undef;
-	}
-
-	return { id => $id, userId => $userId, sponsored => $sponsored, suspendedTo => $suspendedTo };
+	return { id => $id, userId => $userId, sponsored => $sponsored };
 }
 
 sub getId
@@ -113,35 +106,6 @@ sub setSponsored
 	return;
 }
 
-sub getSuspendedTo
-{
-	my $self = shift;
-	
-}
-
-sub setSuspendedTo
-{
-	my $self = shift;
-	$self->{_suspendedTo} = shift;
-
-  return;
-}
-
-sub isSuspended
-{
-	my $self = shift;
-
-	return ($self->{_suspendedTo}) ? 1 : 0;
-}
-
-sub isSuspendedToPrint
-{
-	my $self = shift;
-
-	return ($self->{_suspendedTo}) ? 'true' : 'false';
-}
-
-
 sub getStatus {
 	my $self = shift;
 	return $self->{_status};
@@ -160,11 +124,11 @@ sub getMembershipType {
 
 sub getCommonArrayRepresentation {
 	my $member = shift;
-	return ($member->getId, $member->getUserId, $member->getStatus, $member->getGroupStatus, $member->getMembershipType, $member->isSponsoredToPrint, $member->getSuspendedTo);
+	return ($member->getId, $member->getUserId, $member->getStatus, $member->getGroupStatus, $member->getMembershipType, $member->isSponsoredToPrint);
 }
 
 sub getCommonArrayRepresentationHeading {
-	return('Id', 'UserId', 'Status', 'Group Status', 'Membership type', 'Sponsored', 'SuspendedTo');
+	return('Id', 'UserId', 'Status', 'Group Status', 'Membership type', 'Sponsored');
 }
 
 1;

--- a/perun-cli/Perun/beans/RichMember.pm
+++ b/perun-cli/Perun/beans/RichMember.pm
@@ -125,11 +125,11 @@ sub getGroupStatus {
 
 sub getCommonArrayRepresentation {
 	my $self = shift;
-	return($self->{_id}, $self->{_user}->{id}, $self->getDisplayName, $self->{_status}, $self->{_groupStatus}, $self->{_membershipType}, $self->isSponsoredToPrint, $self->{_suspendedTo});
+	return($self->{_id}, $self->{_user}->{id}, $self->getDisplayName, $self->{_status}, $self->{_groupStatus}, $self->{_membershipType}, $self->isSponsoredToPrint);
 }
 
 sub getCommonArrayRepresentationHeading {
-	return('Member Id', 'User Id', 'Name', 'VO Status', 'Group Status', 'Membership type', 'Sponsored', 'SuspendedTo');
+	return('Member Id', 'User Id', 'Name', 'VO Status', 'Group Status', 'Membership type', 'Sponsored');
 }
 
 1;

--- a/perun-cli/exportGroupMembers
+++ b/perun-cli/exportGroupMembers
@@ -32,7 +32,7 @@ sub help {
 		   ...
 		   default value -a u:d:preferredMail m:d:organization
 		**)if parameter -s is not used the default value is
-		   VALID+INVALID+SUSPENDED
+		   VALID+INVALID
 		   if parameter -s is used but the list of statuses is empty
 		   ALL statuses are listed
 	};
@@ -72,13 +72,13 @@ unless (defined $groupId) {
 }
 
 unless (defined $statuses[0]) {
-	@statuses = ("VALID", "INVALID", "SUSPENDED");
+	@statuses = ("VALID", "INVALID");
 }
 if (defined $statuses[0] and $statuses[0] eq "") {
 	@statuses = ();
 }
 foreach my $stat (@statuses) {
-	if ($stat ne "VALID" and $stat ne "INVALID" and $stat ne "SUSPENDED" and $stat ne "EXPIRED" and $stat ne "DISABLED") {die "ERROR: wrong status value. \n";}
+	if ($stat ne "VALID" and $stat ne "INVALID" and $stat ne "EXPIRED" and $stat ne "DISABLED") {die "ERROR: wrong status value. \n";}
 }
 
 my $parentGroup = 0;

--- a/perun-cli/exportVoMembers
+++ b/perun-cli/exportVoMembers
@@ -27,7 +27,7 @@ sub help {
 		   ...
 		   default value -a u:d:preferredMail m:d:organization
 		**)if parameter -s is not used the default value is
-		   VALID+INVALID+SUSPENDED
+		   VALID+INVALID
 		   if parameter -s is used but the list of statuses is empty
 		   ALL statuses are listed
 	};
@@ -60,13 +60,13 @@ unless (defined $voId) {
 }
 
 unless (defined $statuses[0]) {
-	@statuses = ("VALID", "INVALID", "SUSPENDED");
+	@statuses = ("VALID", "INVALID");
 }
 if (defined $statuses[0] and $statuses[0] eq "") {
 	@statuses = ();
 }
 foreach my $stat (@statuses) {
-	if ($stat ne "VALID" and $stat ne "INVALID" and $stat ne "SUSPENDED" and $stat ne "EXPIRED" and $stat ne "DISABLED") {die "ERROR: wrong status value. \n";}
+	if ($stat ne "VALID" and $stat ne "INVALID" and $stat ne "EXPIRED" and $stat ne "DISABLED") {die "ERROR: wrong status value. \n";}
 }
 
 my %attrShort;

--- a/perun-cli/setMemberStatus
+++ b/perun-cli/setMemberStatus
@@ -13,7 +13,7 @@ sub help {
 	--------------------------------------
 	Available options:
 	--memberId        | -m member id
-	--status          | -s VALID/INVALID/SUSPENDED/EXPIRED/DISABLED
+	--status          | -s VALID/INVALID/EXPIRED/DISABLED
 	--batch           | -b batch
 	--help            | -h prints this help
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/MembersManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/MembersManager.java
@@ -953,23 +953,6 @@ public interface MembersManager {
 	Member setStatus(PerunSession sess, Member member, Status status) throws PrivilegeException, MemberNotExistsException, WrongAttributeValueException, WrongReferenceAttributeValueException, MemberNotValidYetException;
 
 	/**
-	 *  Set status of the member to specified status.
-	 *
-	 * @param sess
-	 * @param member
-	 * @param status new status
-	 * @param message message with reason for suspension
-	 * @return member with status set
-	 * @throws InternalErrorException
-	 * @throws MemberNotExistsException
-	 * @throws MemberNotValidYetException
-	 * @throws WrongReferenceAttributeValueException
-	 * @throws WrongAttributeValueException
-	 * @throws PrivilegeException
-	 */
-	Member setStatus(PerunSession sess, Member member, Status status, String message) throws PrivilegeException, MemberNotExistsException, WrongAttributeValueException, WrongReferenceAttributeValueException, MemberNotValidYetException;
-
-	/**
 	 * Set date to which will be member suspended in his VO.
 	 *
 	 * For almost unlimited time please use time in the far future.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/VosManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/VosManager.java
@@ -1,9 +1,11 @@
 package cz.metacentrum.perun.core.api;
 
 import cz.metacentrum.perun.core.api.exceptions.AlreadyAdminException;
+import cz.metacentrum.perun.core.api.exceptions.BanNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.GroupNotAdminException;
 import cz.metacentrum.perun.core.api.exceptions.GroupNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.MemberNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
 import cz.metacentrum.perun.core.api.exceptions.RelationExistsException;
 import cz.metacentrum.perun.core.api.exceptions.RoleNotSupportedException;
@@ -482,4 +484,68 @@ public interface VosManager {
 	 */
 	void removeSponsorRole(PerunSession sess, Vo vo, Group group) throws GroupNotAdminException, VoNotExistsException, GroupNotExistsException, PrivilegeException;
 
+	/**
+	 * Set ban for member on his vo.
+	 *
+	 * @param sess session
+	 * @param ban ban information
+	 * @return created ban object
+	 * @throws PrivilegeException insufficient permissions
+	 * @throws MemberNotExistsException if there is no member with specified id
+	 */
+	BanOnVo setBan(PerunSession sess, BanOnVo ban) throws PrivilegeException, MemberNotExistsException;
+
+	/**
+	 * Remove vo ban with given id.
+	 *
+	 * @param sess session
+	 * @param banId if of vo ban
+	 * @throws PrivilegeException insufficient permissions
+	 * @throws BanNotExistsException if there is no ban with specified id
+	 */
+	void removeBan(PerunSession sess, int banId) throws PrivilegeException, BanNotExistsException;
+
+	/**
+	 * Remove vo ban for given member.
+	 *
+	 * @param sess session
+	 * @param member member
+	 * @throws PrivilegeException insufficient permissions
+	 * @throws BanNotExistsException if there is no ban for member with given id
+	 * @throws MemberNotExistsException if there is no such member
+	 */
+	void removeBanForMember(PerunSession sess, Member member) throws PrivilegeException, BanNotExistsException, MemberNotExistsException;
+
+	/**
+	 * Get vo ban with given id.
+	 *
+	 * @param sess session
+	 * @param banId ban id
+	 * @return found ban
+	 * @throws BanNotExistsException if there is no such ban
+	 * @throws PrivilegeException insufficient permissions
+	 */
+	BanOnVo getBanById(PerunSession sess, int banId) throws BanNotExistsException, PrivilegeException;
+
+	/**
+	 * Get ban for given member, or null if he is not banned.
+	 *
+	 * @param sess session
+	 * @param member member
+	 * @return found ban or null if the member is not banned
+	 * @throws PrivilegeException insufficient permissions
+	 * @throws MemberNotExistsException if there is no such member
+	 */
+	BanOnVo getBanForMember(PerunSession sess, Member member) throws PrivilegeException, MemberNotExistsException;
+
+	/**
+	 * Get list of all bans for vo with given id.
+	 *
+	 * @param sess session
+	 * @param voId vo id
+	 * @return vo bans for given vo
+	 * @throws PrivilegeException insufficient permissions
+	 * @throws VoNotExistsException if there is no vo with given id
+	 */
+	List<BanOnVo> getBansForVo(PerunSession sess, int voId) throws PrivilegeException, VoNotExistsException;
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/MembersManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/MembersManagerBl.java
@@ -1158,22 +1158,6 @@ public interface MembersManagerBl {
 	Member setStatus(PerunSession sess, Member member, Status status) throws WrongAttributeValueException, WrongReferenceAttributeValueException, MemberNotValidYetException;
 
 	/**
-	 *  Set status of the member to specified status.
-	 *
-	 * @param sess
-	 * @param member
-	 * @param status new status
-	 * @param message message with reason for suspension
-	 * @return member with status set
-	 *
-	 * @throws InternalErrorException
-	 * @throws WrongReferenceAttributeValueException
-	 * @throws MemberNotValidYetException
-	 * @throws WrongAttributeValueException
-	 */
-	Member setStatus(PerunSession sess, Member member, Status status, String message) throws WrongAttributeValueException, WrongReferenceAttributeValueException, MemberNotValidYetException;
-
-	/**
 	 * Validate all atributes for member and set member's status to VALID.
 	 * This method runs synchronously.
 	 *
@@ -1214,35 +1198,6 @@ public interface MembersManagerBl {
 	 * @throws InternalErrorException
 	 */
 	Member invalidateMember(PerunSession sess, Member member);
-
-	/**
-	 * Suspend member.
-	 *
-	 * As side effect it will change status of the object member.
-	 *
-	 * @param sess
-	 * @param member
-	 * @return member with new status set
-	 *
-	 * @throws InternalErrorException
-	 * @throws MemberNotValidYetException
-	 */
-	Member suspendMember(PerunSession sess, Member member) throws MemberNotValidYetException;
-
-	/**
-	 * Suspend member with reason for suspension.
-	 *
-	 * As side effect it will change status of the object member.
-	 *
-	 * @param sess
-	 * @param member
-	 * @param message
-	 * @return member with new status set
-	 *
-	 * @throws InternalErrorException
-	 * @throws MemberNotValidYetException
-	 */
-	Member suspendMember(PerunSession sess, Member member, String message) throws MemberNotValidYetException;
 
 	/**
 	 * Set member's status to expired.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/VosManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/VosManagerBl.java
@@ -1,5 +1,6 @@
 package cz.metacentrum.perun.core.bl;
 
+import cz.metacentrum.perun.core.api.BanOnVo;
 import cz.metacentrum.perun.core.api.Candidate;
 import cz.metacentrum.perun.core.api.ExtSource;
 import cz.metacentrum.perun.core.api.Facility;
@@ -13,14 +14,18 @@ import cz.metacentrum.perun.core.api.RichUser;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.Vo;
 import cz.metacentrum.perun.core.api.exceptions.AlreadyAdminException;
+import cz.metacentrum.perun.core.api.exceptions.BanNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.GroupNotAdminException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.MemberNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotAdminException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.VoExistsException;
 import cz.metacentrum.perun.core.api.exceptions.VoNotExistsException;
 
+import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * <p>VOs manager can create, delete, update and find VO.</p>
@@ -426,4 +431,77 @@ public interface VosManagerBl {
 	 * @throws InternalErrorException
 	 */
 	void handleGroupLostVoRole(PerunSession sess, Group group, Vo vo, String role);
+
+	/**
+	 * Set given ban.
+	 *
+	 * @param sess session
+	 * @param banOnVo ban information, memberId, voId, validity and description are needed
+	 * @return created ban object
+	 */
+	BanOnVo setBan(PerunSession sess, BanOnVo banOnVo) throws MemberNotExistsException;
+
+	/**
+	 * Get ban by its id.
+	 *
+	 * @param sess session
+	 * @param banId ban id
+	 * @return ban object
+	 * @throws BanNotExistsException if ban with given id is not found
+	 */
+	BanOnVo getBanById(PerunSession sess, int banId) throws BanNotExistsException;
+
+	/**
+	 * Get ban for given member, if it exists.
+	 *
+	 * @param sess session
+	 * @param memberId member id
+	 * @return ban object, or null if there is no ban for given member
+	 */
+	Optional<BanOnVo> getBanForMember(PerunSession sess, int memberId);
+
+	/**
+	 * Get list of all bans for vo with given id.
+	 *
+	 * @param sess session
+	 * @param voId vo id
+	 * @return list of bans for given vo
+	 */
+	List<BanOnVo> getBansForVo(PerunSession sess, int voId);
+
+	/**
+	 * Update ban information. Only description and validity are updated.
+	 *
+	 * @param sess session
+	 * @param banOnVo updated ban
+	 * @return updated ban object
+	 */
+	BanOnVo updateBan(PerunSession sess, BanOnVo banOnVo);
+
+	/**
+	 * Removes ban with given id.
+	 *
+	 * @param sess session
+	 * @param banId ban id
+	 * @throws BanNotExistsException if there is no ban with given id
+	 */
+	void removeBan(PerunSession sess, int banId) throws BanNotExistsException;
+
+	/**
+	 * Removes ban for member with given id.
+	 *
+	 * @param sess session
+	 * @param memberId member id
+	 * @throws BanNotExistsException if there is no ban for member with given id
+	 */
+	void removeBanForMember(PerunSession sess, int memberId) throws BanNotExistsException;
+
+	/**
+	 * Information if there is a ban for member with given id.
+	 *
+	 * @param sess session
+	 * @param memberId member id
+	 * @return true, if member with given id is banned, false otherwise
+	 */
+	boolean isMemberBanned(PerunSession sess, int memberId);
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
@@ -25,6 +25,7 @@ import cz.metacentrum.perun.core.api.ActionType;
 import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AuthzResolver;
+import cz.metacentrum.perun.core.api.BanOnVo;
 import cz.metacentrum.perun.core.api.BeansUtils;
 import cz.metacentrum.perun.core.api.ExtSource;
 import cz.metacentrum.perun.core.api.Facility;
@@ -2118,6 +2119,13 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 	 * The source object is returned alongside its related objects.
 	 */
 	private enum RelatedObjectsResolver implements Function<PerunBean, List<PerunBean>> {
+		BanOnVo((object) -> {
+			Vo vo = new Vo();
+			vo.setId(((BanOnVo)object).getVoId());
+			Member member = new Member();
+			member.setId(((BanOnVo)object).getMemberId());
+			return Arrays.asList(vo, object);
+		}),
 		UserExtSource((object) -> {
 			User user = new User();
 			user.setId(((UserExtSource) object).getUserId());

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/MembersManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/MembersManagerEntry.java
@@ -986,20 +986,6 @@ public class MembersManagerEntry implements MembersManager {
 	}
 
 	@Override
-	public Member setStatus(PerunSession sess, Member member, Status status, String message) throws PrivilegeException, MemberNotExistsException, WrongAttributeValueException, WrongReferenceAttributeValueException, MemberNotValidYetException {
-		Utils.checkPerunSession(sess);
-
-		getMembersManagerBl().checkMemberExists(sess, member);
-
-		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "setStatus_Member_Status_String_policy", member)) {
-			throw new PrivilegeException(sess, "setStatus");
-		}
-
-		return getMembersManagerBl().setStatus(sess, member, status, message);
-	}
-
-	@Override
 	public void suspendMemberTo(PerunSession sess, Member member, Date suspendedTo) throws MemberNotExistsException, PrivilegeException {
 		Utils.checkPerunSession(sess);
 		Utils.notNull(suspendedTo, "suspendedTo");
@@ -1024,8 +1010,6 @@ public class MembersManagerEntry implements MembersManager {
 		if (!AuthzResolver.authorizedInternal(sess, "unsuspendMember_Member_policy", member)) {
 			throw new PrivilegeException(sess, "unsuspendMember");
 		}
-
-		if(member.getSuspendedTo() == null) throw new MemberNotSuspendedException(member);
 
 		membersManagerBl.unsuspendMember(sess, member);
 	}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Auditer.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Auditer.java
@@ -52,8 +52,6 @@ public class Auditer {
 	@GuardedBy("Auditer.class")
 	private static volatile Auditer selfInstance;
 
-	public final static String engineForceKeyword = "forceit";
-
 	private final static Logger log = LoggerFactory.getLogger(Auditer.class);
 	private final static Logger transactionLogger = LoggerFactory.getLogger("transactionLogger");
 	private JdbcPerunTemplate jdbc;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/MembersManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/MembersManagerImpl.java
@@ -48,7 +48,6 @@ public class MembersManagerImpl implements MembersManagerImplApi {
 	final static String memberMappingSelectQuery = "members.id as members_id, members.user_id as members_user_id, members.vo_id as members_vo_id, members.status as members_status, " +
 			"members.sponsored as members_sponsored, " +
 			"members.created_at as members_created_at, members.created_by as members_created_by, members.modified_by as members_modified_by, members.modified_at as members_modified_at, " +
-			"members.suspended_to as members_suspended_to, " +
 			"members.created_by_uid as members_created_by_uid, members.modified_by_uid as members_modified_by_uid";
 
 	final static String groupsMembersMappingSelectQuery = memberMappingSelectQuery + ", groups_members.membership_type as membership_type, " +
@@ -68,7 +67,6 @@ public class MembersManagerImpl implements MembersManagerImplApi {
 				rs.getInt("members_created_by_uid") == 0 ? null : rs.getInt("members_created_by_uid"),
 				rs.getInt("members_modified_by_uid") == 0 ? null : rs.getInt("members_modified_by_uid"));
 		member.setSponsored(rs.getBoolean("members_sponsored"));
-		member.setSuspendedTo(rs.getDate("members_suspended_to"));
 		return member;
 	};
 
@@ -243,27 +241,6 @@ public class MembersManagerImpl implements MembersManagerImplApi {
 			return false;
 		} catch (EmptyResultDataAccessException ex) {
 			return false;
-		} catch (RuntimeException ex) {
-			throw new InternalErrorException(ex);
-		}
-	}
-
-	@Override
-	public void suspendMemberTo(PerunSession sess, Member member, Date suspendedTo) {
-		Utils.notNull(member, "member");
-		Utils.notNull(suspendedTo, "suspendedTo");
-		try {
-			jdbc.update("update members set suspended_to=?, modified_by=?, modified_at=" + Compatibility.getSysdate() + "  where id=?", suspendedTo, sess.getPerunPrincipal().getActor(), member.getId());
-		} catch (RuntimeException ex) {
-			throw new InternalErrorException(ex);
-		}
-	}
-
-	@Override
-	public void unsuspendMember(PerunSession sess, Member member) {
-		Utils.notNull(member, "member");
-		try {
-			jdbc.update("update members set suspended_to=?, modified_by=?, modified_at=" + Compatibility.getSysdate() + "  where id=?", null, sess.getPerunPrincipal().getActor(), member.getId());
 		} catch (RuntimeException ex) {
 			throw new InternalErrorException(ex);
 		}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/MembersManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/MembersManagerImplApi.java
@@ -129,29 +129,6 @@ public interface MembersManagerImplApi {
 	boolean memberExists(PerunSession perunSession, Member member);
 
 	/**
-	 * Set date to which will be member suspended in his VO.
-	 *
-	 * For almost unlimited time please use time in the far future.
-	 *
-	 * @param sess
-	 * @param member member who will be suspended
-	 * @param suspendedTo date to which will be member suspended (after this date, he will not be affected by suspension any more)
-	 * @throws InternalErrorException
-	 */
-	void suspendMemberTo(PerunSession sess, Member member, Date suspendedTo);
-
-	/**
-	 * Remove suspend state from Member - remove date to which member should be considered as suspended in the VO.
-	 *
-	 * WARNING: this method will always succeed if member exists, because it will set date for suspension to null
-	 *
-	 * @param sess
-	 * @param member member for which the suspend state will be removed
-	 * @throws InternalErrorException
-	 */
-	void unsuspendMember(PerunSession sess, Member member);
-
-	/**
 	 * Check if member exists in underlaying data source.
 	 *
 	 * @param perunSession

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/VosManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/VosManagerImplApi.java
@@ -1,10 +1,13 @@
 package cz.metacentrum.perun.core.implApi;
 
+import cz.metacentrum.perun.core.api.BanOnVo;
 import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.Pair;
+import cz.metacentrum.perun.core.api.Perun;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.Vo;
+import cz.metacentrum.perun.core.api.exceptions.BanNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.VoExistsException;
 import cz.metacentrum.perun.core.api.exceptions.VoNotExistsException;
@@ -238,4 +241,68 @@ public interface VosManagerImplApi {
 	 */
 	int getVosCount(PerunSession perunSession);
 
+	/**
+	 * Set given ban.
+	 *
+	 * @param sess session
+	 * @param banOnVo ban information, memberId, voId, validity and description are needed
+	 * @return created ban object
+	 */
+	BanOnVo setBan(PerunSession sess, BanOnVo banOnVo);
+
+	/**
+	 * Get ban by its id.
+	 *
+	 * @param sess session
+	 * @param banId ban id
+	 * @return ban object
+	 * @throws BanNotExistsException if ban with given id is not found
+	 */
+	BanOnVo getBanById(PerunSession sess, int banId) throws BanNotExistsException;
+
+	/**
+	 * Get ban for given member.
+	 *
+	 * @param sess session
+	 * @param memberId member id
+	 * @return ban object
+	 * @throws BanNotExistsException if there is no ban for member with given id
+	 */
+	BanOnVo getBanForMember(PerunSession sess, int memberId) throws BanNotExistsException;
+
+	/**
+	 * Get list of all bans for vo with given id.
+	 *
+	 * @param sess session
+	 * @param voId vo id
+	 * @return list of bans for given vo
+	 */
+	List<BanOnVo> getBansForVo(PerunSession sess, int voId);
+
+	/**
+	 * Update ban information. Only description and validity are updated.
+	 *
+	 * @param sess session
+	 * @param banOnVo updated ban
+	 * @return updated ban object
+	 */
+	BanOnVo updateBan(PerunSession sess, BanOnVo banOnVo);
+
+	/**
+	 * Removes ban with given id.
+	 *
+	 * @param sess session
+	 * @param banId ban id
+	 * @throws BanNotExistsException if there is no ban with given id
+	 */
+	void removeBan(PerunSession sess, int banId) throws BanNotExistsException;
+
+	/**
+	 * Information if there is a ban for member with given id.
+	 *
+	 * @param sess session
+	 * @param memberId member id
+	 * @return true, if member with given id is banned, false otherwise
+	 */
+	boolean isMemberBanned(PerunSession sess, int memberId);
 }

--- a/perun-core/src/main/resources/hsqldbChangelog.txt
+++ b/perun-core/src/main/resources/hsqldbChangelog.txt
@@ -3,6 +3,9 @@
 
 -- this update is not supported on hsql since its used only as in-memory db
 
+3.1.68
+update configurations set value='3.1.68' where property='DATABASE VERSION';
+
 3.1.67
 update configurations set value='3.1.67' where property='DATABASE VERSION';
 

--- a/perun-core/src/main/resources/postgresChangelog.txt
+++ b/perun-core/src/main/resources/postgresChangelog.txt
@@ -6,6 +6,17 @@
 -- Directly under version number should be version commands. They will be executed in the order they are written here.
 -- Comments are prefixed with -- and can be written only between version blocks, that means not in the lines with commands. They have to be at the start of the line.
 
+3.1.68
+CREATE TABLE vos_bans (id integer not null, member_id integer not null, vo_id integer not null, description varchar, banned_to timestamp default '2999-01-01 00:00:00' not null, created_at timestamp default statement_timestamp() not null, created_by varchar default user not null, modified_at timestamp default statement_timestamp() not null, modified_by varchar default user not null, created_by_uid integer, modified_by_uid integer, constraint vos_bans_pk primary key (id), constraint vos_bans_u unique (member_id), constraint vos_bans_mem_fk foreign key (member_id) references members (id), constraint vos_bans_vo_fk foreign key (vo_id) references vos (id));
+CREATE SEQUENCE "vos_bans_id_seq";
+CREATE INDEX idx_fk_vos_ban_member ON vos_bans (member_id);
+CREATE INDEX idx_fk_vos_ban_vos ON vos_bans (vo_id);
+GRANT ALL ON vos_bans TO perun;
+INSERT INTO vos_bans (id, description, banned_to, member_id, vo_id) SELECT nextval('vos_bans_id_seq'), 'AUTO CREATED FROM SUSPEND STATUS', members.suspended_to, members.id, members.vo_id FROM members WHERE status = 2;
+UPDATE members SET status=0 WHERE status = 2;
+ALTER TABLE members DROP COLUMN suspended_to;
+UPDATE configurations SET value='3.1.68' WHERE property='DATABASE VERSION';
+
 3.1.67
 ALTER TABLE users ADD COLUMN uu_id UUID not null default gen_random_uuid();
 ALTER TABLE groups ADD COLUMN uu_id UUID not null default gen_random_uuid();

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/MembersManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/MembersManagerEntryIntegrationTest.java
@@ -249,7 +249,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 		perun.getAttributesManagerBl().setAttributes(sess, createdMember, resource, new ArrayList<>(Collections.singletonList(memberResourceAttribute1)));
 
 		List<String> attrNames = new ArrayList<>(Arrays.asList(userAttribute1.getName(), memberAttribute1.getName(), userFacilityAttribute1.getName(), memberResourceAttribute1.getName()));
-		List<RichMember> richMembers = membersManagerEntry.getCompleteRichMembers(sess, createdGroup, resource, attrNames, Arrays.asList("INVALID", "DISABLED", "SUSPENDED", "EXPIRED"));
+		List<RichMember> richMembers = membersManagerEntry.getCompleteRichMembers(sess, createdGroup, resource, attrNames, Arrays.asList("INVALID", "DISABLED", "EXPIRED"));
 		assertTrue(richMembers.isEmpty());
 		richMembers = membersManagerEntry.getCompleteRichMembers(sess, createdGroup, resource, attrNames, Collections.singletonList("VALID"));
 
@@ -336,22 +336,11 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 		Date tommorow = Date.from(today.plusDays(1).atStartOfDay(ZoneId.systemDefault()).toInstant());
 
 		Member member = perun.getMembersManager().getMemberById(sess, createdMember.getId());
-		assertTrue(member.getSuspendedTo() == null);
-		assertFalse(member.isSuspended());
 
 		perun.getMembersManager().suspendMemberTo(sess, member, yesterday);
 		member = perun.getMembersManager().getMemberById(sess, member.getId());
-		String returnedValue = BeansUtils.getDateFormatterWithoutTime().format(member.getSuspendedTo());
-		String expectedValue = BeansUtils.getDateFormatterWithoutTime().format(yesterday);
-		assertEquals(expectedValue, returnedValue);
-		assertFalse(member.isSuspended());
 
 		perun.getMembersManager().suspendMemberTo(sess, member, tommorow);
-		member = perun.getMembersManager().getMemberById(sess, member.getId());
-		returnedValue = BeansUtils.getDateFormatterWithoutTime().format(member.getSuspendedTo());
-		expectedValue = BeansUtils.getDateFormatterWithoutTime().format(tommorow);
-		assertEquals(expectedValue, returnedValue);
-		assertTrue(member.isSuspended());
 	}
 
 	@Test
@@ -361,16 +350,9 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 		Date tommorow = Date.from(today.plusDays(1).atStartOfDay(ZoneId.systemDefault()).toInstant());
 
 		Member member = perun.getMembersManager().getMemberById(sess, createdMember.getId());
-		assertTrue(member.getSuspendedTo() == null);
-		assertFalse(member.isSuspended());
 
 		perun.getMembersManager().suspendMemberTo(sess, member, tommorow);
-		member = perun.getMembersManager().getMemberById(sess, member.getId());
-		assertTrue(member.isSuspended());
-
 		perun.getMembersManager().unsuspendMember(sess, member);
-		member = perun.getMembersManager().getMemberById(sess, member.getId());
-		assertFalse(member.isSuspended());
 	}
 
 	@Test
@@ -657,8 +639,8 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 	public void getMembersCountByStatus() throws Exception {
 		System.out.println(CLASS_NAME + "getMembersCountByStatus");
 
-		final int count = membersManagerEntry.getMembersCount(sess, createdVo, Status.SUSPENDED);
-		assertTrue("testing VO should have 0 members with SUSPENDED status", count == 0);
+		final int count = membersManagerEntry.getMembersCount(sess, createdVo, Status.EXPIRED);
+		assertTrue("testing VO should have 0 members with EXPIRED status", count == 0);
 		final int count2 = membersManagerEntry.getMembersCount(sess, createdVo, Status.VALID);
 		assertTrue("testing VO should have 1 member with VALID status", count2 == 1);
 

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/VosManagerImplIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/VosManagerImplIntegrationTest.java
@@ -1,0 +1,172 @@
+package cz.metacentrum.perun.core.impl;
+
+import cz.metacentrum.perun.core.AbstractPerunIntegrationTest;
+import cz.metacentrum.perun.core.api.BanOnVo;
+import cz.metacentrum.perun.core.api.Member;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.Vo;
+import cz.metacentrum.perun.core.api.exceptions.BanNotExistsException;
+import cz.metacentrum.perun.core.implApi.MembersManagerImplApi;
+import cz.metacentrum.perun.core.implApi.VosManagerImplApi;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Date;
+import java.util.List;
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+/**
+ * @author Vojtech Sassmann <vojtech.sassmann@gmail.com>
+ */
+public class VosManagerImplIntegrationTest extends AbstractPerunIntegrationTest {
+
+	private final static String CLASS_NAME = "VosManagerImpl.";
+
+	private User user;
+	private Member member;
+	private Member otherMember;
+	private Vo vo;
+	private Vo otherVo;
+
+	private VosManagerImplApi vosManagerImpl;
+
+	@Before
+	public void setUp() throws Exception {
+		MembersManagerImplApi membersManagerImplApi = (MembersManagerImplApi) ReflectionTestUtils.getField(
+				perun.getMembersManagerBl(), "membersManagerImpl");
+		if (membersManagerImplApi == null) {
+			throw new RuntimeException("Failed to get membersManagerImpl");
+		}
+
+		vosManagerImpl = (VosManagerImplApi) ReflectionTestUtils.getField(perun.getVosManagerBl(), "vosManagerImpl");
+		if (vosManagerImpl == null) {
+			throw new RuntimeException("Failed to get vosManagerImpl");
+		}
+
+		user = new User(-1, "John", "Doe", "", "", "");
+		user = perun.getUsersManagerBl().createUser(sess, user);
+
+		vo = new Vo(-1, "Vo", "vo");
+		vo = perun.getVosManagerBl().createVo(sess, vo);
+
+		member = membersManagerImplApi.createMember(sess, vo, user);
+
+		otherVo = new Vo(-1, "Other vo", "othervo");
+		otherVo = perun.getVosManagerBl().createVo(sess, otherVo);
+
+		otherMember = membersManagerImplApi.createMember(sess, otherVo, user);
+	}
+
+	@Test
+	public void setBan() throws Exception {
+		System.out.println(CLASS_NAME + "setBan");
+
+		BanOnVo originBan = new BanOnVo(-1, member.getId(), vo.getId(), new Date(), "noob");
+		originBan = vosManagerImpl.setBan(sess, originBan);
+
+		BanOnVo actualBan = vosManagerImpl.getBanForMember(sess, originBan.getMemberId());
+
+		assertThat(originBan).isEqualTo(actualBan);
+	}
+
+	@Test
+	public void getBanById() throws Exception {
+		System.out.println(CLASS_NAME + "getBanById");
+
+		BanOnVo originBan = new BanOnVo(-1, member.getId(), vo.getId(), new Date(), "noob");
+		originBan = vosManagerImpl.setBan(sess, originBan);
+
+		BanOnVo actualBan = vosManagerImpl.getBanById(sess, originBan.getId());
+
+		isValidBan(actualBan, originBan.getId(), originBan.getMemberId(), originBan.getVoId(),
+				originBan.getValidityTo(), originBan.getDescription());
+	}
+
+	@Test
+	public void getBanForMember() throws Exception {
+		System.out.println(CLASS_NAME + "getBanForMember");
+
+		BanOnVo originBan = new BanOnVo(-1, member.getId(), vo.getId(), new Date(), "noob");
+		originBan = vosManagerImpl.setBan(sess, originBan);
+
+		BanOnVo actualBan = vosManagerImpl.getBanById(sess, originBan.getId());
+
+		isValidBan(actualBan, originBan.getId(), originBan.getMemberId(), originBan.getVoId(),
+				originBan.getValidityTo(), originBan.getDescription());
+	}
+
+	@Test
+	public void getBansForVo() {
+		System.out.println(CLASS_NAME + "getBansForVo");
+
+		BanOnVo originBan = new BanOnVo(-1, member.getId(), vo.getId(), new Date(), "noob");
+		originBan = vosManagerImpl.setBan(sess, originBan);
+
+		BanOnVo otherBan = new BanOnVo(-1, otherMember.getId(), otherVo.getId(), new Date(), "noob");
+		vosManagerImpl.setBan(sess, otherBan);
+
+		List<BanOnVo> voBans = vosManagerImpl.getBansForVo(sess, vo.getId());
+
+		assertThat(voBans).containsOnly(originBan);
+	}
+
+	@Test
+	public void updateBanDescription() throws Exception {
+		System.out.println(CLASS_NAME + "updateBanDescription");
+
+		testUpdateBan(ban -> ban.setDescription("Updated Description"));
+	}
+
+	@Test
+	public void updateBanValidity() throws Exception {
+		System.out.println(CLASS_NAME + "updateBanValidity");
+
+		testUpdateBan(ban -> ban.setValidityTo(new Date(1434343L)));
+	}
+
+	@Test
+	public void removeBan() throws Exception {
+		System.out.println(CLASS_NAME + "removeBan");
+
+		BanOnVo originBan = new BanOnVo(-1, member.getId(), vo.getId(), new Date(), "noob");
+		vosManagerImpl.setBan(sess, originBan);
+
+		vosManagerImpl.removeBan(sess, originBan.getId());
+
+		assertThatExceptionOfType(BanNotExistsException.class)
+				.isThrownBy(() -> vosManagerImpl.getBanById(sess, originBan.getId()));
+	}
+
+	private void testUpdateBan(Consumer<BanOnVo> banChange) throws Exception {
+		BanOnVo originBan = new BanOnVo(-1, member.getId(), vo.getId(), new Date(), "noob");
+		originBan = vosManagerImpl.setBan(sess, originBan);
+		originBan = vosManagerImpl.getBanById(sess, originBan.getId());
+
+		banChange.accept(originBan);
+
+		vosManagerImpl.updateBan(sess, originBan);
+
+		BanOnVo updatedBan = vosManagerImpl.getBanById(sess, originBan.getId());
+
+		assertThat(updatedBan).isEqualByComparingTo(originBan);
+	}
+
+	private void isValidBan(BanOnVo ban, int banId, int memberId, int voId, Date validity, String description) {
+		assertThat(ban.getId()).isEqualTo(banId);
+		assertThat(ban.getMemberId()).isEqualTo(memberId);
+		assertThat(ban.getVoId()).isEqualTo(voId);
+		assertThat(ban.getValidityTo()).isEqualTo(validity);
+		assertThat(ban.getDescription()).isEqualTo(description);
+
+		assertThat(ban.getCreatedAt()).isNotNull();
+		assertThat(ban.getCreatedBy()).isNotNull();
+		assertThat(ban.getCreatedByUid()).isNotNull();
+		assertThat(ban.getModifiedAt()).isNotNull();
+		assertThat(ban.getModifiedBy()).isNotNull();
+		assertThat(ban.getModifiedByUid()).isNotNull();
+	}
+}

--- a/perun-db/postgres.sql
+++ b/perun-db/postgres.sql
@@ -1,4 +1,4 @@
--- database version 3.1.67 (don't forget to update insert statement at the end of file)
+-- database version 3.1.68 (don't forget to update insert statement at the end of file)
 
 -- VOS - virtual organizations
 create table vos (
@@ -238,7 +238,6 @@ create table members (
 	modified_by varchar default user not null,
 	status integer default 0 not null, --status of membership
 	sponsored boolean default false not null,
-	suspended_to timestamp,
 	created_by_uid integer,
 	modified_by_uid integer,
 	constraint mem_pk primary key(id),
@@ -1312,6 +1311,24 @@ create table blacklists (
   constraint bllist_user_fk foreign key (user_id) references users(id)
 );
 
+create table vos_bans (
+	id integer not null,
+	member_id integer not null,
+	vo_id integer not null,
+	description varchar,
+	banned_to timestamp default '2999-01-01 00:00:00' not null,
+	created_at timestamp default statement_timestamp() not null,
+	created_by varchar default user not null,
+	modified_at timestamp default statement_timestamp() not null,
+	modified_by varchar default user not null,
+	created_by_uid integer,
+	modified_by_uid integer,
+	constraint vos_bans_pk primary key (id),
+	constraint vos_bans_u unique (member_id),
+	constraint vos_bans_mem_fk foreign key (member_id) references members (id),
+	constraint vos_bans_vo_fk foreign key (vo_id) references vos (id)
+);
+
 create table resources_bans (
 	id integer not null,
 	member_id integer not null,
@@ -1463,6 +1480,7 @@ create sequence "pwdreset_id_seq";
 create sequence "security_teams_id_seq";
 create sequence "resources_bans_id_seq";
 create sequence "facilities_bans_id_seq";
+create sequence "vos_bans_id_seq";
 
 create index idx_namespace on attr_names(namespace);
 create index idx_authz_user_role_id on authz (user_id,role_id);
@@ -1599,6 +1617,8 @@ create index idx_fk_res_ban_member_res on resources_bans (member_id, resource_id
 create index idx_fk_fac_ban_user on facilities_bans (user_id);
 create index idx_fk_fac_ban_fac on facilities_bans (facility_id);
 create index idx_fk_fac_ban_user_fac on facilities_bans (user_id, facility_id);
+create index idx_fk_vos_ban_member on vos_bans (member_id);
+create index idx_fk_vos_ban_vos on vos_bans (vo_id);
 create index idx_fk_ues_attr_values_ues on user_ext_source_attr_values (user_ext_source_id);
 create index idx_fk_ues_attr_values_attr on user_ext_source_attr_values (attr_id);
 create index idx_fk_memspons_mem ON members_sponsored(sponsored_id);
@@ -1709,13 +1729,14 @@ grant all on security_teams_facilities to perun;
 grant all on blacklists to perun;
 grant all on resources_bans to perun;
 grant all on facilities_bans to perun;
+grant all on vos_bans to perun;
 grant all on membership_types to perun;
 grant all on user_ext_source_attr_values to perun;
 grant all on user_ext_source_attr_u_values to perun;
 grant all on members_sponsored to perun;
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.1.67');
+insert into configurations values ('DATABASE VERSION','3.1.68');
 
 -- insert membership types
 insert into membership_types (id, membership_type, description) values (1, 'DIRECT', 'Member is directly added into group');

--- a/perun-ldapc/src/main/resources/perun-ldapc.xml
+++ b/perun-ldapc/src/main/resources/perun-ldapc.xml
@@ -565,7 +565,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 							<value>cz.metacentrum.perun.core.api.Member</value>
 						</list>
 					</property>
-					<property name="pattern" value="expired.$|disabled.$|invalidated.$|suspended #"/>
+					<property name="pattern" value="expired.$|disabled.$|invalidated.$|suspended.$"/>
 					<property name="handlerMethodName" value="processMemberRemoved"/>
 				</bean>
 				<bean class="cz.metacentrum.perun.ldapc.processor.impl.RegexpDispatchEventCondition">
@@ -612,7 +612,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 							<value>cz.metacentrum.perun.core.api.Member</value>
 						</list>
 					</property>
-					<property name="pattern" value="expired.$|disabled.$|invalidated.$|suspended #"/>
+					<property name="pattern" value="expired.$|disabled.$|invalidated.$|suspended.$"/>
 					<property name="handlerMethodName" value="processMemberInvalidated"/>
 				</bean>
 				<bean class="cz.metacentrum.perun.ldapc.processor.impl.RegexpDispatchEventCondition">

--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -124,8 +124,6 @@ components:
             membershipType: { type: string }
             sourceGroupId: { type: integer }
             sponsored: { type: boolean }
-            suspendedTo: { type: string }
-            suspended: { type: boolean }
             groupStatus:  { type: string }
             groupStatuses:
               type: object
@@ -481,7 +479,6 @@ components:
       enum:
         - VALID
         - INVALID
-        - SUSPENDED
         - EXPIRED
         - DISABLED
 
@@ -709,6 +706,15 @@ components:
         - properties:
             memberId: { type: integer }
             resourceId: { type: integer }
+      discriminator:
+        propertyName: beanName
+
+    BanOnVo:
+      allOf:
+        - $ref: '#/components/schemas/Ban'
+        - properties:
+            memberId: { type: integer }
+            voId: { type: integer }
       discriminator:
         propertyName: beanName
 
@@ -1531,6 +1537,22 @@ components:
                 type: string
                 enum: [DOT, TGF]
 
+    BanOnVoResponse:
+      description: "returns banOnVo"
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/BanOnVo"
+
+    ListOfBanOnVoResponse:
+      description: "return List<BanOnVo>"
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/BanOnVo"
+
     BanOnResourceResponse:
       description: "returns banOnResource"
       content:
@@ -1984,6 +2006,14 @@ components:
     voId:
       name: vo
       description: "id of Vo"
+      schema:
+        type: integer
+      in: query
+      required: true
+
+    banId:
+      name: banId
+      description: "id of a ban"
       schema:
         type: integer
       in: query
@@ -11715,6 +11745,103 @@ paths:
           $ref: '#/components/responses/ListOfRichUsersResponse'
         default:
           $ref: '#/components/responses/ExceptionResponse'
+
+  /json/vosManager/setBan:
+    post:
+      tags:
+        - VosManager
+      operationId: setVoBan
+      description: |
+        Set ban for member on his vo. The member id is required,
+        validityTo and description are optional. voId is ignored.
+      responses:
+        '200':
+          $ref: '#/components/responses/BanOnVoResponse'
+        default:
+          $ref: '#/components/responses/ExceptionResponse'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              title: InputSetVoBan
+              description: "input to set vo ban"
+              type: object
+              required:
+                - banOnVo
+              properties:
+                banOnVo: { $ref: '#/components/schemas/BanOnVo' }
+
+  /urlinjsonout/vosManager/removeBan:
+    post:
+      tags:
+        - VosManager
+      operationId: removeVoBan
+      summary: Remove vo ban with given id.
+      parameters:
+        - $ref: '#/components/parameters/banId'
+      responses:
+        '200':
+          $ref: '#/components/responses/VoidResponse'
+        default:
+          $ref: '#/components/responses/ExceptionResponse'
+
+  /urlinjsonout/vosManager/removeBanForMember:
+    post:
+      tags:
+        - VosManager
+      operationId: removeVoBanForMember
+      summary: Remove vo ban for member with given id.
+      parameters:
+        - $ref: '#/components/parameters/memberId'
+      responses:
+        '200':
+          $ref: '#/components/responses/VoidResponse'
+        default:
+          $ref: '#/components/responses/ExceptionResponse'
+
+  /json/vosManager/getBanById:
+    get:
+      tags:
+        - VosManager
+      operationId: getVoBanById
+      summary: Get vo ban with given id.
+      parameters:
+        - $ref: '#/components/parameters/banId'
+      responses:
+        '200':
+          $ref: '#/components/responses/BanOnVoResponse'
+        default:
+          $ref: '#/components/responses/ExceptionResponse'
+
+  /json/vosManager/getBanForMember:
+    get:
+      tags:
+        - VosManager
+      operationId: getVoBanForMember
+      summary: Get ban for given member, or null if he is not banned.
+      parameters:
+        - $ref: '#/components/parameters/memberId'
+      responses:
+        '200':
+          $ref: '#/components/responses/BanOnVoResponse'
+        default:
+          $ref: '#/components/responses/ExceptionResponse'
+
+  /json/vosManager/getBansForVo:
+    get:
+      tags:
+        - VosManager
+      operationId: getVoBansForVo
+      summary: Get list of all bans for vo with given id.
+      parameters:
+        - $ref: '#/components/parameters/voId'
+      responses:
+        '200':
+          $ref: '#/components/responses/ListOfBanOnVoResponse'
+        default:
+          $ref: '#/components/responses/ExceptionResponse'
+
 
   #################################################
   #                                               #

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/ExpirationNotifScheduler.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/ExpirationNotifScheduler.java
@@ -312,7 +312,6 @@ public class ExpirationNotifScheduler {
 		// Only members with following statuses will be notified
 		List<Status> allowedStatuses = new ArrayList<>();
 		allowedStatuses.add(Status.VALID);
-		allowedStatuses.add(Status.SUSPENDED);
 
 		Map<Integer, Vo> vosMap = new HashMap<>();
 		for (Vo vo : vos) {
@@ -565,7 +564,6 @@ public class ExpirationNotifScheduler {
 		// Only members with following statuses will be notified
 		List<Status> allowedStatuses = new ArrayList<>();
 		allowedStatuses.add(Status.VALID);
-		allowedStatuses.add(Status.SUSPENDED);
 		// in opposite to vo expiration we want to notify about incoming group expirations even when user is expired in VO
 		allowedStatuses.add(Status.EXPIRED);
 

--- a/perun-registrar-lib/src/test/java/cz/metacentrum/perun/registrar/ExpirationNotifSchedulerTest.java
+++ b/perun-registrar-lib/src/test/java/cz/metacentrum/perun/registrar/ExpirationNotifSchedulerTest.java
@@ -133,13 +133,10 @@ public class ExpirationNotifSchedulerTest extends RegistrarBaseIntegrationTest {
 		// set statuses synchronizer should ignore
 		perun.getMembersManager().setStatus(session, member2, Status.DISABLED);
 		perun.getMembersManager().setStatus(session, member3, Status.INVALID);
-		perun.getMembersManager().setStatus(session, member4, Status.SUSPENDED);
 		perun.getMembersManager().setStatus(session, member7, Status.DISABLED);
 		perun.getMembersManager().setStatus(session, member8, Status.INVALID);
-		perun.getMembersManager().setStatus(session, member9, Status.SUSPENDED);
 		perun.getMembersManager().setStatus(session, member12, Status.DISABLED);
 		perun.getMembersManager().setStatus(session, member13, Status.INVALID);
-		perun.getMembersManager().setStatus(session, member14, Status.SUSPENDED);
 
 		// set status synchronizer should keep
 		perun.getMembersManager().setStatus(session, member5, Status.EXPIRED);  // expiration today
@@ -160,9 +157,6 @@ public class ExpirationNotifSchedulerTest extends RegistrarBaseIntegrationTest {
 		Member returnedMember3 = perun.getMembersManager().getMemberById(session, member3.getId());
 		assertEquals("Member3 should be kept invalid!", returnedMember3.getStatus(), Status.INVALID);
 
-		Member returnedMember4 = perun.getMembersManager().getMemberById(session, member4.getId());
-		assertEquals("Member4 should be kept suspended!", returnedMember4.getStatus(), Status.SUSPENDED);
-
 		Member returnedMember5 = perun.getMembersManager().getMemberById(session, member5.getId());
 		assertEquals("Member5 should be kept expired!", returnedMember5.getStatus(), Status.EXPIRED);
 
@@ -175,9 +169,6 @@ public class ExpirationNotifSchedulerTest extends RegistrarBaseIntegrationTest {
 		Member returnedMember8 = perun.getMembersManager().getMemberById(session, member8.getId());
 		assertEquals("Member8 should be kept invalid!", returnedMember8.getStatus(), Status.INVALID);
 
-		Member returnedMember9 = perun.getMembersManager().getMemberById(session, member9.getId());
-		assertEquals("Member9 should be kept suspended!", returnedMember9.getStatus(), Status.SUSPENDED);
-
 		Member returnedMember10 = perun.getMembersManager().getMemberById(session, member10.getId());
 		assertEquals("Member10 should be kept valid!", returnedMember10.getStatus(), Status.VALID);
 
@@ -189,9 +180,6 @@ public class ExpirationNotifSchedulerTest extends RegistrarBaseIntegrationTest {
 
 		Member returnedMember13 = perun.getMembersManager().getMemberById(session, member13.getId());
 		assertEquals("Member13 should be kept invalid!", returnedMember13.getStatus(), Status.INVALID);
-
-		Member returnedMember14 = perun.getMembersManager().getMemberById(session, member14.getId());
-		assertEquals("Member14 should be kept suspended!", returnedMember14.getStatus(), Status.SUSPENDED);
 
 		Member returnedMember15 = perun.getMembersManager().getMemberById(session, member15.getId());
 		assertEquals("Member15 should be kept expired!", returnedMember15.getStatus(), Status.EXPIRED);

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/MembersManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/MembersManagerMethod.java
@@ -517,7 +517,7 @@ public enum MembersManagerMethod implements ManagerMethod {
 	 * Returns all members of a VO.
 	 *
 	 * @param vo int VO <code>id</code>
-	 * @param status String VALID | INVALID | SUSPENDED | EXPIRED | DISABLED
+	 * @param status String VALID | INVALID | EXPIRED | DISABLED
 	 * @return List<Member> VO members
 	 */
 	getMembers {
@@ -541,7 +541,7 @@ public enum MembersManagerMethod implements ManagerMethod {
 	 * Returns all members of a VO with additional information.
 	 *
 	 * @param vo int VO <code>id</code>
-	 * @param status String VALID | INVALID | SUSPENDED | EXPIRED | DISABLED
+	 * @param status String VALID | INVALID | EXPIRED | DISABLED
 	 * @return List<RichMember> VO members
 	 */
 	getRichMembers {
@@ -566,7 +566,7 @@ public enum MembersManagerMethod implements ManagerMethod {
  	 *
  	 * @param vo int Vo <code>id</code>
  	 * @param attrsNames List<String> Attribute names
- 	 * @param allowedStatuses List<String> Allowed statuses (VALID | INVALID | SUSPENDED | EXPIRED | DISABLED)
+ 	 * @param allowedStatuses List<String> Allowed statuses (VALID | INVALID | EXPIRED | DISABLED)
  	 * @return List<RichMember> List of richMembers with specific attributes from Vo
  	 */
 	/*#
@@ -588,7 +588,7 @@ public enum MembersManagerMethod implements ManagerMethod {
  	 *
  	 * @param group int Group <code>id</code>
  	 * @param attrsNames List<String> Attribute names
- 	 * @param allowedStatuses List<String> Allowed statuses (VALID | INVALID | SUSPENDED | EXPIRED | DISABLED)
+ 	 * @param allowedStatuses List<String> Allowed statuses (VALID | INVALID | EXPIRED | DISABLED)
  	 * @param lookingInParentGroup boolean If true, look up in a parent group
  	 * @return List<RichMember> List of richMembers with specific attributes from group
  	 */
@@ -614,7 +614,7 @@ public enum MembersManagerMethod implements ManagerMethod {
 	 * @param group int Group <code>id</code>
 	 * @param resource int Resource <code>id</code>
 	 * @param attrsNames List<String> Attribute names
-	 * @param allowedStatuses List<String> Allowed statuses (VALID | INVALID | SUSPENDED | EXPIRED | DISABLED)
+	 * @param allowedStatuses List<String> Allowed statuses (VALID | INVALID | EXPIRED | DISABLED)
 	 * @return List<RichMember> List of richMembers with selected specific attributes
 	 */
 	getCompleteRichMembers {
@@ -726,7 +726,7 @@ public enum MembersManagerMethod implements ManagerMethod {
  	 * Get all RichMembers of VO with specified status. RichMember object contains user, member, userExtSources and member/user attributes.
  	 *
  	 * @param vo int Vo <code>id</code>
- 	 * @param status String Status (VALID | INVALID | SUSPENDED | EXPIRED | DISABLED)
+ 	 * @param status String Status (VALID | INVALID | EXPIRED | DISABLED)
  	 * @return List<RichMember> List of RichMembers with all member/user attributes, empty list if there are no members in VO with specified status
  	 */
 	/*#
@@ -812,7 +812,7 @@ public enum MembersManagerMethod implements ManagerMethod {
 	 * Returns count of VO members with specified status.
 	 *
 	 * @param vo int VO <code>id</code>
-	 * @param status String Status (VALID | INVALID | SUSPENDED | EXPIRED | DISABLED)
+	 * @param status String Status (VALID | INVALID | EXPIRED | DISABLED)
 	 * @return int Members count
 	 */
 	/*#
@@ -1095,17 +1095,8 @@ public enum MembersManagerMethod implements ManagerMethod {
 	 * Set membership status of a member.
 	 *
 	 * @param member int Member <code>id</code>
-	 * @param status String VALID | INVALID | SUSPENDED | EXPIRED | DISABLED
-	 * @exampleParam status "SUSPENDED"
-	 * @param message String reason for suspension
-	 * @return Member Member with status after change
-	 */
-	/*#
-	 * Set membership status of a member.
-	 *
-	 * @param member int Member <code>id</code>
-	 * @param status String VALID | INVALID | SUSPENDED | EXPIRED | DISABLED
-	 * @exampleParam status "SUSPENDED"
+	 * @param status String VALID | INVALID | EXPIRED | DISABLED
+	 * @exampleParam status "VALID"
 	 * @return Member Member with status after change
 	 */
 	setStatus {
@@ -1114,9 +1105,6 @@ public enum MembersManagerMethod implements ManagerMethod {
 			parms.stateChangingCheck();
 
 			Status status = Status.valueOf(parms.readString("status"));
-			if (parms.contains("message")){
-				return ac.getMembersManager().setStatus(ac.getSession(), ac.getMemberById(parms.readInt("member")), status, parms.readString("message"));
-			}
 			return ac.getMembersManager().setStatus(ac.getSession(), ac.getMemberById(parms.readInt("member")), status);
 		}
 	},
@@ -1126,6 +1114,7 @@ public enum MembersManagerMethod implements ManagerMethod {
 	 *
 	 * For almost unlimited time please use time in the far future.
 	 *
+	 * @deprecated use vosManager setBan
 	 * @param member int Member <code>id</code>
 	 * @param suspendedTo String date in format yyyy-MM-dd to which member will be suspended
 	 */
@@ -1154,6 +1143,7 @@ public enum MembersManagerMethod implements ManagerMethod {
 	 *
 	 * WARNING: this will remove the date even if it is in the past (so member is no longer considered as suspended)
 	 *
+	 * @deprecated use vosManager removeBan
 	 * @param member int Member <code>id</code>
 	 */
 	unsuspendMember {

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/VosManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/VosManagerMethod.java
@@ -1,7 +1,9 @@
 package cz.metacentrum.perun.rpc.methods;
 
 import cz.metacentrum.perun.core.api.*;
+import cz.metacentrum.perun.core.api.exceptions.BanNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.PerunException;
+import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
 import cz.metacentrum.perun.rpc.*;
 import cz.metacentrum.perun.rpc.deserializer.Deserializer;
 import cz.metacentrum.perun.core.api.exceptions.RpcException;
@@ -593,5 +595,109 @@ public enum VosManagerMethod implements ManagerMethod {
 					ac.getVoById(parms.readInt("vo")),
 					parms.readList("specificAttributes", String.class));
 		}
-	};
+	},
+
+	/*#
+	 * Set ban for member on his vo. The member id is required,
+	 * validityTo and description are optional. voId is ignored.
+	 *
+	 * @param banOnVo BanOnVo JSON object
+	 * @return BanOnVo Created banOnVo
+	 */
+	setBan {
+		@Override
+		public BanOnVo call(ApiCaller ac, Deserializer parms) throws PerunException {
+			parms.stateChangingCheck();
+
+			return ac.getVosManager().setBan(ac.getSession(),
+					parms.read("banOnVo", BanOnVo.class));
+		}
+	},
+
+	/*#
+	 * Remove vo ban with given id.
+	 *
+	 * @param banId int of vo ban
+	 * @throw PrivilegeException insufficient permissions
+	 * @throw BanNotExistsException if there is no ban with specified id
+	 */
+	removeBan {
+
+		@Override
+		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
+			parms.stateChangingCheck();
+
+			ac.getVosManager().removeBan(ac.getSession(),
+					parms.readInt("banId"));
+
+			return null;
+		}
+	},
+
+	/*#
+	 * Remove vo ban for member with given id.
+	 *
+	 * @param member int member id
+	 * @throw PrivilegeException insufficient permissions
+	 * @throw BanNotExistsException if there is no ban for member with given id
+	 */
+	removeBanForMember {
+		@Override
+		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
+			parms.stateChangingCheck();
+
+			ac.getVosManager().removeBanForMember(ac.getSession(),
+					ac.getMemberById(parms.readInt("member")));
+
+			return null;
+		}
+	},
+
+	/*#
+	 * Get vo ban with given id.
+	 *
+	 * @param banId int id
+	 * @return BanOnVo found ban
+	 * @throw BanNotExistsException if there is no such ban
+	 * @throw PrivilegeException insufficient permissions
+	 */
+	getBanById {
+		@Override
+		public BanOnVo call(ApiCaller ac, Deserializer parms) throws PerunException {
+			return ac.getVosManager().getBanById(ac.getSession(),
+					parms.readInt("banId"));
+		}
+	},
+
+	/*#
+	 * Get ban for given member, or null if he is not banned.
+	 *
+	 * @param member int member id
+	 * @return BanOnVo found ban or null if the member is not banned
+	 * @throw PrivilegeException insufficient permissions
+	 * @throw MemberNotExistsException if there is no member with given id
+	 */
+	getBanForMember {
+		@Override
+		public BanOnVo call(ApiCaller ac, Deserializer parms) throws PerunException {
+			return ac.getVosManager().getBanForMember(ac.getSession(),
+					ac.getMemberById(parms.readInt("member")));
+		}
+	},
+
+	/*#
+	 * Get list of all bans for vo with given id.
+	 *
+	 * @param vo int vo id
+	 * @return List<BanOnVo> vo bans for given vo
+	 * @throw PrivilegeException insufficient permissions
+	 * @throw VoNotExistsException if there is no vo with given id
+	 */
+	getBansForVo {
+		@Override
+		public List<BanOnVo> call(ApiCaller ac, Deserializer parms) throws PerunException {
+			return ac.getVosManager().getBansForVo(ac.getSession(),
+					parms.readInt("vo"));
+		}
+	}
 }

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/resources/PerunStatus.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/resources/PerunStatus.java
@@ -9,7 +9,6 @@ package cz.metacentrum.perun.webgui.client.resources;
 public enum PerunStatus {
 	VALID,
 	INVALID,
-	SUSPENDED,
 	EXPIRED,
 	DISABLED
 }

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/membersManager/SetStatus.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/membersManager/SetStatus.java
@@ -22,7 +22,6 @@ public class SetStatus implements JsonStatusSetCallback {
 	private PerunWebSession session = PerunWebSession.getInstance();
 	private int memberId = 0;
 	private String status = "";
-	private String message;
 	final String JSON_URL = "membersManager/setStatus";
 	private JsonCallbackEvents events = new JsonCallbackEvents();
 
@@ -35,22 +34,9 @@ public class SetStatus implements JsonStatusSetCallback {
 		this.memberId = memberId;
 	}
 
-	/**
-	 * Creates a new request with custom events
-	 *
-	 * @param memberId ID of member to set new status
-	 * @param events Custom events
-	 */
-	public SetStatus(int memberId, JsonCallbackEvents events, String message) {
-		this.memberId = memberId;
-		this.events = events;
-		this.message = message;
-	}
-
 	public SetStatus(int memberId, JsonCallbackEvents events) {
 		this.memberId = memberId;
 		this.events = events;
-		this.message = "";
 	}
 
 	/**
@@ -83,7 +69,7 @@ public class SetStatus implements JsonStatusSetCallback {
 	/**
 	 * Attempts to set new status for selected member
 	 *
-	 * @param status new status (VALID,INVALID,SUSPENDED,EXPIRED,DISABLED)
+	 * @param status new status (VALID,INVALID,EXPIRED,DISABLED)
 	 */
 	public void setStatus(String status)
 	{
@@ -126,9 +112,6 @@ public class SetStatus implements JsonStatusSetCallback {
 		JSONObject jsonQuery = new JSONObject();
 		jsonQuery.put("member", new JSONNumber(memberId));
 		jsonQuery.put("status", new JSONString(status));
-		if (status.equals("SUSPENDED") && !message.equals("")) {
-			jsonQuery.put("message", new JSONString(message));
-		}
 		return jsonQuery;
 	}
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/Application.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/Application.java
@@ -266,7 +266,7 @@ public class Application extends JavaScriptObject {
 
 	/**
 	 * Returns the status of this item in Perun system as String
-	 * VALID, INVALID, SUSPENDED, EXPIRED, DISABLED
+	 * VALID, INVALID, EXPIRED, DISABLED
 	 *
 	 * @return string which defines item status
 	 */

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/ApplicationForm.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/ApplicationForm.java
@@ -102,7 +102,7 @@ public class ApplicationForm extends JavaScriptObject {
 
 		/**
 		 * Returns the status of this item in Perun system as String
-		 * VALID, INVALID, SUSPENDED, EXPIRED, DISABLED
+		 * VALID, INVALID, EXPIRED, DISABLED
 		 *
 		 * @return string which defines item status
 		 */

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/ApplicationFormItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/ApplicationFormItem.java
@@ -269,7 +269,7 @@ public class ApplicationFormItem extends JavaScriptObject {
 
 	/**
 	 * Returns the status of this item in Perun system as String
-	 * VALID, INVALID, SUSPENDED, EXPIRED, DISABLED
+	 * VALID, INVALID, EXPIRED, DISABLED
 	 *
 	 * @return string which defines item status
 	 */

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/ApplicationFormItemData.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/ApplicationFormItemData.java
@@ -137,7 +137,7 @@ public class ApplicationFormItemData extends JavaScriptObject {
 
 		/**
 		 * Returns the status of this item in Perun system as String
-		 * VALID, INVALID, SUSPENDED, EXPIRED, DISABLED
+		 * VALID, INVALID, EXPIRED, DISABLED
 		 *
 		 * @return string which defines item status
 		 */

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/ApplicationFormItemWithPrefilledValue.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/ApplicationFormItemWithPrefilledValue.java
@@ -124,7 +124,7 @@ public class ApplicationFormItemWithPrefilledValue extends JavaScriptObject {
 
 		/**
 		 * Returns the status of this item in Perun system as String
-		 * VALID, INVALID, SUSPENDED, EXPIRED, DISABLED
+		 * VALID, INVALID, EXPIRED, DISABLED
 		 *
 		 * @return string which defines item status
 		 */

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/ApplicationMail.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/ApplicationMail.java
@@ -195,7 +195,7 @@ public class ApplicationMail extends JavaScriptObject {
 
 	/**
 	 * Returns the status of this item in Perun system as String
-	 * VALID, INVALID, SUSPENDED, EXPIRED, DISABLED
+	 * VALID, INVALID, EXPIRED, DISABLED
 	 *
 	 * @return string which defines item status
 	 */

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/Attribute.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/Attribute.java
@@ -374,7 +374,7 @@ public class Attribute extends JavaScriptObject {
 
 	/**
 	 * Returns the status of this item in Perun system as String
-	 * VALID, INVALID, SUSPENDED, EXPIRED, DISABLED
+	 * VALID, INVALID, EXPIRED, DISABLED
 	 *
 	 * @return string which defines item status
 	 */

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/AttributeDefinition.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/AttributeDefinition.java
@@ -189,7 +189,7 @@ public class AttributeDefinition extends JavaScriptObject {
 
 	/**
 	 * Returns the status of this item in Perun system as String
-	 * VALID, INVALID, SUSPENDED, EXPIRED, DISABLED
+	 * VALID, INVALID, EXPIRED, DISABLED
 	 *
 	 * @return string which defines item status
 	 */

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/AuditMessage.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/AuditMessage.java
@@ -78,7 +78,7 @@ public class AuditMessage extends JavaScriptObject {
 
 		/**
 		 * Returns the status of this item in Perun system as String
-		 * VALID, INVALID, SUSPENDED, EXPIRED, DISABLED
+		 * VALID, INVALID, EXPIRED, DISABLED
 		 *
 		 * @return string which defines item status
 		 */

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/Author.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/Author.java
@@ -163,7 +163,7 @@ public class Author extends JavaScriptObject {
 
 	/**
 	 * Returns the status of this item in Perun system as String
-	 * VALID, INVALID, SUSPENDED, EXPIRED, DISABLED
+	 * VALID, INVALID, EXPIRED, DISABLED
 	 *
 	 * @return string which defines item status
 	 */

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/Authorship.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/Authorship.java
@@ -90,7 +90,7 @@ public class Authorship extends JavaScriptObject {
 
 		/**
 		 * Returns the status of this item in Perun system as String
-		 * VALID, INVALID, SUSPENDED, EXPIRED, DISABLED
+		 * VALID, INVALID, EXPIRED, DISABLED
 		 *
 		 * @return string which defines item status
 		 */

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/Candidate.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/Candidate.java
@@ -201,7 +201,7 @@ public class Candidate extends JavaScriptObject {
 
 	/**
 	 * Returns the status of this item in Perun system as String
-	 * VALID, INVALID, SUSPENDED, EXPIRED, DISABLED
+	 * VALID, INVALID, EXPIRED, DISABLED
 	 *
 	 * @return string which defines item status
 	 */

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/Category.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/Category.java
@@ -69,7 +69,7 @@ public class Category extends JavaScriptObject {
 
 		/**
 		 * Returns the status of this item in Perun system as String
-		 * VALID, INVALID, SUSPENDED, EXPIRED, DISABLED
+		 * VALID, INVALID, EXPIRED, DISABLED
 		 *
 		 * @return string which defines item status
 		 */

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/Destination.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/Destination.java
@@ -127,7 +127,7 @@ public class Destination extends JavaScriptObject {
 
 	/**
 	 * Returns the status of this item in Perun system as String
-	 * VALID, INVALID, SUSPENDED, EXPIRED, DISABLED
+	 * VALID, INVALID, EXPIRED, DISABLED
 	 *
 	 * @return string which defines item status
 	 */

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/ExtSource.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/ExtSource.java
@@ -50,7 +50,7 @@ public class ExtSource extends JavaScriptObject {
 
 	/**
 	 * Returns the status of this item in Perun system as String
-	 * VALID, INVALID, SUSPENDED, EXPIRED, DISABLED
+	 * VALID, INVALID, EXPIRED, DISABLED
 	 *
 	 * @return string which defines item status
 	 */

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/Facility.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/Facility.java
@@ -67,7 +67,7 @@ public class Facility extends JavaScriptObject {
 
 	/**
 	 * Returns the status of this item in Perun system as String
-	 * VALID, INVALID, SUSPENDED, EXPIRED, DISABLED
+	 * VALID, INVALID, EXPIRED, DISABLED
 	 *
 	 * @return string which defines item status
 	 */

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/GeneralObject.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/GeneralObject.java
@@ -57,7 +57,7 @@ public class GeneralObject extends JavaScriptObject {
 
 	/**
 	 * Returns the status of this item in Perun system as String
-	 * VALID, INVALID, SUSPENDED, EXPIRED, DISABLED
+	 * VALID, INVALID, EXPIRED, DISABLED
 	 *
 	 * @return string which defines item status
 	 */
@@ -67,7 +67,7 @@ public class GeneralObject extends JavaScriptObject {
 
 	/**
 	 * Sets the status
-	 * VALID, INVALID, SUSPENDED, EXPIRED, DISABLED
+	 * VALID, INVALID, EXPIRED, DISABLED
 	 *
 	 * @param status String which defines item status
 	 */

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/Group.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/Group.java
@@ -136,7 +136,7 @@ public class Group extends JavaScriptObject {
 
 	/**
 	 * Returns the status of this item in Perun system as String
-	 * VALID, INVALID, SUSPENDED, EXPIRED, DISABLED
+	 * VALID, INVALID, EXPIRED, DISABLED
 	 *
 	 * @return string which defines item status
 	 */

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/Host.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/Host.java
@@ -52,7 +52,7 @@ public class Host extends JavaScriptObject {
 
 		/**
 		 * Returns the status of this item in Perun system as String
-		 * VALID, INVALID, SUSPENDED, EXPIRED, DISABLED
+		 * VALID, INVALID, EXPIRED, DISABLED
 		 *
 		 * @return string which defines item status
 		 */

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/ItemTexts.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/ItemTexts.java
@@ -117,7 +117,7 @@ public class ItemTexts extends JavaScriptObject {
 
 		/**
 		 * Returns the status of this item in Perun system as String
-		 * VALID, INVALID, SUSPENDED, EXPIRED, DISABLED
+		 * VALID, INVALID, EXPIRED, DISABLED
 		 *
 		 * @return string which defines item status
 		 */

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/MailText.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/MailText.java
@@ -109,7 +109,7 @@ public class MailText extends JavaScriptObject {
 
 		/**
 		 * Returns the status of this item in Perun system as String
-		 * VALID, INVALID, SUSPENDED, EXPIRED, DISABLED
+		 * VALID, INVALID, EXPIRED, DISABLED
 		 *
 		 * @return string which defines item status
 		 */

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/Member.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/Member.java
@@ -71,7 +71,7 @@ public class Member extends JavaScriptObject {
 
 	/**
 	 * Returns the status of this item in Perun system as String
-	 * VALID, INVALID, SUSPENDED, EXPIRED, DISABLED
+	 * VALID, INVALID, EXPIRED, DISABLED
 	 *
 	 * @return string which defines item status
 	 */
@@ -102,7 +102,7 @@ public class Member extends JavaScriptObject {
 
 	/**
 	 * Set the status of this item in Perun system as String
-	 * VALID, INVALID, SUSPENDED, EXPIRED, DISABLED
+	 * VALID, INVALID, EXPIRED, DISABLED
 	 *
 	 * @param status string which defines item status
 	 */

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/Owner.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/Owner.java
@@ -72,7 +72,7 @@ public class Owner extends JavaScriptObject {
 
 		/**
 		 * Returns the status of this item in Perun system as String
-		 * VALID, INVALID, SUSPENDED, EXPIRED, DISABLED
+		 * VALID, INVALID, EXPIRED, DISABLED
 		 *
 		 * @return string which defines item status
 		 */

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/PerunError.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/PerunError.java
@@ -458,7 +458,7 @@ public class PerunError extends JavaScriptObject {
 
     /**
      * Returns the status of this item in Perun system as String
-     * VALID, INVALID, SUSPENDED, EXPIRED, DISABLED
+     * VALID, INVALID, EXPIRED, DISABLED
      *
      * @return string which defines item status
      */

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/PerunPrincipal.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/PerunPrincipal.java
@@ -129,7 +129,7 @@ public class PerunPrincipal extends JavaScriptObject {
 
 		/**
 		 * Returns the status of this item in Perun system as String
-		 * VALID, INVALID, SUSPENDED, EXPIRED, DISABLED
+		 * VALID, INVALID, EXPIRED, DISABLED
 		 *
 		 * @return string which defines item status
 		 */

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/Publication.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/Publication.java
@@ -340,7 +340,7 @@ public class Publication extends JavaScriptObject {
 
 	/**
 	 * Returns the status of this item in Perun system as String
-	 * VALID, INVALID, SUSPENDED, EXPIRED, DISABLED
+	 * VALID, INVALID, EXPIRED, DISABLED
 	 *
 	 * @return string which defines item status
 	 */

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/PublicationSystem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/PublicationSystem.java
@@ -95,7 +95,7 @@ public class PublicationSystem  extends JavaScriptObject {
 
 		/**
 		 * Returns the status of this item in Perun system as String
-		 * VALID, INVALID, SUSPENDED, EXPIRED, DISABLED
+		 * VALID, INVALID, EXPIRED, DISABLED
 		 *
 		 * @return string which defines item status
 		 */

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/RTMessage.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/RTMessage.java
@@ -44,7 +44,7 @@ public class RTMessage extends JavaScriptObject {
 
 		/**
 		 * Returns the status of this item in Perun system as String
-		 * VALID, INVALID, SUSPENDED, EXPIRED, DISABLED
+		 * VALID, INVALID, EXPIRED, DISABLED
 		 *
 		 * @return string which defines item status
 		 */

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/Resource.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/Resource.java
@@ -64,7 +64,7 @@ public class Resource extends JavaScriptObject {
 
 		/**
 		 * Returns the status of this item in Perun system as String
-		 * VALID, INVALID, SUSPENDED, EXPIRED, DISABLED
+		 * VALID, INVALID, EXPIRED, DISABLED
 		 *
 		 * @return string which defines item status
 		 */

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/ResourceTag.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/ResourceTag.java
@@ -52,7 +52,7 @@ public class ResourceTag extends JavaScriptObject {
 
 		/**
 		 * Returns the status of this item in Perun system as String
-		 * VALID, INVALID, SUSPENDED, EXPIRED, DISABLED
+		 * VALID, INVALID, EXPIRED, DISABLED
 		 *
 		 * @return string which defines item status
 		 */

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/RichMember.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/RichMember.java
@@ -217,7 +217,7 @@ public class RichMember extends JavaScriptObject {
 
 	/**
 	 * Returns the status of this item in Perun system as String
-	 * VALID, INVALID, SUSPENDED, EXPIRED, DISABLED
+	 * VALID, INVALID, EXPIRED, DISABLED
 	 *
 	 * @return string which defines item status
 	 */
@@ -258,7 +258,7 @@ public class RichMember extends JavaScriptObject {
 
 	/**
 	 * Set the status of this item in Perun system as String
-	 * VALID, INVALID, SUSPENDED, EXPIRED, DISABLED
+	 * VALID, INVALID, EXPIRED, DISABLED
 	 *
 	 * @param status string which defines item status
 	 */

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/RichResource.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/RichResource.java
@@ -87,7 +87,7 @@ public class RichResource extends JavaScriptObject {
 
 	/**
 	 * Returns the status of this item in Perun system as String
-	 * VALID, INVALID, SUSPENDED, EXPIRED, DISABLED
+	 * VALID, INVALID, EXPIRED, DISABLED
 	 *
 	 * @return string which defines item status
 	 */

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/RichService.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/RichService.java
@@ -53,7 +53,7 @@ public class RichService extends JavaScriptObject {
 
 		/**
 		 * Returns the status of this item in Perun system as String
-		 * VALID, INVALID, SUSPENDED, EXPIRED, DISABLED
+		 * VALID, INVALID, EXPIRED, DISABLED
 		 *
 		 * @return string which defines item status
 		 */

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/Roles.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/Roles.java
@@ -95,7 +95,7 @@ public class Roles extends JavaScriptObject {
 
 	/**
 	 * Returns the status of this item in Perun system as String
-	 * VALID, INVALID, SUSPENDED, EXPIRED, DISABLED
+	 * VALID, INVALID, EXPIRED, DISABLED
 	 *
 	 * @return string which defines item status
 	 */

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/SecurityTeam.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/SecurityTeam.java
@@ -55,7 +55,7 @@ public class SecurityTeam extends JavaScriptObject {
 
 	/**
 	 * Returns the status of this item in Perun system as String
-	 * VALID, INVALID, SUSPENDED, EXPIRED, DISABLED
+	 * VALID, INVALID, EXPIRED, DISABLED
 	 *
 	 * @return string which defines item status
 	 */

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/Service.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/Service.java
@@ -176,7 +176,7 @@ public class Service extends JavaScriptObject {
 
 	/**
 	 * Returns the status of this item in Perun system as String
-	 * VALID, INVALID, SUSPENDED, EXPIRED, DISABLED
+	 * VALID, INVALID, EXPIRED, DISABLED
 	 *
 	 * @return string which defines item status
 	 */

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/ServiceState.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/ServiceState.java
@@ -81,7 +81,7 @@ public class ServiceState extends JavaScriptObject {
 
 	/**
 	 * Returns the status of this item in Perun system as String
-	 * VALID, INVALID, SUSPENDED, EXPIRED, DISABLED
+	 * VALID, INVALID, EXPIRED, DISABLED
 	 *
 	 * @return string which defines item status
 	 */

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/ServicesPackage.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/ServicesPackage.java
@@ -79,7 +79,7 @@ public class ServicesPackage extends JavaScriptObject {
 
 		/**
 		 * Returns the status of this item in Perun system as String
-		 * VALID, INVALID, SUSPENDED, EXPIRED, DISABLED
+		 * VALID, INVALID, EXPIRED, DISABLED
 		 *
 		 * @return string which defines item status
 		 */

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/Task.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/Task.java
@@ -101,7 +101,7 @@ public class Task extends JavaScriptObject {
 
 	/**
 	 * Returns the status of this item in Perun system as String
-	 * VALID, INVALID, SUSPENDED, EXPIRED, DISABLED
+	 * VALID, INVALID, EXPIRED, DISABLED
 	 *
 	 * @return string which defines item status
 	 */

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/TaskResult.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/TaskResult.java
@@ -85,7 +85,7 @@ public class TaskResult extends JavaScriptObject {
 
 	/**
 	 * Returns the status of this item in Perun system as String
-	 * VALID, INVALID, SUSPENDED, EXPIRED, DISABLED
+	 * VALID, INVALID, EXPIRED, DISABLED
 	 *
 	 * @return string which defines item status
 	 */

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/Thanks.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/Thanks.java
@@ -95,7 +95,7 @@ public class Thanks extends JavaScriptObject {
 
 		/**
 		 * Returns the status of this item in Perun system as String
-		 * VALID, INVALID, SUSPENDED, EXPIRED, DISABLED
+		 * VALID, INVALID, EXPIRED, DISABLED
 		 *
 		 * @return string which defines item status
 		 */

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/User.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/User.java
@@ -258,7 +258,7 @@ public class User extends JavaScriptObject {
 
 	/**
 	 * Returns the status of this item in Perun system as String
-	 * VALID, INVALID, SUSPENDED, EXPIRED, DISABLED
+	 * VALID, INVALID, EXPIRED, DISABLED
 	 *
 	 * @return string which defines item status
 	 */

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/UserExtSource.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/UserExtSource.java
@@ -60,7 +60,7 @@ public class UserExtSource extends JavaScriptObject {
 
 	/**
 	 * Returns the status of this item in Perun system as String
-	 * VALID, INVALID, SUSPENDED, EXPIRED, DISABLED
+	 * VALID, INVALID, EXPIRED, DISABLED
 	 *
 	 * @return string which defines item status
 	 */

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/VirtualOrganization.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/VirtualOrganization.java
@@ -76,7 +76,7 @@ public class VirtualOrganization extends JavaScriptObject {
 
 		/**
 		 * Returns the status of this item in Perun system as String
-		 * VALID, INVALID, SUSPENDED, EXPIRED, DISABLED
+		 * VALID, INVALID, EXPIRED, DISABLED
 		 *
 		 * @return string which defines item status
 		 */

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/ChangeStatusTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/ChangeStatusTabItem.java
@@ -90,7 +90,6 @@ public class ChangeStatusTabItem implements TabItem {
 		final ListBox lb = new ListBox(false);
 		lb.addItem("VALID", "VALID");
 		lb.addItem("INVALID", "INVALID");
-		lb.addItem("SUSPENDED", "SUSPENDED");
 		lb.addItem("EXPIRED", "EXPIRED");
 		lb.addItem("DISABLED", "DISABLED");
 
@@ -102,8 +101,6 @@ public class ChangeStatusTabItem implements TabItem {
 			layout.setHTML(1, 0, "Member is properly configured and have access on provided resources.");
 		} else if (member.getStatus().equalsIgnoreCase("INVALID")) {
 			layout.setHTML(1, 0, "Member have configuration error and DON'T have access on provided resources. You can check what is wrong by changing member's status to VALID. If possible, procedure will configure all necessary settings by itself.");
-		} else if (member.getStatus().equalsIgnoreCase("SUSPENDED")) {
-			layout.setHTML(1, 0, "Member violated some rules and DON'T have access on provided resources.");
 		} else if (member.getStatus().equalsIgnoreCase("EXPIRED")) {
 			layout.setHTML(1, 0, "Member didn't extend membership and DON'T have access on provided resources.");
 		} else if (member.getStatus().equalsIgnoreCase("DISABLED")) {
@@ -135,9 +132,6 @@ public class ChangeStatusTabItem implements TabItem {
 		description.setText("Reason for suspension:");
 		description.setVisible(false);
 
-		TextArea messageArea = new TextArea();
-		messageArea.setWidth("95%");
-		messageArea.setVisible(false);
 
 		final CustomButton changeButton = new CustomButton("Change status", SmallIcons.INSTANCE.diskIcon());
 		// by default false
@@ -179,7 +173,7 @@ public class ChangeStatusTabItem implements TabItem {
 							session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 						}
 					}
-				})), messageArea.getText());
+				})));
 				request.setStatus(lb.getValue(lb.getSelectedIndex()));
 			}
 		});
@@ -209,7 +203,6 @@ public class ChangeStatusTabItem implements TabItem {
 				if (lb.getSelectedIndex() == 0) {
 					// VALIDATING NOTICE
 					if (!member.getStatus().equalsIgnoreCase("VALID")) text.setHTML("Changing status to VALID <strong>will trigger automatic configuration</strong> for provided resources. <br/><strong>If successful</strong>, member will have access on provided resources. <br /><strong>If not</strong>, see displayed error message and do manual configuration on 'settings' tab on members detail.");
-					messageArea.setVisible(false);
 					description.setVisible(false);
 				} else {
 					// INVALIDATING NOTICE
@@ -219,23 +212,16 @@ public class ChangeStatusTabItem implements TabItem {
 				// SET INFO
 				if (lb.getSelectedIndex() == 1) {
 					text.setHTML(text.getHTML()+"INVALID status means there is configuration error, which prevents him from access on provided resources.");
-					messageArea.setVisible(false);
 					description.setVisible(false);
 				} else if (lb.getSelectedIndex() == 2) {
-					text.setHTML(text.getHTML()+"SUSPENDED status means, that member did something bad (against VO rules).");
-					messageArea.setVisible(true);
-					description.setVisible(true);
-				} else if (lb.getSelectedIndex() == 3) {
 					text.setHTML(text.getHTML()+"EXPIRED status means, that member didn't extend his membership in VO, but it's still possible for him to do so.");
-					messageArea.setVisible(false);
 					description.setVisible(false);
-				} else if (lb.getSelectedIndex() == 4) {
+				} else if (lb.getSelectedIndex() == 3) {
 					text.setHTML(text.getHTML()+"DISABLED status means, that member didn't extend his membership long ago or was manually disabled by administrator. Member can't enable/extend membership by himself.");
-					messageArea.setVisible(false);
 					description.setVisible(false);
 				}
 
-				if ((lb.getSelectedIndex() == 0 || lb.getSelectedIndex() == 3) && !lb.getValue(lb.getSelectedIndex()).equalsIgnoreCase(member.getStatus())) {
+				if ((lb.getSelectedIndex() == 0 || lb.getSelectedIndex() == 2) && !lb.getValue(lb.getSelectedIndex()).equalsIgnoreCase(member.getStatus())) {
 					changeButton.setText("Change status and set expiration");
 				} else {
 					changeButton.setText("Change status");
@@ -246,7 +232,6 @@ public class ChangeStatusTabItem implements TabItem {
 
 		vp.add(layout);
 		vp.add(description);
-		vp.add(messageArea);
 		vp.add(menu);
 		vp.setCellHorizontalAlignment(menu, HasHorizontalAlignment.ALIGN_RIGHT);
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/MemberOverviewTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/MemberOverviewTabItem.java
@@ -160,8 +160,6 @@ public class MemberOverviewTabItem implements TabItem {
 			memberLayout.setHTML(1, 0, "Member is properly configured and have access on provided resources.");
 		} else if (member.getStatus().equalsIgnoreCase("INVALID")) {
 			memberLayout.setHTML(1, 0, "Member have configuration error and DON'T have access on provided resources. You can check what is wrong by changing member's status to VALID. If possible, procedure will configure all necessary settings by itself.");
-		} else if (member.getStatus().equalsIgnoreCase("SUSPENDED")) {
-			memberLayout.setHTML(1, 0, "Member violated some rules and DON'T have access on provided resources.");
 		} else if (member.getStatus().equalsIgnoreCase("EXPIRED")) {
 			memberLayout.setHTML(1, 0, "Member didn't extend membership and DON'T have access on provided resources.");
 		} else if (member.getStatus().equalsIgnoreCase("DISABLED")) {

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/perunadmintabs/StatisticsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/perunadmintabs/StatisticsTabItem.java
@@ -102,11 +102,10 @@ public class StatisticsTabItem implements TabItem, TabItemWithUrl {
 		vosTable.setWidget(0, 1, new HTML("<strong>" + "Members" + "</strong>"));
 		vosTable.setWidget(0, 2, new HTML("<strong>" + "Valid members" + "</strong>"));
 		vosTable.setWidget(0, 3, new HTML("<strong>" + "Invalid members" + "</strong>"));
-		vosTable.setWidget(0, 4, new HTML("<strong>" + "Suspended members" + "</strong>"));
-		vosTable.setWidget(0, 5, new HTML("<strong>" + "Expired members" + "</strong>"));
-		vosTable.setWidget(0, 6, new HTML("<strong>" + "Disabled members" + "</strong>"));
-		vosTable.setWidget(0, 7, new HTML("<strong>" + "Groups" + "</strong>"));
-		vosTable.setWidget(0, 8, new HTML("<strong>" + "Resources" + "</strong>"));
+		vosTable.setWidget(0, 4, new HTML("<strong>" + "Expired members" + "</strong>"));
+		vosTable.setWidget(0, 5, new HTML("<strong>" + "Disabled members" + "</strong>"));
+		vosTable.setWidget(0, 6, new HTML("<strong>" + "Groups" + "</strong>"));
+		vosTable.setWidget(0, 7, new HTML("<strong>" + "Resources" + "</strong>"));
 
 		// vos events - adds the VOs to the table and calls how many members the VO has
 		JsonCallbackEvents vosEvents = new JsonCallbackEvents(){
@@ -129,9 +128,6 @@ public class StatisticsTabItem implements TabItem, TabItemWithUrl {
 					GetMembersCount countInvalidMembers = new GetMembersCount(vo.getId(), PerunStatus.INVALID);
 					countInvalidMembers.retrieveData();
 
-					GetMembersCount countSuspendedMembers = new GetMembersCount(vo.getId(), PerunStatus.SUSPENDED);
-					countSuspendedMembers.retrieveData();
-
 					GetMembersCount countExpiredMembers = new GetMembersCount(vo.getId(), PerunStatus.EXPIRED);
 					countExpiredMembers.retrieveData();
 
@@ -150,11 +146,10 @@ public class StatisticsTabItem implements TabItem, TabItemWithUrl {
 					vosTable.setWidget(i + 1, 1, countMembers.getMembersCountHyperlink());
 					vosTable.setWidget(i + 1, 2, countValidMembers.getMembersCountHyperlink());
 					vosTable.setWidget(i + 1, 3, countInvalidMembers.getMembersCountHyperlink());
-					vosTable.setWidget(i + 1, 4, countSuspendedMembers.getMembersCountHyperlink());
-					vosTable.setWidget(i + 1, 5, countExpiredMembers.getMembersCountHyperlink());
-					vosTable.setWidget(i + 1, 6, countDisabledMembers.getMembersCountHyperlink());
-					vosTable.setWidget(i + 1, 7, countGroups.getGroupsCountHyperlink());
-					vosTable.setWidget(i + 1, 8, countResources.getResourcesCountHyperlink());
+					vosTable.setWidget(i + 1, 4, countExpiredMembers.getMembersCountHyperlink());
+					vosTable.setWidget(i + 1, 5, countDisabledMembers.getMembersCountHyperlink());
+					vosTable.setWidget(i + 1, 6, countGroups.getGroupsCountHyperlink());
+					vosTable.setWidget(i + 1, 7, countResources.getResourcesCountHyperlink());
 
 				}
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/UserDetailTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/UserDetailTabItem.java
@@ -606,8 +606,6 @@ public class UserDetailTabItem implements TabItem, TabItemWithUrl {
 					ir = SmallIcons.INSTANCE.acceptIcon();
 				} else if (member.getStatus().equalsIgnoreCase("INVALID")){
 					ir = SmallIcons.INSTANCE.flagRedIcon();
-				} else if (member.getStatus().equalsIgnoreCase("SUSPENDED")){
-					ir = SmallIcons.INSTANCE.stopIcon();
 				} else if (member.getStatus().equalsIgnoreCase("EXPIRED")){
 					ir = SmallIcons.INSTANCE.flagYellowIcon();
 				} else if (member.getStatus().equalsIgnoreCase("DISABLED")){

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/vostabs/VoOverviewTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/vostabs/VoOverviewTabItem.java
@@ -216,7 +216,6 @@ public class VoOverviewTabItem implements TabItem {
 		final GetMembersCount countMembers = new GetMembersCount(vo.getId(), null);
 		final GetMembersCount countValidMembers = new GetMembersCount(vo.getId(), PerunStatus.VALID);
 		final GetMembersCount countInvalidMembers = new GetMembersCount(vo.getId(), PerunStatus.INVALID);
-		final GetMembersCount countSuspendedMembers = new GetMembersCount(vo.getId(), PerunStatus.SUSPENDED);
 		final GetMembersCount countExpiredMembers = new GetMembersCount(vo.getId(), PerunStatus.EXPIRED);
 		final GetMembersCount countDisabledMembers = new GetMembersCount(vo.getId(), PerunStatus.DISABLED);
 
@@ -245,7 +244,6 @@ public class VoOverviewTabItem implements TabItem {
 					countMembers.retrieveData();
 					countValidMembers.retrieveData();
 					countInvalidMembers.retrieveData();
-					countSuspendedMembers.retrieveData();
 					countExpiredMembers.retrieveData();
 					countDisabledMembers.retrieveData();
 
@@ -263,18 +261,16 @@ public class VoOverviewTabItem implements TabItem {
 		vosTable.setWidget(1, 1, countValidMembers.getMembersCountLabel());
 		vosTable.setWidget(2, 0, new HTML(" - invalid"));
 		vosTable.setWidget(2, 1, countInvalidMembers.getMembersCountLabel());
-		vosTable.setWidget(3, 0, new HTML(" - suspended"));
-		vosTable.setWidget(3, 1, countSuspendedMembers.getMembersCountLabel());
-		vosTable.setWidget(4, 0, new HTML(" - expired"));
-		vosTable.setWidget(4, 1, countExpiredMembers.getMembersCountLabel());
-		vosTable.setWidget(5, 0, new HTML(" - disabled"));
+		vosTable.setWidget(3, 0, new HTML(" - expired"));
+		vosTable.setWidget(3, 1, countExpiredMembers.getMembersCountLabel());
+		vosTable.setWidget(4, 0, new HTML(" - disabled"));
 		vosTable.setWidget(5, 1, countDisabledMembers.getMembersCountLabel());
 
-		vosTable.setWidget(6, 0, new HTML("<strong>" + "Resources" + "</strong>"));
-		vosTable.setWidget(6, 1, countResources.getResourcesCountLabel());
+		vosTable.setWidget(5, 0, new HTML("<strong>" + "Resources" + "</strong>"));
+		vosTable.setWidget(5, 1, countResources.getResourcesCountLabel());
 
-		vosTable.setWidget(7, 0, new HTML("<strong>" + "Groups" + "</strong>"));
-		vosTable.setWidget(7, 1, countGroups.getGroupsCountLabel());
+		vosTable.setWidget(6, 0, new HTML("<strong>" + "Groups" + "</strong>"));
+		vosTable.setWidget(6, 1, countGroups.getGroupsCountLabel());
 
 		vp2.add(statistics);
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/widgets/PerunStatusWidget.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/widgets/PerunStatusWidget.java
@@ -24,7 +24,6 @@ public class PerunStatusWidget<T extends JavaScriptObject> extends Composite {
 
 	static private final ImageResource VALID = SmallIcons.INSTANCE.acceptIcon();
 	static private final ImageResource INVALID = SmallIcons.INSTANCE.flagRedIcon();
-	static private final ImageResource SUSPENDED = SmallIcons.INSTANCE.stopIcon();
 	static private final ImageResource EXPIRED = SmallIcons.INSTANCE.flagYellowIcon();
 	static private final ImageResource DISABLED = SmallIcons.INSTANCE.binClosedIcon();
 
@@ -142,8 +141,6 @@ public class PerunStatusWidget<T extends JavaScriptObject> extends Composite {
 			ir = VALID;
 		} else if (status.equalsIgnoreCase("INVALID")){
 			ir = INVALID;
-		} else if (status.equalsIgnoreCase("SUSPENDED")){
-			ir = SUSPENDED;
 		} else if (status.equalsIgnoreCase("EXPIRED")){
 			ir = EXPIRED;
 		} else if (status.equalsIgnoreCase("DISABLED")){

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/widgets/cells/PerunStatusCell.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/widgets/cells/PerunStatusCell.java
@@ -19,13 +19,11 @@ public class PerunStatusCell extends ClickableTextCell {
 	/*
 		 VALID  (0),
 		 INVALID (1),    //just created object, where some information (e.g. attribute)  is missing
-		 SUSPENDED (2),  //security issue
 		 EXPIRED (3),
 		 DISABLED (4);   //use this status instead of deleting the entity
 		 */
 	static private final ImageResource VALID = SmallIcons.INSTANCE.acceptIcon();
 	static private final ImageResource INVALID = SmallIcons.INSTANCE.flagRedIcon();
-	static private final ImageResource SUSPENDED = SmallIcons.INSTANCE.stopIcon();
 	static private final ImageResource EXPIRED = SmallIcons.INSTANCE.flagYellowIcon();
 	static private final ImageResource DISABLED = SmallIcons.INSTANCE.binClosedIcon();
 
@@ -44,8 +42,6 @@ public class PerunStatusCell extends ClickableTextCell {
 			ir = VALID;
 		} else if (status.equalsIgnoreCase("INVALID")){
 			ir = INVALID;
-		} else if (status.equalsIgnoreCase("SUSPENDED")){
-			ir = SUSPENDED;
 		} else if (status.equalsIgnoreCase("EXPIRED")){
 			ir = EXPIRED;
 		} else if (status.equalsIgnoreCase("DISABLED")){


### PR DESCRIPTION
* DEPLOYMENT: 
  * New DB version 
* With the old implemetation of the member suspension it was difficult
to determine in which state the object was before. It wasn't also
possible to specify a reason why the member has been suspended.
Therefore, a new implementation using bans has been created.
* SUSPEND status has been completely removed and it has been replaced
with new implementation of VoBans.
* The old method `suspendMemberTo` now creates ban objects, but it has
been marked as deprecated and one should use the newly created methods
that work directly with bans.
* Updated isSuspended attribute's module to read the information from
bans.
* Created new methods that work with vo bans.
* New methods added to the OpenApi.