### PR TITLE
CORE,GUI: Respect authentication prefix in mail validation links

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Utils.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Utils.java
@@ -935,6 +935,9 @@ public class Utils {
 				path = "/krb/gui/";
 			} else if (urlObject.getPath().contains("/fed/")) {
 				path = "/fed/gui/";
+			} else if (urlObject.getPath().contains("/ceitec/")) {
+				// to support ceitec proxy, since it gets more fed attributes than IDM SP.
+				path = "/ceitec/gui/";
 			} else if (urlObject.getPath().contains("/cert/")) {
 				path = "/cert/gui/";
 			}

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/usersManager/RequestPreferredEmailChange.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/usersManager/RequestPreferredEmailChange.java
@@ -124,6 +124,7 @@ public class RequestPreferredEmailChange {
 		String locale = LocaleInfo.getCurrentLocale().getLocaleName();
 		if ("default".equals(locale)) locale = "en";
 		jsonQuery.put("lang", new JSONString(locale));
+		jsonQuery.put("linkPath", new JSONString("/"+PerunWebSession.getInstance().getRpcServer() + "/gui/"));
 		return jsonQuery;
 	}
 


### PR DESCRIPTION
- When user requests preferred email change from GUI on different
  authentication prefix, it is not respected when mail validation
  link is sent.
- Prefix "/ceitec/" was added between known prefixes, so that users
  don't lose attributes from IdP when accessing instance outside
  of ceitec proxy.
- GUI will provide own "linkPath" in order to support all
  custom prefixes.