### PR TITLE
SameSite=Strict session cookies

### DIFF
--- a/perun-rpc/src/main/webapp/META-INF/context.xml
+++ b/perun-rpc/src/main/webapp/META-INF/context.xml
@@ -1,2 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Context sessionCookieName="PERUNSESSION" sessionCookiePath="/" />
+<Context sessionCookieName="PERUNSESSION" sessionCookiePath="/" >
+	<CookieProcessor sameSiteCookies="strict" />
+</Context>


### PR DESCRIPTION
This PR prevents XSRF (Cross-Site Request Forgery) attacks on Perun API session cookies.

It sets Tomcat to add the flag "SameSite=Strict" to session cookies for the perun-rpc web application. The flag tells browsers not to send the cookie when a request is made from another site. The session cookies then look like this:

```set-cookie: PERUNSESSION=6BD47BBA906E0FA06E210E313CAD802B; Path=/; Secure; HttpOnly; SameSite=Strict```