### PR TITLE
stringToMapOfAttributes will return empty map

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/BeansUtils.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/BeansUtils.java
@@ -486,10 +486,13 @@ public class BeansUtils {
 	 *
 	 * @param attributesAsString Map attribute in String representation.
 	 * @return LinkedHashMap with key values pairs extracted from the input
+	 *         or an empty map when the input parameter is an empty string or null.
 	 */
+	@SuppressWarnings("unchecked") // It is ok, we know that stringToAttributeValue always returns LinkedHashMap or null
 	public static LinkedHashMap<String, String> stringToMapOfAttributes(String attributesAsString) {
 		Object mapAsObject = BeansUtils.stringToAttributeValue(attributesAsString, LinkedHashMap.class.getName());
-		return objectMapper.convertValue(mapAsObject, new TypeReference<LinkedHashMap<String, String>>() {});
+		if (mapAsObject == null) return new LinkedHashMap<>();
+		return (LinkedHashMap<String, String>) mapAsObject;
 	}
 
 	/**

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/CoreConfig.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/CoreConfig.java
@@ -81,6 +81,7 @@ public class CoreConfig {
 	private List<String> autocreatedNamespaces;
 	private String groupNameSecondaryRegex;
 	private String groupFullNameSecondaryRegex;
+	private List<String> attributesToSearchUsersAndMembersBy;
 
 	public int getGroupMaxConcurentGroupsToSynchronize() {
 		return groupMaxConcurentGroupsToSynchronize;
@@ -670,5 +671,13 @@ public class CoreConfig {
 
 	public void setGroupFullNameSecondaryRegex(String groupFullNameSecondaryRegex) {
 		this.groupFullNameSecondaryRegex = groupFullNameSecondaryRegex;
+	}
+
+	public List<String> getAttributesToSearchUsersAndMembersBy() {
+		return attributesToSearchUsersAndMembersBy;
+	}
+
+	public void setAttributesToSearchUsersAndMembersBy(List<String> attributesToSearchUsersAndMembersBy) {
+		this.attributesToSearchUsersAndMembersBy = attributesToSearchUsersAndMembersBy;
 	}
 }

--- a/perun-base/src/main/resources/perun-base.xml
+++ b/perun-base/src/main/resources/perun-base.xml
@@ -64,6 +64,7 @@
 		<property name="rtSendToMail" value="${perun.rt.sendToMail}" />
 		<property name="queryTimeout" value="${perun.queryTimeout}" />
 		<property name="defaultLoaIdP" value="${perun.defaultLoa.idp}"/>
+		<property name="attributesToSearchUsersAndMembersBy" value="#{'${perun.attributesToSearchUsersAndMembersBy}'.split('\s*,\s*')}"/>
 	</bean>
 
 
@@ -127,6 +128,7 @@
 				<prop key="perun.allowedCorsDomains"></prop>
 				<prop key="perun.queryTimeout">-1</prop>
 				<prop key="perun.defaultLoa.idp">2</prop>
+				<prop key="perun.attributesToSearchUsersAndMembersBy">urn:perun:user:attribute-def:def:preferredMail, urn:perun:member:attribute-def:def:mail</prop>
 				<!--
 				   this creates a map from OIDC issuer to user extsources that are used for looking up a user identified by "sub" claim
 				-->

--- a/perun-base/src/main/resources/perun-roles.yml
+++ b/perun-base/src/main/resources/perun-roles.yml
@@ -1,5 +1,84 @@
 ---
 # A list of Perun roles that are loaded to the database
+#
+# PERUNADMIN role can perform all the actions possible in the Perun system.
+# It is the only role that is able to also set this role to other users.
+#
+# PERUNOBSERVER role has access to all the information, but it is not able to perform any changes.
+# The role can be set only by Perun administrators.
+#
+# VOADMIN role has full control over a virtual organization that is associated with the role.
+# It can create, set up and manage groups in the VO, assign groups and services to resources, set up external
+# sources for the VO, define rules for VO membership, and set up registration sheet for the VO.
+# VO administrators are able to set up roles associated with the Vo: other VO administrators, Resource administrators,
+# Group administrators, Top group creators, Resource self-service, and Sponsor roles.
+# The VO administrator role may be set to users or groups of users by other VO administrators or Perun administrators.
+#
+# GROUPADMIN role can create subgroups for the group which is associated with this role
+# and add members to the group and its subgroups. Users with this role are also able to send group invitations
+# to other VO members, and to create a registration sheet for group membership. The role may be set
+# to users or groups of users by Perun administrators, VO administrators, and other Group administrators.
+#
+# SELF role is a user’s primary role through which the user is able to read and to change
+# only their personal information. It is assigned to all the authenticated users and cannot be removed.
+#
+# FACILITYADMIN role has complete control over a facility that is associated with the role.
+# For example, Facility administrators have a right to create facility resources, to set up attributes and destinations
+# for services, or to propagate these services. This role may be set by a Perun administrator
+# or by another facility administrator associated with the same facility.
+# Moreover, the role can also be assigned to a single user or a group of users.
+#
+# RESOURCEADMIN role can assign groups to and remove them from the resources with which this role is connected.
+# The group and the resource have to be in the same VO in order to make an assignment or to remove it.
+# Resource administrators, VO administrators, and Perun administrators are able to set this role
+# to other users or groups of users.
+#
+# RESOURCESELFSERVICE has the same privileges as the Resource administrator role,
+# but users with this role are able to manage group on resources only when they are Group administrators for that group.
+# VO administrators, Perun administrators, and Resource administrators are allowed to assign this role
+# to users or groups of users. However, a user with Resource self-service role cannot delegate this role further.
+#
+# REGISTRAR is a system role that belongs to the Registration module. It is allowed to perform actions
+# that are connected to users’ registrations and to creating and changing users’ passwords.
+# It cannot be managed by other roles.
+#
+# ENGINE is another system role that represents the Engine component. This role is authorized to take actions
+# connected with users’ propagations to services. Same as the role RPC, this role cannot be managed by other roles.
+#
+# RPC is a system role, which allows the RPC component to call the API and thus transfer outer API parameters
+# into objects. Perun does not provide an explicit functionality for managing system roles.
+# Therefore, it is not possible to manage this role by any other role.
+#
+# NOTIFICATIONS role does not have any special privileges. Its purpose is to identify whether
+# the Notification module is calling the core API. It is a system role; therefore, it cannot be assigned to anyone.
+#
+# SERVICEUSER is a role that can be assigned to a certain process, service, or user.
+# It is a sign of an account with a Self role being created by someone else.
+# The only role with privileges to create a Service user is the Perun administrator role.
+#
+# SPONSOR users or groups of a VO can provide other users with VO membership even without them passing the VO registration.
+# The sponsor role may be assigned to users or groups of users by VO administrators or Perun administrators.
+# However, Sponsors are not allowed to delegate this role to other users or groups.
+#
+# VOOBSERVER can see everything that VO admin sees, but the observer is not able to perform any changes in the VO.
+# Roles which have a right to set this role are Perun administrator and VO administrator.
+#
+# TOPGROUPCREATOR role is able to create a new top-level group in a VO (a group which does not have a parent group)
+# and to copy forms and emails from one group to another (within the same VO). This role can also be assigned to
+# users and groups of users. The only roles which have a right to set this role are the Perun administrator and the
+# VO administrator.
+#
+# SECURITYADMIN role has the privilege to put users on a blacklist in a facility. The blacklist is associated
+# with a security team, and the team is associated with the facility. Security administrators are members
+# of at least one security team, either directly, or indirectly as members of another group.
+# Together with Perun administrators, they can add other administrators to the team.
+#
+# CABINETADMIN role is able to manage users’ publications in the cabinet module.
+# Cabinet administrators and Perun administrators are able to delegate this role to other users,
+# but the role cannot be set to groups.
+#
+# UNKNOWN exists, but it is not used in Perun.
+#
 perun_roles:
   - PERUNADMIN
   - PERUNOBSERVER

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/MembersManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/MembersManagerImpl.java
@@ -508,14 +508,7 @@ public class MembersManagerImpl implements MembersManagerImplApi {
 			sponsoredQueryString+=" members.sponsored=1 and ";
 		}
 
-		String userNameQueryString;
-		if (Compatibility.isPostgreSql()) {
-			userNameQueryString= " strpos(lower("+Compatibility.convertToAscii("COALESCE(users.first_name,'') || COALESCE(users.middle_name,'') || COALESCE(users.last_name,'')")+"),:nameString) > 0 ";
-		} else if (Compatibility.isHSQLDB()) {
-			userNameQueryString=" lower("+Compatibility.convertToAscii("COALESCE(users.first_name,'') || COALESCE(users.middle_name,'') || COALESCE(users.last_name,'')")+") like '%' || :nameString || '%' ";
-		} else {
-			throw new InternalErrorException("Unsupported db type");
-		}
+		String userNameQueryString = Utils.prepareUserSearchQuerySimilarMatch();
 
 		String idQueryString = "";
 		try {
@@ -526,39 +519,12 @@ public class MembersManagerImpl implements MembersManagerImplApi {
 		}
 
 		// Divide attributes received from CoreConfig into member, user and userExtSource attributes
-		List<String> allAttributes = BeansUtils.getCoreConfig().getAttributesToSearchUsersAndMembersBy();
-		List<String> memberAttributes = new ArrayList<>();
-		List<String> userAttributes = new ArrayList<>();
-		List<String> uesAttributes = new ArrayList<>();
-		for (String attribute : allAttributes) {
-			if (attribute.startsWith(AttributesManager.NS_MEMBER_ATTR)) {
-				memberAttributes.add(attribute);
-			} else if (attribute.startsWith(AttributesManager.NS_USER_ATTR)) {
-				userAttributes.add(attribute);
-			} else if (attribute.startsWith(AttributesManager.NS_UES_ATTR)) {
-				uesAttributes.add(attribute);
-			}
-		}
+		Map<String, List<String>> attributesToSearchBy = Utils.getDividedAttributes();
 
-		Pair<String, String> memberAttributesQueryString = new Pair<>("", "");
-		if (!memberAttributes.isEmpty()) {
-			memberAttributesQueryString.put(" left join member_attr_values mav on members.id=mav.member_id and mav.attr_id in (select id from attr_names where attr_name in (:memberAttributes))", " lower(mav.attr_value)=lower(:searchString) or " );
-		}
-		Pair<String, String> userAttributesQueryString = new Pair<>("", "");
-		if (!userAttributes.isEmpty()) {
-			userAttributesQueryString.put(" left join user_attr_values uav on users.id=uav.user_id and uav.attr_id in (select id from attr_names where attr_name in (:userAttributes))" , " lower(uav.attr_value)=lower(:searchString) or ");
-		}
-		Pair<String, String> uesAttributesQueryString = new Pair<>("", "");
-		if (!uesAttributes.isEmpty()) {
-			uesAttributesQueryString.put(" left join user_ext_source_attr_values uesav on uesav.user_ext_source_id=ues.id and uesav.attr_id in (select id from attr_names where attr_name in (:uesAttributes))", " lower(uesav.attr_value)=lower(:searchString) or ");
-		}
+		// Parts of query to search by attributes
+		Map<String, Pair<String, String>> attributesToSearchByQueries = Utils.getAttributesQuery(attributesToSearchBy.get("memberAttributes"), attributesToSearchBy.get("userAttributes"), attributesToSearchBy.get("uesAttributes"));
 
-		MapSqlParameterSource namedParams = new MapSqlParameterSource();
-		namedParams.addValue("searchString", searchString);
-		namedParams.addValue("nameString", Utils.utftoasci(searchString.toLowerCase()));
-		namedParams.addValue("memberAttributes", memberAttributes);
-		namedParams.addValue("userAttributes", userAttributes);
-		namedParams.addValue("uesAttributes", uesAttributes);
+		MapSqlParameterSource namedParams = Utils.getMapSqlParameterSourceToSearchUsersOrMembers(searchString, attributesToSearchBy);
 
 		//searching by member attributes
 		//searching by user attributes
@@ -570,17 +536,17 @@ public class MembersManagerImpl implements MembersManagerImplApi {
 				" from members " +
 				" left join users on members.user_id=users.id " +
 				" left join user_ext_sources ues on ues.user_id=users.id " +
-				memberAttributesQueryString.getLeft() +
-				userAttributesQueryString.getLeft() +
-				uesAttributesQueryString.getLeft() +
+				attributesToSearchByQueries.get("memberAttributesQuery").getLeft() +
+				attributesToSearchByQueries.get("userAttributesQuery").getLeft() +
+				attributesToSearchByQueries.get("uesAttributesQuery").getLeft() +
 				" where " +
 				voIdQueryString +
 				sponsoredQueryString +
 				" ( " +
 				" lower(ues.login_ext)=lower(:searchString) or " +
-				memberAttributesQueryString.getRight() +
-				userAttributesQueryString.getRight() +
-				uesAttributesQueryString.getRight() +
+				attributesToSearchByQueries.get("memberAttributesQuery").getRight() +
+				attributesToSearchByQueries.get("userAttributesQuery").getRight() +
+				attributesToSearchByQueries.get("uesAttributesQuery").getRight() +
 				idQueryString +
 				userNameQueryString +
 				" ) ", namedParams, MEMBER_MAPPER));

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/UsersManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/UsersManagerImpl.java
@@ -816,18 +816,18 @@ public class UsersManagerImpl implements UsersManagerImplApi {
 		if (exactMatch) {
 			// Part of query to search by user name (exact)
 			if (Compatibility.isPostgreSql()) {
-				userNameQueryString= " strpos(lower("+Compatibility.convertToAscii("COALESCE(users.first_name,'') || COALESCE(users.middle_name,'') || COALESCE(users.last_name,'')") + ")=?";
+				userNameQueryString= " strpos(lower("+Compatibility.convertToAscii("COALESCE(users.first_name,'') || COALESCE(users.middle_name,'') || COALESCE(users.last_name,'')") + ")=:nameString";
 			} else if (Compatibility.isHSQLDB()) {
-				userNameQueryString=" lower("+Compatibility.convertToAscii("COALESCE(users.first_name,'') || COALESCE(users.middle_name,'') || COALESCE(users.last_name,'')")+")=?";
+				userNameQueryString=" lower("+Compatibility.convertToAscii("COALESCE(users.first_name,'') || COALESCE(users.middle_name,'') || COALESCE(users.last_name,'')")+")=:nameString";
 			} else {
 				throw new InternalErrorException("Unsupported db type");
 			}
 		} else {
 			// Part of query to search by user name (not exact)
 			if (Compatibility.isPostgreSql()) {
-				userNameQueryString = " strpos(lower(" + Compatibility.convertToAscii("COALESCE(users.first_name,'') || COALESCE(users.middle_name,'') || COALESCE(users.last_name,'')") + "),?) > 0 ";
+				userNameQueryString = " strpos(lower(" + Compatibility.convertToAscii("COALESCE(users.first_name,'') || COALESCE(users.middle_name,'') || COALESCE(users.last_name,'')") + "),:nameString) > 0 ";
 			} else if (Compatibility.isHSQLDB()) {
-				userNameQueryString = " lower(" + Compatibility.convertToAscii("COALESCE(users.first_name,'') || COALESCE(users.middle_name,'') || COALESCE(users.last_name,'')") + ") like '%' || ? || '%' ";
+				userNameQueryString = " lower(" + Compatibility.convertToAscii("COALESCE(users.first_name,'') || COALESCE(users.middle_name,'') || COALESCE(users.last_name,'')") + ") like '%' || :nameString || '%' ";
 			} else {
 				throw new InternalErrorException("Unsupported db type");
 			}
@@ -844,18 +844,38 @@ public class UsersManagerImpl implements UsersManagerImplApi {
 
 		// Divide attributes received from CoreConfig into member, user and userExtSource attributes
 		List<String> allAttributes = BeansUtils.getCoreConfig().getAttributesToSearchUsersAndMembersBy();
-		StringBuilder memberAttributes = new StringBuilder("''");
-		StringBuilder userAttributes = new StringBuilder("''");
-		StringBuilder uesAttributes = new StringBuilder("''");
+		List<String> memberAttributes = new ArrayList<>();
+		List<String> userAttributes = new ArrayList<>();
+		List<String> uesAttributes = new ArrayList<>();
 		for (String attribute : allAttributes) {
 			if (attribute.startsWith(AttributesManager.NS_MEMBER_ATTR)) {
-				memberAttributes.append(",'").append(attribute).append("'");
+				memberAttributes.add(attribute);
 			} else if (attribute.startsWith(AttributesManager.NS_USER_ATTR)) {
-				userAttributes.append(",'").append(attribute).append("'");
+				userAttributes.add(attribute);
 			} else if (attribute.startsWith(AttributesManager.NS_UES_ATTR)) {
-				uesAttributes.append(",'").append(attribute).append("'");
+				uesAttributes.add(attribute);
 			}
 		}
+
+		Pair<String, String> memberAttributesQueryString = new Pair<>("", "");
+		if (!memberAttributes.isEmpty()) {
+			memberAttributesQueryString.put(" left join member_attr_values mav on members.id=mav.member_id and mav.attr_id in (select id from attr_names where attr_name in (:memberAttributes))", " lower(mav.attr_value)=lower(:searchString) or " );
+		}
+		Pair<String, String> userAttributesQueryString = new Pair<>("", "");
+		if (!userAttributes.isEmpty()) {
+			userAttributesQueryString.put(" left join user_attr_values uav on users.id=uav.user_id and uav.attr_id in (select id from attr_names where attr_name in (:userAttributes))" , " lower(uav.attr_value)=lower(:searchString) or ");
+		}
+		Pair<String, String> uesAttributesQueryString = new Pair<>("", "");
+		if (!uesAttributes.isEmpty()) {
+			uesAttributesQueryString.put(" left join user_ext_source_attr_values uesav on uesav.user_ext_source_id=ues.id and uesav.attr_id in (select id from attr_names where attr_name in (:uesAttributes))", " lower(uesav.attr_value)=lower(:searchString) or ");
+		}
+
+		MapSqlParameterSource namedParams = new MapSqlParameterSource();
+		namedParams.addValue("searchString", searchString);
+		namedParams.addValue("nameString", Utils.utftoasci(searchString.toLowerCase()));
+		namedParams.addValue("memberAttributes", memberAttributes);
+		namedParams.addValue("userAttributes", userAttributes);
+		namedParams.addValue("uesAttributes", uesAttributes);
 
 		// Search by member attributes
 		// Search by user attributes
@@ -863,22 +883,22 @@ public class UsersManagerImpl implements UsersManagerImplApi {
 		// Search by userExtSource attributes
 		// Search by user id
 		// Search by name for user
-		Set<User> users = new HashSet<>(jdbc.query("select distinct " + userMappingSelectQuery +
+		Set<User> users = new HashSet<>(namedParameterJdbcTemplate.query("select distinct " + userMappingSelectQuery +
 			" from users " +
-			" left join members m on users.id=m.user_id " +
-			" left join member_attr_values mav on m.id=mav.member_id and mav.attr_id in (select id from attr_names where attr_name in (" + memberAttributes.toString() + "))" +
-			" left join user_attr_values uav on users.id=uav.user_id and uav.attr_id in (select id from attr_names where attr_name in (" + userAttributes.toString() + "))" +
+			" left join members on users.id=members.user_id " +
 			" left join user_ext_sources ues on ues.user_id=users.id " +
-			" left join user_ext_source_attr_values uesav on uesav.user_ext_source_id=ues.id and uesav.attr_id in (select id from attr_names where attr_name in (" + uesAttributes.toString() + "))" +
+			memberAttributesQueryString.getLeft() +
+			userAttributesQueryString.getLeft() +
+			uesAttributesQueryString.getLeft() +
 			" where " +
 			" ( " +
-			" lower(mav.attr_value)=lower(?) or " +
-			" lower(uav.attr_value)=lower(?) or " +
-			" lower(ues.login_ext)=lower(?) or " +
-			" lower(uesav.attr_value)=lower(?) or " +
+			" lower(ues.login_ext)=lower(:searchString) or " +
+			memberAttributesQueryString.getRight() +
+			userAttributesQueryString.getRight() +
+			uesAttributesQueryString.getRight() +
 			idQueryString +
 			userNameQueryString +
-			" ) ", USER_MAPPER, searchString, searchString, searchString, searchString, Utils.utftoasci(searchString.toLowerCase())));
+			" ) ", namedParams, USER_MAPPER));
 
 		log.debug("Searching for users using searchString '{}'", searchString);
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Utils.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Utils.java
@@ -2,6 +2,7 @@ package cz.metacentrum.perun.core.impl;
 
 import com.zaxxer.hikari.HikariDataSource;
 import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.BeansUtils;
 import cz.metacentrum.perun.core.api.Destination;
 import cz.metacentrum.perun.core.api.ExtSource;
@@ -39,6 +40,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.mail.MailException;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
@@ -1637,5 +1639,125 @@ public class Utils {
 		} catch (PatternSyntaxException e) {
 			throw new InternalErrorException("Invalid group name regex defined: " + regex, e);
 		}
+	}
+
+	/**
+	 * Returns search query to search by user name (exact match) based on databased in use.
+	 *
+	 * @return search query
+	 */
+	public static String prepareUserSearchQueryExactMatch() {
+		if (Compatibility.isPostgreSql()) {
+			return " strpos(lower("+Compatibility.convertToAscii("COALESCE(users.first_name,'') || COALESCE(users.middle_name,'') || COALESCE(users.last_name,'')") + ")=:nameString";
+		} else if (Compatibility.isHSQLDB()) {
+			return " lower("+Compatibility.convertToAscii("COALESCE(users.first_name,'') || COALESCE(users.middle_name,'') || COALESCE(users.last_name,'')")+")=:nameString";
+		} else {
+			throw new InternalErrorException("Unsupported db type");
+		}
+	}
+
+	/**
+	 * Returns search query to search by user name (similar match) based on databased in use.
+	 *
+	 * @return search query
+	 */
+	public static String prepareUserSearchQuerySimilarMatch() {
+		if (Compatibility.isPostgreSql()) {
+			return " strpos(lower(" + Compatibility.convertToAscii("COALESCE(users.first_name,'') || COALESCE(users.middle_name,'') || COALESCE(users.last_name,'')") + "),:nameString) > 0 ";
+		} else if (Compatibility.isHSQLDB()) {
+			return " lower(" + Compatibility.convertToAscii("COALESCE(users.first_name,'') || COALESCE(users.middle_name,'') || COALESCE(users.last_name,'')") + ") like '%' || :nameString || '%' ";
+		} else {
+			throw new InternalErrorException("Unsupported db type");
+		}
+	}
+
+	/**
+	 * Takes attributes from CoreConfig used in users or members search and divides them into correct categories based
+	 * on attribute type (member, user, userExtSource).
+	 *
+	 * Then returns map: memberAttributes -> list of member attributes
+	 *                   userAttributes -> list of user attributes
+	 *                   uesAttributes -> list of userExtSource attributes
+	 *
+	 * @return map of attributes
+	 */
+	public static Map<String, List<String>> getDividedAttributes() {
+		Map<String, List<String>> result = new HashMap<>();
+
+		List<String> allAttributes = BeansUtils.getCoreConfig().getAttributesToSearchUsersAndMembersBy();
+		List<String> memberAttributes = new ArrayList<>();
+		List<String> userAttributes = new ArrayList<>();
+		List<String> uesAttributes = new ArrayList<>();
+		for (String attribute : allAttributes) {
+			if (attribute.startsWith(AttributesManager.NS_MEMBER_ATTR)) {
+				memberAttributes.add(attribute);
+			} else if (attribute.startsWith(AttributesManager.NS_USER_ATTR)) {
+				userAttributes.add(attribute);
+			} else if (attribute.startsWith(AttributesManager.NS_UES_ATTR)) {
+				uesAttributes.add(attribute);
+			}
+		}
+
+		result.put("memberAttributes", memberAttributes);
+		result.put("userAttributes", userAttributes);
+		result.put("uesAttributes", uesAttributes);
+
+		return result;
+	}
+
+	/**
+	 * Prepares query to search users or members by attributes if received attribute list is not empty.
+	 *
+	 * Returns map: memberAttributesQueryString -> pair of parts of query to search by member attributes
+	 * 	            userAttributesQueryString -> pair of parts of query to search by user attributes
+	 * 	            uesAttributesQueryString -> pair of parts of query to search by userExtSource attributes
+	 *
+	 * @param memberAttributes member attributes
+	 * @param userAttributes user attributes
+	 * @param uesAttributes userExtSource attributes
+	 *
+	 * @return map of parts of query
+	 */
+	public static Map<String, Pair<String, String>> getAttributesQuery(List<String> memberAttributes, List<String> userAttributes, List<String> uesAttributes) {
+		Map<String, Pair<String, String>> result = new HashMap<>();
+
+		Pair<String, String> memberAttributesQueryString = new Pair<>("", "");
+		if (!memberAttributes.isEmpty()) {
+			memberAttributesQueryString.put(" left join member_attr_values mav on members.id=mav.member_id and mav.attr_id in (select id from attr_names where attr_name in (:memberAttributes))", " lower(mav.attr_value)=lower(:searchString) or " );
+		}
+		result.put("memberAttributesQuery", memberAttributesQueryString);
+
+		Pair<String, String> userAttributesQueryString = new Pair<>("", "");
+		if (!userAttributes.isEmpty()) {
+			userAttributesQueryString.put(" left join user_attr_values uav on users.id=uav.user_id and uav.attr_id in (select id from attr_names where attr_name in (:userAttributes))" , " lower(uav.attr_value)=lower(:searchString) or ");
+		}
+		result.put("userAttributesQuery", userAttributesQueryString);
+
+		Pair<String, String> uesAttributesQueryString = new Pair<>("", "");
+		if (!uesAttributes.isEmpty()) {
+			uesAttributesQueryString.put(" left join user_ext_source_attr_values uesav on uesav.user_ext_source_id=ues.id and uesav.attr_id in (select id from attr_names where attr_name in (:uesAttributes))", " lower(uesav.attr_value)=lower(:searchString) or ");
+		}
+		result.put("uesAttributesQuery", uesAttributesQueryString);
+
+		return result;
+	}
+
+	/**
+	 * Returns MapSqlParameterSource with values added to search members or users.
+	 *
+	 * @param searchString string used to search by
+	 * @param attributesToSearchBy map of attributes used to search for users or members
+	 *
+	 * @return filled MapSqlParameterSource
+	 */
+	public static MapSqlParameterSource getMapSqlParameterSourceToSearchUsersOrMembers(String searchString, Map<String, List<String>> attributesToSearchBy) {
+		MapSqlParameterSource namedParams = new MapSqlParameterSource();
+		namedParams.addValue("searchString", searchString);
+		namedParams.addValue("nameString", Utils.utftoasci(searchString.toLowerCase()));
+		namedParams.addValue("memberAttributes", attributesToSearchBy.get("memberAttributes"));
+		namedParams.addValue("userAttributes", attributesToSearchBy.get("userAttributes"));
+		namedParams.addValue("uesAttributes", attributesToSearchBy.get("uesAttributes"));
+
+		return namedParams;
 	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/MembersManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/MembersManagerImplApi.java
@@ -342,7 +342,7 @@ public interface MembersManagerImplApi {
 
 	/**
 	 * Return list of members by specific string.
-	 * Looking for searchString in member mail, user preferredMail, logins, name and IDs (user and member).
+	 * Looking for searchString in user name, member and user id, member, users and userExtSource attributes specified by perun.properties.
 	 * All searches are case insensitive.
 	 * If parameter onlySponsored is true, it will return only sponsored members by searchString.
 	 * If vo is null, looking for any members in whole Perun. If vo is not null, looking only in specific VO.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/UsersManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/UsersManagerImplApi.java
@@ -506,22 +506,22 @@ public interface UsersManagerImplApi {
 	List<Vo> getVosWhereUserIsMember(PerunSession sess, User user);
 
 	/**
-	 * Returns list of users who matches the searchString, searching name, email and logins.
+	 * Returns list of users who matches the searchString, searching name, id, member attributes, user attributes
+	 * and userExtSource attributes (listed in perun.properties).
 	 *
-	 * @param sess
-	 * @param searchString
+	 * @param sess perun session
+	 * @param searchString it will be looking for this search string in the specific parameters in DB
 	 * @return list of users
-	 * @throws InternalErrorException
 	 */
 	List<User> findUsers(PerunSession sess, String searchString);
 
 	/**
-	 * Returns list of users who matches the searchString, searching name, email and logins.
+	 * Returns list of users who matches the searchString, searching name (exact match), id, member attributes, user attributes
+	 * and userExtSource attributes (listed in perun.properties).
 	 *
-	 * @param sess
-	 * @param searchString
+	 * @param sess perun session
+	 * @param searchString it will be looking for this search string in the specific parameters in DB
 	 * @return list of users
-	 * @throws InternalErrorException
 	 */
 	List<User> findUsersByExactMatch(PerunSession sess, String searchString);
 

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/MembersManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/MembersManagerEntryIntegrationTest.java
@@ -1345,6 +1345,11 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 		groupsManagerEntry.addMember(sess, createdGroup, member);
 		groupsManagerEntry.addMember(sess, createdGroup, member2);
 
+		// add user attribute to CoreConfig
+		List<String> attributes = BeansUtils.getCoreConfig().getAttributesToSearchUsersAndMembersBy();
+		attributes.add("urn:perun:user:attribute-def:def:login-namespace:testMichal");
+		BeansUtils.getCoreConfig().setAttributesToSearchUsersAndMembersBy(attributes);
+
 		List<Member> foundMembers = membersManagerEntry.findMembersInGroup(sess, createdGroup, "FirstTest");
 		assertTrue(foundMembers.contains(member));
 		foundMembers.remove(member);
@@ -1362,6 +1367,10 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 		assertTrue(foundMembers.contains(member));
 		foundMembers.remove(member);
 		assertTrue(foundMembers.isEmpty());
+
+		// reset CoreConfig to previous state
+		attributes.remove("urn:perun:user:attribute-def:def:login-namespace:testMichal");
+		BeansUtils.getCoreConfig().setAttributesToSearchUsersAndMembersBy(attributes);
 	}
 
 	@Ignore

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/UsersManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/UsersManagerEntryIntegrationTest.java
@@ -1327,8 +1327,8 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 	}
 
 	@Test
-	public void findUserByMemberMail() throws Exception {
-		System.out.println(CLASS_NAME + "findUserByMemberMail");
+	public void findUserByMemberAttribute() throws Exception {
+		System.out.println(CLASS_NAME + "findUserByMemberAttribute");
 
 		Member member = setUpMember(vo);
 

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/UsersManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/UsersManagerEntryIntegrationTest.java
@@ -6,6 +6,7 @@ import cz.metacentrum.perun.core.AbstractPerunIntegrationTest;
 import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.BeansUtils;
 import cz.metacentrum.perun.core.api.Candidate;
 import cz.metacentrum.perun.core.api.ExtSource;
 import cz.metacentrum.perun.core.api.ExtSourcesManager;
@@ -1301,6 +1302,124 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 			},
 			ATTR_UES_O
 		);
+	}
+
+	@Test
+	public void findUserById() {
+		System.out.println(CLASS_NAME + "findUserById");
+
+		List<User> users = perun.getUsersManagerBl().findUsers(sess, String.valueOf(user.getId()));
+		assertEquals(1, users.size());
+		assertEquals(user, users.get(0));
+	}
+
+	@Test
+	public void findUserByNames() {
+		System.out.println(CLASS_NAME + "findUserByNames");
+
+		List<User> users = perun.getUsersManagerBl().findUsers(sess, user.getFirstName());
+		assertEquals(1, users.size());
+		assertEquals(user, users.get(0));
+
+		users = perun.getUsersManagerBl().findUsers(sess, user.getLastName());
+		assertEquals(1, users.size());
+		assertEquals(user, users.get(0));
+	}
+
+	@Test
+	public void findUserByMemberMail() throws Exception {
+		System.out.println(CLASS_NAME + "findUserByMemberMail");
+
+		Member member = setUpMember(vo);
+
+		User user = perun.getUsersManagerBl().getUserByMember(sess, member);
+
+		// add member attribute to CoreConfig
+		List<String> attributes = BeansUtils.getCoreConfig().getAttributesToSearchUsersAndMembersBy();
+		attributes.add("urn:perun:member:attribute-def:def:test");
+		BeansUtils.getCoreConfig().setAttributesToSearchUsersAndMembersBy(attributes);
+
+		AttributeDefinition attrDef = new AttributeDefinition();
+		attrDef.setNamespace("urn:perun:member:attribute-def:def");
+		attrDef.setFriendlyName("test");
+		attrDef.setType(String.class.getName());
+		attrDef = perun.getAttributesManagerBl().createAttribute(sess, attrDef);
+		Attribute attribute = new Attribute(attrDef);
+		attribute.setValue("login");
+		perun.getAttributesManagerBl().setAttribute(sess, member, attribute);
+
+		List<User> users = perun.getUsersManagerBl().findUsers(sess, "login");
+		assertEquals(1, users.size());
+		assertEquals(user, users.get(0));
+
+		// reset CoreConfig to previous state
+		attributes.remove("urn:perun:member:attribute-def:def:test");
+		BeansUtils.getCoreConfig().setAttributesToSearchUsersAndMembersBy(attributes);
+	}
+
+	@Test
+	public void findUserByUserAttribute() throws Exception {
+		System.out.println(CLASS_NAME + "findUserByUserAttribute");
+
+		// add user attribute to CoreConfig
+		List<String> attributes = BeansUtils.getCoreConfig().getAttributesToSearchUsersAndMembersBy();
+		attributes.add("urn:perun:user:attribute-def:def:test");
+		BeansUtils.getCoreConfig().setAttributesToSearchUsersAndMembersBy(attributes);
+
+		AttributeDefinition attrDef = new AttributeDefinition();
+		attrDef.setNamespace("urn:perun:user:attribute-def:def");
+		attrDef.setFriendlyName("test");
+		attrDef.setType(String.class.getName());
+		attrDef = perun.getAttributesManagerBl().createAttribute(sess, attrDef);
+		Attribute attribute = new Attribute(attrDef);
+		attribute.setValue("login");
+
+		perun.getAttributesManagerBl().setAttribute(sess, user, attribute);
+
+		List<User> users = perun.getUsersManagerBl().findUsers(sess, "login");
+		assertEquals(1, users.size());
+		assertEquals(user, users.get(0));
+
+		// reset CoreConfig to previous state
+		attributes.remove("urn:perun:user:attribute-def:def:test");
+		BeansUtils.getCoreConfig().setAttributesToSearchUsersAndMembersBy(attributes);
+	}
+
+	@Test
+	public void findUserByUserExtSourceAttribute() throws Exception {
+		System.out.println(CLASS_NAME + "findUserByUserExtSourceAttribute");
+
+		// add userExtSource attribute to CoreConfig
+		List<String> attributes = BeansUtils.getCoreConfig().getAttributesToSearchUsersAndMembersBy();
+		attributes.add("urn:perun:ues:attribute-def:def:test");
+		BeansUtils.getCoreConfig().setAttributesToSearchUsersAndMembersBy(attributes);
+
+		AttributeDefinition attrDef = new AttributeDefinition();
+		attrDef.setNamespace("urn:perun:ues:attribute-def:def");
+		attrDef.setFriendlyName("test");
+		attrDef.setType(String.class.getName());
+		attrDef = perun.getAttributesManagerBl().createAttribute(sess, attrDef);
+		Attribute attribute = new Attribute(attrDef);
+		attribute.setValue("login");
+
+		perun.getAttributesManagerBl().setAttribute(sess, userExtSource, attribute);
+
+		List<User> users = perun.getUsersManagerBl().findUsers(sess, "login");
+		assertEquals(1, users.size());
+		assertEquals(user, users.get(0));
+
+		// reset CoreConfig to previous state
+		attributes.remove("urn:perun:ues:attribute-def:def:test");
+		BeansUtils.getCoreConfig().setAttributesToSearchUsersAndMembersBy(attributes);
+	}
+
+	@Test
+	public void findUserByUserExtSourceLogin() {
+		System.out.println(CLASS_NAME + "findUserByUserExtSourceLogin");
+
+		List<User> users = perun.getUsersManagerBl().findUsers(sess, extLogin);
+		assertEquals(1, users.size());
+		assertEquals(user, users.get(0));
 	}
 
 	// PRIVATE METHODS -------------------------------------------------------------


### PR DESCRIPTION
- When an empty string was passed to the method stringToMapOfAttributes
   null value was returned. That was causing nullPointerExceptions on
   other places which did not expect that (getAdditionalInformations)
- Therefore, the method was changed so it returns empty map when the
   input parameter is null or an empty string.