### PR TITLE
Added getUsersSubjects to ExtSources

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/UsersManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/UsersManager.java
@@ -46,6 +46,9 @@ import java.util.Map;
  */
 public interface UsersManager {
 
+	// Contains query needed to get users from external source
+	String USERS_QUERY = "usersQuery";
+
 	/**
 	 * Returns user by his login in external source and external source.
 	 *

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceCSV.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceCSV.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.dataformat.csv.CsvMapper;
 import com.fasterxml.jackson.dataformat.csv.CsvSchema;
 import cz.metacentrum.perun.core.api.ExtSource;
 import cz.metacentrum.perun.core.api.GroupsManager;
+import cz.metacentrum.perun.core.api.UsersManager;
 import cz.metacentrum.perun.core.api.exceptions.ExtSourceUnsupportedOperationException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.SubjectNotExistsException;
@@ -150,7 +151,7 @@ public class ExtSourceCSV extends ExtSource implements ExtSourceApi {
 	public List<Map<String, String>> getUsersSubjects() {
 		try {
 			// Get the query for the user subjects
-			String queryForUsers = getAttributes().get("usersQuery");
+			String queryForUsers = getAttributes().get(UsersManager.USERS_QUERY);
 
 			// If there is no query for users, throw exception
 			if (queryForUsers == null) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceCSV.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceCSV.java
@@ -147,8 +147,25 @@ public class ExtSourceCSV extends ExtSource implements ExtSourceApi {
     }
 
 	@Override
-	public List<Map<String, String>> getUsersSubjects() throws ExtSourceUnsupportedOperationException {
-		throw new ExtSourceUnsupportedOperationException();
+	public List<Map<String, String>> getUsersSubjects() {
+		try {
+			// Get the query for the user subjects
+			String queryForUsers = getAttributes().get("usersQuery");
+
+			// If there is no query for users, throw exception
+			if (queryForUsers == null) {
+				throw new InternalErrorException("usersQuery can't be null");
+			}
+
+			// Get CSV file
+			prepareFile();
+
+			return csvParsing(queryForUsers, 0);
+
+		} catch (IOException ex) {
+			log.error("IOException in getUsersSubjects() method while parsing csv file", ex);
+		}
+		return null;
 	}
 
     @Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceEGISSO.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceEGISSO.java
@@ -2,6 +2,7 @@ package cz.metacentrum.perun.core.impl;
 
 import cz.metacentrum.perun.core.api.GroupsManager;
 import cz.metacentrum.perun.core.api.Pair;
+import cz.metacentrum.perun.core.api.UsersManager;
 import cz.metacentrum.perun.core.api.exceptions.ExtSourceUnsupportedOperationException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.implApi.ExtSourceApi;
@@ -86,7 +87,7 @@ public class ExtSourceEGISSO extends ExtSourceLdap implements ExtSourceApi {
 
 	@Override
 	public List<Map<String, String>> getUsersSubjects() {
-		String query = getAttributes().get("usersQuery");
+		String query = getAttributes().get(UsersManager.USERS_QUERY);
 
 		return getUsersOrGroupSubjects(query);
 	}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceEGISSO.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceEGISSO.java
@@ -33,34 +33,9 @@ public class ExtSourceEGISSO extends ExtSourceLdap implements ExtSourceApi {
 
 	@Override
 	public List<Map<String, String>> getGroupSubjects(Map<String, String> attributes) {
-		List<Map<String, String>> subjects = new ArrayList<>();
-		NamingEnumeration<SearchResult> results = null;
-
 		String query = attributes.get(GroupsManager.GROUPMEMBERSQUERY_ATTRNAME);
-		String base = "ou=People,dc=egi,dc=eu";
 
-		List<String> ldapGroupSubjects = new ArrayList<>();
-		try {
-			SearchControls controls = new SearchControls();
-			controls.setTimeLimit(5000);
-			results = getContext().search(base, query, controls);
-			while(results.hasMore()) {
-				SearchResult searchResult = results.next();
-				subjects.add(processResultToSubject(searchResult));
-			}
-		} catch (NamingException e) {
-			log.error("LDAP exception during query {}.", query);
-			throw new InternalErrorException("LDAP exception during running query " + query , e);
-		} finally {
-			try {
-				if (results != null) { results.close(); }
-			} catch (Exception e) {
-				log.error("LDAP exception during closing result, while running query '{}'", query);
-				throw new InternalErrorException(e);
-			}
-		}
-
-		return subjects;
+		return getUsersOrGroupSubjects(query);
 	}
 
 	@Override
@@ -110,8 +85,10 @@ public class ExtSourceEGISSO extends ExtSourceLdap implements ExtSourceApi {
 	}
 
 	@Override
-	public List<Map<String, String>> getUsersSubjects() throws ExtSourceUnsupportedOperationException {
-		throw new ExtSourceUnsupportedOperationException();
+	public List<Map<String, String>> getUsersSubjects() {
+		String query = getAttributes().get("usersQuery");
+
+		return getUsersOrGroupSubjects(query);
 	}
 
 	protected Map<String,String> processResultToSubject(SearchResult sr) {
@@ -222,5 +199,34 @@ public class ExtSourceEGISSO extends ExtSourceLdap implements ExtSourceApi {
 		}
 
 		return subjectCert;
+	}
+
+	private List<Map<String, String>> getUsersOrGroupSubjects(String query) {
+		List<Map<String, String>> subjects = new ArrayList<>();
+		NamingEnumeration<SearchResult> results = null;
+
+		String base = "ou=People,dc=egi,dc=eu";
+
+		try {
+			SearchControls controls = new SearchControls();
+			controls.setTimeLimit(5000);
+			results = getContext().search(base, query, controls);
+			while(results.hasMore()) {
+				SearchResult searchResult = results.next();
+				subjects.add(processResultToSubject(searchResult));
+			}
+		} catch (NamingException e) {
+			log.error("LDAP exception during query {}.", query);
+			throw new InternalErrorException("LDAP exception during running query " + query , e);
+		} finally {
+			try {
+				if (results != null) { results.close(); }
+			} catch (Exception e) {
+				log.error("LDAP exception during closing result, while running query '{}'", query);
+				throw new InternalErrorException(e);
+			}
+		}
+
+		return subjects;
 	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceGoogle.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceGoogle.java
@@ -186,9 +186,32 @@ public class ExtSourceGoogle extends ExtSource implements ExtSourceApi {
 
 	@Override
 	public List<Map<String, String>> getGroupSubjects(Map<String, String> attributes) {
+		// Get the query for the group subjects
+		String queryForGroup = attributes.get(GroupsManager.GROUPMEMBERSQUERY_ATTRNAME);
+
+		//If there is no query for group, throw exception
+		if (queryForGroup == null) {
+			throw new InternalErrorException("Attribute " + GroupsManager.GROUPMEMBERSQUERY_ATTRNAME + " can't be null.");
+		}
+
+		return getUsersOrGroupSubjects(queryForGroup);
+	}
+
+	@Override
+	public List<Map<String, String>> getUsersSubjects() {
+		// Get the query for the user subjects
+		String queryForUsers = getAttributes().get("usersQuery");
+
+		//If there is no query for users, throw exception
+		if (queryForUsers == null) {
+			throw new InternalErrorException("usersQuery can't be null");
+		}
+
+		return getUsersOrGroupSubjects(queryForUsers);
+	}
+
+	private List<Map<String, String>> getUsersOrGroupSubjects(String queryToGetSubjects) {
 		try {
-			// Get the query for the group subjects
-			String queryForGroup = attributes.get(GroupsManager.GROUPMEMBERSQUERY_ATTRNAME);
 			domainName = getAttributes().get("domain");
 			groupName = getAttributes().get("group");
 
@@ -200,15 +223,10 @@ public class ExtSourceGoogle extends ExtSource implements ExtSourceApi {
 				throw new InternalErrorException("groupName attribute is required");
 			}
 
-			//If there is no query for group, throw exception
-			if (queryForGroup == null) {
-				throw new InternalErrorException("Attribute " + GroupsManager.GROUPMEMBERSQUERY_ATTRNAME + " can't be null.");
-			}
-
 			//Get connection to Google Groups
 			prepareEnvironment();
 
-			return querySource(queryForGroup, 0);
+			return querySource(queryToGetSubjects, 0);
 
 		} catch (IOException ex) {
 			log.error("IOException in getGroupSubjects() method while parsing data from Google Groups", ex);
@@ -216,11 +234,6 @@ public class ExtSourceGoogle extends ExtSource implements ExtSourceApi {
 			log.error("GeneralSecurityException while trying to connect to Google Apps account", ex);
 		}
 		return null;
-	}
-
-	@Override
-	public List<Map<String, String>> getUsersSubjects() throws ExtSourceUnsupportedOperationException {
-		throw new ExtSourceUnsupportedOperationException();
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceGoogle.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceGoogle.java
@@ -12,6 +12,7 @@ import com.google.api.services.admin.directory.model.Member;
 import com.google.api.services.admin.directory.model.Members;
 import cz.metacentrum.perun.core.api.ExtSource;
 import cz.metacentrum.perun.core.api.GroupsManager;
+import cz.metacentrum.perun.core.api.UsersManager;
 import cz.metacentrum.perun.core.api.exceptions.ExtSourceUnsupportedOperationException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.SubjectNotExistsException;
@@ -200,7 +201,7 @@ public class ExtSourceGoogle extends ExtSource implements ExtSourceApi {
 	@Override
 	public List<Map<String, String>> getUsersSubjects() {
 		// Get the query for the user subjects
-		String queryForUsers = getAttributes().get("usersQuery");
+		String queryForUsers = getAttributes().get(UsersManager.USERS_QUERY);
 
 		//If there is no query for users, throw exception
 		if (queryForUsers == null) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceISMU.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceISMU.java
@@ -5,6 +5,7 @@ package cz.metacentrum.perun.core.impl;
 
 import cz.metacentrum.perun.core.api.ExtSource;
 import cz.metacentrum.perun.core.api.GroupsManager;
+import cz.metacentrum.perun.core.api.UsersManager;
 import cz.metacentrum.perun.core.api.exceptions.ExtSourceUnsupportedOperationException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.blImpl.PerunBlImpl;
@@ -66,7 +67,7 @@ public class ExtSourceISMU extends ExtSource implements ExtSourceSimpleApi {
 	@Override
 	public List<Map<String, String>> getUsersSubjects() {
 		// Get the url query for users subjects
-		String queryForUsers = getAttributes().get("usersQuery");
+		String queryForUsers = getAttributes().get(UsersManager.USERS_QUERY);
 
 		return querySource(queryForUsers, null, 0);
 	}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceLdap.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceLdap.java
@@ -164,8 +164,16 @@ public class ExtSourceLdap extends ExtSource implements ExtSourceApi {
 	}
 
 	@Override
-	public List<Map<String, String>> getUsersSubjects() throws ExtSourceUnsupportedOperationException {
-		throw new ExtSourceUnsupportedOperationException();
+	public List<Map<String, String>> getUsersSubjects() {
+		// if usersQuery is null, there is no filter and method returns all users subjects
+		String filter = getAttributes().get("usersQuery");
+
+		String base = getAttributes().get("base");
+		if (base == null) {
+			throw new InternalErrorException("base attributes is required");
+		}
+
+		return querySource(filter, base, 0);
 	}
 
 	protected void initContext() {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceLdap.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceLdap.java
@@ -2,6 +2,7 @@ package cz.metacentrum.perun.core.impl;
 
 import cz.metacentrum.perun.core.api.ExtSource;
 import cz.metacentrum.perun.core.api.GroupsManager;
+import cz.metacentrum.perun.core.api.UsersManager;
 import cz.metacentrum.perun.core.api.exceptions.ExtSourceUnsupportedOperationException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.SubjectNotExistsException;
@@ -166,7 +167,7 @@ public class ExtSourceLdap extends ExtSource implements ExtSourceApi {
 	@Override
 	public List<Map<String, String>> getUsersSubjects() {
 		// if usersQuery is null, there is no filter and method returns all users subjects
-		String filter = getAttributes().get("usersQuery");
+		String filter = getAttributes().get(UsersManager.USERS_QUERY);
 
 		String base = getAttributes().get("base");
 		if (base == null) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourcePerun.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourcePerun.java
@@ -7,6 +7,7 @@ import cz.metacentrum.perun.core.api.GroupsManager;
 import cz.metacentrum.perun.core.api.RichMember;
 import cz.metacentrum.perun.core.api.RichUser;
 import cz.metacentrum.perun.core.api.UserExtSource;
+import cz.metacentrum.perun.core.api.UsersManager;
 import cz.metacentrum.perun.core.api.exceptions.ExtSourceUnsupportedOperationException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.PerunException;
@@ -124,7 +125,7 @@ public class ExtSourcePerun extends ExtSource implements ExtSourceApi {
 
 	@Override
 	public List<Map<String, String>> getUsersSubjects() {
-		String query = getAttributes().get("usersQuery");
+		String query = getAttributes().get(UsersManager.USERS_QUERY);
 
 		setEnviroment();
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourcePerun.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourcePerun.java
@@ -123,8 +123,12 @@ public class ExtSourcePerun extends ExtSource implements ExtSourceApi {
 	}
 
 	@Override
-	public List<Map<String, String>> getUsersSubjects() throws ExtSourceUnsupportedOperationException {
-		throw new ExtSourceUnsupportedOperationException();
+	public List<Map<String, String>> getUsersSubjects() {
+		String query = getAttributes().get("usersQuery");
+
+		setEnviroment();
+
+		return convertRichUsersToListOfSubjects(findRichUsers(query));
 	}
 
 	private List<Map<String, String>> convertRichUsersToListOfSubjects(List<RichUser> richUsers) {
@@ -294,7 +298,7 @@ public class ExtSourcePerun extends ExtSource implements ExtSourceApi {
 		return this.call(managerName, methodName, null);
 	}
 
-	private Deserializer call(String managerName, String methodName, String query) throws PerunException {
+	protected Deserializer call(String managerName, String methodName, String query) throws PerunException {
 		//Prepare sending message
 		HttpResponse response;
 		HttpClientBuilder httpClientBuilder = HttpClientBuilder.create();

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceREMS.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceREMS.java
@@ -84,8 +84,9 @@ public class ExtSourceREMS extends ExtSourceSqlComplex implements ExtSourceApi {
 	}
 
 	@Override
-	public List<Map<String, String>> getUsersSubjects() throws ExtSourceUnsupportedOperationException {
-		throw new ExtSourceUnsupportedOperationException();
+	public List<Map<String, String>> getUsersSubjects() {
+		List<Map<String, String>> subjects = super.getUsersSubjects();
+		return filterNonExistingUsers(subjects);
 	}
 
 	/**

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceSql.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceSql.java
@@ -111,7 +111,7 @@ public class ExtSourceSql extends ExtSource implements ExtSourceSimpleApi {
 	}
 
 	@Override
-	public List<Map<String,String>> getUsersSubjects() throws ExtSourceUnsupportedOperationException{
+	public List<Map<String,String>> getUsersSubjects() {
 		String query = getAttributes().get("usersQuery");
 
 		if (query == null) {
@@ -456,7 +456,7 @@ public class ExtSourceSql extends ExtSource implements ExtSourceSimpleApi {
 	 * @return
 	 * @throws SQLException
 	 */
-	private PreparedStatement getPreparedStatement(String query, String searchString, int maxResults) throws SQLException {
+	protected PreparedStatement getPreparedStatement(String query, String searchString, int maxResults) throws SQLException {
 		PreparedStatement st = this.con.prepareStatement(query);
 
 		// Substitute the ? in the query by the searchString

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceSql.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceSql.java
@@ -2,6 +2,7 @@ package cz.metacentrum.perun.core.impl;
 
 import cz.metacentrum.perun.core.api.ExtSource;
 import cz.metacentrum.perun.core.api.GroupsManager;
+import cz.metacentrum.perun.core.api.UsersManager;
 import cz.metacentrum.perun.core.api.exceptions.ExtSourceUnsupportedOperationException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.SubjectNotExistsException;
@@ -112,7 +113,7 @@ public class ExtSourceSql extends ExtSource implements ExtSourceSimpleApi {
 
 	@Override
 	public List<Map<String,String>> getUsersSubjects() {
-		String query = getAttributes().get("usersQuery");
+		String query = getAttributes().get(UsersManager.USERS_QUERY);
 
 		if (query == null) {
 			throw new InternalErrorException("usersQuery attribute is required");

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceTCS.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceTCS.java
@@ -85,8 +85,10 @@ public class ExtSourceTCS extends ExtSource implements ExtSourceApi {
 	}
 
 	@Override
-	public List<Map<String, String>> getUsersSubjects() throws ExtSourceUnsupportedOperationException {
-		throw new ExtSourceUnsupportedOperationException();
+	public List<Map<String, String>> getUsersSubjects() {
+		String url = getAttributes().get("usersQuery");
+
+		return getUsersOrGroupSubjects(url);
 	}
 
 	@Override
@@ -104,6 +106,18 @@ public class ExtSourceTCS extends ExtSource implements ExtSourceApi {
 		//get pem file from url and parse it
 		String url = attributes.get(GroupsManager.GROUPMEMBERSQUERY_ATTRNAME);
 
+		return getUsersOrGroupSubjects(url);
+	}
+
+	//Private methods
+
+	/**
+	 * Get the list of the subjects by query (either members of group or users).
+	 *
+	 * @param url url to get subjects from
+	 * @return list of maps, which contains attr_name-&gt;attr_value, e.g. firstName-&gt;Michal
+	 */
+	private List<Map<String, String>> getUsersOrGroupSubjects(String url) {
 		//Prepare structure of all valid certificates mapped by login
 		Map<String, Pair<X509CertificateHolder, String>> validCertificatesForLogin = prepareStructureOfValidCertificates(url);
 
@@ -125,8 +139,6 @@ public class ExtSourceTCS extends ExtSource implements ExtSourceApi {
 
 		return subjects;
 	}
-
-	//Private methods
 
 	/**
 	 * Create perunSession for ExtSourceTCS
@@ -174,7 +186,7 @@ public class ExtSourceTCS extends ExtSource implements ExtSourceApi {
 	 * @return map of logins (in key) to pair of parsed certificate in the left part and certificate in base64 in the right part
 	 * @throws InternalErrorException If there is any IO problem with parsing and processing the certificate
 	 */
-	private Map<String, Pair<X509CertificateHolder, String>> prepareStructureOfValidCertificates(String url) {
+	protected Map<String, Pair<X509CertificateHolder, String>> prepareStructureOfValidCertificates(String url) {
 		Map<String, Pair<X509CertificateHolder, String>> validCertificatesForLogin = new HashMap<>();
 
 		//prepare all already known logins from Perun
@@ -300,5 +312,9 @@ public class ExtSourceTCS extends ExtSource implements ExtSourceApi {
 			throw new InternalErrorException(ex);
 		}
 		return exportedCert;
+	}
+
+	protected Map<String,String> getAttributes() {
+		return perunBl.getExtSourcesManagerBl().getAttributes(this);
 	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceTCS.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceTCS.java
@@ -9,6 +9,7 @@ import cz.metacentrum.perun.core.api.Pair;
 import cz.metacentrum.perun.core.api.PerunClient;
 import cz.metacentrum.perun.core.api.PerunPrincipal;
 import cz.metacentrum.perun.core.api.PerunSession;
+import cz.metacentrum.perun.core.api.UsersManager;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ExtSourceUnsupportedOperationException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
@@ -86,7 +87,7 @@ public class ExtSourceTCS extends ExtSource implements ExtSourceApi {
 
 	@Override
 	public List<Map<String, String>> getUsersSubjects() {
-		String url = getAttributes().get("usersQuery");
+		String url = getAttributes().get(UsersManager.USERS_QUERY);
 
 		return getUsersOrGroupSubjects(url);
 	}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceUnity.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceUnity.java
@@ -2,6 +2,7 @@ package cz.metacentrum.perun.core.impl;
 
 import cz.metacentrum.perun.core.api.ExtSource;
 import cz.metacentrum.perun.core.api.GroupsManager;
+import cz.metacentrum.perun.core.api.UsersManager;
 import cz.metacentrum.perun.core.api.exceptions.ExtSourceUnsupportedOperationException;
 import cz.metacentrum.perun.core.api.exceptions.IllegalArgumentException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
@@ -129,7 +130,7 @@ public class ExtSourceUnity extends ExtSource implements ExtSourceApi {
 
 	@Override
 	public List<Map<String, String>> getUsersSubjects() {
-		String query = getAttributes().get("usersQuery");
+		String query = getAttributes().get(UsersManager.USERS_QUERY);
 
 		prepareEnvironment();
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceUnity.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceUnity.java
@@ -128,8 +128,12 @@ public class ExtSourceUnity extends ExtSource implements ExtSourceApi {
     }
 
 	@Override
-	public List<Map<String, String>> getUsersSubjects() throws ExtSourceUnsupportedOperationException {
-		throw new ExtSourceUnsupportedOperationException();
+	public List<Map<String, String>> getUsersSubjects() {
+		String query = getAttributes().get("usersQuery");
+
+		prepareEnvironment();
+
+		return jsonParsing(query, 0);
 	}
 
     @Override
@@ -212,7 +216,7 @@ public class ExtSourceUnity extends ExtSource implements ExtSourceApi {
      * @param uri
      * @returns if responseCode to the uri is 200, then returns connection
      */
-    private HttpURLConnection createConnection(String uri) throws IOException {
+    protected HttpURLConnection createConnection(String uri) throws IOException {
         HttpURLConnection connection;
 
         username = getAttributes().get("user");

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceVOOT.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceVOOT.java
@@ -2,6 +2,7 @@ package cz.metacentrum.perun.core.impl;
 
 import cz.metacentrum.perun.core.api.ExtSource;
 import cz.metacentrum.perun.core.api.GroupsManager;
+import cz.metacentrum.perun.core.api.UsersManager;
 import cz.metacentrum.perun.core.api.exceptions.ExtSourceUnsupportedOperationException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.SubjectNotExistsException;
@@ -160,7 +161,7 @@ public class ExtSourceVOOT extends ExtSource implements ExtSourceApi {
 
 	@Override
 	public List<Map<String, String>> getUsersSubjects() {
-		query = getAttributes().get("usersQuery");
+		query = getAttributes().get(UsersManager.USERS_QUERY);
 
 		prepareEnvironment();
 
@@ -211,7 +212,7 @@ public class ExtSourceVOOT extends ExtSource implements ExtSourceApi {
 
     // use uriMembership attribute to obtain list of available groups
     private List<String> getGroupsFromRemote() throws IOException {
-        List<String> groups = new ArrayList();
+        List<String> groups = new ArrayList<>();
 
         HttpURLConnection connection = createConnection(uriMembership);
         InputStream is = null;
@@ -236,7 +237,7 @@ public class ExtSourceVOOT extends ExtSource implements ExtSourceApi {
 		        connection.disconnect();
 	        }
         }
-        return null;
+        return groups;
     }
 
     private List<Map<String, String>> getUsersFromRemote(List<String> groups, int maxResults) throws IOException {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceVOOT.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceVOOT.java
@@ -159,8 +159,19 @@ public class ExtSourceVOOT extends ExtSource implements ExtSourceApi {
     }
 
 	@Override
-	public List<Map<String, String>> getUsersSubjects() throws ExtSourceUnsupportedOperationException {
-		throw new ExtSourceUnsupportedOperationException();
+	public List<Map<String, String>> getUsersSubjects() {
+		query = getAttributes().get("usersQuery");
+
+		prepareEnvironment();
+
+		try {
+			return getUsersFromRemote(getGroupsFromRemote(), 0);
+		} catch (IOException ex) {
+			log.error("IOException in getUsersSubjects() method while obtaining users"
+				+ "from VOOT external source", ex);
+		}
+
+		return null;
 	}
 
     @Override
@@ -169,7 +180,7 @@ public class ExtSourceVOOT extends ExtSource implements ExtSourceApi {
                 "Using this method is not supported for VOOT");
     }
 
-    private HttpURLConnection createConnection(String uri) throws IOException {
+    protected HttpURLConnection createConnection(String uri) throws IOException {
         HttpURLConnection connection;
 
         username = getAttributes().get("user");

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceXML.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceXML.java
@@ -150,8 +150,17 @@ public class ExtSourceXML extends ExtSource implements ExtSourceApi {
 	}
 
 	@Override
-	public List<Map<String, String>> getUsersSubjects() throws ExtSourceUnsupportedOperationException {
-		throw new ExtSourceUnsupportedOperationException();
+	public List<Map<String, String>> getUsersSubjects() {
+		// Get the query for the users subjects
+		String queryForUsers = getAttributes().get("usersQuery");
+
+		//If there is no query for users, throw exception
+		if(queryForUsers == null) throw new InternalErrorException("usersQuery can't be null");
+
+		//Get file or uri of xml
+		prepareEnvironment();
+
+		return xpathParsing(queryForUsers, 0);
 	}
 
 	protected void prepareEnvironment() {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceXML.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceXML.java
@@ -2,6 +2,7 @@ package cz.metacentrum.perun.core.impl;
 
 import cz.metacentrum.perun.core.api.ExtSource;
 import cz.metacentrum.perun.core.api.GroupsManager;
+import cz.metacentrum.perun.core.api.UsersManager;
 import cz.metacentrum.perun.core.api.exceptions.ExtSourceUnsupportedOperationException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.SubjectNotExistsException;
@@ -152,7 +153,7 @@ public class ExtSourceXML extends ExtSource implements ExtSourceApi {
 	@Override
 	public List<Map<String, String>> getUsersSubjects() {
 		// Get the query for the users subjects
-		String queryForUsers = getAttributes().get("usersQuery");
+		String queryForUsers = getAttributes().get(UsersManager.USERS_QUERY);
 
 		//If there is no query for users, throw exception
 		if(queryForUsers == null) throw new InternalErrorException("usersQuery can't be null");

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/ExtSourceCSVTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/ExtSourceCSVTest.java
@@ -1,0 +1,100 @@
+package cz.metacentrum.perun.core.impl;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.doReturn;
+
+/**
+ * @author Metodej Klang
+ */
+public class ExtSourceCSVTest {
+
+	@Spy
+	private static ExtSourceCSV extSourceCSV;
+
+	@Before
+	public void setUp() throws Exception {
+		extSourceCSV = new ExtSourceCSV();
+
+		MockitoAnnotations.initMocks(this);
+	}
+
+	@Test
+	public void getUsersSubjectsQueryWithContainsTest() throws Exception {
+		System.out.println("getUsersSubjectsQueryWithContainsTest");
+
+		// create temporal csv file containing new subjects
+		File temp = File.createTempFile("temp",".csv");
+		temp.deleteOnExit();
+
+		// define needed attributes
+		Map<String, String> mapOfAttributes = new HashMap<>();
+		mapOfAttributes.put("usersQuery", "login contains ");
+		mapOfAttributes.put("file", temp.getAbsolutePath());
+		mapOfAttributes.put("csvMapping", "firstName={firstName},\nlogin={login}");
+		doReturn(mapOfAttributes).when(extSourceCSV).getAttributes();
+
+		// fill in the file
+		try (BufferedWriter bw = new BufferedWriter(new FileWriter(temp))) {
+			bw.write("\"firstName\",\"login\"\n\"bruce\",\"xwayne\"\n\"batman\",\"xbatman\"");
+		}
+
+		// create expected subject to get
+		List<Map<String, String>> expectedSubjects = new ArrayList<>();
+		Map<String, String> mapOfSubject = new HashMap<>();
+		mapOfSubject.put("firstName", "bruce");
+		mapOfSubject.put("login", "xwayne");
+		expectedSubjects.add(mapOfSubject);
+		mapOfSubject = new HashMap<>();
+		mapOfSubject.put("firstName", "batman");
+		mapOfSubject.put("login", "xbatman");
+		expectedSubjects.add(mapOfSubject);
+
+		List<Map<String, String>> actualSubjects = extSourceCSV.getUsersSubjects();
+		assertEquals("subjects should be same", expectedSubjects, actualSubjects);
+	}
+
+	@Test
+	public void getUsersSubjectsQueryWithEqualTest() throws Exception {
+		System.out.println("getUsersSubjectsQueryWithEqualTest");
+
+		// create temporal csv file containing new subjects
+		File temp = File.createTempFile("temp",".csv");
+		temp.deleteOnExit();
+
+		// define needed attributes
+		Map<String, String> mapOfAttributes = new HashMap<>();
+		mapOfAttributes.put("usersQuery", "login=xwayne");
+		mapOfAttributes.put("file", temp.getAbsolutePath());
+		mapOfAttributes.put("csvMapping", "firstName={firstName},\nlogin={login}");
+		doReturn(mapOfAttributes).when(extSourceCSV).getAttributes();
+
+		// fill in the file
+		try (BufferedWriter bw = new BufferedWriter(new FileWriter(temp))) {
+			bw.write("\"firstName\",\"login\"\n\"bruce\",\"xwayne\"\n\"batman\",\"xbatman\"");
+		}
+
+		// create expected subject to get
+		List<Map<String, String>> expectedSubjects = new ArrayList<>();
+		Map<String, String> mapOfSubject = new HashMap<>();
+		mapOfSubject.put("firstName", "bruce");
+		mapOfSubject.put("login", "xwayne");
+		expectedSubjects.add(mapOfSubject);
+
+		// test the method
+		List<Map<String, String>> actualSubjects = extSourceCSV.getUsersSubjects();
+		assertEquals("subjects should be same", expectedSubjects, actualSubjects);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/ExtSourceEGISSOTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/ExtSourceEGISSOTest.java
@@ -1,0 +1,73 @@
+package cz.metacentrum.perun.core.impl;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+
+import javax.naming.NamingEnumeration;
+import javax.naming.directory.Attributes;
+import javax.naming.directory.BasicAttribute;
+import javax.naming.directory.BasicAttributes;
+import javax.naming.directory.DirContext;
+import javax.naming.directory.SearchResult;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+/**
+ * @author Metodej Klang
+ */
+public class ExtSourceEGISSOTest {
+
+	@Spy
+	private static ExtSourceEGISSO extSourceEGISSO;
+
+	@Before
+	public void setUp() throws Exception {
+		extSourceEGISSO = new ExtSourceEGISSO();
+
+		MockitoAnnotations.initMocks(this);
+	}
+
+	@Test
+	public void getUsersSubjectsTest() throws Exception {
+		System.out.println("getUsersSubjectsTest");
+
+		// define needed attributes
+		String usersQuery = "firstName=josef";
+		Map<String, String> mapOfAttributes = new HashMap<>();
+		mapOfAttributes.put("usersQuery", usersQuery);
+		doReturn(mapOfAttributes).when(extSourceEGISSO).getAttributes();
+
+		// mock connection and define received attributes
+		DirContext dirContext = mock(DirContext.class);
+		doReturn(dirContext).when(extSourceEGISSO).getContext();
+		Attributes attributes = new BasicAttributes();
+		attributes.put(new BasicAttribute("cn", "josef"));
+		NamingEnumeration<SearchResult> namingEnumeration = mock(NamingEnumeration.class);
+		doReturn(namingEnumeration).when(dirContext).search(anyString(), anyString(), any());
+		doReturn(true,false).when(namingEnumeration).hasMore();
+		SearchResult searchResult = new SearchResult("name", namingEnumeration, attributes);
+		doReturn(searchResult).when(namingEnumeration).next();
+		extSourceEGISSO.mapping = new HashMap<>();
+		extSourceEGISSO.mapping.put("cn", "cn");
+
+		// create expected subject to get
+		List<Map<String, String>> expectedSubjects = new ArrayList<>();
+		Map<String, String> subject = new HashMap<>();
+		subject.put("cn", "josef");
+		expectedSubjects.add(subject);
+
+		// test the method
+		List<Map<String, String>> actualSubjects = extSourceEGISSO.getUsersSubjects();
+		assertEquals("subjects should be same", expectedSubjects, actualSubjects);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/ExtSourceGoogleTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/ExtSourceGoogleTest.java
@@ -1,0 +1,148 @@
+package cz.metacentrum.perun.core.impl;
+
+import com.google.api.services.admin.directory.Directory;
+import com.google.api.services.admin.directory.model.Member;
+import com.google.api.services.admin.directory.model.Members;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Metodej Klang
+ */
+public class ExtSourceGoogleTest {
+
+	@Spy
+	private static ExtSourceGoogle extSourceGoogle;
+
+	private String domainName;
+	private String groupName;
+
+	@Before
+	public void setUp() throws Exception {
+		extSourceGoogle = new ExtSourceGoogle();
+
+		Members members = fillInMemberList();
+		domainName = "parker.sm";
+		groupName = "spectacular";
+
+		MockitoAnnotations.initMocks(this);
+
+		// mock google connection
+		Directory directory = mock(Directory.class, RETURNS_DEEP_STUBS);
+		doReturn(directory).when(extSourceGoogle).getDirectoryService();
+		when(directory.members().list(groupName).execute()).thenReturn(members);
+
+	}
+
+	@Test
+	public void getUsersSubjectsQueryWithEqualTest() throws Exception {
+		System.out.println("getUsersSubjectsQueryWithEqualTest");
+
+		// define needed attributes
+		Map<String, String> mapOfAttributes = new HashMap<>();
+		mapOfAttributes.put("usersQuery", "id=1");
+		mapOfAttributes.put("userEmail", domainName);
+		mapOfAttributes.put("domain", domainName);
+		mapOfAttributes.put("group", groupName);
+		mapOfAttributes.put("googleMapping", "userID={userID},\ndomainName={domainName},\ngroupName={groupName}");
+		doReturn(mapOfAttributes).when(extSourceGoogle).getAttributes();
+
+		// create expected subject to get
+		List<Map<String, String>> expectedSubjects = new ArrayList<>();
+		Map<String, String> subject = new HashMap<>();
+		subject.put("userID", "1");
+		subject.put("domainName", domainName);
+		subject.put("groupName", groupName);
+		expectedSubjects.add(subject);
+
+		// test the method
+		List<Map<String, String>> actualSubjects = extSourceGoogle.getUsersSubjects();
+		assertEquals("subjects should be same", expectedSubjects, actualSubjects);
+	}
+
+	@Test
+	public void getUsersSubjectsQueryWithContainsAnyTest() throws Exception {
+		System.out.println("getUsersSubjectsQueryWithContainsAnyTest");
+
+		// define needed attributes
+		Map<String, String> mapOfAttributes = new HashMap<>();
+		mapOfAttributes.put("usersQuery", "email contains ");
+		mapOfAttributes.put("userEmail", domainName);
+		mapOfAttributes.put("domain", domainName);
+		mapOfAttributes.put("group", groupName);
+		mapOfAttributes.put("googleMapping", "userID={userID},\ndomainName={domainName},\ngroupName={groupName}");
+		doReturn(mapOfAttributes).when(extSourceGoogle).getAttributes();
+
+		// create expected subject to get
+		List<Map<String, String>> expectedSubjects = new ArrayList<>();
+		Map<String, String> subject = new HashMap<>();
+		subject.put("userID", "1");
+		subject.put("domainName", domainName);
+		subject.put("groupName", groupName);
+		expectedSubjects.add(subject);
+		subject = new HashMap<>();
+		subject.put("userID", "2");
+		subject.put("domainName", domainName);
+		subject.put("groupName", groupName);
+		expectedSubjects.add(subject);
+
+		// test the method
+		List<Map<String, String>> actualSubjects = extSourceGoogle.getUsersSubjects();
+		assertEquals("subjects should be same", expectedSubjects, actualSubjects);
+	}
+
+	@Test
+	public void getUsersSubjectsQueryWithContainsTest() throws Exception {
+		System.out.println("getUsersSubjectsQueryWithContainsTest");
+
+		// define needed attributes
+		Map<String, String> mapOfAttributes = new HashMap<>();
+		mapOfAttributes.put("usersQuery", "email contains mj");
+		mapOfAttributes.put("userEmail", domainName);
+		mapOfAttributes.put("domain", domainName);
+		mapOfAttributes.put("group", groupName);
+		mapOfAttributes.put("googleMapping", "userID={userID},\ndomainName={domainName},\ngroupName={groupName}");
+		doReturn(mapOfAttributes).when(extSourceGoogle).getAttributes();
+
+		// create expected subject to get
+		List<Map<String, String>> expectedSubjects = new ArrayList<>();
+		Map<String, String> subject = new HashMap<>();
+		subject.put("userID", "2");
+		subject.put("domainName", domainName);
+		subject.put("groupName", groupName);
+		expectedSubjects.add(subject);
+
+		// test the method
+		List<Map<String, String>> actualSubjects = extSourceGoogle.getUsersSubjects();
+		assertEquals("subjects should be same", expectedSubjects, actualSubjects);
+	}
+
+	private Members fillInMemberList() {
+		List<Member> memberList = new ArrayList<>();
+		Member member = new Member();
+		member.setId("1");
+		member.setEmail("peter@parker.sm");
+		memberList.add(member);
+		member = new Member();
+		member.setId("2");
+		member.setEmail("mj@parker.sm");
+		memberList.add(member);
+		Members members = new Members();
+		members.setMembers(memberList);
+
+		return members;
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/ExtSourceISMUTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/ExtSourceISMUTest.java
@@ -1,0 +1,67 @@
+package cz.metacentrum.perun.core.impl;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+/**
+ * @author Metodej Klang
+ */
+public class ExtSourceISMUTest {
+
+	@Spy
+	private static ExtSourceISMU extSourceISMU;
+
+	@Before
+	public void setUp() throws Exception {
+		extSourceISMU = new ExtSourceISMU();
+
+		MockitoAnnotations.initMocks(this);
+	}
+
+	@Test
+	public void getUsersSubjectsTest() throws Exception {
+		System.out.println("getUsersSubjectsTest");
+		String usersQuery = "https://some.url.cz/";
+
+		// define needed attributes
+		Map<String, String> mapOfAttributes = new HashMap<>();
+		mapOfAttributes.put("usersQuery", usersQuery);
+		doReturn(mapOfAttributes).when(extSourceISMU).getAttributes();
+
+		// create expected subject to get
+		List<Map<String, String>> expectedSubjects = new ArrayList<>();
+		Map<String, String> subject = new HashMap<>();
+		subject.put("login", "123456");
+		subject.put("titleBefore", null);
+		subject.put("firstName", "Metodej");
+		subject.put("lastName", "Klang");
+		subject.put("additionalues_1", "https://idp2.ics.muni.cz/idp/shibboleth|cz.metacentrum.perun.core.impl.ExtSourceIdp|123456@muni.cz|2");
+		subject.put("titleAfter", null);
+		expectedSubjects.add(subject);
+
+		// mock connection
+		HttpURLConnection http = mock(HttpURLConnection.class);
+		doReturn(http).when(extSourceISMU).getHttpConnection(usersQuery, null);
+		String input = "123456;;\"Metodej Klang\";Klang;Metodej;";
+		InputStream is = new ByteArrayInputStream(input.getBytes());
+		doReturn(is).when(http).getInputStream();
+
+		// test the method
+		List<Map<String, String>> actualSubjects = extSourceISMU.getUsersSubjects();
+		assertEquals("subjects should be same", expectedSubjects, actualSubjects);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/ExtSourceLdapTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/ExtSourceLdapTest.java
@@ -1,0 +1,114 @@
+package cz.metacentrum.perun.core.impl;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+
+import javax.naming.NamingEnumeration;
+import javax.naming.directory.Attribute;
+import javax.naming.directory.Attributes;
+import javax.naming.directory.BasicAttribute;
+import javax.naming.directory.BasicAttributes;
+import javax.naming.directory.DirContext;
+import javax.naming.directory.SearchResult;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+/**
+ * @author Metodej Klang
+ */
+public class ExtSourceLdapTest {
+
+	@Spy
+	private static ExtSourceLdap extSourceLdap;
+
+	@Before
+	public void setUp() throws Exception {
+		extSourceLdap = new ExtSourceLdap();
+
+		MockitoAnnotations.initMocks(this);
+
+		extSourceLdap.mapping = new HashMap<>();
+		extSourceLdap.mapping.put("cn", "{firstName}");
+		extSourceLdap.mapping.put("dc", "{dc}");
+	}
+
+	@Test
+	public void getUsersSubjectsNullQueryTest() throws Exception {
+		System.out.println("getUsersSubjectsNullQueryTest");
+
+		// define needed attributes
+		String base = "cn=firstName,dc=dc";
+		Map<String, String> mapOfAttributes = new HashMap<>();
+		mapOfAttributes.put("usersQuery", null);
+		mapOfAttributes.put("base", base);
+		doReturn(mapOfAttributes).when(extSourceLdap).getAttributes();
+
+		// mock connection and define received attributes
+		DirContext dirContext = mock(DirContext.class);
+		doReturn(dirContext).when(extSourceLdap).getContext();
+		Attributes attributes = new BasicAttributes();
+		attributes.put(new BasicAttribute("firstName", "josef"));
+		attributes.put(new BasicAttribute("dc", "cz"));
+		doReturn(attributes).when(dirContext).getAttributes(base);
+
+		// create expected subject to get
+		List<Map<String, String>> expectedSubjects = new ArrayList<>();
+		Map<String, String> subject = new HashMap<>();
+		subject.put("cn", "josef");
+		subject.put("dc", "cz");
+		expectedSubjects.add(subject);
+
+		// test the method
+		List<Map<String, String>> actualSubjects = extSourceLdap.getUsersSubjects();
+		assertEquals("subjects should be same", expectedSubjects, actualSubjects);
+	}
+
+	@Test
+	public void getUsersSubjectsTest() throws Exception {
+		System.out.println("getUsersSubjectsTest");
+
+		// define needed attributes
+		String base = "cn=firstName,dc=dc";
+		String usersQuery = "dc=cz";
+		Map<String, String> mapOfAttributes = new HashMap<>();
+		mapOfAttributes.put("usersQuery", usersQuery);
+		mapOfAttributes.put("base", base);
+		doReturn(mapOfAttributes).when(extSourceLdap).getAttributes();
+
+		// mock connection and define received attributes
+		DirContext dirContext = mock(DirContext.class);
+		doReturn(dirContext).when(extSourceLdap).getContext();
+		Attribute attribute = new BasicAttribute("firstName", "josef");
+		Attribute attribute2 = new BasicAttribute("dc", "cz");
+		Attributes attributes = new BasicAttributes();
+		attributes.put(attribute);
+		attributes.put(attribute2);
+		NamingEnumeration<SearchResult> namingEnumeration = mock(NamingEnumeration.class);
+		doReturn(namingEnumeration).when(dirContext).search(anyString(), anyString(), any());
+		doReturn(true,false).when(namingEnumeration).hasMore();
+		SearchResult searchResult = new SearchResult("name", namingEnumeration, attributes);
+		doReturn(searchResult).when(namingEnumeration).next();
+
+		// create expected subject to get
+		List<Map<String, String>> expectedSubjects = new ArrayList<>();
+		Map<String, String> subject = new HashMap<>();
+		subject.put("cn", "josef");
+		subject.put("dc", "cz");
+		expectedSubjects.add(subject);
+
+		// test the method
+		List<Map<String, String>> actualSubjects = extSourceLdap.getUsersSubjects();
+		assertEquals("subjects should be same", expectedSubjects, actualSubjects);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/ExtSourcePerunTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/ExtSourcePerunTest.java
@@ -1,0 +1,88 @@
+package cz.metacentrum.perun.core.impl;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.ExtSource;
+import cz.metacentrum.perun.core.api.RichUser;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.UserExtSource;
+import cz.metacentrum.perun.rpc.deserializer.JsonDeserializer;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+/**
+ * @author Metodej Klang
+ */
+public class ExtSourcePerunTest {
+
+	@Spy
+	private static ExtSourcePerun extSourcePerun;
+
+	@Before
+	public void setUp() throws Exception {
+		extSourcePerun = new ExtSourcePerun();
+
+		MockitoAnnotations.initMocks(this);
+	}
+
+	@Test
+	public void getUsersSubjectsTest() throws Exception {
+		System.out.println("getUsersSubjectsTest");
+
+		// set up list of rich users
+		AttributeDefinition attributeDefinition = new AttributeDefinition();
+		attributeDefinition.setFriendlyName("firstName");
+		attributeDefinition.setNamespace(AttributesManager.NS_USER_ATTR_DEF);
+		attributeDefinition.setType(String.class.getName());
+		Attribute attribute = new Attribute(attributeDefinition, "metodej");
+
+		ExtSource extSource = new ExtSource();
+		extSource.setName("extSourceNameForLogin");
+
+		UserExtSource userExtSource = new UserExtSource();
+		userExtSource.setLogin("extSourceNameForLogin");
+		userExtSource.setExtSource(extSource);
+		RichUser richUser = new RichUser(new User(), Collections.singletonList(userExtSource), Collections.singletonList(attribute));
+
+		List<RichUser> richUserList = new ArrayList<>();
+		richUserList.add(richUser);
+
+		JsonDeserializer deserializer = mock(JsonDeserializer.class);
+		doReturn(deserializer).when(extSourcePerun).call("usersManager", "findRichUsers", "searchString=query");
+		doReturn(richUserList).when(deserializer).readList(RichUser.class);
+
+		// define needed attributes
+		Map<String, String> mapOfAttributes = new HashMap<>();
+		mapOfAttributes.put("usersQuery", "query");
+		mapOfAttributes.put("perunUrl", "perunUrl");
+		mapOfAttributes.put("username", "username");
+		mapOfAttributes.put("password", "password");
+		mapOfAttributes.put("extSourceNameForLogin", "extSourceNameForLogin");
+		mapOfAttributes.put("xmlMapping", "firstName={urn:perun:user:attribute-def:def:firstName},\nlogin={login}");
+		doReturn(mapOfAttributes).when(extSourcePerun).getAttributes();
+
+		// create expected subject to get
+		List<Map<String, String>> expectedSubjects = new ArrayList<>();
+		Map<String, String> subject = new HashMap<>();
+		subject.put("login", "extSourceNameForLogin");
+		subject.put("firstName", "metodej");
+		expectedSubjects.add(subject);
+
+		// test the method
+		List<Map<String, String>> actualSubjects = extSourcePerun.getUsersSubjects();
+		assertEquals("subjects should be same", expectedSubjects, actualSubjects);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/ExtSourceREMSTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/ExtSourceREMSTest.java
@@ -1,0 +1,87 @@
+package cz.metacentrum.perun.core.impl;
+
+import cz.metacentrum.perun.core.AbstractPerunIntegrationTest;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.blImpl.PerunBlImpl;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Metodej Klang
+ */
+public class ExtSourceREMSTest extends AbstractPerunIntegrationTest {
+
+	@Spy
+	private static ExtSourceREMS extSourceREMS;
+
+	private static PerunBlImpl perunBl;
+
+	@Before
+	public void setUp() throws Exception {
+		extSourceREMS = new ExtSourceREMS();
+		perunBl = mock(PerunBlImpl.class, RETURNS_DEEP_STUBS);
+
+		MockitoAnnotations.initMocks(this);
+		ExtSourceREMS.setPerunBlImpl(perunBl);
+	}
+
+	@Test
+	public void getUsersSubjectsTest() throws Exception {
+		System.out.println("getUsersSubjectsTest");
+
+		// define needed attributes
+		String usersQuery = "usersQuery";
+		Map<String, String> mapOfAttributes = new HashMap<>();
+		mapOfAttributes.put("usersQuery", usersQuery);
+		mapOfAttributes.put("url", "some.url.com");
+		doReturn(mapOfAttributes).when(extSourceREMS).getAttributes();
+
+		// mock data got from database
+		doNothing().when(extSourceREMS).createConnection();
+		PreparedStatement preparedStatement = mock(PreparedStatement.class);
+		doReturn(preparedStatement).when(extSourceREMS).getPreparedStatement(usersQuery, null, 0);
+		ResultSet resultSet = mock(ResultSet.class, RETURNS_DEEP_STUBS);
+		doReturn(resultSet).when(preparedStatement).executeQuery();
+		doReturn(true, false).when(resultSet).next();
+		doReturn("josef").when(resultSet).getString("firstName");
+		doReturn("xjosef").when(resultSet).getString("login");
+		User user = new User();
+		user.setFirstName("josef");
+		when(perunBl.getUsersManagerBl().getUsersByExtSourceTypeAndLogin(any(), anyString(), eq("xjosef"))).thenReturn(Collections.singletonList(user));
+
+		// create expected subject to get
+		List<Map<String, String>> expectedSubjects = new ArrayList<>();
+		Map<String, String> subject = new HashMap<>();
+		subject.put("firstName", "josef");
+		subject.put("login", "xjosef");
+		subject.put("lastName", null);
+		subject.put("titleBefore", null);
+		subject.put("titleAfter", null);
+		subject.put("middleName", null);
+		expectedSubjects.add(subject);
+
+		// test the method
+		List<Map<String, String>> actualSubjects = extSourceREMS.getUsersSubjects();
+		assertEquals("subjects should be same", expectedSubjects, actualSubjects);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/ExtSourceSqlTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/ExtSourceSqlTest.java
@@ -1,0 +1,72 @@
+package cz.metacentrum.perun.core.impl;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+/**
+ * @author Metodej Klang
+ */
+public class ExtSourceSqlTest {
+
+	@Spy
+	private static ExtSourceSql extSourceSql;
+
+	@Before
+	public void setUp() throws Exception {
+		extSourceSql = new ExtSourceSql();
+
+		MockitoAnnotations.initMocks(this);
+	}
+
+	@Test
+	public void getUsersSubjectsTest() throws Exception {
+		System.out.println("getUsersSubjectsTest");
+
+		// define needed attributes
+		String usersQuery = "usersQuery";
+		Map<String, String> mapOfAttributes = new HashMap<>();
+		mapOfAttributes.put("usersQuery", usersQuery);
+		mapOfAttributes.put("url", "some.url.com");
+		doReturn(mapOfAttributes).when(extSourceSql).getAttributes();
+
+		// mock data got from database
+		doNothing().when(extSourceSql).createConnection();
+		PreparedStatement preparedStatement = mock(PreparedStatement.class);
+		doReturn(preparedStatement).when(extSourceSql).getPreparedStatement(usersQuery, null, 0);
+		ResultSet resultSet = mock(ResultSet.class, RETURNS_DEEP_STUBS);
+		doReturn(resultSet).when(preparedStatement).executeQuery();
+		doReturn(true, false).when(resultSet).next();
+		doReturn("josef").when(resultSet).getString("firstName");
+		doReturn("xjosef").when(resultSet).getString("login");
+
+		// create expected subject to get
+		List<Map<String, String>> expectedSubjects = new ArrayList<>();
+		Map<String, String> subject = new HashMap<>();
+		subject.put("firstName", "josef");
+		subject.put("login", "xjosef");
+		subject.put("lastName", null);
+		subject.put("titleBefore", null);
+		subject.put("titleAfter", null);
+		subject.put("middleName", null);
+		expectedSubjects.add(subject);
+
+		// test the method
+		List<Map<String, String>> actualSubjects = extSourceSql.getUsersSubjects();
+		assertEquals("subjects should be same", expectedSubjects, actualSubjects);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/ExtSourceTCSTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/ExtSourceTCSTest.java
@@ -1,0 +1,63 @@
+package cz.metacentrum.perun.core.impl;
+
+import cz.metacentrum.perun.core.api.Pair;
+import org.bouncycastle.cert.X509CertificateHolder;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Metodej Klang
+ */
+public class ExtSourceTCSTest {
+
+	@Spy
+	private static ExtSourceTCS extSourceTCS;
+
+	@Before
+	public void setUp() throws Exception {
+		extSourceTCS = new ExtSourceTCS();
+
+		MockitoAnnotations.initMocks(this);
+	}
+
+	@Test
+	public void getUsersSubjects() {
+		// mock certificates
+		X509CertificateHolder certificateHolder = mock(X509CertificateHolder.class, RETURNS_DEEP_STUBS);
+		when(certificateHolder.getSubject().toString()).thenReturn("certificate");
+		Map<String, Pair<X509CertificateHolder, String>> validCertificatesForLogin = new HashMap<>();
+		validCertificatesForLogin.put("123456", new Pair<>(certificateHolder, "value"));
+		doReturn(validCertificatesForLogin).when(extSourceTCS).prepareStructureOfValidCertificates("url");
+
+		// define needed attributes
+		Map<String, String> mapOfAttributes = new HashMap<>();
+		mapOfAttributes.put("usersQuery", "url");
+		mapOfAttributes.put("googleMapping", "userID={userID},\ndomainName={domainName},\ngroupName={groupName}");
+		doReturn(mapOfAttributes).when(extSourceTCS).getAttributes();
+
+		// create expected subject to get
+		List<Map<String, String>> expectedSubjects = new ArrayList<>();
+		Map<String, String> subject = new HashMap<>();
+		subject.put("login", "123456");
+		subject.put("additionalues_1", "https://idp2.ics.muni.cz/idp/shibboleth|cz.metacentrum.perun.core.impl.ExtSourceIdp|123456@muni.cz|2");
+		subject.put("urn:perun:user:attribute-def:def:userCertificates", "certificate:value,");
+		expectedSubjects.add(subject);
+
+		// test the method
+		List<Map<String, String>> actualSubjects = extSourceTCS.getUsersSubjects();
+		assertEquals("subjects should be same", expectedSubjects, actualSubjects);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/ExtSourceUnityTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/ExtSourceUnityTest.java
@@ -1,0 +1,76 @@
+package cz.metacentrum.perun.core.impl;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+/**
+ * @author Metodej Klang
+ */
+public class ExtSourceUnityTest {
+
+	@Spy
+	private static ExtSourceUnity extSourceUnity;
+
+	@Before
+	public void setUp() throws Exception {
+		extSourceUnity = new ExtSourceUnity();
+
+		MockitoAnnotations.initMocks(this);
+	}
+
+	@Test
+	public void getUsersSubjectsTest() throws Exception {
+		System.out.println("getUsersSubjectsTest");
+
+		// mock connection
+		HttpURLConnection http = mock(HttpURLConnection.class);
+		doReturn(http).when(extSourceUnity).createConnection("uriAll");
+		String input = "{\"members\":[1]}";
+		InputStream is = new ByteArrayInputStream(input.getBytes());
+		doReturn(is).when(http).getInputStream();
+
+		HttpURLConnection http2 = mock(HttpURLConnection.class);
+		doReturn(http2).when(extSourceUnity).createConnection("uriEntity/1/");
+		String input2 = "{\"id\":1,\"name\":miles,\"state\":valid,\"identities\":[{\"typeId\":identifier,\"translationProfile\":profile,\"value\":xmorales}]}";
+		InputStream is2 = new ByteArrayInputStream(input2.getBytes());
+		doReturn(is2).when(http2).getInputStream();
+
+		HttpURLConnection http3 = mock(HttpURLConnection.class);
+		doReturn(http3).when(extSourceUnity).createConnection("uriEntity/1/attributes");
+		String input3 = "[{\"name\":name,\"values\":[miles morales]}]";
+		InputStream is3 = new ByteArrayInputStream(input3.getBytes());
+		doReturn(is3).when(http3).getInputStream();
+
+		// define needed attributes
+		Map<String, String> mapOfAttributes = new HashMap<>();
+		mapOfAttributes.put("usersQuery", "login=xmorales");
+		mapOfAttributes.put("uriAll", "uriAll");
+		mapOfAttributes.put("uriEntity", "uriEntity");
+		mapOfAttributes.put("unityMapping", "login={login},\nfirstName={firstName}");
+		doReturn(mapOfAttributes).when(extSourceUnity).getAttributes();
+
+		// create expected subject to get
+		List<Map<String, String>> expectedSubjects = new ArrayList<>();
+		Map<String, String> subject = new HashMap<>();
+		subject.put("login", "xmorales");
+		expectedSubjects.add(subject);
+
+		// test the method
+		List<Map<String, String>> actualSubjects = extSourceUnity.getUsersSubjects();
+		assertEquals("subjects should be same", expectedSubjects, actualSubjects);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/ExtSourceVOOTTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/ExtSourceVOOTTest.java
@@ -1,0 +1,71 @@
+package cz.metacentrum.perun.core.impl;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+/**
+ * @author Metodej Klang
+ */
+public class ExtSourceVOOTTest {
+
+	@Spy
+	private static ExtSourceVOOT extSourceVOOT;
+
+	@Before
+	public void setUp() throws Exception {
+		extSourceVOOT = new ExtSourceVOOT();
+
+		MockitoAnnotations.initMocks(this);
+	}
+
+	@Test
+	public void getUsersSubjectsTest() throws Exception {
+		System.out.println("getUsersSubjectsTest");
+
+		// mock connection
+		HttpURLConnection http = mock(HttpURLConnection.class);
+		doReturn(http).when(extSourceVOOT).createConnection("uriMembership");
+		String input = "{\"entry\":[{\"id\":\"1\"}]}";
+		InputStream is = new ByteArrayInputStream(input.getBytes());
+		doReturn(is).when(http).getInputStream();
+
+		HttpURLConnection http2 = mock(HttpURLConnection.class);
+		doReturn(http2).when(extSourceVOOT).createConnection("uriMembers/1");
+		String input2 = "{\"entry\":[{\"id\":\"xmorales@1\",\"login\":xmorales@miles.sp,\"emails\":[{\"value\":miles@morales.sp}]}]}";
+		InputStream is2 = new ByteArrayInputStream(input2.getBytes());
+		doReturn(is2).when(http2).getInputStream();
+
+		// define needed attributes
+		Map<String, String> mapOfAttributes = new HashMap<>();
+		mapOfAttributes.put("usersQuery", "id=xmorales@1");
+		mapOfAttributes.put("uriMembership", "uriMembership");
+		mapOfAttributes.put("uriMembers", "uriMembers");
+		mapOfAttributes.put("vootMapping", "login={login},\nemail={email}");
+		doReturn(mapOfAttributes).when(extSourceVOOT).getAttributes();
+
+		// create expected subject to get
+		List<Map<String, String>> expectedSubjects = new ArrayList<>();
+		Map<String, String> subject = new HashMap<>();
+		subject.put("login", "xmorales");
+		subject.put("email", "miles@morales.sp");
+		expectedSubjects.add(subject);
+
+		// test the method
+		List<Map<String, String>> actualSubjects = extSourceVOOT.getUsersSubjects();
+		assertEquals("subjects should be same", expectedSubjects, actualSubjects);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/ExtSourceXMLTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/ExtSourceXMLTest.java
@@ -1,0 +1,65 @@
+package cz.metacentrum.perun.core.impl;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.doReturn;
+
+/**
+ * @author Metodej Klang
+ */
+public class ExtSourceXMLTest {
+
+	@Spy
+	private static ExtSourceXML extSourceXML;
+
+	@Before
+	public void setUp() throws Exception {
+		extSourceXML = new ExtSourceXML();
+
+		MockitoAnnotations.initMocks(this);
+	}
+
+	@Test
+	public void getUsersSubjectsTest() throws Exception {
+		System.out.println("getUsersSubjectsTest");
+
+		// create temporal csv file containing new subjects
+		File temp = File.createTempFile("temp",".xml");
+		temp.deleteOnExit();
+
+		// define needed attributes
+		Map<String, String> mapOfAttributes = new HashMap<>();
+		mapOfAttributes.put("usersQuery", "/Users/User[@id='42']");
+		mapOfAttributes.put("file", temp.getAbsolutePath());
+		mapOfAttributes.put("xmlMapping", "firstName=firstName,\nlogin=login");
+		doReturn(mapOfAttributes).when(extSourceXML).getAttributes();
+
+		// fill in the file
+		try (BufferedWriter bw = new BufferedWriter(new FileWriter(temp))) {
+			bw.write("<Users>\n<User id='42'>\n<firstName>arthur</firstName>\n<login>xdent</login>\n</User>\n</Users>");
+		}
+
+		// create expected subject to get
+		List<Map<String, String>> expectedSubjects = new ArrayList<>();
+		Map<String, String> mapOfSubject = new HashMap<>();
+		mapOfSubject.put("firstName", "arthur");
+		mapOfSubject.put("login", "xdent");
+		expectedSubjects.add(mapOfSubject);
+
+		// test the method
+		List<Map<String, String>> actualSubjects = extSourceXML.getUsersSubjects();
+		assertEquals("subjects should be same", expectedSubjects, actualSubjects);
+	}
+}


### PR DESCRIPTION
- method getUsersSubjects is now implemented everywhere where getGroupSubjects is
- query used by this method should be defined in perun-extSources.xml
- method to get http connection separated to protected method for better testing in ExtSourceISMU, also some other methods accessibility changed to protected to be mocked in tests
- also added tests for this method