### PR TITLE
Added start of last synchronization

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/GroupsManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/GroupsManager.java
@@ -83,6 +83,8 @@ public interface GroupsManager {
 	String GROUP_STRUCTURE_SYNCHRO_TIMES_ATTRNAME = AttributesManager.NS_GROUP_ATTR_DEF + ":groupStructureSynchronizationTimes";
 	// Defines timestamp with start of last successful synchronization
 	String GROUP_START_OF_LAST_SUCCESSFUL_SYNC_ATTRNAME = AttributesManager.NS_GROUP_ATTR_DEF + ":startOfLastSuccessfulSynchronization";
+	// Defines timestamp with start of last synchronization
+	String GROUP_START_OF_LAST_SYNC_ATTRNAME = AttributesManager.NS_GROUP_ATTR_DEF + ":startOfLastSynchronization";
 
 	String GROUP_SHORT_NAME_REGEXP = "^[-a-zA-Z.0-9_ ]+$";
 	String GROUP_FULL_NAME_REGEXP = "^[-a-zA-Z.0-9_ ]+([:][-a-zA-Z.0-9_ ]+)*";

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -7357,6 +7357,19 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		rights.add(new AttributeRights(-1, Role.GROUPADMIN, Collections.singletonList(ActionType.READ)));
 		attributes.put(attr, rights);
 
+		//urn:perun:group:attribute-def:def:startOfLastSynchronization
+		attr = new AttributeDefinition();
+		attr.setNamespace(AttributesManager.NS_GROUP_ATTR_DEF);
+		attr.setType(String.class.getName());
+		attr.setFriendlyName("startOfLastSynchronization");
+		attr.setDisplayName("Start of last synchronization");
+		attr.setDescription("If group started synchronization, start time of last synchronization will be set.");
+		//set attribute rights (with dummy id of attribute - not known yet)
+		rights = new ArrayList<>();
+		rights.add(new AttributeRights(-1, Role.VOADMIN, Collections.singletonList(ActionType.READ)));
+		rights.add(new AttributeRights(-1, Role.GROUPADMIN, Collections.singletonList(ActionType.READ)));
+		attributes.put(attr, rights);
+
 		//urn:perun:group:attribute-def:def:groupStructureSynchronizationEnabled
 		attr = new AttributeDefinition();
 		attr.setNamespace(AttributesManager.NS_GROUP_ATTR_DEF);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
@@ -2056,6 +2056,15 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 					// Set the start time, so we can check the timeout of the thread
 					startTime = System.currentTimeMillis();
 
+					try {
+						// Create attribute with start of last synchronization timestamp
+						Attribute startOfSynchronization = new Attribute(((PerunBl) sess.getPerun()).getAttributesManagerBl().getAttributeDefinition(sess, GroupsManager.GROUP_START_OF_LAST_SYNC_ATTRNAME));
+						startOfSynchronization.setValue(BeansUtils.getDateFormatter().format(new Date(startTime)));
+						((PerunBl) sess.getPerun()).getAttributesManagerBl().setAttribute(sess, group, startOfSynchronization);
+					} catch (AttributeNotExistsException ex) {
+						log.error("Can't save startOfLastSynchronization, because there is missing attribute with name {}", GroupsManager.GROUP_START_OF_LAST_SYNC_ATTRNAME);
+					}
+
 					log.debug("Synchronization thread started synchronization for group {}.", group);
 
 					//synchronize Group and get information about skipped Members


### PR DESCRIPTION
- added new attribute to store start of last synchronization (even if the sync was unsuccessful)
- attribute is set and filled at the start of group synchronization