### PR TITLE
Core - new overloaded version of authorizedInternal

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/AuthzResolver.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/AuthzResolver.java
@@ -22,6 +22,7 @@ import cz.metacentrum.perun.core.impl.Privileges;
 import cz.metacentrum.perun.core.impl.Utils;
 import cz.metacentrum.perun.registrar.model.Application;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -54,6 +55,23 @@ public class AuthzResolver {
 	public static boolean authorizedInternal(PerunSession sess, String policyDefinition, List<PerunBean> objects) {
 		try {
 			return AuthzResolverBlImpl.authorized(sess, policyDefinition, objects);
+		} catch (PolicyNotExistsException e) {
+			throw new InternalErrorException(e);
+		}
+	}
+
+	/**
+	 * Checks if the principal is authorized.
+	 * This method should be used in the internal code.
+	 *
+	 * @param sess PerunSession which contains the principal.
+	 * @param policyDefinition of policy which contains authorization rules.
+	 * @param objects an array of PerunBeans on which will be authorization provided. (e.g. groups, Vos, etc...)
+	 * @return true if the principal has particular rights, false otherwise.
+	 */
+	public static boolean authorizedInternal(PerunSession sess, String policyDefinition, PerunBean... objects) {
+		try {
+			return AuthzResolverBlImpl.authorized(sess, policyDefinition, Arrays.asList(objects));
 		} catch (PolicyNotExistsException e) {
 			throw new InternalErrorException(e);
 		}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/AttributesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/AttributesManagerEntry.java
@@ -806,7 +806,7 @@ public class AttributesManagerEntry implements AttributesManager {
 		getAttributesManagerBl().checkAttributeExists(sess, attributeDefinition);
 
 		//Authorization
-		if(!AuthzResolver.authorizedInternal(sess, "getAttributesByAttributeDefinition_AttributeDefinition_policy", Collections.singletonList(attributeDefinition))) {
+		if(!AuthzResolver.authorizedInternal(sess, "getAttributesByAttributeDefinition_AttributeDefinition_policy", attributeDefinition)) {
 			throw new PrivilegeException("For getting the attributes, you need to be PerunAdmin or PerunObserver.");
 		}
 
@@ -1616,7 +1616,7 @@ public class AttributesManagerEntry implements AttributesManager {
 		getAttributesManagerBl().checkAttributeExists(sess, attribute);
 
 		//Authorization
-		if(!AuthzResolver.authorizedInternal(sess, "deleteAttribute_AttributeDefinition_policy", Collections.singletonList(attribute))) {
+		if(!AuthzResolver.authorizedInternal(sess, "deleteAttribute_AttributeDefinition_policy", attribute)) {
 			throw new PrivilegeException("Only perunAdmin can delete existing Attribute.");
 		}
 
@@ -1629,7 +1629,7 @@ public class AttributesManagerEntry implements AttributesManager {
 		getAttributesManagerBl().checkAttributeExists(sess, attributeDefinition);
 
 		// Authorization
-		if(!AuthzResolver.authorizedInternal(sess, "deleteAttribute_AttributeDefinition_boolean", Collections.singletonList(attributeDefinition))) {
+		if(!AuthzResolver.authorizedInternal(sess, "deleteAttribute_AttributeDefinition_boolean", attributeDefinition)) {
 			throw new PrivilegeException("Only perunAdmin can delete existing Attribute.");
 		}
 
@@ -4444,7 +4444,7 @@ public class AttributesManagerEntry implements AttributesManager {
 		getAttributesManagerBl().checkAttributeExists(perunSession, attributeDefinition);
 
 		// Authorization
-		if(!AuthzResolver.authorizedInternal(perunSession, "updateAttributeDefinition_AttributeDefinition_policy", Collections.singletonList(attributeDefinition))) {
+		if(!AuthzResolver.authorizedInternal(perunSession, "updateAttributeDefinition_AttributeDefinition_policy", attributeDefinition)) {
 			throw new PrivilegeException("Only PerunAdmin can update AttributeDefinition");
 		}
 
@@ -4457,7 +4457,7 @@ public class AttributesManagerEntry implements AttributesManager {
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
 
 		// Authorization
-		if(!AuthzResolver.authorizedInternal(sess, "doTheMagic_Member_policy", Collections.singletonList(member))) {
+		if(!AuthzResolver.authorizedInternal(sess, "doTheMagic_Member_policy", member)) {
 			throw new PrivilegeException("This operation can do only PerunAdmin.");
 		}
 
@@ -4470,7 +4470,7 @@ public class AttributesManagerEntry implements AttributesManager {
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
 
 		// Authorization
-		if(!AuthzResolver.authorizedInternal(sess, "doTheMagic_Member_boolean_policy", Collections.singletonList(member))) {
+		if(!AuthzResolver.authorizedInternal(sess, "doTheMagic_Member_boolean_policy", member)) {
 			throw new PrivilegeException("This operation can do only PerunAdmin.");
 		}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ExtSourcesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ExtSourcesManagerEntry.java
@@ -76,7 +76,7 @@ public class ExtSourcesManagerEntry implements ExtSourcesManager {
 		getExtSourcesManagerBl().checkExtSourceExists(sess, extSource);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "deleteExtSource_ExtSource_policy", Collections.singletonList(extSource)))
+		if (!AuthzResolver.authorizedInternal(sess, "deleteExtSource_ExtSource_policy", extSource))
 			throw new PrivilegeException(sess, "deleteExtSource");
 
 		getExtSourcesManagerBl().deleteExtSource(sess, extSource);
@@ -113,7 +113,7 @@ public class ExtSourcesManagerEntry implements ExtSourcesManager {
 		getPerunBl().getVosManagerBl().checkVoExists(sess, vo);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getVoExtSources_Vo_policy", Collections.singletonList(vo)))
+		if (!AuthzResolver.authorizedInternal(sess, "getVoExtSources_Vo_policy", vo))
 			throw new PrivilegeException(sess, "getVoExtSources");
 
 		return getExtSourcesManagerBl().getVoExtSources(sess, vo);
@@ -126,7 +126,7 @@ public class ExtSourcesManagerEntry implements ExtSourcesManager {
 		getPerunBl().getGroupsManagerBl().checkGroupExists(sess, group);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getGroupExtSources_Group_policy", Collections.singletonList(group)))
+		if (!AuthzResolver.authorizedInternal(sess, "getGroupExtSources_Group_policy", group))
 			throw new PrivilegeException(sess, "getGroupExtSources");
 
 		return getExtSourcesManagerBl().getGroupExtSources(sess, group);
@@ -218,7 +218,7 @@ public class ExtSourcesManagerEntry implements ExtSourcesManager {
 		getExtSourcesManagerBl().checkExtSourceExists(sess, source);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getInvalidUsers_ExtSource_policy", Collections.singletonList(source)))
+		if (!AuthzResolver.authorizedInternal(sess, "getInvalidUsers_ExtSource_policy", source))
 			throw new PrivilegeException(sess, "removeExtSource");
 
 		return getExtSourcesManagerBl().getInvalidUsers(sess, source);
@@ -275,7 +275,7 @@ public class ExtSourcesManagerEntry implements ExtSourcesManager {
 		getExtSourcesManagerBl().checkExtSourceExists(sess, source);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getCandidate_ExtSource_String_policy", Collections.singletonList(source)))
+		if (!AuthzResolver.authorizedInternal(sess, "getCandidate_ExtSource_String_policy", source))
 			throw new PrivilegeException(sess, "getCandidate");
 
 		return getExtSourcesManagerBl().getCandidate(sess, source, login);
@@ -290,7 +290,7 @@ public class ExtSourcesManagerEntry implements ExtSourcesManager {
 		getExtSourcesManagerBl().checkExtSourceExists(perunSession, source);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(perunSession, "getCandidate_Map<String_String>_ExtSource_policy", Collections.singletonList(source)))
+		if (!AuthzResolver.authorizedInternal(perunSession, "getCandidate_Map<String_String>_ExtSource_policy", source))
 			throw new PrivilegeException(perunSession, "getCandidate");
 
 		return getExtSourcesManagerBl().getCandidate(perunSession, subjectData, source, subjectData.get("login"));
@@ -303,7 +303,7 @@ public class ExtSourcesManagerEntry implements ExtSourcesManager {
 		getExtSourcesManagerBl().checkExtSourceExists(sess, extSource);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getAttributes_ExtSource_policy", Collections.singletonList(extSource)))
+		if (!AuthzResolver.authorizedInternal(sess, "getAttributes_ExtSource_policy", extSource))
 			throw new PrivilegeException(sess, "getAttributes");
 
 		return getExtSourcesManagerBl().getAttributes(extSource);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntry.java
@@ -101,7 +101,7 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 		Facility facility = getFacilitiesManagerBl().getFacilityById(sess, id);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getFacilityById_int_policy", Collections.singletonList(facility))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getFacilityById_int_policy", facility)) {
 			throw new PrivilegeException(sess, "getFacilityById");
 				}
 
@@ -116,7 +116,7 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 		Facility facility = getFacilitiesManagerBl().getFacilityByName(sess, name);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getFacilityByName_String_policy", Collections.singletonList(facility))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getFacilityByName_String_policy", facility)) {
 			throw new PrivilegeException(sess, "getFacilityByName");
 				}
 
@@ -132,7 +132,7 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 			throw new PrivilegeException(sess, "getRichFacilities");
 		}
 		List<Facility> facilities = getFacilitiesManagerBl().getFacilities(sess);
-		facilities.removeIf(facility -> !AuthzResolver.authorizedInternal(sess, "filter-getRichFacilities_policy", Collections.singletonList(facility)));
+		facilities.removeIf(facility -> !AuthzResolver.authorizedInternal(sess, "filter-getRichFacilities_policy", facility));
 
 		return getFacilitiesManagerBl().getRichFacilities(sess, facilities);
 	}
@@ -147,7 +147,7 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 			throw new PrivilegeException(sess, "getFacilitiesByDestination");
 		}
 		List<Facility> facilities = getFacilitiesManagerBl().getFacilitiesByDestination(sess, destination);
-		facilities.removeIf(facility -> !AuthzResolver.authorizedInternal(sess, "filter-getFacilitiesByDestination_String_policy", Collections.singletonList(facility)));
+		facilities.removeIf(facility -> !AuthzResolver.authorizedInternal(sess, "filter-getFacilitiesByDestination_String_policy", facility));
 
 		return facilities;
 	}
@@ -195,7 +195,7 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 			throw new PrivilegeException(sess, "getFacilities");
 		}
 		List<Facility> facilities = getFacilitiesManagerBl().getFacilities(sess);
-		facilities.removeIf(facility -> !AuthzResolver.authorizedInternal(sess, "filter-getFacilities_policy", Collections.singletonList(facility)));
+		facilities.removeIf(facility -> !AuthzResolver.authorizedInternal(sess, "filter-getFacilities_policy", facility));
 
 		return facilities;
 	}
@@ -207,7 +207,7 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 		getFacilitiesManagerBl().checkFacilityExists(sess, facility);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getOwners_Facility_policy", Collections.singletonList(facility))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getOwners_Facility_policy", facility)) {
 			throw new PrivilegeException(sess, "getOwners");
 				}
 
@@ -286,7 +286,7 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 		getFacilitiesManagerBl().checkFacilityExists(sess, facility);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getAllowedVos_Facility_policy", Collections.singletonList(facility))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getAllowedVos_Facility_policy", facility)) {
 			throw new PrivilegeException(sess, "getAllowedVos");
 		}
 
@@ -331,7 +331,7 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 		getFacilitiesManagerBl().checkFacilityExists(sess, facility);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getAllowedUsers_Facility_policy", Collections.singletonList(facility))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getAllowedUsers_Facility_policy", facility)) {
 			throw new PrivilegeException(sess, "getAllowedUsers");
 		}
 
@@ -359,7 +359,7 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 		getFacilitiesManagerBl().checkFacilityExists(sess, facility);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getAssignedResources_Facility_policy", Collections.singletonList(facility))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getAssignedResources_Facility_policy", facility)) {
 			throw new PrivilegeException(sess, "getAssignedResources");
 		}
 
@@ -373,7 +373,7 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 		getFacilitiesManagerBl().checkFacilityExists(sess, facility);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getAssignedRichResources_Facility_policy", Collections.singletonList(facility))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getAssignedRichResources_Facility_policy", facility)) {
 			throw new PrivilegeException(sess, "getAssignedRichResources");
 		}
 
@@ -400,7 +400,7 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 		getFacilitiesManagerBl().checkFacilityExists(sess, facility);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "deleteFacility_Facility_Boolean_policy", Collections.singletonList(facility))) {
+		if (!AuthzResolver.authorizedInternal(sess, "deleteFacility_Facility_Boolean_policy", facility)) {
 			throw new PrivilegeException(sess, "deleteFacility");
 		}
 
@@ -415,7 +415,7 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 		Utils.notNull(facility.getName(), "facility.name");
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "updateFacility_Facility_policy", Collections.singletonList(facility))) {
+		if (!AuthzResolver.authorizedInternal(sess, "updateFacility_Facility_policy", facility)) {
 			throw new PrivilegeException(sess, "updateFacility");
 		}
 
@@ -429,7 +429,7 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 		getPerunBl().getOwnersManagerBl().checkOwnerExists(sess, owner);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getOwnerFacilities_Owner_policy", Collections.singletonList(owner))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getOwnerFacilities_Owner_policy", owner)) {
 			throw new PrivilegeException(sess, "getOwnerFacilities");
 		}
 
@@ -590,7 +590,7 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 		getFacilitiesManagerBl().checkFacilityExists(sess, facility);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getHostsCount_Facility_policy", Collections.singletonList(facility))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getHostsCount_Facility_policy", facility)) {
 			throw new PrivilegeException(sess, "getHostsCount");
 		}
 
@@ -605,7 +605,7 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 		getFacilitiesManagerBl().checkFacilityExists(sess, facility);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "addHosts_List<Host>_Facility_policy", Collections.singletonList(facility))) {
+		if (!AuthzResolver.authorizedInternal(sess, "addHosts_List<Host>_Facility_policy", facility)) {
 			throw new PrivilegeException(sess, "addHosts");
 		}
 
@@ -620,7 +620,7 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 			if(!facilitiesByHostname.isEmpty()) {
 				boolean hasRight = false;
 				for(Facility facilityByHostname: facilitiesByHostname) {
-					if(AuthzResolver.authorizedInternal(sess, "addHosts_List<Host>_Facility_policy", Collections.singletonList(facilityByHostname))) {
+					if(AuthzResolver.authorizedInternal(sess, "addHosts_List<Host>_Facility_policy", facilityByHostname)) {
 						hasRight = true;
 						break;
 					}
@@ -630,7 +630,7 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 			if(!facilitiesByDestination.isEmpty()) {
 				boolean hasRight = false;
 				for(Facility facilityByDestination: facilitiesByDestination) {
-					if(AuthzResolver.authorizedInternal(sess, "addHosts_List<Host>_Facility_policy", Collections.singletonList(facilityByDestination))) {
+					if(AuthzResolver.authorizedInternal(sess, "addHosts_List<Host>_Facility_policy", facilityByDestination)) {
 						hasRight = true;
 						break;
 					}
@@ -652,7 +652,7 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 		getFacilitiesManagerBl().checkFacilityExists(sess, facility);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "addHosts_Facility_List<String>_policy", Collections.singletonList(facility))) {
+		if (!AuthzResolver.authorizedInternal(sess, "addHosts_Facility_List<String>_policy", facility)) {
 			throw new PrivilegeException(sess, "addHosts");
 		}
 
@@ -672,7 +672,7 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 			if(!facilitiesByHostname.isEmpty()) {
 				boolean hasRight = false;
 				for(Facility facilityByHostname: facilitiesByHostname) {
-					if(AuthzResolver.authorizedInternal(sess, "addHosts_Facility_List<String>_policy", Collections.singletonList(facilityByHostname))) {
+					if(AuthzResolver.authorizedInternal(sess, "addHosts_Facility_List<String>_policy", facilityByHostname)) {
 						hasRight = true;
 						break;
 					}
@@ -682,7 +682,7 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 			if(!facilitiesByDestination.isEmpty()) {
 				boolean hasRight = false;
 				for(Facility facilityByDestination: facilitiesByDestination) {
-					if(AuthzResolver.authorizedInternal(sess, "addHosts_Facility_List<String>_policy", Collections.singletonList(facilityByDestination))) {
+					if(AuthzResolver.authorizedInternal(sess, "addHosts_Facility_List<String>_policy", facilityByDestination)) {
 						hasRight = true;
 						break;
 					}
@@ -781,7 +781,7 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 		getFacilitiesManagerBl().checkFacilityExists(perunSession, facility);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(perunSession, "getAdmins_Facility_boolean_policy", Collections.singletonList(facility))) {
+		if (!AuthzResolver.authorizedInternal(perunSession, "getAdmins_Facility_boolean_policy", facility)) {
 			throw new PrivilegeException(perunSession, "getAdmins");
 		}
 
@@ -796,7 +796,7 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 		if(!allUserAttributes) Utils.notNull(specificAttributes, "specificAttributes");
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(perunSession, "getRichAdmins_Facility_List<String>_boolean_boolean_policy", Collections.singletonList(facility))) {
+		if (!AuthzResolver.authorizedInternal(perunSession, "getRichAdmins_Facility_List<String>_boolean_boolean_policy", facility)) {
 			throw new PrivilegeException(perunSession, "getRichAdmins");
 		}
 
@@ -840,7 +840,7 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 		getFacilitiesManagerBl().checkFacilityExists(sess, facility);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getAdminGroups_Facility_policy", Collections.singletonList(facility))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getAdminGroups_Facility_policy", facility)) {
 			throw new PrivilegeException(sess, "getAdminGroups");
 		}
 
@@ -914,7 +914,7 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 		getPerunBl().getUsersManagerBl().checkUserExists(sess, user);
 
 		// Authorization
-		if(!AuthzResolver.authorizedInternal(sess, "getFacilitiesWhereUserIsAdmin_User_policy", Collections.singletonList(user))) {
+		if(!AuthzResolver.authorizedInternal(sess, "getFacilitiesWhereUserIsAdmin_User_policy", user)) {
 			throw new PrivilegeException(sess, "getFacilitiesWhereUserIsAdmin");
 		}
 
@@ -974,7 +974,7 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 		getFacilitiesManagerBl().checkFacilityExists(sess, facility);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "addHost_Host_Facility_policy", Collections.singletonList(facility))) {
+		if (!AuthzResolver.authorizedInternal(sess, "addHost_Host_Facility_policy", facility)) {
 			throw new PrivilegeException(sess, "addHost");
 		}
 
@@ -987,7 +987,7 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 		if(!facilitiesByHostname.isEmpty()) {
 			boolean hasRight = false;
 			for(Facility facilityByHostname: facilitiesByHostname) {
-				if(AuthzResolver.authorizedInternal(sess, "addHost_Host_Facility_policy", Collections.singletonList(facilityByHostname))) {
+				if(AuthzResolver.authorizedInternal(sess, "addHost_Host_Facility_policy", facilityByHostname)) {
 					hasRight = true;
 					break;
 				}
@@ -997,7 +997,7 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 		if(!facilitiesByDestination.isEmpty()) {
 			boolean hasRight = false;
 			for(Facility facilityByDestination: facilitiesByDestination) {
-				if(AuthzResolver.authorizedInternal(sess, "addHost_Host_Facility_policy", Collections.singletonList(facilityByDestination))) {
+				if(AuthzResolver.authorizedInternal(sess, "addHost_Host_Facility_policy", facilityByDestination)) {
 					hasRight = true;
 					break;
 				}
@@ -1088,7 +1088,7 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 		getFacilitiesManagerBl().checkHostExists(sess, host);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getFacilityForHost_Host_policy", Collections.singletonList(host))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getFacilityForHost_Host_policy", host)) {
 			throw new PrivilegeException(sess, "getFacilityForHost");
 		}
 
@@ -1102,7 +1102,7 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 		List<Facility> facilities = getFacilitiesManagerBl().getFacilitiesByHostName(sess, hostname);
 
 		//Authorization
-		facilities.removeIf(facility -> !AuthzResolver.authorizedInternal(sess, "getFacilitiesByHostName_String_policy", Collections.singletonList(facility)));
+		facilities.removeIf(facility -> !AuthzResolver.authorizedInternal(sess, "getFacilitiesByHostName_String_policy", facility));
 
 		return facilities;
 	}
@@ -1114,7 +1114,7 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 		getFacilitiesManagerBl().checkFacilityExists(sess, facility);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getAssignedUsers_Facility_policy", Collections.singletonList(facility))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getAssignedUsers_Facility_policy", facility)) {
 			throw new PrivilegeException(sess, "getAssignedUser");
 		}
 
@@ -1187,7 +1187,7 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 		perunBl.getFacilitiesManagerBl().checkFacilityExists(sess, facility);
 
 		//Authorization
-		if(!AuthzResolver.authorizedInternal(sess, "getFacilityContactGroups_Facility_policy", Collections.singletonList(facility))) {
+		if(!AuthzResolver.authorizedInternal(sess, "getFacilityContactGroups_Facility_policy", facility)) {
 			throw new PrivilegeException(sess, "getFacilityContactGroups");
 		}
 
@@ -1201,7 +1201,7 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 		this.getFacilitiesManagerBl().checkFacilityExists(sess, facility);
 
 		//Authorization
-		if(!AuthzResolver.authorizedInternal(sess, "getFacilityContactGroup_Facility_String_policy", Collections.singletonList(facility))) {
+		if(!AuthzResolver.authorizedInternal(sess, "getFacilityContactGroup_Facility_String_policy", facility)) {
 			throw new PrivilegeException(sess, "getFacilityContactGroup");
 		}
 
@@ -1220,7 +1220,7 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 		this.checkFacilityContactsEntitiesExist(sess, contactGroupsToAdd);
 
 		//Authorization
-		contactGroupsToAdd.removeIf(contactGroupToAdd -> !AuthzResolver.authorizedInternal(sess, "addFacilityContacts_List<ContactGroup>_policy", Collections.singletonList(contactGroupToAdd.getFacility())));
+		contactGroupsToAdd.removeIf(contactGroupToAdd -> !AuthzResolver.authorizedInternal(sess, "addFacilityContacts_List<ContactGroup>_policy", contactGroupToAdd.getFacility()));
 
 		if(!contactGroupsToAdd.isEmpty()) {
 			this.facilitiesManagerBl.addFacilityContacts(sess, contactGroupsToAdd);
@@ -1233,7 +1233,7 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 		this.checkFacilityContactEntitiesExists(sess, contactGroupToAdd);
 
 		//Authorization
-		if(!AuthzResolver.authorizedInternal(sess, "addFacilityContact_ContactGroup_policy", Collections.singletonList(contactGroupToAdd.getFacility()))) {
+		if(!AuthzResolver.authorizedInternal(sess, "addFacilityContact_ContactGroup_policy", contactGroupToAdd.getFacility())) {
 			throw new PrivilegeException(sess, "addFacilityContact");
 		}
 
@@ -1247,7 +1247,7 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 
 		//Authorization
 		for (ContactGroup contactGroupToRemove : contactGroupsToRemove) {
-			if (!AuthzResolver.authorizedInternal(sess, "removeFacilityContacts_List<ContactGroup>_policy", Collections.singletonList(contactGroupToRemove.getFacility()))) {
+			if (!AuthzResolver.authorizedInternal(sess, "removeFacilityContacts_List<ContactGroup>_policy", contactGroupToRemove.getFacility())) {
 				throw new PrivilegeException(sess, "removeFacilityContacts");
 			}
 		}
@@ -1261,7 +1261,7 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 		this.checkFacilityContactEntitiesExists(sess, contactGroupToRemove);
 
 		//Authorization
-		if(!AuthzResolver.authorizedInternal(sess, "removeFacilityContact_ContactGroup_policy", Collections.singletonList(contactGroupToRemove.getFacility()))) {
+		if(!AuthzResolver.authorizedInternal(sess, "removeFacilityContact_ContactGroup_policy", contactGroupToRemove.getFacility())) {
 			throw new PrivilegeException(sess, "contactGroupToRemove");
 		}
 
@@ -1274,7 +1274,7 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 		getFacilitiesManagerBl().checkFacilityExists(sess, facility);
 
 		//Authorization
-		if(!AuthzResolver.authorizedInternal(sess, "getAssignedSecurityTeams_Facility_policy", Collections.singletonList(facility))) {
+		if(!AuthzResolver.authorizedInternal(sess, "getAssignedSecurityTeams_Facility_policy", facility)) {
 			throw new PrivilegeException(sess, "getAssignedSecurityTeams");
 		}
 
@@ -1383,7 +1383,7 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 		Facility facility = this.getFacilitiesManagerBl().getFacilityById(sess, facilityId);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getBansForFacility_int_policy", Collections.singletonList(facility))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getBansForFacility_int_policy", facility)) {
 			throw new PrivilegeException(sess, "getBansForFacility");
 		}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/GroupsManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/GroupsManagerEntry.java
@@ -103,7 +103,7 @@ public class GroupsManagerEntry implements GroupsManager {
 		if (group.getParentGroupId() != null) throw new InternalErrorException("Top-level groups can't have parentGroupId set!");
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "createGroup_Vo_Group_policy", Collections.singletonList(vo))) {
+		if (!AuthzResolver.authorizedInternal(sess, "createGroup_Vo_Group_policy", vo)) {
 			throw new PrivilegeException(sess, "createGroup");
 		}
 
@@ -124,7 +124,7 @@ public class GroupsManagerEntry implements GroupsManager {
 		Utils.validateGroupName(group.getName());
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "createGroup_Group_Group_policy", Collections.singletonList(parentGroup))) {
+		if (!AuthzResolver.authorizedInternal(sess, "createGroup_Group_Group_policy", parentGroup)) {
 			throw new PrivilegeException(sess, "createGroup - subGroup");
 		}
 
@@ -145,7 +145,7 @@ public class GroupsManagerEntry implements GroupsManager {
 		getGroupsManagerBl().checkGroupExists(sess, group);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "deleteGroup_Group_boolean_policy", Collections.singletonList(group))) {
+		if (!AuthzResolver.authorizedInternal(sess, "deleteGroup_Group_boolean_policy", group)) {
 			throw new PrivilegeException(sess, "deleteGroup");
 				}
 
@@ -167,7 +167,7 @@ public class GroupsManagerEntry implements GroupsManager {
 		getPerunBl().getVosManagerBl().checkVoExists(sess, vo);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "deleteAllGroups_Vo_policy", Collections.singletonList(vo))) {
+		if (!AuthzResolver.authorizedInternal(sess, "deleteAllGroups_Vo_policy", vo)) {
 			throw new PrivilegeException(sess, "deleteAllGroups");
 		}
 
@@ -206,7 +206,7 @@ public class GroupsManagerEntry implements GroupsManager {
 		Utils.validateGroupName(group.getShortName());
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "updateGroup_Group_policy", Collections.singletonList(group))) {
+		if (!AuthzResolver.authorizedInternal(sess, "updateGroup_Group_policy", group)) {
 			throw new PrivilegeException(sess, "updateGroup");
 				}
 
@@ -231,13 +231,13 @@ public class GroupsManagerEntry implements GroupsManager {
 			}
 
 			// Authorization (destination group is not null)
-			if ((!AuthzResolver.authorizedInternal(sess, "moveGroup_Group_Group_policy", Collections.singletonList(movingGroup))) ||
-				(!AuthzResolver.authorizedInternal(sess, "moveGroup_Group_Group_policy", Collections.singletonList(destinationGroup)))) {
+			if ((!AuthzResolver.authorizedInternal(sess, "moveGroup_Group_Group_policy", movingGroup)) ||
+				(!AuthzResolver.authorizedInternal(sess, "moveGroup_Group_Group_policy", destinationGroup))) {
 				throw new PrivilegeException(sess, "moveGroup");
 			}
 		} else {
 			// Authorization (destination group is null)
-			if (!AuthzResolver.authorizedInternal(sess, "destination_null-moveGroup_Group_Group_policy", Collections.singletonList(movingGroup))) {
+			if (!AuthzResolver.authorizedInternal(sess, "destination_null-moveGroup_Group_Group_policy", movingGroup)) {
 				throw new PrivilegeException(sess, "moveGroup");
 			}
 		}
@@ -448,7 +448,7 @@ public class GroupsManagerEntry implements GroupsManager {
 		getGroupsManagerBl().checkGroupExists(sess, group);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getGroupMembers_Group_policy", Collections.singletonList(group))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getGroupMembers_Group_policy", group)) {
 			throw new PrivilegeException(sess, "getGroupMembers");
 				}
 
@@ -461,7 +461,7 @@ public class GroupsManagerEntry implements GroupsManager {
 		getGroupsManagerBl().checkGroupExists(sess, group);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getGroupDirectMembers_Group_policy", Collections.singletonList(group))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getGroupDirectMembers_Group_policy", group)) {
 			throw new PrivilegeException(sess, "getGroupDirectMembers");
 		}
 
@@ -474,7 +474,7 @@ public class GroupsManagerEntry implements GroupsManager {
 		getGroupsManagerBl().checkGroupExists(sess, group);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getActiveGroupMembers_Group_policy", Collections.singletonList(group))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getActiveGroupMembers_Group_policy", group)) {
 			throw new PrivilegeException(sess, "getActiveGroupMembers");
 		}
 
@@ -487,7 +487,7 @@ public class GroupsManagerEntry implements GroupsManager {
 		getGroupsManagerBl().checkGroupExists(sess, group);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getInactiveGroupMembers_Group_policy", Collections.singletonList(group))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getInactiveGroupMembers_Group_policy", group)) {
 			throw new PrivilegeException(sess, "getInactiveGroupMembers");
 		}
 
@@ -500,7 +500,7 @@ public class GroupsManagerEntry implements GroupsManager {
 		getGroupsManagerBl().checkGroupExists(sess, group);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getGroupMembers_Group_Status_policy", Collections.singletonList(group))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getGroupMembers_Group_Status_policy", group)) {
 			throw new PrivilegeException(sess, "getGroupMembers");
 				}
 
@@ -513,7 +513,7 @@ public class GroupsManagerEntry implements GroupsManager {
 		getGroupsManagerBl().checkGroupExists(sess, group);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getGroupRichMembers_Group_policy", Collections.singletonList(group))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getGroupRichMembers_Group_policy", group)) {
 			throw new PrivilegeException(sess, "getGroupRichMembers");
 				}
 
@@ -526,7 +526,7 @@ public class GroupsManagerEntry implements GroupsManager {
 		getGroupsManagerBl().checkGroupExists(sess, group);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getGroupDirectRichMembers_Group_policy", Collections.singletonList(group))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getGroupDirectRichMembers_Group_policy", group)) {
 			throw new PrivilegeException(sess, "getGroupDirectRichMembers");
 		}
 
@@ -539,7 +539,7 @@ public class GroupsManagerEntry implements GroupsManager {
 		getGroupsManagerBl().checkGroupExists(sess, group);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getGroupRichMembers_Group_Status_policy", Collections.singletonList(group))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getGroupRichMembers_Group_Status_policy", group)) {
 			throw new PrivilegeException(sess, "getGroupRichMembers");
 				}
 
@@ -552,7 +552,7 @@ public class GroupsManagerEntry implements GroupsManager {
 		getGroupsManagerBl().checkGroupExists(sess, group);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getGroupRichMembersWithAttributes_Group_policy", Collections.singletonList(group))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getGroupRichMembersWithAttributes_Group_policy", group)) {
 			throw new PrivilegeException(sess, "getGroupRichMembersWithAttributes");
 				}
 
@@ -565,7 +565,7 @@ public class GroupsManagerEntry implements GroupsManager {
 		getGroupsManagerBl().checkGroupExists(sess, group);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getGroupRichMembersWithAttributes_Group_Status_policy", Collections.singletonList(group))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getGroupRichMembersWithAttributes_Group_Status_policy", group)) {
 			throw new PrivilegeException(sess, "getGroupRichMembersWithAttributes");
 				}
 		return getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, getGroupsManagerBl().getGroupRichMembersWithAttributes(sess, group, status), group, true);
@@ -591,7 +591,7 @@ public class GroupsManagerEntry implements GroupsManager {
 		getGroupsManagerBl().checkGroupExists(sess, group);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getGroupMembersCount_Group_policy", Collections.singletonList(group))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getGroupMembersCount_Group_policy", group)) {
 			throw new PrivilegeException(sess, "getGroupMembersCount");
 				}
 
@@ -619,7 +619,7 @@ public class GroupsManagerEntry implements GroupsManager {
 		getGroupsManagerBl().checkGroupExists(sess, authorizedGroup);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "addAdmin_Group_Group_policy", Collections.singletonList(group))) {
+		if (!AuthzResolver.authorizedInternal(sess, "addAdmin_Group_Group_policy", group)) {
 
 			throw new PrivilegeException(sess, "addAdmin");
 				}
@@ -648,7 +648,7 @@ public class GroupsManagerEntry implements GroupsManager {
 		getGroupsManagerBl().checkGroupExists(sess, authorizedGroup);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "removeAdmin_Group_Group_policy", Collections.singletonList(group))) {
+		if (!AuthzResolver.authorizedInternal(sess, "removeAdmin_Group_Group_policy", group)) {
 			throw new PrivilegeException(sess, "removeAdmin");
 				}
 
@@ -661,7 +661,7 @@ public class GroupsManagerEntry implements GroupsManager {
 		getGroupsManagerBl().checkGroupExists(perunSession, group);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(perunSession, "getAdmins_Group_boolean_policy", Collections.singletonList(group))) {
+		if (!AuthzResolver.authorizedInternal(perunSession, "getAdmins_Group_boolean_policy", group)) {
 			throw new PrivilegeException(perunSession, "getAdmins");
 		}
 
@@ -678,7 +678,7 @@ public class GroupsManagerEntry implements GroupsManager {
 		}
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(perunSession, "getRichAdmins_Group_List<String>_boolean_boolean_policy", Collections.singletonList(group))) {
+		if (!AuthzResolver.authorizedInternal(perunSession, "getRichAdmins_Group_List<String>_boolean_boolean_policy", group)) {
 			throw new PrivilegeException(perunSession, "getRichAdmins");
 		}
 
@@ -725,7 +725,7 @@ public class GroupsManagerEntry implements GroupsManager {
 		getGroupsManagerBl().checkGroupExists(sess, group);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getAdminGroups_Group_policy", Collections.singletonList(group))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getAdminGroups_Group_policy", group)) {
 			throw new PrivilegeException(sess, "getAdminGroups");
 				}
 
@@ -807,13 +807,13 @@ public class GroupsManagerEntry implements GroupsManager {
 		getPerunBl().getVosManagerBl().checkVoExists(sess, vo);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getAllGroups_Vo_policy", Collections.singletonList(vo))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getAllGroups_Vo_policy", vo)) {
 			throw new PrivilegeException(sess, "getAllGroups");
 				}
 
 		List<Group> groups = getGroupsManagerBl().getAllGroups(sess, vo);
 
-		groups.removeIf(group -> !AuthzResolver.authorizedInternal(sess, "filter-getAllGroups_Vo_policy", Collections.singletonList(group)));
+		groups.removeIf(group -> !AuthzResolver.authorizedInternal(sess, "filter-getAllGroups_Vo_policy", group));
 		return groups;
 	}
 
@@ -824,13 +824,13 @@ public class GroupsManagerEntry implements GroupsManager {
 		getPerunBl().getVosManagerBl().checkVoExists(sess, vo);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getAllGroupsWithHierarchy_Vo_policy", Collections.singletonList(vo))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getAllGroupsWithHierarchy_Vo_policy", vo)) {
 			throw new PrivilegeException(sess, "getAllGroupsWithHierarchy");
 		}
 
 		Map<Group, Object> groups =  getGroupsManagerBl().getAllGroupsWithHierarchy(sess, vo);
 
-		groups.keySet().removeIf(group -> !AuthzResolver.authorizedInternal(sess, "filter-getAllGroupsWithHierarchy_Vo_policy", Collections.singletonList(group)));
+		groups.keySet().removeIf(group -> !AuthzResolver.authorizedInternal(sess, "filter-getAllGroupsWithHierarchy_Vo_policy", group));
 		return groups;
 	}
 
@@ -840,7 +840,7 @@ public class GroupsManagerEntry implements GroupsManager {
 		getGroupsManagerBl().checkGroupExists(sess, parentGroup);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getSubGroups_Group_policy", Collections.singletonList(parentGroup))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getSubGroups_Group_policy", parentGroup)) {
 			throw new PrivilegeException(sess, "getSubGroups");
 				}
 
@@ -853,7 +853,7 @@ public class GroupsManagerEntry implements GroupsManager {
 		getGroupsManagerBl().checkGroupExists(sess, parentGroup);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getAllSubGroups_Group_policy", Collections.singletonList(parentGroup))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getAllSubGroups_Group_policy", parentGroup)) {
 			throw new PrivilegeException(sess, "getAllSubGroups");
 				}
 
@@ -866,7 +866,7 @@ public class GroupsManagerEntry implements GroupsManager {
 		getGroupsManagerBl().checkGroupExists(sess, group);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getParentGroup_Group_policy", Collections.singletonList(group))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getParentGroup_Group_policy", group)) {
 			throw new PrivilegeException(sess, "getParentGroup");
 				}
 
@@ -879,13 +879,13 @@ public class GroupsManagerEntry implements GroupsManager {
 		getPerunBl().getVosManagerBl().checkVoExists(sess, vo);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getGroups_Vo_policy", Collections.singletonList(vo))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getGroups_Vo_policy", vo)) {
 			throw new PrivilegeException(sess, "getGroups");
 				}
 
 		List<Group> groups =  getGroupsManagerBl().getGroups(sess, vo);
 
-		groups.removeIf(group -> !AuthzResolver.authorizedInternal(sess, "filter-getGroups_Vo_policy", Collections.singletonList(group)));
+		groups.removeIf(group -> !AuthzResolver.authorizedInternal(sess, "filter-getGroups_Vo_policy", group));
 		return groups;
 	}
 
@@ -895,7 +895,7 @@ public class GroupsManagerEntry implements GroupsManager {
 		getPerunBl().getVosManagerBl().checkVoExists(sess, vo);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getGroupsCount_Vo_policy", Collections.singletonList(vo))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getGroupsCount_Vo_policy", vo)) {
 			throw new PrivilegeException(sess, "getGroupsCount");
 		}
 
@@ -915,7 +915,7 @@ public class GroupsManagerEntry implements GroupsManager {
 		getGroupsManagerBl().checkGroupExists(sess, parentGroup);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getSubGroupsCount_Group_policy", Collections.singletonList(parentGroup))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getSubGroupsCount_Group_policy", parentGroup)) {
 			throw new PrivilegeException(sess, "getSubGroupsCount for " + parentGroup.getName());
 				}
 
@@ -930,7 +930,7 @@ public class GroupsManagerEntry implements GroupsManager {
 		Vo vo =  getGroupsManagerBl().getVo(sess, group);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getVo_Group_policy", Collections.singletonList(group))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getVo_Group_policy", group)) {
 			throw new PrivilegeException(sess, "getVo");
 		}
 
@@ -943,7 +943,7 @@ public class GroupsManagerEntry implements GroupsManager {
 		getGroupsManagerBl().checkGroupExists(sess, group);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getParentGroupMembers_Group_policy", Collections.singletonList(group))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getParentGroupMembers_Group_policy", group)) {
 			throw new PrivilegeException(sess, "getParentGroupMembers for " + group.getName());
 		}
 
@@ -956,7 +956,7 @@ public class GroupsManagerEntry implements GroupsManager {
 		getGroupsManagerBl().checkGroupExists(sess, group);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getParentGroupRichMembers_Group_policy", Collections.singletonList(group))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getParentGroupRichMembers_Group_policy", group)) {
 			throw new PrivilegeException(sess, "getParentGroupRichMembers for " + group.getName());
 		}
 
@@ -969,7 +969,7 @@ public class GroupsManagerEntry implements GroupsManager {
 		getGroupsManagerBl().checkGroupExists(sess, group);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getParentGroupMembersWithAttributes_Group_policy", Collections.singletonList(group))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getParentGroupMembersWithAttributes_Group_policy", group)) {
 			throw new PrivilegeException(sess, "getParentGroupRichMembers for " + group.getName());
 				}
 
@@ -1016,7 +1016,7 @@ public class GroupsManagerEntry implements GroupsManager {
 		getGroupsManagerBl().checkGroupExists(sess, group);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "forceGroupSynchronization_Group_policy", Collections.singletonList(group)))  {
+		if (!AuthzResolver.authorizedInternal(sess, "forceGroupSynchronization_Group_policy", group))  {
 			throw new PrivilegeException(sess, "synchronizeGroup");
 		}
 
@@ -1029,7 +1029,7 @@ public class GroupsManagerEntry implements GroupsManager {
 		getGroupsManagerBl().checkGroupExists(sess, group);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "forceAllSubGroupsSynchronization_Group_policy", Collections.singletonList(group)))  {
+		if (!AuthzResolver.authorizedInternal(sess, "forceAllSubGroupsSynchronization_Group_policy", group))  {
 			throw new PrivilegeException(sess, "forceAllSubGroupsSynchronization");
 		}
 
@@ -1042,7 +1042,7 @@ public class GroupsManagerEntry implements GroupsManager {
 		getGroupsManagerBl().checkGroupExists(sess, group);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "forceGroupStructureSynchronization_Group_policy", Collections.singletonList(group)))  {
+		if (!AuthzResolver.authorizedInternal(sess, "forceGroupStructureSynchronization_Group_policy", group))  {
 			throw new PrivilegeException(sess, "forceGroupStructureSynchronization");
 		}
 
@@ -1079,7 +1079,7 @@ public class GroupsManagerEntry implements GroupsManager {
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getMemberGroups_Member_policy", Collections.singletonList(member))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getMemberGroups_Member_policy", member)) {
 			throw new PrivilegeException(sess, "getMemberGroups for " + member);
 		}
 
@@ -1099,7 +1099,7 @@ public class GroupsManagerEntry implements GroupsManager {
 		}
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getMemberGroupsByAttribute_Member_Attribute_policy", Collections.singletonList(member))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getMemberGroupsByAttribute_Member_Attribute_policy", member)) {
 			throw new PrivilegeException(sess, "getMemberGroupsByAttribute for " + member);
 		}
 
@@ -1121,7 +1121,7 @@ public class GroupsManagerEntry implements GroupsManager {
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getAllMemberGroups_Member_policy", Collections.singletonList(member))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getAllMemberGroups_Member_policy", member)) {
 			throw new PrivilegeException(sess, "getAllMemberGroups for " + member);
 		}
 
@@ -1134,7 +1134,7 @@ public class GroupsManagerEntry implements GroupsManager {
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getGroupsWhereMemberIsActive_Member_policy", Collections.singletonList(member))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getGroupsWhereMemberIsActive_Member_policy", member)) {
 			throw new PrivilegeException(sess, "getGroupsWhereMemberIsActive");
 		}
 
@@ -1147,7 +1147,7 @@ public class GroupsManagerEntry implements GroupsManager {
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getGroupsWhereMemberIsInactive_Member_policy", Collections.singletonList(member))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getGroupsWhereMemberIsInactive_Member_policy", member)) {
 			throw new PrivilegeException(sess, "getGroupsWhereMemberIsInactive");
 		}
 
@@ -1160,7 +1160,7 @@ public class GroupsManagerEntry implements GroupsManager {
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getAllGroupsWhereMemberIsActive_Member_policy", Collections.singletonList(member))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getAllGroupsWhereMemberIsActive_Member_policy", member)) {
 			throw new PrivilegeException(sess, "getAllGroupsWhereMemberIsActive");
 		}
 
@@ -1173,7 +1173,7 @@ public class GroupsManagerEntry implements GroupsManager {
 		this.getPerunBl().getResourcesManagerBl().checkResourceExists(sess, resource);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getRichGroupsAssignedToResourceWithAttributesByNames_Resource_List<String>_policy", Collections.singletonList(resource))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getRichGroupsAssignedToResourceWithAttributesByNames_Resource_List<String>_policy", resource)) {
 			throw new PrivilegeException(sess, "getRichGroupsAssignedToResourceWithAttributesByNames");
 		}
 
@@ -1203,7 +1203,7 @@ public class GroupsManagerEntry implements GroupsManager {
 		this.getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getMemberRichGroupsWithAttributesByNames_Member_List<String>_policy", Collections.singletonList(member))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getMemberRichGroupsWithAttributesByNames_Member_List<String>_policy", member)) {
 			throw new PrivilegeException(sess, "getMemberRichGroupsWithAttributesByNames");
 		}
 
@@ -1220,13 +1220,13 @@ public class GroupsManagerEntry implements GroupsManager {
 		this.getPerunBl().getVosManagerBl().checkVoExists(sess, vo);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getAllRichGroupsWithAttributesByNames_Vo_List<String>_policy", Collections.singletonList(vo))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getAllRichGroupsWithAttributesByNames_Vo_List<String>_policy", vo)) {
 			throw new PrivilegeException(sess, "getAllRichGroupsWithAttributesByNames");
 		}
 
 		List<RichGroup> richGroups = getGroupsManagerBl().getAllRichGroupsWithAttributesByNames(sess, vo, attrNames);
 
-		richGroups.removeIf(richGroup -> !AuthzResolver.authorizedInternal(sess, "filter-getAllRichGroupsWithAttributesByNames_Vo_List<String>_policy", Collections.singletonList(richGroup)));
+		richGroups.removeIf(richGroup -> !AuthzResolver.authorizedInternal(sess, "filter-getAllRichGroupsWithAttributesByNames_Vo_List<String>_policy", richGroup));
 
 		return getGroupsManagerBl().filterOnlyAllowedAttributes(sess, richGroups, null, true);
 	}
@@ -1237,12 +1237,12 @@ public class GroupsManagerEntry implements GroupsManager {
 		this.getGroupsManagerBl().checkGroupExists(sess, parentGroup);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getRichSubGroupsWithAttributesByNames_Group_List<String>_policy", Collections.singletonList(parentGroup))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getRichSubGroupsWithAttributesByNames_Group_List<String>_policy", parentGroup)) {
 			throw new PrivilegeException(sess, "getRichSubGroupsWithAttributesByNames");
 		}
 		List<RichGroup> richGroups = getGroupsManagerBl().getRichSubGroupsWithAttributesByNames(sess, parentGroup, attrNames);
 
-		richGroups.removeIf(richGroup -> !AuthzResolver.authorizedInternal(sess, "filter-getRichSubGroupsWithAttributesByNames_Group_List<String>_policy", Collections.singletonList(richGroup)));
+		richGroups.removeIf(richGroup -> !AuthzResolver.authorizedInternal(sess, "filter-getRichSubGroupsWithAttributesByNames_Group_List<String>_policy", richGroup));
 
 		return getGroupsManagerBl().filterOnlyAllowedAttributes(sess, richGroups, null, true);
 	}
@@ -1253,12 +1253,12 @@ public class GroupsManagerEntry implements GroupsManager {
 		this.getGroupsManagerBl().checkGroupExists(sess, parentGroup);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getAllRichSubGroupsWithAttributesByNames_Group_List<String>_policy", Collections.singletonList(parentGroup))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getAllRichSubGroupsWithAttributesByNames_Group_List<String>_policy", parentGroup)) {
 			throw new PrivilegeException(sess, "getAllRichSubGroupsWithAttributesByNames");
 		}
 		List<RichGroup> richGroups = getGroupsManagerBl().getAllRichSubGroupsWithAttributesByNames(sess, parentGroup, attrNames);
 
-		richGroups.removeIf(richGroup -> !AuthzResolver.authorizedInternal(sess, "filter-getAllRichSubGroupsWithAttributesByNames_Group_List<String>_policy", Collections.singletonList(richGroup)));
+		richGroups.removeIf(richGroup -> !AuthzResolver.authorizedInternal(sess, "filter-getAllRichSubGroupsWithAttributesByNames_Group_List<String>_policy", richGroup));
 
 		return getGroupsManagerBl().filterOnlyAllowedAttributes(sess, richGroups, null, true);
 	}
@@ -1270,7 +1270,7 @@ public class GroupsManagerEntry implements GroupsManager {
 		Group group = groupsManagerBl.getGroupById(sess, groupId);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getRichGroupByIdWithAttributesByNames_int_List<String>_policy", Collections.singletonList(group))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getRichGroupByIdWithAttributesByNames_int_List<String>_policy", group)) {
 			throw new PrivilegeException(sess, "getRichGroupByIdWithAttributesByNames");
 		}
 
@@ -1320,7 +1320,7 @@ public class GroupsManagerEntry implements GroupsManager {
 		getGroupsManagerBl().checkGroupExists(sess, group);
 
 		// Authorization
-		if ( !AuthzResolver.authorizedInternal(sess, "getGroupUnions_Group_boolean_policy", Collections.singletonList(group))) {
+		if ( !AuthzResolver.authorizedInternal(sess, "getGroupUnions_Group_boolean_policy", group)) {
 			throw new PrivilegeException(sess, "getGroupUnions");
 		}
 
@@ -1363,7 +1363,7 @@ public class GroupsManagerEntry implements GroupsManager {
 		getGroupsManagerBl().checkGroupExists(sess, group);
 
 		// Authorization
-		if ( !AuthzResolver.authorizedInternal(sess, "getGroupMemberById_Group_int_policy", Collections.singletonList(group))) {
+		if ( !AuthzResolver.authorizedInternal(sess, "getGroupMemberById_Group_int_policy", group)) {
 			throw new PrivilegeException(sess, "getGroupMemberById");
 		}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/MembersManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/MembersManagerEntry.java
@@ -93,7 +93,7 @@ public class MembersManagerEntry implements MembersManager {
 		getMembersManagerBl().checkMemberExists(sess, member);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "deleteMember_Member_policy", Collections.singletonList(member))) {
+		if (!AuthzResolver.authorizedInternal(sess, "deleteMember_Member_policy", member)) {
 			throw new PrivilegeException(sess, "deleteMember");
 		}
 
@@ -124,7 +124,7 @@ public class MembersManagerEntry implements MembersManager {
 		getPerunBl().getVosManagerBl().checkVoExists(sess, vo);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "deleteAllMembers_Vo_policy", Collections.singletonList(vo))) {
+		if (!AuthzResolver.authorizedInternal(sess, "deleteAllMembers_Vo_policy", vo)) {
 			throw new PrivilegeException(sess, "deleteAllMembers");
 		}
 
@@ -415,7 +415,7 @@ public class MembersManagerEntry implements MembersManager {
 		Member member = getMembersManagerBl().getMemberById(sess, id);
 
 		//  Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getMemberById_int_policy", Collections.singletonList(member))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getMemberById_int_policy", member)) {
 			throw new PrivilegeException(sess, "getMemberById");
 		}
 
@@ -444,7 +444,7 @@ public class MembersManagerEntry implements MembersManager {
 		getPerunBl().getUsersManagerBl().checkUserExists(sess, user);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getMembersByUser_User_policy", Collections.singletonList(user))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getMembersByUser_User_policy", user)) {
 			throw new PrivilegeException(sess, "getMembersByUser");
 		}
 
@@ -458,7 +458,7 @@ public class MembersManagerEntry implements MembersManager {
 		getPerunBl().getVosManagerBl().checkVoExists(sess, vo);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getMembers_Vo_policy", Collections.singletonList(vo))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getMembers_Vo_policy", vo)) {
 			throw new PrivilegeException(sess, "getMembers");
 		}
 
@@ -472,7 +472,7 @@ public class MembersManagerEntry implements MembersManager {
 		getPerunBl().getVosManagerBl().checkVoExists(sess, vo);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getMembers_Vo_Status_policy", Collections.singletonList(vo))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getMembers_Vo_Status_policy", vo)) {
 			throw new PrivilegeException(sess, "getMembers");
 		}
 
@@ -486,7 +486,7 @@ public class MembersManagerEntry implements MembersManager {
 		Member member = getPerunBl().getMembersManagerBl().getMemberById(sess, id);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getRichMemberById_int_policy", Collections.singletonList(member))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getRichMemberById_int_policy", member)) {
 			throw new PrivilegeException(sess, "getRichMemberById");
 		}
 
@@ -500,7 +500,7 @@ public class MembersManagerEntry implements MembersManager {
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getRichMemberWithAttributes_Member_policy", Collections.singletonList(member))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getRichMemberWithAttributes_Member_policy", member)) {
 			throw new PrivilegeException(sess, "getRichMemberWithAttributes");
 		}
 
@@ -514,7 +514,7 @@ public class MembersManagerEntry implements MembersManager {
 		perunBl.getVosManagerBl().checkVoExists(sess, vo);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getRichMembersWithAttributes_Vo_List<AttributeDefinition>_policy", Collections.singletonList(vo))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getRichMembersWithAttributes_Vo_List<AttributeDefinition>_policy", vo)) {
 			throw new PrivilegeException(sess, "getRichMemberWithAttributes");
 		}
 
@@ -528,7 +528,7 @@ public class MembersManagerEntry implements MembersManager {
 		getPerunBl().getGroupsManagerBl().checkGroupExists(sess, group);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getRichMembersWithAttributes_List<String>_Group_policy", Collections.singletonList(group))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getRichMembersWithAttributes_List<String>_Group_policy", group)) {
 			throw new PrivilegeException(sess, "getRichMembersWithAttributes");
 		}
 
@@ -542,7 +542,7 @@ public class MembersManagerEntry implements MembersManager {
 		perunBl.getVosManagerBl().checkVoExists(sess, vo);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getRichMembersWithAttributesByNames_Vo_List<String>_policy", Collections.singletonList(vo))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getRichMembersWithAttributesByNames_Vo_List<String>_policy", vo)) {
 			throw new PrivilegeException(sess, "getRichMembersWithAttributesByNames");
 		}
 
@@ -556,7 +556,7 @@ public class MembersManagerEntry implements MembersManager {
 		perunBl.getVosManagerBl().checkVoExists(sess, vo);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getCompleteRichMembers_Vo_List<String>_policy", Collections.singletonList(vo))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getCompleteRichMembers_Vo_List<String>_policy", vo)) {
 			throw new PrivilegeException(sess, "getCompleteRichMembers");
 		}
 
@@ -570,7 +570,7 @@ public class MembersManagerEntry implements MembersManager {
 		perunBl.getVosManagerBl().checkVoExists(sess, vo);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getCompleteRichMembers_Vo_List<String>_List<String>_policy", Collections.singletonList(vo))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getCompleteRichMembers_Vo_List<String>_List<String>_policy", vo)) {
 			throw new PrivilegeException(sess, "getCompleteRichMembers");
 		}
 
@@ -584,7 +584,7 @@ public class MembersManagerEntry implements MembersManager {
 		perunBl.getGroupsManagerBl().checkGroupExists(sess, group);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getCompleteRichMembers_Group_List<String>_boolean_policy", Collections.singletonList(group))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getCompleteRichMembers_Group_List<String>_boolean_policy", group)) {
 			throw new PrivilegeException(sess, "getCompleteRichMembers");
 		}
 
@@ -614,7 +614,7 @@ public class MembersManagerEntry implements MembersManager {
 		perunBl.getGroupsManagerBl().checkGroupExists(sess, group);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getCompleteRichMembers_Group_List<String>_List<String>_boolean_policy", Collections.singletonList(group))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getCompleteRichMembers_Group_List<String>_List<String>_boolean_policy", group)) {
 			throw new PrivilegeException(sess, "getCompleteRichMembers");
 		}
 
@@ -628,7 +628,7 @@ public class MembersManagerEntry implements MembersManager {
 		perunBl.getVosManagerBl().checkVoExists(sess, vo);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "findCompleteRichMembers_Vo_List<String>_String_policy", Collections.singletonList(vo))) {
+		if (!AuthzResolver.authorizedInternal(sess, "findCompleteRichMembers_Vo_List<String>_String_policy", vo)) {
 			throw new PrivilegeException(sess, "findCompleteRichMembers");
 		}
 
@@ -642,7 +642,7 @@ public class MembersManagerEntry implements MembersManager {
 		perunBl.getVosManagerBl().checkVoExists(sess, vo);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "findCompleteRichMembers_Vo_List<String>_List<String>_String_policy", Collections.singletonList(vo))) {
+		if (!AuthzResolver.authorizedInternal(sess, "findCompleteRichMembers_Vo_List<String>_List<String>_String_policy", vo)) {
 			throw new PrivilegeException(sess, "findCompleteRichMembers");
 		}
 
@@ -664,13 +664,13 @@ public class MembersManagerEntry implements MembersManager {
 		while (richMemberIter.hasNext()) {
 			RichMember richMember = richMemberIter.next();
 
-			if (AuthzResolver.authorizedInternal(sess, "filter-findCompleteRichMembers_List<String>_List<String>_String_policy", Collections.singletonList(richMember)))
+			if (AuthzResolver.authorizedInternal(sess, "filter-findCompleteRichMembers_List<String>_List<String>_String_policy", richMember))
 				continue;
 
 			List<Resource> membersResources = getPerunBl().getResourcesManagerBl().getAssignedResources(sess, richMember);
 			boolean found = false;
 			for (Resource resource : membersResources) {
-				if (AuthzResolver.authorizedInternal(sess, "filter-findCompleteRichMembers_List<String>_List<String>_String_policy", Collections.singletonList(resource))) {
+				if (AuthzResolver.authorizedInternal(sess, "filter-findCompleteRichMembers_List<String>_List<String>_String_policy", resource)) {
 					found = true;
 					break;
 				}
@@ -690,7 +690,7 @@ public class MembersManagerEntry implements MembersManager {
 		perunBl.getGroupsManagerBl().checkGroupExists(sess, group);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "findCompleteRichMembers_Group_List<String>_String_boolean_policy", Collections.singletonList(group))) {
+		if (!AuthzResolver.authorizedInternal(sess, "findCompleteRichMembers_Group_List<String>_String_boolean_policy", group)) {
 			throw new PrivilegeException(sess, "findCompleteRichMembers");
 		}
 
@@ -704,7 +704,7 @@ public class MembersManagerEntry implements MembersManager {
 		perunBl.getGroupsManagerBl().checkGroupExists(sess, group);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "findCompleteRichMembers_Group_List<String>_List<String>_String_boolean_policy", Collections.singletonList(group))) {
+		if (!AuthzResolver.authorizedInternal(sess, "findCompleteRichMembers_Group_List<String>_List<String>_String_boolean_policy", group)) {
 			throw new PrivilegeException(sess, "findCompleteRichMembers");
 		}
 
@@ -718,7 +718,7 @@ public class MembersManagerEntry implements MembersManager {
 		perunBl.getGroupsManagerBl().checkGroupExists(sess, group);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getRichMembersWithAttributesByNames_Group_List<String>_policy", Collections.singletonList(group))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getRichMembersWithAttributesByNames_Group_List<String>_policy", group)) {
 			throw new PrivilegeException(sess, "getRichMembersWithAttributesByNames");
 		}
 
@@ -732,7 +732,7 @@ public class MembersManagerEntry implements MembersManager {
 		perunBl.getGroupsManagerBl().checkGroupExists(sess, group);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getRichMembersWithAttributes_Group_List<AttributeDefinition>_policy", Collections.singletonList(group))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getRichMembersWithAttributes_Group_List<AttributeDefinition>_policy", group)) {
 			throw new PrivilegeException(sess, "getRichMemberWithAttributes");
 		}
 
@@ -746,7 +746,7 @@ public class MembersManagerEntry implements MembersManager {
 		perunBl.getGroupsManagerBl().checkGroupExists(sess, group);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getRichMembers_Group_policy", Collections.singletonList(group))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getRichMembers_Group_policy", group)) {
 			throw new PrivilegeException(sess, "getRichMembers");
 		}
 
@@ -760,7 +760,7 @@ public class MembersManagerEntry implements MembersManager {
 		getPerunBl().getVosManagerBl().checkVoExists(sess, vo);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getRichMembers_Vo_policy", Collections.singletonList(vo))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getRichMembers_Vo_policy", vo)) {
 			throw new PrivilegeException(sess, "getMembers");
 		}
 
@@ -774,7 +774,7 @@ public class MembersManagerEntry implements MembersManager {
 		getPerunBl().getVosManagerBl().checkVoExists(sess, vo);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getRichMembers_Vo_Status_policy", Collections.singletonList(vo))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getRichMembers_Vo_Status_policy", vo)) {
 			throw new PrivilegeException(sess, "getRichMembers");
 		}
 
@@ -788,7 +788,7 @@ public class MembersManagerEntry implements MembersManager {
 		getPerunBl().getVosManagerBl().checkVoExists(sess, vo);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getRichMembersWithAttributes_Vo_policy", Collections.singletonList(vo))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getRichMembersWithAttributes_Vo_policy", vo)) {
 			throw new PrivilegeException(sess, "getRichMembersWithAttributes");
 		}
 
@@ -802,7 +802,7 @@ public class MembersManagerEntry implements MembersManager {
 		getPerunBl().getVosManagerBl().checkVoExists(sess, vo);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getRichMembersWithAttributes_Vo_Status_policy", Collections.singletonList(vo))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getRichMembersWithAttributes_Vo_Status_policy", vo)) {
 			throw new PrivilegeException(sess, "getRichMembersWithAttributes");
 		}
 
@@ -815,7 +815,7 @@ public class MembersManagerEntry implements MembersManager {
 		getPerunBl().getVosManagerBl().checkVoExists(sess, vo);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getMembersCount_Vo_policy", Collections.singletonList(vo))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getMembersCount_Vo_policy", vo)) {
 			throw new PrivilegeException(sess, "getMembersCount");
 		}
 
@@ -828,7 +828,7 @@ public class MembersManagerEntry implements MembersManager {
 		getPerunBl().getVosManagerBl().checkVoExists(sess, vo);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getMembersCount_Vo_Status_policy", Collections.singletonList(vo))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getMembersCount_Vo_Status_policy", vo)) {
 			throw new PrivilegeException(sess, "getMembersCount");
 		}
 
@@ -865,7 +865,7 @@ public class MembersManagerEntry implements MembersManager {
 		getPerunBl().getVosManagerBl().checkVoExists(sess, vo);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "findMembersByNameInVo_Vo_String_policy", Collections.singletonList(vo))) {
+		if (!AuthzResolver.authorizedInternal(sess, "findMembersByNameInVo_Vo_String_policy", vo)) {
 			throw new PrivilegeException(sess, "findMembersByNameInVo");
 		}
 
@@ -879,7 +879,7 @@ public class MembersManagerEntry implements MembersManager {
 		getPerunBl().getVosManagerBl().checkVoExists(sess, vo);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "findMembersInVo_Vo_String_policy", Collections.singletonList(vo))) {
+		if (!AuthzResolver.authorizedInternal(sess, "findMembersInVo_Vo_String_policy", vo)) {
 			throw new PrivilegeException(sess, "findMembersInVo");
 		}
 
@@ -892,7 +892,7 @@ public class MembersManagerEntry implements MembersManager {
 		getPerunBl().getGroupsManagerBl().checkGroupExists(sess, group);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "findMembersInGroup_Group_String_policy", Collections.singletonList(group))) {
+		if (!AuthzResolver.authorizedInternal(sess, "findMembersInGroup_Group_String_policy", group)) {
 			throw new PrivilegeException(sess, "findMembersInGroup");
 		}
 
@@ -905,7 +905,7 @@ public class MembersManagerEntry implements MembersManager {
 		getPerunBl().getGroupsManagerBl().checkGroupExists(sess, group);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "findRichMembersWithAttributesInGroup_Group_String_policy", Collections.singletonList(group))) {
+		if (!AuthzResolver.authorizedInternal(sess, "findRichMembersWithAttributesInGroup_Group_String_policy", group)) {
 			throw new PrivilegeException(sess, "findRichMembersInGroup");
 		}
 
@@ -919,7 +919,7 @@ public class MembersManagerEntry implements MembersManager {
 		getPerunBl().getGroupsManagerBl().checkGroupExists(sess, getPerunBl().getGroupsManagerBl().getParentGroup(sess, group));
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "findMembersInParentGroup_Group_String_policy", Collections.singletonList(group))) {
+		if (!AuthzResolver.authorizedInternal(sess, "findMembersInParentGroup_Group_String_policy", group)) {
 			throw new PrivilegeException(sess, "findMembersInParentGroup");
 		}
 
@@ -932,7 +932,7 @@ public class MembersManagerEntry implements MembersManager {
 		getPerunBl().getGroupsManagerBl().checkGroupExists(sess, group);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "findRichMembersWithAttributesInParentGroup_Group_String_policy", Collections.singletonList(group))) {
+		if (!AuthzResolver.authorizedInternal(sess, "findRichMembersWithAttributesInParentGroup_Group_String_policy", group)) {
 			throw new PrivilegeException(sess, "findRichMembersInParentGroup");
 		}
 
@@ -946,7 +946,7 @@ public class MembersManagerEntry implements MembersManager {
 		getPerunBl().getVosManagerBl().checkVoExists(sess, vo);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "findRichMembersInVo_Vo_String_policy", Collections.singletonList(vo))) {
+		if (!AuthzResolver.authorizedInternal(sess, "findRichMembersInVo_Vo_String_policy", vo)) {
 			throw new PrivilegeException(sess, "findRichMembersInVo");
 		}
 
@@ -960,7 +960,7 @@ public class MembersManagerEntry implements MembersManager {
 		getPerunBl().getVosManagerBl().checkVoExists(sess, vo);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "findRichMembersWithAttributesInVo_Vo_String_policy", Collections.singletonList(vo))) {
+		if (!AuthzResolver.authorizedInternal(sess, "findRichMembersWithAttributesInVo_Vo_String_policy", vo)) {
 			throw new PrivilegeException(sess, "findRichMembersWithAttributesInVo");
 		}
 
@@ -974,7 +974,7 @@ public class MembersManagerEntry implements MembersManager {
 		getMembersManagerBl().checkMemberExists(sess, member);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "setStatus_Member_Status_policy", Collections.singletonList(member))) {
+		if (!AuthzResolver.authorizedInternal(sess, "setStatus_Member_Status_policy", member)) {
 			throw new PrivilegeException(sess, "setStatus");
 		}
 
@@ -988,7 +988,7 @@ public class MembersManagerEntry implements MembersManager {
 		getMembersManagerBl().checkMemberExists(sess, member);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "setStatus_Member_Status_String_policy", Collections.singletonList(member))) {
+		if (!AuthzResolver.authorizedInternal(sess, "setStatus_Member_Status_String_policy", member)) {
 			throw new PrivilegeException(sess, "setStatus");
 		}
 
@@ -1003,7 +1003,7 @@ public class MembersManagerEntry implements MembersManager {
 		getMembersManagerBl().checkMemberExists(sess, member);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "suspendMemberTo_Member_Date_policy", Collections.singletonList(member))) {
+		if (!AuthzResolver.authorizedInternal(sess, "suspendMemberTo_Member_Date_policy", member)) {
 			throw new PrivilegeException(sess, "suspendMemberTo");
 		}
 
@@ -1017,7 +1017,7 @@ public class MembersManagerEntry implements MembersManager {
 		getMembersManagerBl().checkMemberExists(sess, member);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "unsuspendMember_Member_policy", Collections.singletonList(member))) {
+		if (!AuthzResolver.authorizedInternal(sess, "unsuspendMember_Member_policy", member)) {
 			throw new PrivilegeException(sess, "unsuspendMember");
 		}
 
@@ -1032,7 +1032,7 @@ public class MembersManagerEntry implements MembersManager {
 		getMembersManagerBl().checkMemberExists(sess, member);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "validateMemberAsync_Member_policy", Collections.singletonList(member))) {
+		if (!AuthzResolver.authorizedInternal(sess, "validateMemberAsync_Member_policy", member)) {
 			throw new PrivilegeException(sess, "validateMemberAsync");
 		}
 
@@ -1045,7 +1045,7 @@ public class MembersManagerEntry implements MembersManager {
 		getMembersManagerBl().checkMemberExists(sess, member);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "extendMembership_Member_policy", Collections.singletonList(member))) {
+		if (!AuthzResolver.authorizedInternal(sess, "extendMembership_Member_policy", member)) {
 			throw new PrivilegeException(sess, "extendMembership");
 		}
 
@@ -1058,7 +1058,7 @@ public class MembersManagerEntry implements MembersManager {
 		getMembersManagerBl().checkMemberExists(sess, member);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "canExtendMembership_Member_policy", Collections.singletonList(member))) {
+		if (!AuthzResolver.authorizedInternal(sess, "canExtendMembership_Member_policy", member)) {
 			throw new PrivilegeException(sess, "extendMembership");
 		}
 
@@ -1072,7 +1072,7 @@ public class MembersManagerEntry implements MembersManager {
 		getMembersManagerBl().checkMemberExists(sess, member);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "canExtendMembershipWithReason_Member_policy", Collections.singletonList(member))) {
+		if (!AuthzResolver.authorizedInternal(sess, "canExtendMembershipWithReason_Member_policy", member)) {
 			throw new PrivilegeException(sess, "canExtendMembershipWithReason");
 		}
 
@@ -1114,7 +1114,7 @@ public class MembersManagerEntry implements MembersManager {
 		getPerunBl().getVosManagerBl().checkVoExists(sess, vo);
 
 		// Authorization
-		if(!AuthzResolver.authorizedInternal(sess, "getMemberByExtSourceNameAndExtLogin_Vo_String_String_policy", Collections.singletonList(vo))) {
+		if(!AuthzResolver.authorizedInternal(sess, "getMemberByExtSourceNameAndExtLogin_Vo_String_String_policy", vo)) {
 			throw new PrivilegeException(sess, "getMemberByExtSourceNameAndExtLogin");
 		}
 
@@ -1145,7 +1145,7 @@ public class MembersManagerEntry implements MembersManager {
 		getMembersManagerBl().checkMemberExists(sess, member);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "sendPasswordResetLinkEmail_Member_String_String_String_String_policy", Collections.singletonList(member))) {
+		if (!AuthzResolver.authorizedInternal(sess, "sendPasswordResetLinkEmail_Member_String_String_String_String_policy", member)) {
 			throw new PrivilegeException(sess, "sendPasswordResetLinkEmail");
 		}
 
@@ -1216,7 +1216,7 @@ public class MembersManagerEntry implements MembersManager {
 		}
 
 		//Authorization
-		if (!AuthzResolver.authorizedInternal(session, "setSponsorshipForMember_Member_User_policy", Collections.singletonList(sponsoredMember))) {
+		if (!AuthzResolver.authorizedInternal(session, "setSponsorshipForMember_Member_User_policy", sponsoredMember)) {
 			throw new PrivilegeException(session, "setSponsorshipForMember");
 		}
 
@@ -1230,7 +1230,7 @@ public class MembersManagerEntry implements MembersManager {
 		getPerunBl().getMembersManagerBl().checkMemberExists(session, sponsoredMember);
 
 		//Authorization
-		if (!AuthzResolver.authorizedInternal(session, "unsetSponsorshipForMember_Member_policy", Collections.singletonList(sponsoredMember))) {
+		if (!AuthzResolver.authorizedInternal(session, "unsetSponsorshipForMember_Member_policy", sponsoredMember)) {
 			throw new PrivilegeException(session, "unsetSponsorshipForMember");
 		}
 
@@ -1246,7 +1246,7 @@ public class MembersManagerEntry implements MembersManager {
 		log.debug("sponsorMember(sponsored={},sponsor={}", sponsored.getId(), sponsor.getId());
 
 		//Authorization
-		if (!AuthzResolver.authorizedInternal(session, "sponsorMember_Member_User_policy", Collections.singletonList(sponsored))) {
+		if (!AuthzResolver.authorizedInternal(session, "sponsorMember_Member_User_policy", sponsored)) {
 			throw new PrivilegeException(session, "sponsorMember");
 		}
 		//create the link between sponsored and sponsoring users
@@ -1303,7 +1303,7 @@ public class MembersManagerEntry implements MembersManager {
 		perunBl.getVosManagerBl().checkVoExists(sess, vo);
 
 		//Authorization
-		if(!AuthzResolver.authorizedInternal(sess, "getSponsoredMembers_Vo_policy", Collections.singletonList(vo))) {
+		if(!AuthzResolver.authorizedInternal(sess, "getSponsoredMembers_Vo_policy", vo)) {
 			throw new PrivilegeException(sess, "getSponsoredMembers");
 		}
 
@@ -1320,7 +1320,7 @@ public class MembersManagerEntry implements MembersManager {
 		perunBl.getUsersManagerBl().checkUserExists(sess, sponsorUser);
 
 		//Authorization
-		if (!(AuthzResolver.authorizedInternal(sess, "extendExpirationForSponsoredMember_Member_User_policy", Collections.singletonList(sponsoredMember)))) {
+		if (!(AuthzResolver.authorizedInternal(sess, "extendExpirationForSponsoredMember_Member_User_policy", sponsoredMember))) {
 			throw new PrivilegeException(sess, "extendExpirationForSponsoredMember");
 		}
 
@@ -1338,7 +1338,7 @@ public class MembersManagerEntry implements MembersManager {
 		Vo vo = membersManagerBl.getMemberVo(sess, sponsoredMember);
 
 		//Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "removeSponsor_Member_User_policy", Collections.singletonList(sponsoredMember))) {
+		if (!AuthzResolver.authorizedInternal(sess, "removeSponsor_Member_User_policy", sponsoredMember)) {
 			throw new PrivilegeException(sess, "removeSponsor");
 		}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/OwnersManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/OwnersManagerEntry.java
@@ -65,7 +65,7 @@ public class OwnersManagerEntry implements OwnersManager {
 		Utils.checkPerunSession(sess);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "deleteOwner_Owner_policy", Collections.singletonList(owner)))
+		if (!AuthzResolver.authorizedInternal(sess, "deleteOwner_Owner_policy", owner))
 			throw new PrivilegeException(sess, "deleteOwner");
 
 		getOwnersManagerBl().checkOwnerExists(sess, owner);
@@ -78,7 +78,7 @@ public class OwnersManagerEntry implements OwnersManager {
 		Utils.checkPerunSession(sess);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "deleteOwner_Owner_boolean_policy", Collections.singletonList(owner)))
+		if (!AuthzResolver.authorizedInternal(sess, "deleteOwner_Owner_boolean_policy", owner))
 			throw new PrivilegeException(sess, "deleteOwner");
 
 		getOwnersManagerBl().checkOwnerExists(sess, owner);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ResourcesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ResourcesManagerEntry.java
@@ -87,7 +87,7 @@ public class ResourcesManagerEntry implements ResourcesManager {
 		Resource resource = getResourcesManagerBl().getResourceById(sess, id);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getResourceById_int_policy", Collections.singletonList(resource))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getResourceById_int_policy", resource)) {
 			throw new PrivilegeException(sess, "getResourceById");
 				}
 
@@ -101,7 +101,7 @@ public class ResourcesManagerEntry implements ResourcesManager {
 		RichResource rr = getResourcesManagerBl().getRichResourceById(sess, id);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getRichResourceById_int_policy", Collections.singletonList(rr))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getRichResourceById_int_policy", rr)) {
 			throw new PrivilegeException(sess, "getRichResourceById");
 		}
 
@@ -173,7 +173,7 @@ public class ResourcesManagerEntry implements ResourcesManager {
 		getResourcesManagerBl().checkResourceExists(sess, resource);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "deleteResource_Resource_policy", Collections.singletonList(resource))) {
+		if (!AuthzResolver.authorizedInternal(sess, "deleteResource_Resource_policy", resource)) {
 			throw new PrivilegeException(sess, "deleteResource");
 				}
 
@@ -187,7 +187,7 @@ public class ResourcesManagerEntry implements ResourcesManager {
 		getPerunBl().getVosManagerBl().checkVoExists(sess, vo);
 
 		//Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "deleteAllResources_Vo_policy", Collections.singletonList(vo))) {
+		if (!AuthzResolver.authorizedInternal(sess, "deleteAllResources_Vo_policy", vo)) {
 			throw new PrivilegeException(sess, "deleteAllResources");
 		}
 
@@ -200,7 +200,7 @@ public class ResourcesManagerEntry implements ResourcesManager {
 		getResourcesManagerBl().checkResourceExists(sess, resource);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getFacility_Resource_policy", Collections.singletonList(resource))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getFacility_Resource_policy", resource)) {
 			throw new PrivilegeException(sess, "getFacility");
 				}
 
@@ -228,7 +228,7 @@ public class ResourcesManagerEntry implements ResourcesManager {
 		getPerunBl().getResourcesManagerBl().checkResourceExists(sess, resource);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getAllowedMembers_Resource_policy", Collections.singletonList(resource))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getAllowedMembers_Resource_policy", resource)) {
 			throw new PrivilegeException(sess, "getAllowedMembers");
 		}
 
@@ -242,7 +242,7 @@ public class ResourcesManagerEntry implements ResourcesManager {
 		getPerunBl().getResourcesManagerBl().checkResourceExists(sess, resource);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getAllowedUsers_Resource_policy", Collections.singletonList(resource))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getAllowedUsers_Resource_policy", resource)) {
 			throw new PrivilegeException(sess, "getAllowedUsers");
 		}
 
@@ -255,7 +255,7 @@ public class ResourcesManagerEntry implements ResourcesManager {
 		getResourcesManagerBl().checkResourceExists(sess, resource);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getAssignedServices_Resource_policy", Collections.singletonList(resource))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getAssignedServices_Resource_policy", resource)) {
 			throw new PrivilegeException(sess, "getAssignedServices");
 		}
 
@@ -267,7 +267,7 @@ public class ResourcesManagerEntry implements ResourcesManager {
 		Utils.checkPerunSession(sess);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getAssignedMembers_Resource_policy", Collections.singletonList(resource))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getAssignedMembers_Resource_policy", resource)) {
 			throw new PrivilegeException(sess, "getAssignedMembers");
 		}
 
@@ -279,7 +279,7 @@ public class ResourcesManagerEntry implements ResourcesManager {
 		Utils.checkPerunSession(sess);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getAssignedRichMembers_Resource_policy", Collections.singletonList(resource))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getAssignedRichMembers_Resource_policy", resource)) {
 			throw new PrivilegeException(sess, "getAssignedRichMembers");
 		}
 
@@ -393,7 +393,7 @@ public class ResourcesManagerEntry implements ResourcesManager {
 		getResourcesManagerBl().checkResourceExists(sess, resource);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getAssignedGroups_Resource_policy", Collections.singletonList(resource))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getAssignedGroups_Resource_policy", resource)) {
 			throw new PrivilegeException(sess, "getAssignedGroups");
 				}
 
@@ -420,7 +420,7 @@ public class ResourcesManagerEntry implements ResourcesManager {
 		getPerunBl().getGroupsManagerBl().checkGroupExists(sess, group);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getAssignedResources_Group_policy", Collections.singletonList(group))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getAssignedResources_Group_policy", group)) {
 			throw new PrivilegeException(sess, "getAssignedResources");
 		}
 
@@ -433,7 +433,7 @@ public class ResourcesManagerEntry implements ResourcesManager {
 		getPerunBl().getGroupsManagerBl().checkGroupExists(sess, group);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getAssignedRichResources_Group_policy", Collections.singletonList(group))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getAssignedRichResources_Group_policy", group)) {
 			throw new PrivilegeException(sess, "getAssignedRichResources");
 				}
 
@@ -543,7 +543,7 @@ public class ResourcesManagerEntry implements ResourcesManager {
 		getPerunBl().getVosManagerBl().checkVoExists(sess, vo);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getResources_Vo_policy", Collections.singletonList(vo))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getResources_Vo_policy", vo)) {
 			throw new PrivilegeException(sess, "getResources");
 		}
 
@@ -567,7 +567,7 @@ public class ResourcesManagerEntry implements ResourcesManager {
 		getPerunBl().getVosManagerBl().checkVoExists(sess, vo);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getRichResources_Vo_policy", Collections.singletonList(vo))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getRichResources_Vo_policy", vo)) {
 			throw new PrivilegeException(sess, "getRichResources");
 		}
 
@@ -591,7 +591,7 @@ public class ResourcesManagerEntry implements ResourcesManager {
 		getPerunBl().getVosManagerBl().checkVoExists(sess, vo);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getResourcesCount_Vo_policy", Collections.singletonList(vo))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getResourcesCount_Vo_policy", vo)) {
 			throw new PrivilegeException(sess, "getResourcesCount");
 		}
 
@@ -612,7 +612,7 @@ public class ResourcesManagerEntry implements ResourcesManager {
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getAllowedResources_Member_policy", Collections.singletonList(member))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getAllowedResources_Member_policy", member)) {
 			throw new PrivilegeException(sess, "getAllowedResources");
 		}
 
@@ -626,7 +626,7 @@ public class ResourcesManagerEntry implements ResourcesManager {
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getAssignedResources_Member_policy", Collections.singletonList(member))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getAssignedResources_Member_policy", member)) {
 			throw new PrivilegeException(sess, "getAssignedResources");
 		}
 
@@ -655,7 +655,7 @@ public class ResourcesManagerEntry implements ResourcesManager {
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getAssignedRichResources_Member_policy", Collections.singletonList(member))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getAssignedRichResources_Member_policy", member)) {
 			throw new PrivilegeException(sess, "getAssignedRichResources");
 		}
 
@@ -683,7 +683,7 @@ public class ResourcesManagerEntry implements ResourcesManager {
 		resourcesManagerBl.checkResourceExists(sess, resource);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "updateResource_Resource_policy", Collections.singletonList(resource))) {
+		if (!AuthzResolver.authorizedInternal(sess, "updateResource_Resource_policy", resource)) {
 			throw new PrivilegeException(sess, "updateResource");
 		}
 
@@ -697,7 +697,7 @@ public class ResourcesManagerEntry implements ResourcesManager {
 		getPerunBl().getVosManagerBl().checkVoExists(perunSession, vo);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(perunSession, "createResourceTag_ResourceTag_Vo_policy", Collections.singletonList(vo))) {
+		if (!AuthzResolver.authorizedInternal(perunSession, "createResourceTag_ResourceTag_Vo_policy", vo)) {
 			throw new PrivilegeException(perunSession, "createResourceTag");
 		}
 
@@ -711,7 +711,7 @@ public class ResourcesManagerEntry implements ResourcesManager {
 		getResourcesManagerBl().checkResourceTagExists(perunSession, resourceTag);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(perunSession, "updateResourceTag_ResourceTag_policy", Collections.singletonList(resourceTag))) {
+		if (!AuthzResolver.authorizedInternal(perunSession, "updateResourceTag_ResourceTag_policy", resourceTag)) {
 			throw new PrivilegeException(perunSession, "updateResourceTag");
 		}
 
@@ -725,7 +725,7 @@ public class ResourcesManagerEntry implements ResourcesManager {
 		getResourcesManagerBl().checkResourceTagExists(perunSession, resourceTag);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(perunSession, "deleteResourceTag_ResourceTag_policy", Collections.singletonList(resourceTag))) {
+		if (!AuthzResolver.authorizedInternal(perunSession, "deleteResourceTag_ResourceTag_policy", resourceTag)) {
 			throw new PrivilegeException(perunSession, "deleteResourceTag");
 		}
 		resourcesManagerBl.deleteResourceTag(perunSession, resourceTag);
@@ -737,7 +737,7 @@ public class ResourcesManagerEntry implements ResourcesManager {
 		getPerunBl().getVosManagerBl().checkVoExists(perunSession, vo);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(perunSession, "deleteAllResourcesTagsForVo_Vo_policy", Collections.singletonList(vo))) {
+		if (!AuthzResolver.authorizedInternal(perunSession, "deleteAllResourcesTagsForVo_Vo_policy", vo)) {
 			throw new PrivilegeException(perunSession, "deleteAllResourcesTagsForVo");
 		}
 
@@ -782,7 +782,7 @@ public class ResourcesManagerEntry implements ResourcesManager {
 		resourcesManagerBl.checkResourceExists(perunSession, resource);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(perunSession, "removeAllResourcesTagFromResource_Resource_policy", Collections.singletonList(resource))) {
+		if (!AuthzResolver.authorizedInternal(perunSession, "removeAllResourcesTagFromResource_Resource_policy", resource)) {
 			throw new PrivilegeException(perunSession, "removeAllResourcesTagFromResource");
 		}
 
@@ -796,7 +796,7 @@ public class ResourcesManagerEntry implements ResourcesManager {
 		resourcesManagerBl.checkResourceTagExists(perunSession, resourceTag);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(perunSession, "getAllResourcesByResourceTag_ResourceTag_policy", Collections.singletonList(resourceTag))) {
+		if (!AuthzResolver.authorizedInternal(perunSession, "getAllResourcesByResourceTag_ResourceTag_policy", resourceTag)) {
 			throw new PrivilegeException(perunSession, "getAllResourcesByResourceTag");
 			//TODO: what about GROUPADMIN?
 		}
@@ -809,7 +809,7 @@ public class ResourcesManagerEntry implements ResourcesManager {
 		getPerunBl().getVosManagerBl().checkVoExists(perunSession, vo);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(perunSession, "getAllResourcesTagsForVo_Vo_policy", Collections.singletonList(vo))) {
+		if (!AuthzResolver.authorizedInternal(perunSession, "getAllResourcesTagsForVo_Vo_policy", vo)) {
 			throw new PrivilegeException(perunSession, "getAllResourcesTagsForVo");
 			//TODO: what about GROUPADMIN?
 				}
@@ -823,7 +823,7 @@ public class ResourcesManagerEntry implements ResourcesManager {
 		resourcesManagerBl.checkResourceExists(perunSession, resource);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(perunSession, "getAllResourcesTagsForResource_Resource_policy", Collections.singletonList(resource))) {
+		if (!AuthzResolver.authorizedInternal(perunSession, "getAllResourcesTagsForResource_Resource_policy", resource)) {
 			throw new PrivilegeException(perunSession, "getAllResourcesTagsForResource");
 			//TODO: What about GROUPADMIN?
 				}
@@ -882,7 +882,7 @@ public class ResourcesManagerEntry implements ResourcesManager {
 		getResourcesManagerBl().checkResourceExists(perunSession, resource);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(perunSession, "getAdmins_Resource_boolean_policy", Collections.singletonList(resource))) {
+		if (!AuthzResolver.authorizedInternal(perunSession, "getAdmins_Resource_boolean_policy", resource)) {
 			throw new PrivilegeException(perunSession, "getAdmins");
 		}
 
@@ -897,7 +897,7 @@ public class ResourcesManagerEntry implements ResourcesManager {
 		if(!allUserAttributes) Utils.notNull(specificAttributes, "specificAttributes");
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(perunSession, "getRichAdmins_Resource_List<String>_boolean_boolean_policy", Collections.singletonList(resource))) {
+		if (!AuthzResolver.authorizedInternal(perunSession, "getRichAdmins_Resource_List<String>_boolean_boolean_policy", resource)) {
 			throw new PrivilegeException(perunSession, "getRichAdmins");
 		}
 
@@ -911,7 +911,7 @@ public class ResourcesManagerEntry implements ResourcesManager {
 		getPerunBl().getUsersManagerBl().checkUserExists(sess, user);
 
 		// Authorization
-		if(!AuthzResolver.authorizedInternal(sess, "getResourcesWhereUserIsAdmin_User_policy", Collections.singletonList(user))) {
+		if(!AuthzResolver.authorizedInternal(sess, "getResourcesWhereUserIsAdmin_User_policy", user)) {
 			throw new PrivilegeException(sess, "getResourcesWhereUserIsAdmin");
 		}
 
@@ -970,11 +970,11 @@ public class ResourcesManagerEntry implements ResourcesManager {
 
 		//Authorization
 		if(!AuthzResolver.authorizedInternal(sess, "getResourcesWhereGroupIsAdmin_Facility_Vo_Group_policy", Arrays.asList(facility, vo)) &&
-		!AuthzResolver.authorizedInternal(sess, "authorizedGroup-getResourcesWhereGroupIsAdmin_Facility_Vo_Group_policy", Collections.singletonList(authorizedGroup))){
+		!AuthzResolver.authorizedInternal(sess, "authorizedGroup-getResourcesWhereGroupIsAdmin_Facility_Vo_Group_policy", authorizedGroup)){
 			throw new PrivilegeException(sess, "getResourcesByResourceManager");
 		}
 		resources.removeIf(resource -> !AuthzResolver.authorizedInternal(sess, "filter-getResourcesWhereGroupIsAdmin_Facility_Vo_Group_policy", Arrays.asList(vo, resource, facility)) &&
-			!AuthzResolver.authorizedInternal(sess, "filter_authorizedGroup-getResourcesWhereGroupIsAdmin_Facility_Vo_Group_policy", Collections.singletonList(authorizedGroup)));
+			!AuthzResolver.authorizedInternal(sess, "filter_authorizedGroup-getResourcesWhereGroupIsAdmin_Facility_Vo_Group_policy", authorizedGroup));
 
 		return resources;
 	}
@@ -985,7 +985,7 @@ public class ResourcesManagerEntry implements ResourcesManager {
 		getResourcesManagerBl().checkResourceExists(sess, resource);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getAdminGroups_Resource_policy", Collections.singletonList(resource))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getAdminGroups_Resource_policy", resource)) {
 			throw new PrivilegeException(sess, "getAdminGroups");
 		}
 
@@ -1013,8 +1013,8 @@ public class ResourcesManagerEntry implements ResourcesManager {
 		getPerunBl().getGroupsManagerBl().checkGroupExists(sess, group);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "addAdmin_Resource_Group_policy", Collections.singletonList(resource)) &&
-			!AuthzResolver.authorizedInternal(sess, "group-addAdmin_Resource_Group_policy", Collections.singletonList(group))) {
+		if (!AuthzResolver.authorizedInternal(sess, "addAdmin_Resource_Group_policy", resource) &&
+			!AuthzResolver.authorizedInternal(sess, "group-addAdmin_Resource_Group_policy", group)) {
 			throw new PrivilegeException(sess, "addAdmin");
 		}
 
@@ -1042,8 +1042,8 @@ public class ResourcesManagerEntry implements ResourcesManager {
 		getPerunBl().getGroupsManagerBl().checkGroupExists(sess, group);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "removeAdmin_Resource_Group_policy", Collections.singletonList(resource)) &&
-			!AuthzResolver.authorizedInternal(sess, "group-removeAdmin_Resource_Group_policy", Collections.singletonList(group))) {
+		if (!AuthzResolver.authorizedInternal(sess, "removeAdmin_Resource_Group_policy", resource) &&
+			!AuthzResolver.authorizedInternal(sess, "group-removeAdmin_Resource_Group_policy", group)) {
 			throw new PrivilegeException(sess, "removeAdmin");
 		}
 
@@ -1058,7 +1058,7 @@ public class ResourcesManagerEntry implements ResourcesManager {
 		Resource resource = getResourcesManagerBl().getResourceById(sess, banOnResource.getResourceId());
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "setBan_BanOnResource_policy", Collections.singletonList(resource))) {
+		if (!AuthzResolver.authorizedInternal(sess, "setBan_BanOnResource_policy", resource)) {
 			throw new PrivilegeException(sess, "setBan");
 		}
 
@@ -1118,7 +1118,7 @@ public class ResourcesManagerEntry implements ResourcesManager {
 		Resource resource = getPerunBl().getResourcesManagerBl().getResourceById(sess, resourceId);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getBansForResource_int_policy", Collections.singletonList(resource))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getBansForResource_int_policy", resource)) {
 			throw new PrivilegeException(sess, "getBansForResource");
 		}
 
@@ -1194,8 +1194,8 @@ public class ResourcesManagerEntry implements ResourcesManager {
 		getPerunBl().getGroupsManagerBl().checkGroupExists(sess, group);
 
 		//Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "addResourceSelfServiceGroup_Resource_Group_policy", Collections.singletonList(resource)) &&
-		!AuthzResolver.authorizedInternal(sess, "group-addResourceSelfServiceGroup_Resource_Group_policy", Collections.singletonList(group))) {
+		if (!AuthzResolver.authorizedInternal(sess, "addResourceSelfServiceGroup_Resource_Group_policy", resource) &&
+		!AuthzResolver.authorizedInternal(sess, "group-addResourceSelfServiceGroup_Resource_Group_policy", group)) {
 			throw new PrivilegeException(sess, "addResourceSelfServiceGroup");
 		}
 
@@ -1225,8 +1225,8 @@ public class ResourcesManagerEntry implements ResourcesManager {
 		getPerunBl().getGroupsManagerBl().checkGroupExists(sess, group);
 
 		//Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "removeResourceSelfServiceGroup_Resource_Group_policy", Collections.singletonList(resource)) &&
-			!AuthzResolver.authorizedInternal(sess, "group-removeResourceSelfServiceGroup_Resource_Group_policy", Collections.singletonList(group))) {
+		if (!AuthzResolver.authorizedInternal(sess, "removeResourceSelfServiceGroup_Resource_Group_policy", resource) &&
+			!AuthzResolver.authorizedInternal(sess, "group-removeResourceSelfServiceGroup_Resource_Group_policy", group)) {
 			throw new PrivilegeException(sess, "removeResourceSelfServiceGroup");
 		}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/SearcherEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/SearcherEntry.java
@@ -65,7 +65,7 @@ public class SearcherEntry implements Searcher {
 		perunBl.getVosManagerBl().checkVoExists(sess, vo);
 
 		//Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getMembersByUserAttributes_Vo_Map<String_String>_policy", Collections.singletonList(vo)))
+		if (!AuthzResolver.authorizedInternal(sess, "getMembersByUserAttributes_Vo_Map<String_String>_policy", vo))
 			throw new PrivilegeException(sess, "getMembersByUserAttributes");
 
 		//If map is null or empty, return all members from vo
@@ -172,7 +172,7 @@ public class SearcherEntry implements Searcher {
 		perunBl.getGroupsManagerBl().checkGroupExists(sess, group);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getMembersByGroupExpiration_Group_String_LocalDate_policy", Collections.singletonList(group)))
+		if (!AuthzResolver.authorizedInternal(sess, "getMembersByGroupExpiration_Group_String_LocalDate_policy", group))
 			throw new PrivilegeException(sess, "getMembersByGroupExpiration");
 
 		return getPerunBl().getSearcherBl().getMembersByGroupExpiration(sess, group, operator, date);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/SecurityTeamsManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/SecurityTeamsManagerEntry.java
@@ -71,7 +71,7 @@ public class SecurityTeamsManagerEntry implements cz.metacentrum.perun.core.api.
 			throw new PrivilegeException("getSecurityTeams");
 		} else {
 			List<SecurityTeam> securityTeams = getSecurityTeamsManagerBl().getAllSecurityTeams(sess);
-			securityTeams.removeIf(st -> !AuthzResolver.authorizedInternal(sess, "filter-getSecurityTeams_policy", Collections.singletonList(st)));
+			securityTeams.removeIf(st -> !AuthzResolver.authorizedInternal(sess, "filter-getSecurityTeams_policy", st));
 			return securityTeams;
 		}
 	}
@@ -126,7 +126,7 @@ public class SecurityTeamsManagerEntry implements cz.metacentrum.perun.core.api.
 		getSecurityTeamsManagerBl().checkSecurityTeamExists(sess, securityTeam);
 
 		//Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "updateSecurityTeam_SecurityTeam_policy", Collections.singletonList(securityTeam))) {
+		if (!AuthzResolver.authorizedInternal(sess, "updateSecurityTeam_SecurityTeam_policy", securityTeam)) {
 			throw new PrivilegeException(sess, "updateSecurityTeam");
 		}
 
@@ -166,7 +166,7 @@ public class SecurityTeamsManagerEntry implements cz.metacentrum.perun.core.api.
 		getSecurityTeamsManagerBl().checkSecurityTeamExists(sess, securityTeam);
 
 		//Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "deleteSecurityTeam_SecurityTeam__boolean_policy", Collections.singletonList(securityTeam))) {
+		if (!AuthzResolver.authorizedInternal(sess, "deleteSecurityTeam_SecurityTeam__boolean_policy", securityTeam)) {
 			throw new PrivilegeException(sess, "deleteSecurityTeam");
 		}
 
@@ -204,7 +204,7 @@ public class SecurityTeamsManagerEntry implements cz.metacentrum.perun.core.api.
 		getSecurityTeamsManagerBl().checkSecurityTeamExists(sess, securityTeam);
 
 		//Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getAdmins_SecurityTeam_policy", Collections.singletonList(securityTeam))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getAdmins_SecurityTeam_policy", securityTeam)) {
 			throw new PrivilegeException(sess, "getAdmins");
 		}
 
@@ -218,7 +218,7 @@ public class SecurityTeamsManagerEntry implements cz.metacentrum.perun.core.api.
 		getSecurityTeamsManagerBl().checkSecurityTeamExists(sess, securityTeam);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getAdminGroups_SecurityTeam_policy", Collections.singletonList(securityTeam))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getAdminGroups_SecurityTeam_policy", securityTeam)) {
 			throw new PrivilegeException(sess, "getAdminGroups");
 		}
 
@@ -334,7 +334,7 @@ public class SecurityTeamsManagerEntry implements cz.metacentrum.perun.core.api.
 		getSecurityTeamsManagerBl().checkSecurityTeamExists(sess, securityTeam);
 
 		//Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getBlacklist_SecurityTeam_policy", Collections.singletonList(securityTeam))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getBlacklist_SecurityTeam_policy", securityTeam)) {
 			throw new PrivilegeException(sess, "getBlacklist");
 		}
 
@@ -347,7 +347,7 @@ public class SecurityTeamsManagerEntry implements cz.metacentrum.perun.core.api.
 		getPerunBl().getFacilitiesManagerBl().checkFacilityExists(sess, facility);
 
 		//Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getBlacklist_Facility_policy", Collections.singletonList(facility))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getBlacklist_Facility_policy", facility)) {
 			throw new PrivilegeException(sess, "getBlacklist");
 		}
 
@@ -360,7 +360,7 @@ public class SecurityTeamsManagerEntry implements cz.metacentrum.perun.core.api.
 		getSecurityTeamsManagerBl().checkSecurityTeamExists(sess, securityTeam);
 
 		//Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getBlacklistWithDescription_SecurityTeam_policy", Collections.singletonList(securityTeam))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getBlacklistWithDescription_SecurityTeam_policy", securityTeam)) {
 			throw new PrivilegeException(sess, "getBlacklistWithDescription");
 		}
 
@@ -373,7 +373,7 @@ public class SecurityTeamsManagerEntry implements cz.metacentrum.perun.core.api.
 		getPerunBl().getFacilitiesManagerBl().checkFacilityExists(sess, facility);
 
 		//Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getBlacklistWithDescription_Facility_policy", Collections.singletonList(facility))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getBlacklistWithDescription_Facility_policy", facility)) {
 			throw new PrivilegeException(sess, "getBlacklistWithDescription");
 		}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ServicesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ServicesManagerEntry.java
@@ -93,7 +93,7 @@ public class ServicesManagerEntry implements ServicesManager {
 	public void blockAllServicesOnFacility(PerunSession sess, Facility facility) throws FacilityNotExistsException, PrivilegeException {
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "blockAllServicesOnFacility_Facility_policy", Collections.singletonList(facility))) {
+		if (!AuthzResolver.authorizedInternal(sess, "blockAllServicesOnFacility_Facility_policy", facility)) {
 			throw new PrivilegeException(sess, "blockAllServicesOnFacility");
 		}
 		getServicesManagerBl().blockAllServicesOnFacility(sess, facility);
@@ -106,7 +106,7 @@ public class ServicesManagerEntry implements ServicesManager {
 
 
 		for (Facility facility : destinationFacilities) {
-			if (AuthzResolver.authorizedInternal(sess, "blockAllServicesOnDestination_int_policy", Collections.singletonList(facility))) {
+			if (AuthzResolver.authorizedInternal(sess, "blockAllServicesOnDestination_int_policy", facility)) {
 				getServicesManagerBl().blockAllServicesOnDestination(sess, destinationId);
 				return;
 			}
@@ -117,7 +117,7 @@ public class ServicesManagerEntry implements ServicesManager {
 	@Override
 	public List<Service> getServicesBlockedOnFacility(PerunSession perunSession, Facility facility) throws PrivilegeException {
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(perunSession, "getServicesBlockedOnFacility_Facility_policy", Collections.singletonList(facility))) {
+		if (!AuthzResolver.authorizedInternal(perunSession, "getServicesBlockedOnFacility_Facility_policy", facility)) {
 			throw new PrivilegeException(perunSession, "getServicesBlockedOnFacility");
 		}
 		return getServicesManagerBl().getServicesBlockedOnFacility(perunSession, facility);
@@ -129,7 +129,7 @@ public class ServicesManagerEntry implements ServicesManager {
 		List<Facility> destinationFacilities = perunBl.getFacilitiesManagerBl().getFacilitiesByDestination(sess, destination.getDestination());
 
 		for (Facility facility : destinationFacilities) {
-			if (AuthzResolver.authorizedInternal(sess, "getServicesBlockedOnDestination_int_policy", Collections.singletonList(facility))) {
+			if (AuthzResolver.authorizedInternal(sess, "getServicesBlockedOnDestination_int_policy", facility)) {
 				return getServicesManagerBl().getServicesBlockedOnDestination(sess, destinationId);
 			}
 		}
@@ -161,7 +161,7 @@ public class ServicesManagerEntry implements ServicesManager {
 	@Override
 	public void unblockAllServicesOnFacility(PerunSession sess, Facility facility) throws PrivilegeException {
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "unblockAllServicesOnDestination_String_policy", Collections.singletonList(facility))) {
+		if (!AuthzResolver.authorizedInternal(sess, "unblockAllServicesOnDestination_String_policy", facility)) {
 			throw new PrivilegeException(sess, "unblockAllServicesOnFacility");
 		}
 		getServicesManagerBl().unblockAllServicesOnFacility(sess, facility);
@@ -175,7 +175,7 @@ public class ServicesManagerEntry implements ServicesManager {
 				List<Facility> destinationFacilities = perunBl.getFacilitiesManagerBl().getFacilitiesByDestination(sess, destination.getDestination());
 				boolean servicesUnblocked = false;
 				for (Facility facility : destinationFacilities) {
-					if (AuthzResolver.authorizedInternal(sess, "unblockAllServicesOnDestination_String_policy", Collections.singletonList(facility))) {
+					if (AuthzResolver.authorizedInternal(sess, "unblockAllServicesOnDestination_String_policy", facility)) {
 						getServicesManagerBl().unblockAllServicesOnDestination(sess, destination.getId());
 						servicesUnblocked = true;
 						break;
@@ -194,7 +194,7 @@ public class ServicesManagerEntry implements ServicesManager {
 		List<Facility> destinationFacilities = perunBl.getFacilitiesManagerBl().getFacilitiesByDestination(sess, destination.getDestination());
 
 		for (Facility facility : destinationFacilities) {
-			if (AuthzResolver.authorizedInternal(sess, "unblockAllServicesOnDestination_int_policy", Collections.singletonList(facility))) {
+			if (AuthzResolver.authorizedInternal(sess, "unblockAllServicesOnDestination_int_policy", facility)) {
 				getServicesManagerBl().unblockAllServicesOnDestination(sess, destinationId);
 				return;
 			}
@@ -237,7 +237,7 @@ public class ServicesManagerEntry implements ServicesManager {
 	@Override
 	public boolean forceServicePropagation(PerunSession sess, Service service) throws PrivilegeException {
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "forceServicePropagation_Service_policy", Collections.singletonList(service))) {
+		if (!AuthzResolver.authorizedInternal(sess, "forceServicePropagation_Service_policy", service)) {
 			throw new PrivilegeException(sess, "forceServicePropagation");
 		}
 		return getServicesManagerBl().forceServicePropagation(sess, service);
@@ -255,7 +255,7 @@ public class ServicesManagerEntry implements ServicesManager {
 	@Override
 	public boolean planServicePropagation(PerunSession perunSession, Service service) throws PrivilegeException {
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(perunSession, "planServicePropagation_Service_policy", Collections.singletonList(service))) {
+		if (!AuthzResolver.authorizedInternal(perunSession, "planServicePropagation_Service_policy", service)) {
 			throw new PrivilegeException(perunSession, "planServicePropagation");
 		}
 		return getServicesManagerBl().planServicePropagation(perunSession, service);
@@ -264,7 +264,7 @@ public class ServicesManagerEntry implements ServicesManager {
 	@Override
 	public List<ServiceForGUI> getFacilityAssignedServicesForGUI(PerunSession perunSession, Facility facility) throws PrivilegeException, FacilityNotExistsException {
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(perunSession, "getFacilityAssignedServicesForGUI_Facility_policy", Collections.singletonList(facility))) {
+		if (!AuthzResolver.authorizedInternal(perunSession, "getFacilityAssignedServicesForGUI_Facility_policy", facility)) {
 			throw new PrivilegeException(perunSession, "getFacilityAssignedServicesForGUI");
 		}
 		return getServicesManagerBl().getFacilityAssignedServicesForGUI(perunSession, facility);
@@ -293,7 +293,7 @@ public class ServicesManagerEntry implements ServicesManager {
 		Utils.checkPerunSession(sess);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "deleteService_Service_policy", Collections.singletonList(service))) {
+		if (!AuthzResolver.authorizedInternal(sess, "deleteService_Service_policy", service)) {
 			throw new PrivilegeException(sess, "deleteService");
 		}
 
@@ -307,7 +307,7 @@ public class ServicesManagerEntry implements ServicesManager {
 		Utils.checkPerunSession(sess);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "updateService_Service_policy", Collections.singletonList(service))) {
+		if (!AuthzResolver.authorizedInternal(sess, "updateService_Service_policy", service)) {
 			throw new PrivilegeException(sess, "updateService");
 		}
 
@@ -485,7 +485,7 @@ public class ServicesManagerEntry implements ServicesManager {
 		Utils.checkPerunSession(sess);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "createServicesPackage_ServicesPackage_policy", Collections.singletonList(servicesPackage))) {
+		if (!AuthzResolver.authorizedInternal(sess, "createServicesPackage_ServicesPackage_policy", servicesPackage)) {
 			throw new PrivilegeException(sess, "createServicesPackage");
 		}
 
@@ -499,7 +499,7 @@ public class ServicesManagerEntry implements ServicesManager {
 		Utils.checkPerunSession(sess);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "updateServicesPackage_ServicesPackage_policy", Collections.singletonList(servicesPackage))) {
+		if (!AuthzResolver.authorizedInternal(sess, "updateServicesPackage_ServicesPackage_policy", servicesPackage)) {
 			throw new PrivilegeException(sess, "updateServicesPackage");
 		}
 
@@ -513,7 +513,7 @@ public class ServicesManagerEntry implements ServicesManager {
 		Utils.checkPerunSession(sess);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "deleteServicesPackage_ServicesPackage_policy", Collections.singletonList(servicesPackage))) {
+		if (!AuthzResolver.authorizedInternal(sess, "deleteServicesPackage_ServicesPackage_policy", servicesPackage)) {
 			throw new PrivilegeException(sess, "deleteServicesPackage");
 		}
 
@@ -557,7 +557,7 @@ public class ServicesManagerEntry implements ServicesManager {
 		Utils.checkPerunSession(sess);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getServicesFromServicesPackage_ServicesPackage_policy", Collections.singletonList(servicesPackage))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getServicesFromServicesPackage_ServicesPackage_policy", servicesPackage)) {
 			throw new PrivilegeException(sess, "getServicesFromServicesPackage");
 		}
 
@@ -571,7 +571,7 @@ public class ServicesManagerEntry implements ServicesManager {
 		Utils.checkPerunSession(sess);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "addRequiredAttribute_Service_AttributeDefinition_policy", Collections.singletonList(service))) {
+		if (!AuthzResolver.authorizedInternal(sess, "addRequiredAttribute_Service_AttributeDefinition_policy", service)) {
 			throw new PrivilegeException(sess, "addRequiredAttribute");
 		}
 
@@ -586,7 +586,7 @@ public class ServicesManagerEntry implements ServicesManager {
 		Utils.checkPerunSession(sess);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "addRequiredAttributes_Service_List<AttributeDefinition>_policy", Collections.singletonList(service))) {
+		if (!AuthzResolver.authorizedInternal(sess, "addRequiredAttributes_Service_List<AttributeDefinition>_policy", service)) {
 			throw new PrivilegeException(sess, "addRequiredAttributes");
 		}
 
@@ -601,7 +601,7 @@ public class ServicesManagerEntry implements ServicesManager {
 		Utils.checkPerunSession(sess);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "removeRequiredAttribute_Service_AttributeDefinition_policy", Collections.singletonList(service))) {
+		if (!AuthzResolver.authorizedInternal(sess, "removeRequiredAttribute_Service_AttributeDefinition_policy", service)) {
 			throw new PrivilegeException(sess, "removeRequiredAttribute");
 		}
 
@@ -616,7 +616,7 @@ public class ServicesManagerEntry implements ServicesManager {
 		Utils.checkPerunSession(sess);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "removeRequiredAttributes_Service_List<AttributeDefinition>_policy", Collections.singletonList(service))) {
+		if (!AuthzResolver.authorizedInternal(sess, "removeRequiredAttributes_Service_List<AttributeDefinition>_policy", service)) {
 			throw new PrivilegeException(sess, "removeRequiredAttributes");
 		}
 
@@ -631,7 +631,7 @@ public class ServicesManagerEntry implements ServicesManager {
 		Utils.checkPerunSession(sess);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "removeAllRequiredAttributes_Service_policy", Collections.singletonList(service))) {
+		if (!AuthzResolver.authorizedInternal(sess, "removeAllRequiredAttributes_Service_policy", service)) {
 			throw new PrivilegeException(sess, "removeRequiredAttribute");
 		}
 
@@ -647,7 +647,7 @@ public class ServicesManagerEntry implements ServicesManager {
 		getPerunBl().getFacilitiesManagerBl().checkFacilityExists(perunSession, facility);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(perunSession, "addDestination_List<Service>_Facility_Destination_policy", Collections.singletonList(facility))) {
+		if (!AuthzResolver.authorizedInternal(perunSession, "addDestination_List<Service>_Facility_Destination_policy", facility)) {
 			throw new PrivilegeException(perunSession, "addDestination");
 		}
 
@@ -665,7 +665,7 @@ public class ServicesManagerEntry implements ServicesManager {
 			if(!facilitiesByHostname.isEmpty()) {
 				boolean hasRight = false;
 				for(Facility facilityByHostname: facilitiesByHostname) {
-					if(AuthzResolver.authorizedInternal(perunSession, "addDestination_List<Service>_Facility_Destination_policy", Collections.singletonList(facilityByHostname))) {
+					if(AuthzResolver.authorizedInternal(perunSession, "addDestination_List<Service>_Facility_Destination_policy", facilityByHostname)) {
 						hasRight = true;
 						break;
 					}
@@ -676,7 +676,7 @@ public class ServicesManagerEntry implements ServicesManager {
 			if(!facilitiesByDestination.isEmpty()) {
 				boolean hasRight = false;
 				for(Facility facilityByDestination: facilitiesByDestination) {
-					if(AuthzResolver.authorizedInternal(perunSession, "addDestination_List<Service>_Facility_Destination_policy", Collections.singletonList(facilityByDestination))) {
+					if(AuthzResolver.authorizedInternal(perunSession, "addDestination_List<Service>_Facility_Destination_policy", facilityByDestination)) {
 						hasRight = true;
 						break;
 					}
@@ -702,7 +702,7 @@ public class ServicesManagerEntry implements ServicesManager {
 		getPerunBl().getFacilitiesManagerBl().checkFacilityExists(sess, facility);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "addDestination_Service_Facility_Destination_policy", Collections.singletonList(facility))) {
+		if (!AuthzResolver.authorizedInternal(sess, "addDestination_Service_Facility_Destination_policy", facility)) {
 			throw new PrivilegeException(sess, "addDestination");
 		}
 
@@ -720,7 +720,7 @@ public class ServicesManagerEntry implements ServicesManager {
 			if(!facilitiesByHostname.isEmpty()) {
 				boolean hasRight = false;
 				for(Facility facilityByHostname: facilitiesByHostname) {
-					if(AuthzResolver.authorizedInternal(sess, "addDestination_Service_Facility_Destination_policy", Collections.singletonList(facilityByHostname))) {
+					if(AuthzResolver.authorizedInternal(sess, "addDestination_Service_Facility_Destination_policy", facilityByHostname)) {
 						hasRight = true;
 						break;
 					}
@@ -731,7 +731,7 @@ public class ServicesManagerEntry implements ServicesManager {
 			if(!facilitiesByDestination.isEmpty()) {
 				boolean hasRight = false;
 				for(Facility facilityByDestination: facilitiesByDestination) {
-					if(AuthzResolver.authorizedInternal(sess, "addDestination_Service_Facility_Destination_policy", Collections.singletonList(facilityByDestination))) {
+					if(AuthzResolver.authorizedInternal(sess, "addDestination_Service_Facility_Destination_policy", facilityByDestination)) {
 						hasRight = true;
 						break;
 					}
@@ -811,7 +811,7 @@ public class ServicesManagerEntry implements ServicesManager {
 		Utils.checkPerunSession(perunSession);
 
 		//Authorization
-		if (!AuthzResolver.authorizedInternal(perunSession, "getAllRichDestinations_Facility_policy", Collections.singletonList(facility))) {
+		if (!AuthzResolver.authorizedInternal(perunSession, "getAllRichDestinations_Facility_policy", facility)) {
 			throw new PrivilegeException(perunSession, "getAllRichDestinations");
 				}
 
@@ -824,7 +824,7 @@ public class ServicesManagerEntry implements ServicesManager {
 		Utils.checkPerunSession(perunSession);
 
 		//Authorization
-		if (!AuthzResolver.authorizedInternal(perunSession, "getAllRichDestinations_Service_policy", Collections.singletonList(service))) {
+		if (!AuthzResolver.authorizedInternal(perunSession, "getAllRichDestinations_Service_policy", service)) {
 			throw new PrivilegeException(perunSession, "getAllRichDestinations");
 		}
 
@@ -880,7 +880,7 @@ public class ServicesManagerEntry implements ServicesManager {
 		Utils.checkPerunSession(sess);
 
 		//Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getAssignedServices_Facility_policy", Collections.singletonList(facility))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getAssignedServices_Facility_policy", facility)) {
 			throw new PrivilegeException(sess, "getAssignedServices");
 		}
 
@@ -977,7 +977,7 @@ public class ServicesManagerEntry implements ServicesManager {
 		Utils.checkPerunSession(perunSession);
 
 		// Auhtorization
-		if (!AuthzResolver.authorizedInternal(perunSession, "addDestinationsDefinedByHostsOnFacility_Facility_policy", Collections.singletonList(facility))) {
+		if (!AuthzResolver.authorizedInternal(perunSession, "addDestinationsDefinedByHostsOnFacility_Facility_policy", facility)) {
 			throw new PrivilegeException(perunSession, "addDestinationsDefinedByHostsOnFacility");
 		}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/TasksManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/TasksManagerEntry.java
@@ -59,7 +59,7 @@ public class TasksManagerEntry implements TasksManager {
 		Facility facility = task.getFacility();
 
 		//Authorization
-		if (!AuthzResolver.authorizedInternal(perunSession, "getTaskById_int_policy", Collections.singletonList(facility))) {
+		if (!AuthzResolver.authorizedInternal(perunSession, "getTaskById_int_policy", facility)) {
 			throw new PrivilegeException(perunSession, "getTaskResultsByTask");
 		}
 
@@ -78,7 +78,7 @@ public class TasksManagerEntry implements TasksManager {
 		facility.setId(facilityId);
 
 		//Authorization
-		if (!AuthzResolver.authorizedInternal(session, "listAllTasksForFacility_int_policy", Collections.singletonList(facility))) {
+		if (!AuthzResolver.authorizedInternal(session, "listAllTasksForFacility_int_policy", facility)) {
 			throw new PrivilegeException(session, "listAllTasksForFacility");
 		}
 
@@ -117,7 +117,7 @@ public class TasksManagerEntry implements TasksManager {
 		facility.setId(facilityId);
 
 		//Authorization
-		if (!AuthzResolver.authorizedInternal(perunSession, "getTask_int_int_policy", Collections.singletonList(facility))) {
+		if (!AuthzResolver.authorizedInternal(perunSession, "getTask_int_int_policy", facility)) {
 			throw new PrivilegeException(perunSession, "getTask");
 		}
 
@@ -136,7 +136,7 @@ public class TasksManagerEntry implements TasksManager {
 		Facility facility = task.getFacility();
 
 		//Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getTaskResultsByTask_int_policy", Collections.singletonList(facility))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getTaskResultsByTask_int_policy", facility)) {
 			throw new PrivilegeException(sess, "getTaskResultsByTask");
 		}
 
@@ -150,7 +150,7 @@ public class TasksManagerEntry implements TasksManager {
 		Facility facility = task.getFacility();
 
 		//Authorization
-		if (!AuthzResolver.authorizedInternal(session, "getTaskResultsForGUIByTaskOnlyNewest_int_policy", Collections.singletonList(facility))) {
+		if (!AuthzResolver.authorizedInternal(session, "getTaskResultsForGUIByTaskOnlyNewest_int_policy", facility)) {
 			throw new PrivilegeException(session, "getTaskResultsByTask");
 		}
 
@@ -164,7 +164,7 @@ public class TasksManagerEntry implements TasksManager {
 		Facility facility = task.getFacility();
 
 		//Authorization
-		if (!AuthzResolver.authorizedInternal(session, "getTaskResultsForGUIByTaskAndDestination_int_int_policy", Collections.singletonList(facility))) {
+		if (!AuthzResolver.authorizedInternal(session, "getTaskResultsForGUIByTaskAndDestination_int_int_policy", facility)) {
 			throw new PrivilegeException(session, "getTaskResultsByTask");
 		}
 
@@ -178,7 +178,7 @@ public class TasksManagerEntry implements TasksManager {
 		Facility facility = task.getFacility();
 
 		//Authorization
-		if (!AuthzResolver.authorizedInternal(session, "getTaskResultsForGUIByTask_int_policy", Collections.singletonList(facility))) {
+		if (!AuthzResolver.authorizedInternal(session, "getTaskResultsForGUIByTask_int_policy", facility)) {
 			throw new PrivilegeException(session, "getTaskResultsByTask");
 		}
 
@@ -191,7 +191,7 @@ public class TasksManagerEntry implements TasksManager {
 		perun.getFacilitiesManagerBl().checkFacilityExists(session, facility);
 
 		//Authorization
-		if (!AuthzResolver.authorizedInternal(session, "getFacilityState_Facility_policy", Collections.singletonList(facility))) {
+		if (!AuthzResolver.authorizedInternal(session, "getFacilityState_Facility_policy", facility)) {
 			throw new PrivilegeException(session, "getFacilityState");
 		}
 
@@ -211,7 +211,7 @@ public class TasksManagerEntry implements TasksManager {
 		perun.getVosManagerBl().checkVoExists(session, vo);
 
 		//Authorization
-		if (!AuthzResolver.authorizedInternal(session, "getAllFacilitiesStatesForVo_Vo_policy", Collections.singletonList(vo))) {
+		if (!AuthzResolver.authorizedInternal(session, "getAllFacilitiesStatesForVo_Vo_policy", vo)) {
 			throw new PrivilegeException(session, "getAllFacilitiesStatesForVo");
 		}
 
@@ -236,7 +236,7 @@ public class TasksManagerEntry implements TasksManager {
 		perun.getVosManagerBl().checkVoExists(session, vo);
 
 		//Authorization
-		if (!AuthzResolver.authorizedInternal(session, "getResourcesState_Vo_policy", Collections.singletonList(vo))) {
+		if (!AuthzResolver.authorizedInternal(session, "getResourcesState_Vo_policy", vo)) {
 			throw new PrivilegeException(session, "getResourcesState");
 		}
 
@@ -249,7 +249,7 @@ public class TasksManagerEntry implements TasksManager {
 		perun.getFacilitiesManagerBl().checkFacilityExists(sess, facility);
 
 		//Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getFacilityServicesState_Facility_policy", Collections.singletonList(facility))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getFacilityServicesState_Facility_policy", facility)) {
 			throw new PrivilegeException(sess, "getFacilityServicesState");
 		}
 
@@ -263,7 +263,7 @@ public class TasksManagerEntry implements TasksManager {
 		Facility facility = task.getFacility();
 
 		//Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "deleteTask_Task_policy", Collections.singletonList(facility))) {
+		if (!AuthzResolver.authorizedInternal(sess, "deleteTask_Task_policy", facility)) {
 			throw new PrivilegeException(sess, "deleteTask");
 		}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
@@ -125,7 +125,7 @@ public class UsersManagerEntry implements UsersManager {
 
 		User user = getUsersManagerBl().getUserById(sess, id);
 
-		if(!AuthzResolver.authorizedInternal(sess, "getUserById_int_policy", Collections.singletonList(user))) {
+		if(!AuthzResolver.authorizedInternal(sess, "getUserById_int_policy", user)) {
 			throw new PrivilegeException(sess, "getUserById");
 		}
 
@@ -173,8 +173,8 @@ public class UsersManagerEntry implements UsersManager {
 		if (!specificUser.isSpecificUser()) throw new SpecificUserExpectedException(specificUser);
 
 		// Authorization
-		if(!AuthzResolver.authorizedInternal(sess, "removeSpecificUserOwner_User_User_policy", Collections.singletonList(specificUser)) &&
-		!AuthzResolver.authorizedInternal(sess, "owner-removeSpecificUserOwner_User_User_policy", Collections.singletonList(user))) {
+		if(!AuthzResolver.authorizedInternal(sess, "removeSpecificUserOwner_User_User_policy", specificUser) &&
+		!AuthzResolver.authorizedInternal(sess, "owner-removeSpecificUserOwner_User_User_policy", user)) {
 			throw new PrivilegeException(sess, "removeSpecificUserOwner");
 		}
 		getUsersManagerBl().removeSpecificUserOwner(sess, user, specificUser);
@@ -190,8 +190,8 @@ public class UsersManagerEntry implements UsersManager {
 		if (!specificUser.isSpecificUser()) throw new SpecificUserExpectedException(specificUser);
 
 		// Authorization
-		if(!AuthzResolver.authorizedInternal(sess, "addSpecificUserOwner_User_User_policy", Collections.singletonList(specificUser)) &&
-			!AuthzResolver.authorizedInternal(sess, "owner-addSpecificUserOwner_User_User_policy", Collections.singletonList(user))) {
+		if(!AuthzResolver.authorizedInternal(sess, "addSpecificUserOwner_User_User_policy", specificUser) &&
+			!AuthzResolver.authorizedInternal(sess, "owner-addSpecificUserOwner_User_User_policy", user)) {
 			throw new PrivilegeException(sess, "addSpecificUserOwner");
 		}
 		getUsersManagerBl().addSpecificUserOwner(sess, user, specificUser);
@@ -210,7 +210,7 @@ public class UsersManagerEntry implements UsersManager {
 	public User getUserByMember(PerunSession sess, Member member) throws MemberNotExistsException, PrivilegeException {
 		Utils.checkPerunSession(sess);
 
-		if(!AuthzResolver.authorizedInternal(sess, "getUserByMember_Member_policy", Collections.singletonList(member))) {
+		if(!AuthzResolver.authorizedInternal(sess, "getUserByMember_Member_policy", member)) {
 			throw new PrivilegeException(sess, "getUserByMember");
 		}
 
@@ -225,7 +225,7 @@ public class UsersManagerEntry implements UsersManager {
 
 		User user = getUsersManagerBl().getUserByExtSourceNameAndExtLogin(sess, extSourceName, extLogin);
 
-		if(!AuthzResolver.authorizedInternal(sess, "getUserByExtSourceNameAndExtLogin_String_String_policy", Collections.singletonList(user))) {
+		if(!AuthzResolver.authorizedInternal(sess, "getUserByExtSourceNameAndExtLogin_String_String_policy", user)) {
 			throw new PrivilegeException(sess, "getUserByExtSourceNameAndExtLogin");
 		}
 
@@ -251,7 +251,7 @@ public class UsersManagerEntry implements UsersManager {
 		getPerunBl().getUsersManagerBl().checkUserExists(sess, user);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getRichUser_User_policy", Collections.singletonList(user))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getRichUser_User_policy", user)) {
 			throw new PrivilegeException(sess, "getRichUser");
 		}
 
@@ -265,7 +265,7 @@ public class UsersManagerEntry implements UsersManager {
 		getPerunBl().getUsersManagerBl().checkUserExists(sess, user);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getRichUserWithAttributes_User_policy", Collections.singletonList(user))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getRichUserWithAttributes_User_policy", user)) {
 			throw new PrivilegeException(sess, "getRichUserWithAttributes");
 		}
 
@@ -355,8 +355,8 @@ public class UsersManagerEntry implements UsersManager {
 		getPerunBl().getUsersManagerBl().checkUserExists(sess, specificUser);
 
 		// Authorization
-		if(!AuthzResolver.authorizedInternal(sess, "setSpecificUser_User_SpecificUserType_User_policy", Collections.singletonList(specificUser)) &&
-			!AuthzResolver.authorizedInternal(sess, "owner-setSpecificUser_User_SpecificUserType_User_policy", Collections.singletonList(owner))) {
+		if(!AuthzResolver.authorizedInternal(sess, "setSpecificUser_User_SpecificUserType_User_policy", specificUser) &&
+			!AuthzResolver.authorizedInternal(sess, "owner-setSpecificUser_User_SpecificUserType_User_policy", owner)) {
 			throw new PrivilegeException(sess, "Only PerunAdmin should have rights to call this method.");
 		}
 
@@ -371,7 +371,7 @@ public class UsersManagerEntry implements UsersManager {
 		getPerunBl().getUsersManagerBl().checkUserExists(sess, specificUser);
 
 		// Authorization
-		if(!AuthzResolver.authorizedInternal(sess, "unsetSpecificUser_User_SpecificUserType_policy", Collections.singletonList(specificUser))) {
+		if(!AuthzResolver.authorizedInternal(sess, "unsetSpecificUser_User_SpecificUserType_policy", specificUser)) {
 			throw new PrivilegeException(sess, "Only PerunAdmin should have rights to call this method.");
 		}
 
@@ -384,7 +384,7 @@ public class UsersManagerEntry implements UsersManager {
 		Utils.checkPerunSession(sess);
 
 		// Authorization
-		if(!AuthzResolver.authorizedInternal(sess, "deleteUser_User_policy", Collections.singletonList(user))) {
+		if(!AuthzResolver.authorizedInternal(sess, "deleteUser_User_policy", user)) {
 			throw new PrivilegeException(sess, "deleteUser");
 		}
 
@@ -398,7 +398,7 @@ public class UsersManagerEntry implements UsersManager {
 		Utils.checkPerunSession(sess);
 
 		// Authorization
-		if(!AuthzResolver.authorizedInternal(sess, "deleteUser_User_boolean_policy", Collections.singletonList(user))) {
+		if(!AuthzResolver.authorizedInternal(sess, "deleteUser_User_boolean_policy", user)) {
 			throw new PrivilegeException(sess, "deleteUser");
 		}
 
@@ -412,7 +412,7 @@ public class UsersManagerEntry implements UsersManager {
 		Utils.checkPerunSession(sess);
 
 		// Authorization
-		if(!AuthzResolver.authorizedInternal(sess, "updateUser_User_policy", Collections.singletonList(user))) {
+		if(!AuthzResolver.authorizedInternal(sess, "updateUser_User_policy", user)) {
 			throw new PrivilegeException(sess, "updateUser");
 		}
 
@@ -430,7 +430,7 @@ public class UsersManagerEntry implements UsersManager {
 		Utils.checkMaxLength("TitleAfter", user.getTitleAfter(), 40);
 
 		// Authorization
-		if(!AuthzResolver.authorizedInternal(sess, "updateNameTitles_User_policy", Collections.singletonList(user))) {
+		if(!AuthzResolver.authorizedInternal(sess, "updateNameTitles_User_policy", user)) {
 			throw new PrivilegeException(sess, "updateNameTitles");
 		}
 
@@ -444,7 +444,7 @@ public class UsersManagerEntry implements UsersManager {
 		Utils.checkPerunSession(sess);
 
 		// Authorization
-		if(!AuthzResolver.authorizedInternal(sess, "updateUserExtSource_UserExtSource_policy", Collections.singletonList(userExtSource))) {
+		if(!AuthzResolver.authorizedInternal(sess, "updateUserExtSource_UserExtSource_policy", userExtSource)) {
 			throw new PrivilegeException(sess, "updateUserExtSource");
 		}
 
@@ -465,7 +465,7 @@ public class UsersManagerEntry implements UsersManager {
 		Utils.checkPerunSession(sess);
 
 		// Authorization
-		if(!AuthzResolver.authorizedInternal(sess, "getUserExtSources_User_policy", Collections.singletonList(user))) {
+		if(!AuthzResolver.authorizedInternal(sess, "getUserExtSources_User_policy", user)) {
 			throw new PrivilegeException(sess, "getUserExtSources");
 		}
 
@@ -484,7 +484,7 @@ public class UsersManagerEntry implements UsersManager {
 		Utils.checkPerunSession(sess);
 
 		// Authorization
-		if(!AuthzResolver.authorizedInternal(sess, "getRichUserExtSources_User_List<String>_policy", Collections.singletonList(user))) {
+		if(!AuthzResolver.authorizedInternal(sess, "getRichUserExtSources_User_List<String>_policy", user)) {
 			throw new PrivilegeException(sess, "getRichUserExtSources");
 		}
 
@@ -606,7 +606,7 @@ public class UsersManagerEntry implements UsersManager {
 		Utils.checkPerunSession(sess);
 
 		// Authorization
-		if(!AuthzResolver.authorizedInternal(sess, "getUserExtSourceByExtLogin_ExtSource_String_policy", Collections.singletonList(source))) {
+		if(!AuthzResolver.authorizedInternal(sess, "getUserExtSourceByExtLogin_ExtSource_String_policy", source)) {
 			throw new PrivilegeException(sess, "findUserExtSourceByExtLogin");
 		}
 
@@ -621,7 +621,7 @@ public class UsersManagerEntry implements UsersManager {
 		Utils.checkPerunSession(sess);
 
 		// Authorization
-		if(!AuthzResolver.authorizedInternal(sess, "getVosWhereUserIsAdmin_User_policy", Collections.singletonList(user))) {
+		if(!AuthzResolver.authorizedInternal(sess, "getVosWhereUserIsAdmin_User_policy", user)) {
 			throw new PrivilegeException(sess, "getVosWhereUserIsAdmin");
 		}
 
@@ -635,7 +635,7 @@ public class UsersManagerEntry implements UsersManager {
 		Utils.checkPerunSession(sess);
 
 		// Authorization
-		if(!AuthzResolver.authorizedInternal(sess, "getGroupsWhereUserIsAdmin_User_policy", Collections.singletonList(user))) {
+		if(!AuthzResolver.authorizedInternal(sess, "getGroupsWhereUserIsAdmin_User_policy", user)) {
 			throw new PrivilegeException(sess, "getGroupsWhereUserIsAdmin");
 		}
 
@@ -663,7 +663,7 @@ public class UsersManagerEntry implements UsersManager {
 		Utils.checkPerunSession(sess);
 
 		// Authorization
-		if(!AuthzResolver.authorizedInternal(sess, "getVosWhereUserIsMember_User_policy", Collections.singletonList(user))) {
+		if(!AuthzResolver.authorizedInternal(sess, "getVosWhereUserIsMember_User_policy", user)) {
 			throw new PrivilegeException(sess, "getVosWhereUserIsMember");
 		}
 
@@ -690,7 +690,7 @@ public class UsersManagerEntry implements UsersManager {
 	public List<Resource> getAllowedResources(PerunSession sess, User user) throws UserNotExistsException, PrivilegeException {
 		Utils.checkPerunSession(sess);
 
-		if(!AuthzResolver.authorizedInternal(sess, "getAllowedResources_User_policy", Collections.singletonList(user))) {
+		if(!AuthzResolver.authorizedInternal(sess, "getAllowedResources_User_policy", user)) {
 			throw new PrivilegeException(sess, "getAllowedResources");
 		}
 
@@ -703,7 +703,7 @@ public class UsersManagerEntry implements UsersManager {
 	public List<RichResource> getAssignedRichResources(PerunSession sess, User user) throws UserNotExistsException, PrivilegeException {
 		Utils.checkPerunSession(sess);
 
-		if(!AuthzResolver.authorizedInternal(sess, "getAssignedRichResources_User_policy", Collections.singletonList(user))) {
+		if(!AuthzResolver.authorizedInternal(sess, "getAssignedRichResources_User_policy", user)) {
 			throw new PrivilegeException(sess, "getAssignedRichResources");
 		}
 
@@ -737,7 +737,7 @@ public class UsersManagerEntry implements UsersManager {
 	public List<User> getUsersWithoutSpecificVo(PerunSession sess, Vo vo, String searchString) throws VoNotExistsException, PrivilegeException {
 		Utils.checkPerunSession(sess);
 
-		if(!AuthzResolver.authorizedInternal(sess, "getUsersWithoutSpecificVo_Vo_String_policy", Collections.singletonList(vo))) {
+		if(!AuthzResolver.authorizedInternal(sess, "getUsersWithoutSpecificVo_Vo_String_policy", vo)) {
 			throw new PrivilegeException(sess, "findUsersByName");
 		}
 
@@ -860,7 +860,7 @@ public class UsersManagerEntry implements UsersManager {
 		getUsersManagerBl().checkUserExists(sess, user);
 
 		// Authorization
-		if(!AuthzResolver.authorizedInternal(sess, "isUserPerunAdmin_User_policy", Collections.singletonList(user))) {
+		if(!AuthzResolver.authorizedInternal(sess, "isUserPerunAdmin_User_policy", user)) {
 			throw new PrivilegeException(sess, "isUserPerunAdmin");
 		}
 
@@ -875,7 +875,7 @@ public class UsersManagerEntry implements UsersManager {
 		getUsersManagerBl().checkUserExists(sess, user);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "changePassword_User_String_String_String_boolean_policy", Collections.singletonList(user))) {
+		if (!AuthzResolver.authorizedInternal(sess, "changePassword_User_String_String_String_boolean_policy", user)) {
 			throw new PrivilegeException(sess, "changePassword");
 		}
 
@@ -911,7 +911,7 @@ public class UsersManagerEntry implements UsersManager {
 		User user = users.get(0);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "changePassword_String_String_String_String_boolean_policy", Collections.singletonList(user))) {
+		if (!AuthzResolver.authorizedInternal(sess, "changePassword_String_String_String_String_boolean_policy", user)) {
 			throw new PrivilegeException(sess, "changePassword");
 		}
 
@@ -923,8 +923,8 @@ public class UsersManagerEntry implements UsersManager {
 		Utils.checkPerunSession(sess);
 
 		// Authorization
-		if(!AuthzResolver.authorizedInternal(sess, "reserveRandomPassword_User_String_policy", Collections.singletonList(user))
-			&& (!(AuthzResolver.authorizedInternal(sess, "service_user-reserveRandomPassword_User_String_policy", Collections.singletonList(user)) && user.isServiceUser()))) {
+		if(!AuthzResolver.authorizedInternal(sess, "reserveRandomPassword_User_String_policy", user)
+			&& (!(AuthzResolver.authorizedInternal(sess, "service_user-reserveRandomPassword_User_String_policy", user)) && user.isServiceUser())) {
 			throw new PrivilegeException(sess, "reserveRandomPassword");
 		}
 
@@ -957,8 +957,8 @@ public class UsersManagerEntry implements UsersManager {
 		Utils.checkPerunSession(sess);
 
 		// Authorization
-		if(!AuthzResolver.authorizedInternal(sess, "reservePassword_User_String_String_policy", Collections.singletonList(user))
-			&& (!(AuthzResolver.authorizedInternal(sess, "service_user-reservePassword_User_String_String_policy", Collections.singletonList(user)) && user.isServiceUser()))) {
+		if(!AuthzResolver.authorizedInternal(sess, "reservePassword_User_String_String_policy", user)
+			&& (!(AuthzResolver.authorizedInternal(sess, "service_user-reservePassword_User_String_String_policy", user)) && user.isServiceUser())) {
 			throw new PrivilegeException(sess, "reservePassword");
 		}
 
@@ -991,8 +991,8 @@ public class UsersManagerEntry implements UsersManager {
 		Utils.checkPerunSession(sess);
 
 		// Authorization
-		if(!AuthzResolver.authorizedInternal(sess, "validatePasswordAndSetExtSources_User_String_String_policy", Collections.singletonList(user))
-			&& (!(AuthzResolver.authorizedInternal(sess, "service_user-validatePasswordAndSetExtSources_User_String_String_policy", Collections.singletonList(user)) && user.isServiceUser()))) {
+		if(!AuthzResolver.authorizedInternal(sess, "validatePasswordAndSetExtSources_User_String_String_policy", user)
+			&& (!(AuthzResolver.authorizedInternal(sess, "service_user-validatePasswordAndSetExtSources_User_String_String_policy", user)) && user.isServiceUser())) {
 			throw new PrivilegeException(sess, "validatePasswordAndSetExtSources");
 		}
 
@@ -1011,7 +1011,7 @@ public class UsersManagerEntry implements UsersManager {
 		Utils.checkPerunSession(sess);
 
 		// Authorization
-		if(!AuthzResolver.authorizedInternal(sess, "validatePassword_User_String_policy", Collections.singletonList(user))) {
+		if(!AuthzResolver.authorizedInternal(sess, "validatePassword_User_String_policy", user)) {
 			throw new PrivilegeException(sess, "validatePassword");
 		}
 
@@ -1056,7 +1056,7 @@ public class UsersManagerEntry implements UsersManager {
 		Utils.notNull(password, "password");
 
 		// Authorization
-		if(!AuthzResolver.authorizedInternal(sess, "createAlternativePassword_User_String_String_String_policy", Collections.singletonList(user))) {
+		if(!AuthzResolver.authorizedInternal(sess, "createAlternativePassword_User_String_String_String_policy", user)) {
 			throw new PrivilegeException(sess, "createAlternativePassword");
 		}
 
@@ -1072,7 +1072,7 @@ public class UsersManagerEntry implements UsersManager {
 		Utils.notNull(passwordId, "passwordId");
 
 		// Authorization
-		if(!AuthzResolver.authorizedInternal(sess, "deleteAlternativePassword_User_String_String_policy", Collections.singletonList(user))) {
+		if(!AuthzResolver.authorizedInternal(sess, "deleteAlternativePassword_User_String_String_policy", user)) {
 			throw new PrivilegeException(sess, "deleteAlternativePassword");
 		}
 
@@ -1168,7 +1168,7 @@ public class UsersManagerEntry implements UsersManager {
 		Utils.checkPerunSession(sess);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "findRichUsersWithoutSpecificVoWithAttributes_Vo_String_List<String>_policy", Collections.singletonList(vo))) {
+		if (!AuthzResolver.authorizedInternal(sess, "findRichUsersWithoutSpecificVoWithAttributes_Vo_String_List<String>_policy", vo)) {
 			throw new PrivilegeException(sess, "findRichUsersWithoutSpecificVoWithAttributes");
 		}
 
@@ -1195,7 +1195,7 @@ public class UsersManagerEntry implements UsersManager {
 		getPerunBl().getUsersManagerBl().checkUserExists(sess, user);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "setLogin_User_String_String_policy", Collections.singletonList(user)) && !user.isSpecificUser()) {
+		if (!AuthzResolver.authorizedInternal(sess, "setLogin_User_String_String_policy", user) && !user.isSpecificUser()) {
 			throw new PrivilegeException(sess, "setLogin");
 		}
 
@@ -1216,7 +1216,7 @@ public class UsersManagerEntry implements UsersManager {
 		getPerunBl().getUsersManagerBl().checkUserExists(sess, user);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "requestPreferredEmailChange_String_User_String_String_policy", Collections.singletonList(user))) {
+		if (!AuthzResolver.authorizedInternal(sess, "requestPreferredEmailChange_String_User_String_String_policy", user)) {
 			throw new PrivilegeException(sess, "requestPreferredEmailChange");
 		}
 
@@ -1231,7 +1231,7 @@ public class UsersManagerEntry implements UsersManager {
 		getPerunBl().getUsersManagerBl().checkUserExists(sess, user);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "validatePreferredEmailChange_User_String_String_policy", Collections.singletonList(user))) {
+		if (!AuthzResolver.authorizedInternal(sess, "validatePreferredEmailChange_User_String_String_policy", user)) {
 			throw new PrivilegeException(sess, "validatePreferredEmailChange");
 		}
 
@@ -1252,7 +1252,7 @@ public class UsersManagerEntry implements UsersManager {
 		getPerunBl().getUsersManagerBl().checkUserExists(sess, user);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getPendingPreferredEmailChanges_User_policy", Collections.singletonList(user))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getPendingPreferredEmailChanges_User_policy", user)) {
 			throw new PrivilegeException(sess, "getPendingPreferredEmailChanges");
 		}
 
@@ -1288,7 +1288,7 @@ public class UsersManagerEntry implements UsersManager {
 		getPerunBl().getUsersManagerBl().checkUserExtSourceExists(sess, userExtSource);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "updateUserExtSourceLastAccess_UserExtSource_policy", Collections.singletonList(userExtSource))) {
+		if (!AuthzResolver.authorizedInternal(sess, "updateUserExtSourceLastAccess_UserExtSource_policy", userExtSource)) {
 			throw new PrivilegeException(sess, "updateUserExtSourceLastAccess");
 		}
 
@@ -1313,7 +1313,7 @@ public class UsersManagerEntry implements UsersManager {
 		Utils.checkPerunSession(sess);
 		Utils.notNull(member, "member");
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getSponsors_Member_List<String>_policy", Collections.singletonList(member))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getSponsors_Member_List<String>_policy", member)) {
 			throw new PrivilegeException(sess, "getSponsors can be called only by REGISTRAR");
 		}
 		List<User> sponsors = usersManagerBl.getSponsors(sess, member);
@@ -1331,7 +1331,7 @@ public class UsersManagerEntry implements UsersManager {
 		Utils.checkPerunSession(sess);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "changePasswordRandom_User_String_policy", Collections.singletonList(user))) {
+		if (!AuthzResolver.authorizedInternal(sess, "changePasswordRandom_User_String_policy", user)) {
 			throw new PrivilegeException("changePasswordRandom");
 		}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/VosManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/VosManagerEntry.java
@@ -71,7 +71,7 @@ public class VosManagerEntry implements VosManager {
 			List<Vo> tempVos = vosManagerBl.getVos(sess);
 			tempVos.removeIf(vo -> {
 				try {
-					return !AuthzResolver.authorizedInternal(sess, "filter-getVos_policy", Collections.singletonList(vo));
+					return !AuthzResolver.authorizedInternal(sess, "filter-getVos_policy", vo);
 				} catch (InternalErrorException e) {
 					// if we can't determine authorization prevent returning it
 					return true;
@@ -148,7 +148,7 @@ public class VosManagerEntry implements VosManager {
 		vosManagerBl.checkVoExists(sess, vo);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "updateVo_Vo_policy", Collections.singletonList(vo))) {
+		if (!AuthzResolver.authorizedInternal(sess, "updateVo_Vo_policy", vo)) {
 			throw new PrivilegeException(sess, "updateVo");
 		}
 
@@ -170,7 +170,7 @@ public class VosManagerEntry implements VosManager {
 		Vo vo = vosManagerBl.getVoByShortName(sess, shortName);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getVoByShortName_String_policy", Collections.singletonList(vo))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getVoByShortName_String_policy", vo)) {
 			throw new PrivilegeException(sess, "getVoByShortName");
 		}
 
@@ -183,7 +183,7 @@ public class VosManagerEntry implements VosManager {
 		Vo vo = vosManagerBl.getVoById(sess, id);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getVoById_int_policy", Collections.singletonList(vo))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getVoById_int_policy", vo)) {
 			throw new PrivilegeException(sess, "getVoById");
 				}
 
@@ -197,7 +197,7 @@ public class VosManagerEntry implements VosManager {
 		vosManagerBl.checkVoExists(sess, vo);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "findCandidates_Vo_String_int_policy", Collections.singletonList(vo))) {
+		if (!AuthzResolver.authorizedInternal(sess, "findCandidates_Vo_String_int_policy", vo)) {
 			throw new PrivilegeException(sess, "findCandidates");
 				}
 
@@ -211,7 +211,7 @@ public class VosManagerEntry implements VosManager {
 		vosManagerBl.checkVoExists(sess, vo);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "findCandidates_Vo_String_policy", Collections.singletonList(vo))) {
+		if (!AuthzResolver.authorizedInternal(sess, "findCandidates_Vo_String_policy", vo)) {
 			throw new PrivilegeException(sess, "findCandidates");
 		}
 
@@ -225,7 +225,7 @@ public class VosManagerEntry implements VosManager {
 		getPerunBl().getGroupsManagerBl().checkGroupExists(sess, group);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "findCandidates_Group_String_policy", Collections.singletonList(group))) {
+		if (!AuthzResolver.authorizedInternal(sess, "findCandidates_Group_String_policy", group)) {
 			throw new PrivilegeException(sess, "findCandidates");
 		}
 
@@ -242,7 +242,7 @@ public class VosManagerEntry implements VosManager {
 		getPerunBl().getVosManagerBl().checkVoExists(sess, vo);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getCompleteCandidates_Vo_List<String>_String_policy", Collections.singletonList(vo))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getCompleteCandidates_Vo_List<String>_String_policy", vo)) {
 			throw new PrivilegeException(sess, "getCompleteCandidates");
 		}
 
@@ -263,12 +263,12 @@ public class VosManagerEntry implements VosManager {
 		Vo vo = getPerunBl().getGroupsManagerBl().getVo(sess, group);
 
 		// Authorization
-		if (AuthzResolver.authorizedInternal(sess, "getCompleteCandidates_Group_List<String>_String_policy", Collections.singletonList(vo))) {
+		if (AuthzResolver.authorizedInternal(sess, "getCompleteCandidates_Group_List<String>_String_policy", vo)) {
 			extSources = getPerunBl().getExtSourcesManagerBl().getVoExtSources(sess, vo);
 
 			// null the vo so users are searched in whole perun
 			vo = null;
-		} else if (AuthzResolver.authorizedInternal(sess, "groupExtSource-getCompleteCandidates_Group_List<String>_String_policy", Collections.singletonList(group))) {
+		} else if (AuthzResolver.authorizedInternal(sess, "groupExtSource-getCompleteCandidates_Group_List<String>_String_policy", group)) {
 			extSources = getPerunBl().getExtSourcesManagerBl().getGroupExtSources(sess, group);
 		} else {
 			throw new PrivilegeException(sess, "getCompleteCandidates");
@@ -284,7 +284,7 @@ public class VosManagerEntry implements VosManager {
 		perunBl.getUsersManagerBl().checkUserExists(sess, user);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "addAdmin_Vo_User_policy", Collections.singletonList(vo))) {
+		if (!AuthzResolver.authorizedInternal(sess, "addAdmin_Vo_User_policy", vo)) {
 			throw new PrivilegeException(sess, "addAdmin");
 		}
 
@@ -299,7 +299,7 @@ public class VosManagerEntry implements VosManager {
 		perunBl.getGroupsManagerBl().checkGroupExists(sess, group);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "addAdmin_Vo_Group_policy", Collections.singletonList(vo))) {
+		if (!AuthzResolver.authorizedInternal(sess, "addAdmin_Vo_Group_policy", vo)) {
 			throw new PrivilegeException(sess, "addAdmin");
 		}
 
@@ -313,7 +313,7 @@ public class VosManagerEntry implements VosManager {
 		perunBl.getUsersManagerBl().checkUserExists(sess, user);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "removeAdmin_Vo_User_policy", Collections.singletonList(vo))) {
+		if (!AuthzResolver.authorizedInternal(sess, "removeAdmin_Vo_User_policy", vo)) {
 			throw new PrivilegeException(sess, "deleteAdmin");
 		}
 
@@ -327,7 +327,7 @@ public class VosManagerEntry implements VosManager {
 		perunBl.getGroupsManagerBl().checkGroupExists(sess, group);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "removeAdmin_Vo_Group_policy", Collections.singletonList(vo))) {
+		if (!AuthzResolver.authorizedInternal(sess, "removeAdmin_Vo_Group_policy", vo)) {
 			throw new PrivilegeException(sess, "deleteAdmin");
 		}
 
@@ -352,7 +352,7 @@ public class VosManagerEntry implements VosManager {
 		}
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(perunSession, "getAdmins_Vo_String_boolean_policy", Collections.singletonList(vo))) {
+		if (!AuthzResolver.authorizedInternal(perunSession, "getAdmins_Vo_String_boolean_policy", vo)) {
 			throw new PrivilegeException(perunSession, "getAdmins");
 		}
 
@@ -377,7 +377,7 @@ public class VosManagerEntry implements VosManager {
 		}
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(perunSession, "getRichAdmins_Vo_String_List<String>_boolean_boolean_policy", Collections.singletonList(vo))) {
+		if (!AuthzResolver.authorizedInternal(perunSession, "getRichAdmins_Vo_String_List<String>_boolean_boolean_policy", vo)) {
 			throw new PrivilegeException(perunSession, "getDirectRichAdminsWithSpecificAttributes");
 		}
 
@@ -402,7 +402,7 @@ public class VosManagerEntry implements VosManager {
 		}
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(perunSession, "getAdminGroups_Vo_String_policy", Collections.singletonList(vo))) {
+		if (!AuthzResolver.authorizedInternal(perunSession, "getAdminGroups_Vo_String_policy", vo)) {
 			throw new PrivilegeException(perunSession, "getAdminGroups");
 				}
 
@@ -539,7 +539,7 @@ public class VosManagerEntry implements VosManager {
 		perunBl.getUsersManagerBl().checkUserExists(sess, user);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "addSponsorRole_Vo_User_policy", Collections.singletonList(vo))) {
+		if (!AuthzResolver.authorizedInternal(sess, "addSponsorRole_Vo_User_policy", vo)) {
 			throw new PrivilegeException(sess, "addSponsorRole");
 		}
 		log.debug("addSponsorRole({},{})",vo.getShortName(),user.getId());
@@ -556,7 +556,7 @@ public class VosManagerEntry implements VosManager {
 		perunBl.getGroupsManagerBl().checkGroupExists(sess, group);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "addSponsorRole_Vo_Group_policy", Collections.singletonList(vo))) {
+		if (!AuthzResolver.authorizedInternal(sess, "addSponsorRole_Vo_Group_policy", vo)) {
 			throw new PrivilegeException(sess, "addSponsorRole");
 		}
 		AuthzResolverBlImpl.setRole(sess, group, vo, Role.SPONSOR);
@@ -572,7 +572,7 @@ public class VosManagerEntry implements VosManager {
 		perunBl.getUsersManagerBl().checkUserExists(sess, user);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "removeSponsorRole_Vo_User_policy", Collections.singletonList(vo))) {
+		if (!AuthzResolver.authorizedInternal(sess, "removeSponsorRole_Vo_User_policy", vo)) {
 			throw new PrivilegeException(sess, "removeSponsorRole");
 		}
 		AuthzResolverBlImpl.unsetRole(sess, user, vo, Role.SPONSOR);
@@ -588,7 +588,7 @@ public class VosManagerEntry implements VosManager {
 		perunBl.getGroupsManagerBl().checkGroupExists(sess, group);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "removeSponsorRole_Vo_Group_policy", Collections.singletonList(vo))) {
+		if (!AuthzResolver.authorizedInternal(sess, "removeSponsorRole_Vo_Group_policy", vo)) {
 			throw new PrivilegeException(sess, "removeSponsorRole");
 		}
 		AuthzResolverBlImpl.unsetRole(sess, group, vo, Role.SPONSOR);


### PR DESCRIPTION
* The previous version of this method accepted only a list of PerunBeans.
Because of that one had to convert even a single element to a list and
this forced a ton of duplicated code accross all managers.
* Created a new version that takes a variable number of PerunBeans as
parameters.
* For now, I have replaced the usages only where a single PerunBean was
passed to this method.