### PR TITLE
LifeScience persistent shadow attribute

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace_lifescienceid_persistent_shadow.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace_lifescienceid_persistent_shadow.java
@@ -1,6 +1,6 @@
 package cz.metacentrum.perun.core.impl.modules.attributes;
 
-import cz.metacentrum.perun.core.implApi.modules.attributes.UserPersistentShadowAttribute;
+import cz.metacentrum.perun.core.implApi.modules.attributes.UserPersistentShadowAttributeWithConfig;
 
 /**
  * Class for checking logins uniqueness in the namespace and filling lifescienceid-persistent id.
@@ -9,40 +9,41 @@ import cz.metacentrum.perun.core.implApi.modules.attributes.UserPersistentShadow
  * @author Pavel Zlámal <zlamal@cesnet.cz>
  */
 public class urn_perun_user_attribute_def_def_login_namespace_lifescienceid_persistent_shadow
-		extends UserPersistentShadowAttribute {
+		extends UserPersistentShadowAttributeWithConfig {
 
-	private final static String extSourceNamelifescienceid = "https://proxy.aai.lifescience-ri.eu/proxy";
-	private final static String domainNamelifescienceid = "lifescience-ri.eu";
-	private final static String attrNamelifescienceid = "login-namespace:lifescienceid-persistent-shadow";
+	private final static String attrNameLifeScience = "login-namespace:lifescienceid-persistent-shadow";
+
+	private final static String CONFIG_EXT_SOURCE_NAME_LIFESCIENCE = "extSourceNameLifeScience";
+	private final static String CONFIG_DOMAIN_NAME_LIFESCIENCE = "domainNameLifeScience";
+
+	@Override
+	public String getExtSourceConfigName() {
+		return CONFIG_EXT_SOURCE_NAME_LIFESCIENCE;
+	}
+
+	@Override
+	public String getDomainConfigName() {
+		return CONFIG_DOMAIN_NAME_LIFESCIENCE;
+	}
 
 	@Override
 	public String getFriendlyName() {
-		return attrNamelifescienceid;
-	}
-
-	@Override
-	public String getExtSourceName() {
-		return extSourceNamelifescienceid;
-	}
-
-	@Override
-	public String getDomainName() {
-		return domainNamelifescienceid;
+		return attrNameLifeScience;
 	}
 
 	@Override
 	public String getDescription() {
 		return "Login to Lifescienceid. Do not use it directly! " +
-			   "Use \"user:virt:login-namespace:lifescienceid-persistent\" attribute instead.";
-	}
-
-	@Override
-	public String getDisplayName() {
-		return "Lifescienceid login";
+			"Use \"user:virt:login-namespace:lifescienceid-persistent\" attribute instead.";
 	}
 
 	@Override
 	public String getFriendlyNameParameter() {
 		return "lifescienceid-persistent-shadow";
+	}
+
+	@Override
+	public String getDisplayName() {
+		return "Lifescienceid login";
 	}
 }


### PR DESCRIPTION
- This attribute was made configurable because it is used in two
  instances with different values.