### PR TITLE
Core - new method to gen data

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/GenDataNode.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/GenDataNode.java
@@ -1,0 +1,82 @@
+package cz.metacentrum.perun.core.api;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * This class represents a node in the hierarchy of hashed data for provisioning.
+ *
+ * @author Vojtech Sassmann <vojtech.sassmann@gmail.com>
+ */
+public class GenDataNode {
+
+	private final List<String> hashes;
+	private final List<GenDataNode> children;
+	private final List<GenMemberDataNode> members;
+
+	private GenDataNode(List<String> hashes, List<GenDataNode> children, List<GenMemberDataNode> members) {
+		this.hashes = hashes;
+		this.children = children;
+		this.members = members;
+	}
+
+	@JsonProperty("h")
+	public List<String> getHashes() {
+		return Collections.unmodifiableList(hashes);
+	}
+
+	@JsonProperty("c")
+	public List<GenDataNode> getChildren() {
+		return Collections.unmodifiableList(children);
+	}
+
+	@JsonProperty("m")
+	public List<GenMemberDataNode> getMembers() {
+		return Collections.unmodifiableList(members);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		GenDataNode that = (GenDataNode) o;
+		return Objects.equals(hashes, that.hashes) &&
+				Objects.equals(children, that.children) &&
+				Objects.equals(members, that.members);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(hashes, children, members);
+	}
+
+	public static class Builder {
+
+		private List<String> hashes = new ArrayList<>();
+		private List<GenDataNode> children = new ArrayList<>();
+		private List<GenMemberDataNode> members = new ArrayList<>();
+
+		public Builder hashes(List<String> hashes) {
+			this.hashes = hashes;
+			return this;
+		}
+
+		public Builder children(List<GenDataNode> children) {
+			this.children = children;
+			return this;
+		}
+
+		public Builder members(List<GenMemberDataNode> members) {
+			this.members = members;
+			return this;
+		}
+
+		public GenDataNode build() {
+			return new GenDataNode(hashes, children, members);
+		}
+	}
+}

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/GenMemberDataNode.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/GenMemberDataNode.java
@@ -1,0 +1,27 @@
+package cz.metacentrum.perun.core.api;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * @author Vojtech Sassmann <vojtech.sassmann@gmail.com>
+ */
+public class GenMemberDataNode {
+
+	private final List<String> hashes;
+
+	public GenMemberDataNode(List<String> hashes) {
+		this.hashes = hashes;
+	}
+
+	public void addHashes(Collection<String> hashes) {
+		this.hashes.addAll(hashes);
+	}
+
+	public List<String> getH() {
+		return Collections.unmodifiableList(hashes);
+	}
+
+}

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/HashedGenData.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/HashedGenData.java
@@ -1,0 +1,50 @@
+package cz.metacentrum.perun.core.api;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Class representing provisioning data structure with hashes.
+ *
+ * @author Vojtech Sassmann <vojtech.sassmann@gmail.com>
+ */
+public class HashedGenData {
+	private final Map<String, Map<String, Object>> attributes;
+	private final GenDataNode hierarchy;
+
+	public HashedGenData(Map<String, Map<String, Object>> attributes, GenDataNode hierarchy) {
+		this.attributes = attributes;
+		this.hierarchy = hierarchy;
+	}
+
+	public Map<String, Map<String, Object>> getAttributes() {
+		return attributes;
+	}
+
+	public GenDataNode getHierarchy() {
+		return hierarchy;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		HashedGenData that = (HashedGenData) o;
+		return Objects.equals(getAttributes(), that.getAttributes()) &&
+				Objects.equals(getHierarchy(), that.getHierarchy());
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(getAttributes(), getHierarchy());
+	}
+
+	@Override
+	public String toString() {
+		return "HashedGenData[" +
+				"attributes=" + attributes +
+				", hierarchy=" + hierarchy +
+				']';
+	}
+}

--- a/perun-base/src/main/resources/perun-roles.yml
+++ b/perun-base/src/main/resources/perun-roles.yml
@@ -3372,6 +3372,22 @@ perun_policies:
     include_policies:
       - default_policy
 
+  getHashedHierarchicalData_Service_Facility_boolean_policy:
+    policy_roles:
+      - FACILITYADMIN: Facility
+      - ENGINE:
+      - PERUNOBSERVER:
+    include_policies:
+      - default_policy
+
+  getHashedDataWithGroups_Service_Facility_boolean_policy:
+    policy_roles:
+      - FACILITYADMIN: Facility
+      - ENGINE:
+      - PERUNOBSERVER:
+    include_policies:
+      - default_policy
+
   getFlatData_Service_Facility_boolean_policy:
     policy_roles:
       - FACILITYADMIN: Facility

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/ServicesManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/ServicesManager.java
@@ -376,6 +376,102 @@ public interface ServicesManager {
 	ServiceAttributes getHierarchicalData(PerunSession perunSession, Service service, Facility facility, boolean filterExpiredMembers) throws FacilityNotExistsException, ServiceNotExistsException, PrivilegeException;
 
 	/**
+	 * Generates hashed hierarchical data structure for given service and facility.
+	 *
+	 * attributes: {...hashes...}
+	 * hierarchy: {
+	 *    ** facility **
+	 *    hashes: [...hashes...]
+	 *    members: []
+	 *    children: [
+	 *      {
+	 *        ** resource1 **
+	 *        hashes: [...hashes...]
+	 *        children: []
+	 *        members: [
+	 *          {
+	 *            ** member 1 **
+	 *            hashes: [...hashes...]
+	 *          },
+	 *          {
+	 *            ** member 2 **
+	 *            ...
+	 *          }
+	 *        ]
+	 *      },
+	 *      {
+	 *        ** resource2 **
+	 *        ...
+	 *      }
+	 *    ]
+	 * }
+	 *
+	 * @param perunSession perun session
+	 * @param service service
+	 * @param facility facility
+	 * @param filterExpiredMembers if the generator should filter expired members
+	 * @return generated hashed data structure
+	 * @throws FacilityNotExistsException if there is no such facility
+	 * @throws ServiceNotExistsException if there is no such service
+	 * @throws PrivilegeException insufficient permissions
+	 */
+	HashedGenData getHashedHierarchicalData(PerunSession perunSession, Service service, Facility facility, boolean filterExpiredMembers) throws FacilityNotExistsException, ServiceNotExistsException, PrivilegeException;
+
+	/**
+	 * Generates hashed data with group structure for given service and facility.
+	 *
+	 *  Generates data in format:
+	 *
+	 * attributes: {...hashes...}
+	 * hierarchy: {
+	 *    ** facility **
+	 *    hashes: [...hashes...]
+	 *    members: []
+	 *    children: [
+	 *      {
+	 *        ** resource1 **
+	 *        hashes: [...hashes...]
+	 *        children: [
+	 *          {
+	 *            ** group A **
+	 *            hashes: [...hashes...]
+	 *            members: [...group members...]
+	 *            children: []
+	 *          },
+	 *          {
+	 *            ** group B **
+	 *            ...
+	 *          }
+	 *        ]
+	 *        members: [
+	 *          {
+	 *            ** member 1 **
+	 *            hashes: [...hashes...]
+	 *          },
+	 *          {
+	 *            ** member 2 **
+	 *            ...
+	 *          }
+	 *        ]
+	 *      },
+	 *      {
+	 *        ** resource2 **
+	 *        ...
+	 *      }
+	 *    ]
+	 * }
+	 * @param perunSession perun session
+	 * @param service service
+	 * @param facility facility
+	 * @param filterExpiredMembers if the generator should filter expired members
+	 * @return generated hashed data structure
+	 * @throws FacilityNotExistsException if there is no such facility
+	 * @throws ServiceNotExistsException if there is no such service
+	 * @throws PrivilegeException insufficient permissions
+	 */
+	HashedGenData getHashedDataWithGroups(PerunSession perunSession, Service service, Facility facility, boolean filterExpiredMembers) throws FacilityNotExistsException, ServiceNotExistsException, PrivilegeException;
+
+	/**
 	 * Generates the list of attributes per each user and per each resource. Resources are filtered by service.
 	 * Never return member or member-resource attribute.
 	 *

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
@@ -2410,6 +2410,18 @@ public interface AttributesManagerBl {
 	 */
 	List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Member member, Group group) throws MemberGroupMismatchException;
 
+	/**
+	 * Get member-group attributes which are required by the service, for the given members and the given group.
+	 *
+	 * @param sess session
+	 * @param service service
+	 * @param members members
+	 * @param group group
+	 * @return Member-Group attributes grouped by members
+	 * @throws MemberGroupMismatchException if some of the given members is not from the same vo as the given group
+	 */
+	Map<Member, List<Attribute>> getRequiredAttributes(PerunSession sess, Service service, List<Member> members, Group group) throws MemberGroupMismatchException;
+
 	List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Member member, Group group, boolean workWithUserAttributes) throws MemberGroupMismatchException;
 
 	/**
@@ -2487,6 +2499,16 @@ public interface AttributesManagerBl {
 	List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Resource resource, Group group) throws GroupResourceMismatchException;
 
 	List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Group group);
+
+	/**
+	 * Get group attributes which are required by the given service for given groups.
+	 *
+	 * @param sess session
+	 * @param service service for which are taken the required attributes
+	 * @param groups groups
+	 * @return attributes mapped by their groups
+	 */
+	Map<Group, List<Attribute>> getRequiredAttributesForGroups(PerunSession sess, Service service, List<Group> groups);
 
 	/**
 	 * Get host attributes which are required by service

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ServicesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ServicesManagerBl.java
@@ -4,6 +4,7 @@ import cz.metacentrum.perun.controller.model.ServiceForGUI;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.Destination;
 import cz.metacentrum.perun.core.api.Facility;
+import cz.metacentrum.perun.core.api.HashedGenData;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.RichDestination;
@@ -332,6 +333,97 @@ public interface ServicesManagerBl {
 	 * @throws InternalErrorException
 	 */
 	ServiceAttributes getHierarchicalData(PerunSession perunSession, Service service, Facility facility, boolean filterExpiredMembers);
+
+	/**
+	 * Generates hashed hierarchical data structure for given service and resource.
+	 *
+	 * attributes: {...hashes...}
+	 * hierarchy: {
+	 *    ** facility **
+	 *    hashes: [...hashes...]
+	 *    members: []
+	 *    children: [
+	 *      {
+	 *        ** resource1 **
+	 *        hashes: [...hashes...]
+	 *        children: []
+	 *        members: [
+	 *          {
+	 *            ** member 1 **
+	 *            hashes: [...hashes...]
+	 *          },
+	 *          {
+	 *            ** member 2 **
+	 *            ...
+	 *          }
+	 *        ]
+	 *      },
+	 *      {
+	 *        ** resource2 **
+	 *        ...
+	 *      }
+	 *    ]
+	 * }
+	 *
+	 * @param perunSession perun session
+	 * @param service service
+	 * @param facility facility
+	 * @param filterExpiredMembers if the generator should filter expired members
+	 * @return generated hashed data structure
+	 */
+	HashedGenData getHashedHierarchicalData(PerunSession perunSession, Service service, Facility facility, boolean filterExpiredMembers);
+
+	/**
+	 * Generates hashed data with group structure for given service and resource.
+	 *
+	 * Generates data in format:
+	 *
+	 * attributes: {...hashes...}
+	 * hierarchy: {
+	 *    ** facility **
+	 *    hashes: [...hashes...]
+	 *    members: []
+	 *    children: [
+	 *      {
+	 *        ** resource1 **
+	 *        hashes: [...hashes...]
+	 *        children: [
+	 *          {
+	 *            ** group A **
+	 *            hashes: [...hashes...]
+	 *            members: [...group members...]
+	 *            children: []
+	 *          },
+	 *          {
+	 *            ** group B **
+	 *            ...
+	 *          }
+	 *        ]
+	 *        members: [
+	 *          {
+	 *            ** member 1 **
+	 *            hashes: [...hashes...]
+	 *          },
+	 *          {
+	 *            ** member 2 **
+	 *            ...
+	 *          }
+	 *        ]
+	 *      },
+	 *      {
+	 *        ** resource2 **
+	 *        ...
+	 *      }
+	 *    ]
+	 * }
+	 *
+	 * @param perunSession perun session
+	 * @param service service
+	 * @param facility facility
+	 * @param filterExpiredMembers if the generator should filter expired members
+	 * @return generated hashed data structure
+	 */
+	HashedGenData getHashedDataWithGroups(PerunSession perunSession, Service service, Facility facility, boolean filterExpiredMembers);
 
 	/**
 	 * Generates the list of attributes per each resource associated with the facility and filtered by service. Next it generates list of attributes

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -3036,6 +3036,17 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	}
 
 	@Override
+	public Map<Member, List<Attribute>> getRequiredAttributes(PerunSession sess, Service service, List<Member> members, Group group) throws MemberGroupMismatchException {
+		for (Member member : members) {
+			checkMemberIsFromTheSameVoLikeGroup(sess, member, group);
+		}
+		if (members.isEmpty()) {
+			return new HashMap<>();
+		}
+		return getAttributesManagerImpl().getRequiredAttributes(sess, service, members, group);
+	}
+
+	@Override
 	public List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Member member, Group group, boolean workWithUserAttributes) throws MemberGroupMismatchException {
 		this.checkMemberIsFromTheSameVoLikeGroup(sess, member, group);
 		if (!workWithUserAttributes)
@@ -3113,6 +3124,11 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	@Override
 	public List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Group group) {
 		return getAttributesManagerImpl().getRequiredAttributes(sess, service, group);
+	}
+
+	@Override
+	public Map<Group, List<Attribute>> getRequiredAttributesForGroups(PerunSession sess, Service service, List<Group> groups) {
+		return getAttributesManagerImpl().getRequiredAttributesForGroups(sess, service, groups);
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ServicesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ServicesManagerBlImpl.java
@@ -29,10 +29,15 @@ import cz.metacentrum.perun.audit.events.ServicesManagerEvents.ServicesPackageCr
 import cz.metacentrum.perun.audit.events.ServicesManagerEvents.ServicesPackageDeleted;
 import cz.metacentrum.perun.audit.events.ServicesManagerEvents.ServicesPackageUpdated;
 import cz.metacentrum.perun.controller.model.ServiceForGUI;
+import cz.metacentrum.perun.core.api.HashedGenData;
 import cz.metacentrum.perun.core.api.MemberGroupStatus;
 import cz.metacentrum.perun.core.api.exceptions.MemberGroupMismatchException;
 import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
 import cz.metacentrum.perun.core.api.exceptions.ServiceAlreadyBannedException;
+import cz.metacentrum.perun.core.provisioning.GroupsHashedDataGenerator;
+import cz.metacentrum.perun.core.provisioning.HierarchicalHashedDataGenerator;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import cz.metacentrum.perun.core.provisioning.HashedDataGenerator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import cz.metacentrum.perun.core.api.Attribute;
@@ -505,6 +510,28 @@ public class ServicesManagerBlImpl implements ServicesManagerBl {
 			serviceAttributes.addChildElement(resourceServiceAttributes);
 		}
 		return serviceAttributes;
+	}
+
+	@Override
+	public HashedGenData getHashedHierarchicalData(PerunSession sess, Service service, Facility facility, boolean filterExpiredMembers) {
+		HashedDataGenerator hashedDataGenerator = new HierarchicalHashedDataGenerator.Builder()
+				.sess((PerunSessionImpl) sess)
+				.service(service)
+				.facility(facility)
+				.build();
+
+		return hashedDataGenerator.generateData();
+	}
+
+	@Override
+	public HashedGenData getHashedDataWithGroups(PerunSession sess, Service service, Facility facility, boolean filterExpiredMembers) {
+		HashedDataGenerator hashedDataGenerator = new GroupsHashedDataGenerator.Builder()
+				.sess((PerunSessionImpl) sess)
+				.service(service)
+				.facility(facility)
+				.build();
+
+		return hashedDataGenerator.generateData();
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ServicesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ServicesManagerEntry.java
@@ -5,11 +5,11 @@ import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AuthzResolver;
 import cz.metacentrum.perun.core.api.Destination;
 import cz.metacentrum.perun.core.api.Facility;
+import cz.metacentrum.perun.core.api.HashedGenData;
 import cz.metacentrum.perun.core.api.PerunBean;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.RichDestination;
-import cz.metacentrum.perun.core.api.Role;
 import cz.metacentrum.perun.core.api.Service;
 import cz.metacentrum.perun.core.api.ServiceAttributes;
 import cz.metacentrum.perun.core.api.ServicesManager;
@@ -22,7 +22,6 @@ import cz.metacentrum.perun.core.api.exceptions.DestinationAlreadyAssignedExcept
 import cz.metacentrum.perun.core.api.exceptions.DestinationAlreadyRemovedException;
 import cz.metacentrum.perun.core.api.exceptions.DestinationNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.FacilityNotExistsException;
-import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
 import cz.metacentrum.perun.core.api.exceptions.RelationExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ServiceAlreadyAssignedException;
@@ -37,15 +36,12 @@ import cz.metacentrum.perun.core.api.exceptions.VoNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.WrongPatternException;
 import cz.metacentrum.perun.core.bl.PerunBl;
 import cz.metacentrum.perun.core.bl.ServicesManagerBl;
-import cz.metacentrum.perun.core.blImpl.PerunBlImpl;
 import cz.metacentrum.perun.core.impl.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -396,6 +392,36 @@ public class ServicesManagerEntry implements ServicesManager {
 		getPerunBl().getFacilitiesManagerBl().checkFacilityExists(sess, facility);
 
 		return getServicesManagerBl().getHierarchicalData(sess, service, facility, filterExpiredMembers);
+	}
+
+	@Override
+	public HashedGenData getHashedHierarchicalData(PerunSession sess, Service service, Facility facility, boolean filterExpiredMembers) throws FacilityNotExistsException, ServiceNotExistsException, PrivilegeException {
+		Utils.checkPerunSession(sess);
+
+		getServicesManagerBl().checkServiceExists(sess, service);
+		getPerunBl().getFacilitiesManagerBl().checkFacilityExists(sess, facility);
+
+		// Authorization
+		if (!AuthzResolver.authorizedInternal(sess, "getHashedHierarchicalData_Service_Facility_boolean_policy", service, facility)) {
+			throw new PrivilegeException(sess, "getHashedHierarchicalData");
+		}
+
+		return getServicesManagerBl().getHashedHierarchicalData(sess, service, facility, filterExpiredMembers);
+	}
+
+	@Override
+	public HashedGenData getHashedDataWithGroups(PerunSession sess, Service service, Facility facility, boolean filterExpiredMembers) throws FacilityNotExistsException, ServiceNotExistsException, PrivilegeException {
+		Utils.checkPerunSession(sess);
+
+		getServicesManagerBl().checkServiceExists(sess, service);
+		getPerunBl().getFacilitiesManagerBl().checkFacilityExists(sess, facility);
+
+		// Authorization
+		if (!AuthzResolver.authorizedInternal(sess, "getHashedDataWithGroups_Service_Facility_boolean_policy", service, facility)) {
+			throw new PrivilegeException(sess, "getHashedDataWithGroups");
+		}
+
+		return getServicesManagerBl().getHashedDataWithGroups(sess, service, facility, filterExpiredMembers);
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
@@ -1313,6 +1313,19 @@ public interface AttributesManagerImplApi {
 	List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Member member, Group group);
 
 	/**
+	 * Get member-group attributes which are required by the service, for the given members and the given group.
+	 *
+	 * @param sess perun session
+	 * @param members you get attributes for this member and the group
+	 * @param group you get attributes for these groups in which member is associated
+	 * @param service attribute required by this service you'll get
+	 * @return list of attributes which are required by the service.
+	 *
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 */
+	Map<Member, List<Attribute>> getRequiredAttributes(PerunSession sess, Service service, List<Member> members, Group group);
+
+	/**
 	 * Get member-group attributes which are required by services. Services are known from the resourceToGetServicesFrom.
 	 *
 	 * @param sess perun session
@@ -1378,6 +1391,16 @@ public interface AttributesManagerImplApi {
 	List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Host host);
 
 	List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Group group);
+
+	/**
+	 * Get group attributes which are required by the given service for given groups.
+	 *
+	 * @param sess session
+	 * @param service service for which are taken the required attributes
+	 * @param groups groups
+	 * @return attributes mapped by their groups
+	 */
+	Map<Group, List<Attribute>> getRequiredAttributesForGroups(PerunSession sess, Service service, List<Group> groups);
 
 	/**
 	 * Get group attributes which are required by the given services.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/provisioning/GenDataProvider.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/provisioning/GenDataProvider.java
@@ -1,0 +1,120 @@
+package cz.metacentrum.perun.core.provisioning;
+
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.Member;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.Service;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This component is used to efficiently load required attributes.
+ *
+ * Attributes, that can be hashed, must be loaded first via load* methods.
+ * E.g.: to be able to call getResourceAttributesHashes, one must first call
+ * loadResourceSpecificAttributes.
+ *
+ * IMPORTANT: this components has a STATE! The order of load methods is important.
+ * E.g.: loadResourceSpecificAttributes will overwrite data for previously loaded resource.
+ *
+ * @author Vojtech Sassmann <vojtech.sassmann@gmail.com>
+ */
+public interface GenDataProvider {
+
+	/**
+	 * Return all hashes for facility attributes.
+	 *
+	 * @return list of hashes
+	 */
+	List<String> getFacilityAttributesHashes();
+
+	/**
+	 * Return all hashes for given resource attributes.
+	 * If addVoAttributes is true, also adds a hash for resource's vo attributes,
+	 * if they are not empty.
+	 *
+	 * @param resource resource
+	 * @param addVoAttributes if true, add also vo attributes hash, if not empty
+	 * @return list of hashes
+	 */
+	List<String> getResourceAttributesHashes(Resource resource, boolean addVoAttributes);
+
+	/**
+	 * Return all hashes relevant for given member.
+	 * Member, User, Member-Resource, User-Facility.
+	 *
+	 * @param resource resource used to get member-resource attributes hash
+	 * @param member given member
+	 * @return list of hashes
+	 */
+	List<String> getMemberAttributesHashes(Resource resource, Member member);
+
+
+	/**
+	 * Return all hashes relevant for given member.
+	 * Member, User, Member-Resource, User-Facility and Member-Group.
+	 *
+	 * @param resource resource used to get member-resource attributes hash
+	 * @param member given member
+	 * @param group group used to get member-group attributes
+	 * @return list of hashes
+	 */
+	List<String> getMemberAttributesHashes(Resource resource, Member member, Group group);
+
+	/**
+	 * Returns all hashes relevant for given group.
+	 * Group and Group-Resource attributes.
+	 *
+	 * @param resource resource used to get Group-Resource attributes.
+	 * @param group group
+	 * @return list of hashes
+	 */
+	List<String> getGroupAttributesHashes(Resource resource, Group group);
+
+	/**
+	 * Loads Facility attributes.
+	 */
+	void loadFacilityAttributes();
+
+	/**
+	 * Loads Resource and Member specific attributes.
+	 * Resouce, Member, User, User-Facility (if not already loaded).
+	 * Resource-Member (always)
+	 * Vo - if specified by loadVoAttributes
+	 *
+	 * @param resource resource
+	 * @param members members
+	 * @param loadVoAttributes specifies, if the voAttributesShould be loaded as well.
+	 */
+	void loadResourceAttributes(Resource resource, List<Member> members, boolean loadVoAttributes);
+
+	/**
+	 * Loads Group and Group-Resource attributes.
+	 * Group attributes are loaded only for groups that has not been already loaded.
+	 *
+	 * @param resource resource
+	 * @param groups groups
+	 */
+	void loadGroupsAttributes(Resource resource, List<Group> groups);
+
+	/**
+	 * Loads Member-Group attributes.
+	 *
+	 * @param group groups
+	 * @param members members
+	 */
+	void loadMemberGroupAttributes(Group group, List<Member> members);
+
+	/**
+	 * Returns map of all loaded attributes grouped by their hashes.
+	 * Returns only non-empty lists, and only lists, for which their hashes has been returned,
+	 * by some get.*attributesHashes method.
+	 *
+	 * @return map of hashes attributes
+	 */
+	Map<String, Map<String, Object>> getAllFetchedAttributes();
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/provisioning/GenDataProviderImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/provisioning/GenDataProviderImpl.java
@@ -1,0 +1,378 @@
+package cz.metacentrum.perun.core.provisioning;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Facility;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.Member;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.Service;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.Vo;
+import cz.metacentrum.perun.core.api.exceptions.GroupResourceMismatchException;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.MemberGroupMismatchException;
+import cz.metacentrum.perun.core.api.exceptions.VoNotExistsException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
+
+/**
+ * @author Vojtech Sassmann <vojtech.sassmann@gmail.com>
+ */
+public class GenDataProviderImpl implements GenDataProvider {
+
+	private final PerunSessionImpl sess;
+	private final Service service;
+	private final Facility facility;
+
+	private final Map<String, List<Attribute>> attributesByHash = new HashMap<>();
+
+	private List<Attribute> facilityAttrs;
+
+	/**
+	 * Map of Member-Resource attributes. This map is overwritten when data for new resource are loaded!!!
+	 */
+	private Map<Member, List<Attribute>> memberResourceAttrs = new HashMap<>();
+
+	/**
+	 * Map of Group-Resource attributes. This map is overwritten when data for new resource are loaded!!!
+	 */
+	private Map<Group, List<Attribute>> groupResourceAttrs = new HashMap<>();
+
+	/**
+	 * Map of Member-Group attributes. This map is overwritten when data for new group are loaded!!!
+	 */
+	private Map<Member, List<Attribute>> memberGroupAttrs = new HashMap<>();
+
+	/**
+	 * These maps are not overwritten, because they do not depend on currently loaded entities.
+	 */
+	private final Map<Member, List<Attribute>> memberAttrs = new HashMap<>();
+	private final Map<Group, List<Attribute>> groupAttrs = new HashMap<>();
+	private final Map<User, List<Attribute>> userAttrs = new HashMap<>();
+	private final Map<User, List<Attribute>> userFacilityAttrs = new HashMap<>();
+	private final Map<Resource, List<Attribute>> resourceAttrs = new HashMap<>();
+
+	/**
+	 * Vos has to contain only ids, or only vos loaded from DB. Because of the equals and hashCode
+	 * implementations. If they were mixed, it would cause data duplicity.
+	 */
+	private final Map<Vo, List<Attribute>> voAttrs = new HashMap<>();
+
+	private Group lastLoadedGroup;
+	private Resource lastLoadedResource;
+
+	private final Map<Integer, User> loadedUsersById = new HashMap<>();
+	private final Set<Member> processedMembers = new HashSet<>();
+	private final Set<Group> processedGroups = new HashSet<>();
+
+	private final Hasher hasher = new IdHasher();
+
+	public GenDataProviderImpl(PerunSessionImpl sess, Service service, Facility facility) {
+		this.sess = sess;
+		this.service = service;
+		this.facility = facility;
+	}
+
+	@Override
+	public void loadFacilityAttributes() {
+		facilityAttrs = sess.getPerunBl().getAttributesManagerBl().getRequiredAttributes(sess, service, facility);
+	}
+
+	@Override
+	public void loadGroupsAttributes(Resource resource, List<Group> groups) {
+		groupResourceAttrs = new HashMap<>();
+		lastLoadedResource = resource;
+
+		for (Group group: groups) {
+			try {
+				// FIXME - attributes could be loaded at once to get a better performance
+				groupResourceAttrs.put(group,
+						sess.getPerunBl().getAttributesManagerBl().getRequiredAttributes(sess, service, resource, group));
+			} catch (GroupResourceMismatchException e) {
+				throw new InternalErrorException(e);
+			}
+		}
+
+		List<Group> notYetProcessedGroups = new ArrayList<>(groups);
+		notYetProcessedGroups.removeAll(processedGroups);
+		processedGroups.addAll(notYetProcessedGroups);
+
+		groupAttrs.putAll(sess.getPerunBl().getAttributesManagerBl()
+				.getRequiredAttributesForGroups(sess, service, notYetProcessedGroups));
+	}
+
+	@Override
+	public void loadMemberGroupAttributes(Group group, List<Member> members) {
+		lastLoadedGroup = group;
+		memberGroupAttrs = new HashMap<>();
+		try {
+			memberGroupAttrs.putAll(
+					sess.getPerunBl().getAttributesManagerBl().getRequiredAttributes(sess, service, members, group)
+			);
+		} catch (MemberGroupMismatchException e) {
+			throw new InternalErrorException(e);
+		}
+	}
+
+	@Override
+	public void loadResourceAttributes(Resource resource, List<Member> members, boolean loadVoAttributes) {
+		lastLoadedResource = resource;
+
+		if (!resourceAttrs.containsKey(resource)) {
+			resourceAttrs.put(resource,
+					sess.getPerunBl().getAttributesManagerBl().getRequiredAttributes(sess, service, resource));
+		}
+
+		if (loadVoAttributes) {
+			loadVoSpecificAttributes(resource);
+		}
+
+		memberResourceAttrs =
+				sess.getPerunBl().getAttributesManagerBl().getRequiredAttributes(sess, service, resource, members);
+
+		// we don't need to load again attributes for the already processed members
+		List<Member> notYetProcessedMembers = new ArrayList<>(members);
+		notYetProcessedMembers.removeAll(processedMembers);
+		processedMembers.addAll(notYetProcessedMembers);
+
+		loadMemberSpecificAttributes(notYetProcessedMembers);
+	}
+
+	@Override
+	public List<String> getFacilityAttributesHashes() {
+		String hash = hasher.hashFacility(facility);
+
+		if (!attributesByHash.containsKey(hash)) {
+			if (facilityAttrs == null) {
+				throw new IllegalStateException("Facility attributes need to be loaded first.");
+			}
+			attributesByHash.put(hash, facilityAttrs);
+		}
+
+		return attributesByHash.get(hash).isEmpty() ? emptyList() : singletonList(hash);
+	}
+
+	@Override
+	public List<String> getResourceAttributesHashes(Resource resource, boolean addVoAttributes) {
+		List<String> hashes = getResourceAttributesHashes(resource);
+
+		if (addVoAttributes) {
+			// create incomplete vo object with only vo id
+			Vo vo = new Vo();
+			vo.setId(resource.getVoId());
+			hashes.addAll(getVoAttributesHashes(vo));
+		}
+
+		return hashes;
+	}
+
+	@Override
+	public List<String> getMemberAttributesHashes(Resource resource, Member member) {
+		if (!resource.equals(lastLoadedResource)) {
+			throw new IllegalStateException("The last loaded resource is different than the required one. Required: " +
+					resource + ", Last loaded: " + lastLoadedResource);
+		}
+		List<String> hashes = new ArrayList<>();
+
+		User user = loadedUsersById.get(member.getUserId());
+
+		hashes.addAll(getMemberAttributesHashes(member));
+		hashes.addAll(getUserAttributesHashes(user));
+		hashes.addAll(getUserFacilityAttributesHashes(user, facility));
+		hashes.addAll(getMemberResourceAttributesHashes(member, resource));
+
+		return hashes;
+	}
+
+	@Override
+	public List<String> getMemberAttributesHashes(Resource resource, Member member, Group group) {
+		if (!group.equals(lastLoadedGroup)) {
+			throw new IllegalStateException("Cannot load member-group attributes for group " + group + ", because last" +
+					"loaded group is: " + lastLoadedGroup);
+		}
+		List<String> hashes = getMemberAttributesHashes(resource, member);
+
+		hashes.addAll(getMemberGroupAttributesHashes(member, group));
+
+		return hashes;
+	}
+
+	@Override
+	public List<String> getGroupAttributesHashes(Resource resource, Group group) {
+		if (!resource.equals(lastLoadedResource)) {
+			throw new IllegalStateException("The last loaded resource is different than the required one. Required: " +
+					resource + ", Last loaded: " + lastLoadedResource);
+		}
+		List<String> hashes = new ArrayList<>();
+
+		hashes.addAll(getGroupAttributesHashes(group));
+		hashes.addAll(getGroupResourceAttributesHashes(group, resource));
+
+		return hashes;
+	}
+
+	@Override
+	public Map<String, Map<String, Object>> getAllFetchedAttributes() {
+		return attributesByHash.entrySet().stream()
+				.filter(entry -> !entry.getValue().isEmpty())
+				.collect(toMap(Map.Entry::getKey, entry -> convertToMap(entry.getValue())));
+	}
+
+	private Map<String, Object> convertToMap(List<Attribute> attributes) {
+		Map<String, Object> map = new HashMap<>();
+		attributes.forEach(a -> map.put(a.getName(), a.getValue()));
+		return map;
+	}
+
+	private List<String> getVoAttributesHashes(Vo vo) {
+		String hash = hasher.hashVo(vo);
+
+		return getAndStoreHash(hash, vo, voAttrs);
+	}
+
+	private List<String> getMemberGroupAttributesHashes(Member member, Group group) {
+		if (!group.equals(lastLoadedGroup)) {
+			throw new IllegalStateException("Cannot load member-group attributes for group " + group + ", because last" +
+					"loaded group is: " + lastLoadedGroup);
+		}
+		String hash = hasher.hashMemberGroup(member, group);
+
+		return getAndStoreHash(hash, member, memberGroupAttrs);
+	}
+
+	private List<String> getMemberResourceAttributesHashes(Member member, Resource resource) {
+		if (!resource.equals(lastLoadedResource)) {
+			throw new IllegalStateException("The last loaded resource is different than the required one. Required: " +
+					resource + ", Last loaded: " + lastLoadedResource);
+		}
+		String hash = hasher.hashMemberResource(member, resource);
+
+		return getAndStoreHash(hash, member, memberResourceAttrs);
+	}
+
+	private List<String> getResourceAttributesHashes(Resource resource) {
+		String hash = hasher.hashResource(resource);
+
+		return getAndStoreHash(hash, resource, resourceAttrs);
+	}
+
+	private List<String> getMemberAttributesHashes(Member member) {
+		String hash = hasher.hashMember(member);
+
+		return getAndStoreHash(hash, member, memberAttrs);
+	}
+
+
+	private List<String> getGroupAttributesHashes(Group group) {
+		String hash = hasher.hashGroup(group);
+
+		return getAndStoreHash(hash, group, groupAttrs);
+	}
+
+	private List<String> getGroupResourceAttributesHashes(Group group, Resource resource) {
+		if (!resource.equals(lastLoadedResource)) {
+			throw new IllegalStateException("The last loaded resource is different than the required one. Required: " +
+					resource + ", Last loaded: " + lastLoadedResource);
+		}
+
+		// FIXME - need to make sure that data for all of the given groups were loaded
+
+		String hash = hasher.hashGroupResource(group, resource);
+
+		return getAndStoreHash(hash, group, groupResourceAttrs);
+	}
+
+	private List<String> getUserAttributesHashes(User user) {
+		String hash = hasher.hashUser(user);
+
+		return getAndStoreHash(hash, user, userAttrs);
+	}
+
+	private List<String> getUserFacilityAttributesHashes(User user, Facility facility) {
+		String hash = hasher.hashUserFacility(user, facility);
+
+		return getAndStoreHash(hash, user, userFacilityAttrs);
+	}
+
+	/**
+	 * Get a list of attributes for given hash, and loads appropriate entity attributes from given map
+	 * into the map of all processed attributes.
+	 *
+	 * If the map doesn't contain attributes for the given entity, or the list is empty,
+	 * this method returns an empty list. Otherwise, it returns a List with the given hash.
+	 *
+	 * @param hash entity hash
+	 * @param entity the entity which the hash belongs
+	 * @param map map of attributes for the entity
+	 * @param <T> the type of the entity User, Member, ...
+	 * @return List with the hash or empty list if the map doesn't contain any attributes for the given entity
+	 */
+	private <T> List<String> getAndStoreHash(String hash, T entity, Map<T, List<Attribute>> map) {
+		if (!attributesByHash.containsKey(hash)) {
+			if (!map.containsKey(entity)) {
+				return emptyList();
+			}
+			attributesByHash.put(hash, map.get(entity));
+		}
+		return attributesByHash.get(hash).isEmpty() ? emptyList() : singletonList(hash);
+	}
+
+	private void loadMemberSpecificAttributes(List<Member> members) {
+		memberAttrs.putAll(
+				sess.getPerunBl().getAttributesManagerBl().getRequiredAttributes(sess, null, service, members)
+		);
+
+		List<Integer> userIds = members.stream()
+				.map(Member::getUserId)
+				.collect(toList());
+
+		List<User> users = sess.getPerunBl().getUsersManagerBl().getUsersByIds(sess, userIds);
+
+		Map<Integer, User> usersById = users.stream()
+				.collect(toMap(User::getId, Function.identity()));
+		loadedUsersById.putAll(usersById);
+
+		loadUserSpecificAttributes(users);
+	}
+
+	private void loadUserSpecificAttributes(List<User> users) {
+		userAttrs.putAll(
+				sess.getPerunBl().getAttributesManagerBl().getRequiredAttributes(sess, service, users)
+		);
+
+		userFacilityAttrs.putAll(
+				sess.getPerunBl().getAttributesManagerBl().getRequiredAttributes(sess, service, facility, users)
+		);
+	}
+
+	private void loadVoSpecificAttributes(Resource resource) {
+		// create incomplete vo object with only vo id
+		Vo vo = new Vo();
+		vo.setId(resource.getVoId());
+		lastLoadedResource = resource;
+
+		if (!voAttrs.containsKey(vo)) {
+			Vo dbVo;
+
+			try {
+				dbVo = sess.getPerunBl().getVosManagerBl().getVoById(sess, resource.getVoId());
+			} catch (VoNotExistsException e) {
+				throw new InternalErrorException(e);
+			}
+
+			voAttrs.put(vo, sess.getPerunBl().getAttributesManagerBl().getRequiredAttributes(sess, service, dbVo));
+		}
+	}
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/provisioning/GroupsHashedDataGenerator.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/provisioning/GroupsHashedDataGenerator.java
@@ -1,0 +1,209 @@
+package cz.metacentrum.perun.core.provisioning;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Facility;
+import cz.metacentrum.perun.core.api.GenDataNode;
+import cz.metacentrum.perun.core.api.GenMemberDataNode;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.HashedGenData;
+import cz.metacentrum.perun.core.api.Member;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.Service;
+import cz.metacentrum.perun.core.api.VosManager;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Generates data in format:
+ *
+ * attributes: {...hashes...}
+ * hierarchy: {
+ *    ** facility **
+ *    hashes: [...hashes...]
+ *    members: []
+ *    children: [
+ *      {
+ *        ** resource1 **
+ *        hashes: [...hashes...]
+ *        children: [
+ *          {
+ *            ** group A **
+ *            hashes: [...hashes...]
+ *            members: [...group members...]
+ *            children: []
+ *          },
+ *          {
+ *            ** group B **
+ *            ...
+ *          }
+ *        ]
+ *        members: [
+ *          {
+ *            ** member 1 **
+ *            hashes: [...hashes...]
+ *          },
+ *          {
+ *            ** member 2 **
+ *            ...
+ *          }
+ *        ]
+ *      },
+ *      {
+ *        ** resource2 **
+ *        ...
+ *      }
+ *    ]
+ * }
+ *
+ * @author Vojtech Sassmann <vojtech.sassmann@gmail.com>
+ */
+public class GroupsHashedDataGenerator implements HashedDataGenerator {
+
+	private final PerunSessionImpl sess;
+	private final Service service;
+	private final Facility facility;
+	private final GenDataProvider dataProvider;
+	private final boolean filterExpiredMembers;
+
+	private GroupsHashedDataGenerator(PerunSessionImpl sess, Service service, Facility facility,
+	                                 boolean filterExpiredMembers) {
+		this.sess = sess;
+		this.service = service;
+		this.facility = facility;
+		this.filterExpiredMembers = filterExpiredMembers;
+		dataProvider = new GenDataProviderImpl(sess, service, facility);
+	}
+
+	@Override
+	public HashedGenData generateData() {
+		dataProvider.loadFacilityAttributes();
+
+		List<Resource> resources = sess.getPerunBl().getFacilitiesManagerBl().getAssignedResources(sess, facility, null, service);
+
+		List<GenDataNode> childNodes = resources.stream()
+				.map(this::getDataForResource)
+				.collect(Collectors.toList());
+
+		List<String> facilityAttrHashes = dataProvider.getFacilityAttributesHashes();
+		Map<String, Map<String, Object>> attributes = dataProvider.getAllFetchedAttributes();
+
+		GenDataNode root = new GenDataNode.Builder()
+				.hashes(facilityAttrHashes)
+				.children(childNodes)
+				.build();
+
+		return new HashedGenData(attributes, root);
+	}
+
+	private GenDataNode getDataForResource(Resource resource) {
+		List<Member> members;
+		if (filterExpiredMembers) {
+			members = sess.getPerunBl().getResourcesManagerBl().getAllowedMembersNotExpiredInGroups(sess, resource);
+		} else {
+			members = sess.getPerunBl().getResourcesManagerBl().getAllowedMembers(sess, resource);
+		}
+
+		dataProvider.loadResourceAttributes(resource, members, true);
+
+		List<String> resourceAttrHashes = dataProvider.getResourceAttributesHashes(resource, true);
+
+		List<GenMemberDataNode> memberNodes = members.stream()
+				.map(member -> getDataForMember(resource, member))
+				.collect(Collectors.toList());
+
+		List<Group> assignedGroups = sess.getPerunBl().getResourcesManagerBl().getAssignedGroups(sess, resource);
+		dataProvider.loadGroupsAttributes(resource, assignedGroups);
+
+		List<GenDataNode> groupNodes = assignedGroups.stream()
+				.map(group -> getDataForGroup(resource, group))
+				.collect(Collectors.toList());
+
+		return new GenDataNode.Builder()
+				.hashes(resourceAttrHashes)
+				.children(groupNodes)
+				.members(memberNodes)
+				.build();
+	}
+
+	private GenDataNode getDataForGroup(Resource resource, Group group) {
+		List<String> groupAttrHashes = dataProvider.getGroupAttributesHashes(resource, group);
+
+		// This used to be the old way but we dont actually need it
+/*		List<GenDataNode> subGroupNodes;
+		if (!group.getName().equals(VosManager.MEMBERS_GROUP)) {
+			List<Group> subGroups = sess.getPerunBl().getGroupsManagerBl().getSubGroups(sess, group);
+			dataProvider.loadGroupsAttributes(resource, subGroups);
+			subGroupNodes = subGroups.stream()
+					.map(subGroup -> getDataForGroup(resource, subGroup))
+					.collect(Collectors.toList());
+		} else {
+			subGroupNodes = new ArrayList<>();
+		}*/
+
+		List<Member> members;
+		if (filterExpiredMembers) {
+			members = sess.getPerunBl().getGroupsManagerBl().getActiveGroupMembers(sess, group);
+		} else {
+			members = sess.getPerunBl().getGroupsManagerBl().getGroupMembersExceptInvalidAndDisabled(sess, group);
+		}
+
+		dataProvider.loadMemberGroupAttributes(group, members);
+
+		List<GenMemberDataNode> memberNodes = members.stream()
+				.map(member -> getDataForMember(resource, member, group))
+				.collect(Collectors.toList());
+
+		return new GenDataNode.Builder()
+				.hashes(groupAttrHashes)
+//				.children(subGroupNodes)
+				.members(memberNodes)
+				.build();
+	}
+
+	private GenMemberDataNode getDataForMember(Resource resource, Member member, Group group) {
+		List<String> memberAttrHashes = dataProvider.getMemberAttributesHashes(resource, member, group);
+
+		return new GenMemberDataNode(memberAttrHashes);
+	}
+
+	private GenMemberDataNode getDataForMember(Resource resource, Member member) {
+		List<String> memberAttrHashes = dataProvider.getMemberAttributesHashes(resource, member);
+
+		return new GenMemberDataNode(memberAttrHashes);
+	}
+
+	public static class Builder {
+		private PerunSessionImpl sess;
+		private Service service;
+		private Facility facility;
+		private boolean filterExpiredMembers = false;
+
+		public Builder sess(PerunSessionImpl sess) {
+			this.sess = sess;
+			return this;
+		}
+
+		public Builder service(Service service) {
+			this.service = service;
+			return this;
+		}
+
+		public Builder facility(Facility facility) {
+			this.facility = facility;
+			return this;
+		}
+
+		public Builder filterExpiredMembers(boolean filterExpiredMembers) {
+			this.filterExpiredMembers = filterExpiredMembers;
+			return this;
+		}
+
+		public GroupsHashedDataGenerator build() {
+			return new GroupsHashedDataGenerator(sess, service, facility, filterExpiredMembers);
+		}
+	}
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/provisioning/HashedDataGenerator.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/provisioning/HashedDataGenerator.java
@@ -1,0 +1,17 @@
+package cz.metacentrum.perun.core.provisioning;
+
+
+import cz.metacentrum.perun.core.api.HashedGenData;
+
+/**
+ * @author Vojtech Sassmann <vojtech.sassmann@gmail.com>
+ */
+public interface HashedDataGenerator {
+
+	/**
+	 * Generated hashed data structure used for provisioning.
+	 *
+	 * @return hashed data structure
+	 */
+	HashedGenData generateData();
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/provisioning/Hasher.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/provisioning/Hasher.java
@@ -1,0 +1,100 @@
+package cz.metacentrum.perun.core.provisioning;
+
+import cz.metacentrum.perun.core.api.Facility;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.Member;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.Vo;
+
+/**
+ * Component used to generate hashes for objects.
+ *
+ * @author Vojtech Sassmann <vojtech.sassmann@gmail.com>
+ */
+public interface Hasher {
+
+	/**
+	 * Returns hash for facility.
+	 *
+	 * @param facility facility
+	 * @return facility hash
+	 */
+	String hashFacility(Facility facility);
+
+	/**
+	 * Returns hash for resource.
+	 *
+	 * @param resource resource
+	 * @return resource hash
+	 */
+	String hashResource(Resource resource);
+
+	/**
+	 * Returns hash for member.
+	 *
+	 * @param member member
+	 * @return member hash
+	 */
+	String hashMember(Member member);
+
+	/**
+	 * Returns hash for vo.
+	 *
+	 * @param vo vo
+	 * @return vo hash
+	 */
+	String hashVo(Vo vo);
+
+	/**
+	 * Returns hash for group.
+	 *
+	 * @param group group
+	 * @return group hash
+	 */
+	String hashGroup(Group group);
+
+	/**
+	 * Returns hash for group and resource.
+	 *
+	 * @param group group
+	 * @param resource resource
+	 * @return group-resource hash
+	 */
+	String hashGroupResource(Group group, Resource resource);
+
+	/**
+	 * Returns hash for member and resource.
+	 *
+	 * @param member member
+	 * @param resource resource
+	 * @return member-resource hash
+	 */
+	String hashMemberResource(Member member, Resource resource);
+
+	/**
+	 * Returns hash for member and group.
+	 *
+	 * @param member member
+	 * @param group group
+	 * @return member-group hash
+	 */
+	String hashMemberGroup(Member member, Group group);
+
+	/**
+	 * Returns hash for user.
+	 *
+	 * @param user user
+	 * @return user hash
+	 */
+	String hashUser(User user);
+
+	/**
+	 * Returns hash for user and facility.
+	 *
+	 * @param user user
+	 * @param facility facility
+	 * @return user-facility hash
+	 */
+	String hashUserFacility(User user, Facility facility);
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/provisioning/HierarchicalHashedDataGenerator.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/provisioning/HierarchicalHashedDataGenerator.java
@@ -1,0 +1,149 @@
+package cz.metacentrum.perun.core.provisioning;
+
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Facility;
+import cz.metacentrum.perun.core.api.GenDataNode;
+import cz.metacentrum.perun.core.api.GenMemberDataNode;
+import cz.metacentrum.perun.core.api.HashedGenData;
+import cz.metacentrum.perun.core.api.Member;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.Service;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Generates data in format:
+ *
+ * attributes: {...hashes...}
+ * hierarchy: {
+ *    ** facility **
+ *    hashes: [...hashes...]
+ *    members: []
+ *    children: [
+ *      {
+ *        ** resource1 **
+ *        hashes: [...hashes...]
+ *        children: []
+ *        members: [
+ *          {
+ *            ** member 1 **
+ *            hashes: [...hashes...]
+ *          },
+ *          {
+ *            ** member 2 **
+ *            ...
+ *          }
+ *        ]
+ *      },
+ *      {
+ *        ** resource2 **
+ *        ...
+ *      }
+ *    ]
+ * }
+ *
+ * @author Vojtech Sassmann <vojtech.sassmann@gmail.com>
+ */
+public class HierarchicalHashedDataGenerator implements HashedDataGenerator {
+
+	private final PerunSessionImpl sess;
+	private final Service service;
+	private final Facility facility;
+	private final GenDataProvider dataProvider;
+	private final boolean filterExpiredMembers;
+
+	private HierarchicalHashedDataGenerator(PerunSessionImpl sess, Service service, Facility facility,
+	                                        boolean filterExpiredMembers) {
+		this.sess = sess;
+		this.service = service;
+		this.facility = facility;
+		this.filterExpiredMembers = filterExpiredMembers;
+		dataProvider = new GenDataProviderImpl(sess, service, facility);
+	}
+
+	@Override
+	public HashedGenData generateData() {
+		dataProvider.loadFacilityAttributes();
+
+		List<Resource> resources =
+				sess.getPerunBl().getFacilitiesManagerBl().getAssignedResources(sess, facility, null, service);
+
+		List<GenDataNode> childNodes = resources.stream()
+				.map(this::getDataForResource)
+				.collect(Collectors.toList());
+
+		List<String> facilityAttrHashes = dataProvider.getFacilityAttributesHashes();
+		Map<String, Map<String, Object>> attributes = dataProvider.getAllFetchedAttributes();
+
+		GenDataNode root = new GenDataNode.Builder()
+				.hashes(facilityAttrHashes)
+				.children(childNodes)
+				.build();
+
+		return new HashedGenData(attributes, root);
+	}
+
+	private GenDataNode getDataForResource(Resource resource) {
+		List<Member> members;
+		if (filterExpiredMembers) {
+			members = sess.getPerunBl().getResourcesManagerBl().getAllowedMembersNotExpiredInGroups(sess, resource);
+		} else {
+			members = sess.getPerunBl().getResourcesManagerBl().getAllowedMembers(sess, resource);
+		}
+
+		dataProvider.loadResourceAttributes(resource, members, false);
+
+		List<String> resourceAttrHashes = dataProvider.getResourceAttributesHashes(resource, false);
+
+		List<GenMemberDataNode> childNodes = members.stream()
+				.map(member -> getDataForMember(resource, member))
+				.collect(Collectors.toList());
+
+		return new GenDataNode.Builder()
+				.hashes(resourceAttrHashes)
+				.members(childNodes)
+				.build();
+	}
+
+
+	private GenMemberDataNode getDataForMember(Resource resource, Member member) {
+		List<String> memberAttrHashes = dataProvider.getMemberAttributesHashes(resource, member);
+
+		return new GenMemberDataNode(memberAttrHashes);
+	}
+
+	public static class Builder {
+		private PerunSessionImpl sess;
+		private Service service;
+		private Facility facility;
+		private boolean filterExpiredMembers = false;
+
+		public Builder sess(PerunSessionImpl sess) {
+			this.sess = sess;
+			return this;
+		}
+
+		public Builder service(Service service) {
+			this.service = service;
+			return this;
+		}
+
+		public Builder facility(Facility facility) {
+			this.facility = facility;
+			return this;
+		}
+
+		public Builder filterExpiredMembers(boolean filterExpiredMembers) {
+			this.filterExpiredMembers = filterExpiredMembers;
+			return this;
+		}
+
+		public HierarchicalHashedDataGenerator build() {
+			return new HierarchicalHashedDataGenerator(sess, service, facility, filterExpiredMembers);
+		}
+	}
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/provisioning/IdHasher.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/provisioning/IdHasher.java
@@ -1,0 +1,66 @@
+package cz.metacentrum.perun.core.provisioning;
+
+import cz.metacentrum.perun.core.api.Facility;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.Member;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.Vo;
+
+/**
+ * Generates hashes based on ids of the beans.
+ *
+ * @author Vojtech Sassmann <vojtech.sassmann@gmail.com>
+ */
+public class IdHasher implements Hasher {
+
+	@Override
+	public String hashFacility(Facility facility) {
+		return "f-" + facility.getId();
+	}
+
+	@Override
+	public String hashResource(Resource resource) {
+		return "r-" + resource.getId();
+	}
+
+	@Override
+	public String hashMember(Member member) {
+		return "m-" + member.getId();
+	}
+
+	@Override
+	public String hashVo(Vo vo) {
+		return "v-" + vo.getId();
+	}
+
+	@Override
+	public String hashGroup(Group group) {
+		return "g-" + group.getId();
+	}
+
+	@Override
+	public String hashGroupResource(Group group, Resource resource) {
+		return "g-r-" + group.getId() + "-" + resource.getId();
+	}
+
+	@Override
+	public String hashMemberResource(Member member, Resource resource) {
+		return "m-r-" + member.getId() + "-" + resource.getId();
+	}
+
+	@Override
+	public String hashMemberGroup(Member member, Group group) {
+		return "m-g-" + member.getId() + "-" + group.getId();
+	}
+
+	@Override
+	public String hashUser(User user) {
+		return "u-" + user.getId();
+	}
+
+	@Override
+	public String hashUserFacility(User user, Facility facility) {
+		return "u-f-" + user.getId() + "-" + facility.getId();
+	}
+}

--- a/perun-core/src/main/resources/perun-core.xml
+++ b/perun-core/src/main/resources/perun-core.xml
@@ -20,6 +20,8 @@ http://www.springframework.org/schema/context http://www.springframework.org/sch
 		<aop:advisor advice-ref="txAdviceReadOnlySerialized" pointcut="execution(* cz.metacentrum.perun.core.entry.ServicesManagerEntry.getDataWithGroups(..))"/>
 		<aop:advisor advice-ref="txAdviceReadOnlySerialized" pointcut="execution(* cz.metacentrum.perun.core.entry.ServicesManagerEntry.getDataWithVos(..))"/>
 		<aop:advisor advice-ref="txAdviceReadOnlySerialized" pointcut="execution(* cz.metacentrum.perun.core.entry.ServicesManagerEntry.getFlatData(..))"/>
+		<aop:advisor advice-ref="txAdviceReadOnlySerialized" pointcut="execution(* cz.metacentrum.perun.core.entry.ServicesManagerEntry.getHashedHierarchicalData(..))"/>
+		<aop:advisor advice-ref="txAdviceReadOnlySerialized" pointcut="execution(* cz.metacentrum.perun.core.entry.ServicesManagerEntry.getHashedDataWithGroups(..))"/>
 		<aop:advisor advice-ref="txAdviceNestedTransaction" pointcut="execution(* cz.metacentrum.perun.core.entry.*.*(..))"/>
 		<aop:advisor advice-ref="txAdviceNestedTransaction" pointcut="execution(* cz.metacentrum.perun.core.blImpl.AttributesManagerBlImpl.setAttributeInNestedTransaction(..))"/>
 		<aop:advisor advice-ref="txAdviceNestedTransaction" pointcut="execution(* cz.metacentrum.perun.core.impl.AttributesManagerImpl.insertAttribute(..))"/>

--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -759,6 +759,29 @@ components:
         attributes: { type: array, items: { $ref: '#/components/schemas/Attribute' } }
         childElements: { type: array, items: { $ref: '#/components/schemas/ServiceAttributes' } }
 
+    GenDataNode:
+      type: object
+      properties:
+        h: { type: array, items: { type: string } }
+        c: { type: array, items: { $ref: '#/components/schemas/HashedGenData' } }
+        m: { type: array, items: { $ref: '#/components/schemas/GenMemberDataNode' } }
+
+    GenMemberDataNode:
+      type: object
+      properties:
+        h: { type: array, items: { type: string } }
+
+    HashedGenData:
+      type: object
+      properties:
+        attributes:
+          type: object
+          additionalProperties:
+            type: array
+            items: { $ref: '#/components/schemas/Attribute' }
+        hierarchy:
+          $ref: '#/components/schemas/GenDataNode'
+
     ServicesPackage:
       allOf:
         - $ref: '#/components/schemas/Auditable'
@@ -1584,6 +1607,13 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/ServiceAttributes"
+
+    HashedGenDataResponse:
+      description: "return hashed gen data"
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/HashedGenData"
 
     ServicesPackageResponse:
       description: "return ServicesPackage"
@@ -12553,6 +12583,38 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/ServiceAttributesResponse'
+        default:
+          $ref: '#/components/responses/ExceptionResponse'
+
+  /json/servicesManager/getHashedHierarchicalData:
+    get:
+      tags:
+        - ServicesManager
+      operationId: getHashedHierarchicalData
+      summary: Generates hashed hierarchical data structure for given service and facility.
+      parameters:
+        - $ref: '#/components/parameters/serviceId'
+        - $ref: '#/components/parameters/facilityId'
+        - { name: filterExpiredMembers, description: "if true the method does not take members expired in groups into account", schema: { type: boolean },  in: query, required: false }
+      responses:
+        '200':
+          $ref: '#/components/responses/HashedGenDataResponse'
+        default:
+          $ref: '#/components/responses/ExceptionResponse'
+
+  /json/servicesManager/getHashedDataWithGroups:
+    get:
+      tags:
+        - ServicesManager
+      operationId: getHashedDataWithGroups
+      summary: Generates hashed group structure data for given service and facility.
+      parameters:
+        - $ref: '#/components/parameters/serviceId'
+        - $ref: '#/components/parameters/facilityId'
+        - { name: filterExpiredMembers, description: "if true the method does not take members expired in groups into account", schema: { type: boolean },  in: query, required: false }
+      responses:
+        '200':
+          $ref: '#/components/responses/HashedGenDataResponse'
         default:
           $ref: '#/components/responses/ExceptionResponse'
 

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/ServicesManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/ServicesManagerMethod.java
@@ -6,13 +6,17 @@ import java.util.List;
 import cz.metacentrum.perun.controller.model.ServiceForGUI;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.Destination;
+import cz.metacentrum.perun.core.api.HashedGenData;
 import cz.metacentrum.perun.core.api.RichDestination;
 import cz.metacentrum.perun.core.api.Service;
 import cz.metacentrum.perun.core.api.ServiceAttributes;
 import cz.metacentrum.perun.core.api.ServicesPackage;
 import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.exceptions.FacilityNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.PerunException;
+import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
 import cz.metacentrum.perun.core.api.exceptions.RpcException;
+import cz.metacentrum.perun.core.api.exceptions.ServiceNotExistsException;
 import cz.metacentrum.perun.rpc.ApiCaller;
 import cz.metacentrum.perun.rpc.ManagerMethod;
 import cz.metacentrum.perun.rpc.deserializer.Deserializer;
@@ -521,6 +525,220 @@ public enum ServicesManagerMethod implements ManagerMethod {
 					ac.getServiceById(parms.readInt("service")),
 					ac.getFacilityById(parms.readInt("facility")),
 					false);
+			}
+		}
+	},
+
+	/*#
+	 * Generates hashed hierarchical data structure for given service and facility.
+	 *
+	 * attributes: {...hashes...}
+	 * hierarchy: {
+	 *    ** facility **
+	 *    hashes: [...hashes...]
+	 *    members: []
+	 *    children: [
+	 *      {
+	 *        ** resource1 **
+	 *        hashes: [...hashes...]
+	 *        children: []
+	 *        members: [
+	 *          {
+	 *            ** member 1 **
+	 *            hashes: [...hashes...]
+	 *          },
+	 *          {
+	 *            ** member 2 **
+	 *            ...
+	 *          }
+	 *        ]
+	 *      },
+	 *      {
+	 *        ** resource2 **
+	 *        ...
+	 *      }
+	 *    ]
+	 * }
+	 *
+	 * @param service Integer service
+	 * @param facility Integer facility
+	 * @param filterExpiredMembers Boolean if the generator should filter expired members
+	 * @return HashedGenData generated hashed data structure
+	 * @throw FacilityNotExistsException if there is no such facility
+	 * @throw ServiceNotExistsException if there is no such service
+	 * @throw PrivilegeException insufficient permissions
+	 */
+	/*#
+	 * Generates hashed hierarchical data structure for given service and facility.
+	 *
+	 * attributes: {...hashes...}
+	 * hierarchy: {
+	 *    ** facility **
+	 *    hashes: [...hashes...]
+	 *    members: []
+	 *    children: [
+	 *      {
+	 *        ** resource1 **
+	 *        hashes: [...hashes...]
+	 *        children: []
+	 *        members: [
+	 *          {
+	 *            ** member 1 **
+	 *            hashes: [...hashes...]
+	 *          },
+	 *          {
+	 *            ** member 2 **
+	 *            ...
+	 *          }
+	 *        ]
+	 *      },
+	 *      {
+	 *        ** resource2 **
+	 *        ...
+	 *      }
+	 *    ]
+	 * }
+	 *
+	 * @param service Integer service
+	 * @param facility Integer facility
+	 * @return HashedGenData generated hashed data structure
+	 * @throw FacilityNotExistsException if there is no such facility
+	 * @throw ServiceNotExistsException if there is no such service
+	 * @throw PrivilegeException insufficient permissions
+	 */
+	getHashedHierarchicalData {
+		@Override
+		public HashedGenData call(ApiCaller ac, Deserializer parms) throws PerunException {
+			if (parms.contains("filterExpiredMembers")) {
+				return ac.getServicesManager().getHashedHierarchicalData(ac.getSession(),
+						ac.getServiceById(parms.readInt("service")),
+						ac.getFacilityById(parms.readInt("facility")),
+						parms.readBoolean("filterExpiredMembers"));
+			} else {
+				return ac.getServicesManager().getHashedHierarchicalData(ac.getSession(),
+						ac.getServiceById(parms.readInt("service")),
+						ac.getFacilityById(parms.readInt("facility")),
+						false);
+			}
+		}
+	},
+
+	/*#
+	 * Generates hashed data with group structure for given service and resource.
+	 *
+	 * Generates data in format:
+	 *
+	 * attributes: {...hashes...}
+	 * hierarchy: {
+	 *    ** facility **
+	 *    hashes: [...hashes...]
+	 *    members: []
+	 *    children: [
+	 *      {
+	 *        ** resource1 **
+	 *        hashes: [...hashes...]
+	 *        children: [
+	 *          {
+	 *            ** group A **
+	 *            hashes: [...hashes...]
+	 *            members: [...group members...]
+	 *            children: []
+	 *          },
+	 *          {
+	 *            ** group B **
+	 *            ...
+	 *          }
+	 *        ]
+	 *        members: [
+	 *          {
+	 *            ** member 1 **
+	 *            hashes: [...hashes...]
+	 *          },
+	 *          {
+	 *            ** member 2 **
+	 *            ...
+	 *          }
+	 *        ]
+	 *      },
+	 *      {
+	 *        ** resource2 **
+	 *        ...
+	 *      }
+	 *    ]
+	 * }
+	 *
+	 * @param service Integer service
+	 * @param facility Integer facility
+	 * @param filterExpiredMembers Boolean if the generator should filter expired members
+	 * @return HashedGenData generated hashed data structure
+	 * @throw FacilityNotExistsException if there is no such facility
+	 * @throw ServiceNotExistsException if there is no such service
+	 * @throw PrivilegeException insufficient permissions
+	 */
+	/*#
+	 * Generates hashed data with group structure for given service and resource.
+	 *
+	 *  Generates data in format:
+	 *
+	 * attributes: {...hashes...}
+	 * hierarchy: {
+	 *    ** facility **
+	 *    hashes: [...hashes...]
+	 *    members: []
+	 *    children: [
+	 *      {
+	 *        ** resource1 **
+	 *        hashes: [...hashes...]
+	 *        children: [
+	 *          {
+	 *            ** group A **
+	 *            hashes: [...hashes...]
+	 *            members: [...group members...]
+	 *            children: []
+	 *          },
+	 *          {
+	 *            ** group B **
+	 *            ...
+	 *          }
+	 *        ]
+	 *        members: [
+	 *          {
+	 *            ** member 1 **
+	 *            hashes: [...hashes...]
+	 *          },
+	 *          {
+	 *            ** member 2 **
+	 *            ...
+	 *          }
+	 *        ]
+	 *      },
+	 *      {
+	 *        ** resource2 **
+	 *        ...
+	 *      }
+	 *    ]
+	 * }
+	 *
+	 * @param service Integer service
+	 * @param facility Integer facility
+	 * @return HashedGenData generated hashed data structure
+	 * @throw FacilityNotExistsException if there is no such facility
+	 * @throw ServiceNotExistsException if there is no such service
+	 * @throw PrivilegeException insufficient permissions
+	 */
+	getHashedDataWithGroups {
+		@Override
+		public HashedGenData call(ApiCaller ac, Deserializer parms) throws PerunException {
+			if (parms.contains("filterExpiredMembers")) {
+				return ac.getServicesManager().getHashedDataWithGroups(ac.getSession(),
+						ac.getServiceById(parms.readInt("service")),
+						ac.getFacilityById(parms.readInt("facility")),
+						parms.readBoolean("filterExpiredMembers"));
+			} else {
+				return ac.getServicesManager().getHashedDataWithGroups(ac.getSession(),
+						ac.getServiceById(parms.readInt("service")),
+						ac.getFacilityById(parms.readInt("facility")),
+						false);
 			}
 		}
 	},


### PR DESCRIPTION
* Created new methods `getHashedHierarchicalData` and `getHashedDataWithGroups`
that can be used to generate data for provisioning. It doesn't duplicate
attributes data, which was a problem with the old implementation.
* These methods are meant for testing, they might change in the future.
* Created new methods in attributesManager to load attributes in a
single query to increase performance.