### PR TITLE
VOOBSERVER cannot make VOOBSERVER

### DIFF
--- a/perun-base/src/main/resources/perun-roles.yml
+++ b/perun-base/src/main/resources/perun-roles.yml
@@ -5200,7 +5200,6 @@ perun_roles_management:
     privileged_roles:
       - PERUNADMIN:
       - VOADMIN: Vo
-      - VOOBSERVER: Vo
 
   TOPGROUPCREATOR:
     assign_to_objects:


### PR DESCRIPTION
- Fix VOOBSERVER rights for managing roles. Previously, this role could
  delegate its rights further which does not make sense as the purpose
  of it is to observe. Therefore this privilege was removed from the
  role.