### PR TITLE
GUI: Show new group sync attribute with start time

### DIFF
--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/groupsManager/GetAllRichGroups.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/groupsManager/GetAllRichGroups.java
@@ -221,7 +221,7 @@ public class GetAllRichGroups implements JsonCallback, JsonCallbackTable<RichGro
 
 						final RichGroup object = jso.cast();
 
-						String name, syncEnabled, syncInterval, syncTimestamp, syncSuccessTimestamp, syncState, authGroup, syncTimes, syncSuccessStartTimestamp;
+						String name, syncEnabled, syncInterval, syncStartTimestamp, syncTimestamp, syncSuccessTimestamp, syncState, authGroup, syncTimes, syncSuccessStartTimestamp;
 						name = object.getName();
 						if (object.isSyncEnabled()) {
 							syncEnabled = "enabled";
@@ -268,6 +268,11 @@ public class GetAllRichGroups implements JsonCallback, JsonCallbackTable<RichGro
 						} else {
 							syncTimestamp = object.getLastSynchronizationTimestamp().split("\\.")[0];
 						}
+						if (object.getStartOfLastSynchronizationTimestamp() == null) {
+							syncStartTimestamp = "N/A";
+						} else {
+							syncStartTimestamp = object.getStartOfLastSynchronizationTimestamp().split("\\.")[0];
+						}
 						if (object.getLastSuccessSynchronizationTimestamp() == null) {
 							syncSuccessTimestamp = "N/A";
 						} else {
@@ -292,7 +297,8 @@ public class GetAllRichGroups implements JsonCallback, JsonCallbackTable<RichGro
 
 						if (object.isSyncEnabled()) {
 							html += "Last sync. state: <b>"+SafeHtmlUtils.fromString(syncState).asString()+"</b><br>";
-							html += "Last sync. timestamp: <b>"+SafeHtmlUtils.fromString(syncTimestamp).asString()+"</b><br>";
+							html += "Last sync. timestamp (start): <b>"+SafeHtmlUtils.fromString(syncStartTimestamp).asString()+"</b><br>";
+							html += "Last sync. timestamp (end): <b>"+SafeHtmlUtils.fromString(syncTimestamp).asString()+"</b><br>";
 							html += "Last successful sync. timestamp (start): <b>"+SafeHtmlUtils.fromString(syncSuccessStartTimestamp).asString()+"</b><br>";
 							html += "Last successful sync. timestamp (end): <b>"+SafeHtmlUtils.fromString(syncSuccessTimestamp).asString()+"</b><br>";
 						}

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/groupsManager/GetAllRichSubGroups.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/groupsManager/GetAllRichSubGroups.java
@@ -184,7 +184,7 @@ public class GetAllRichSubGroups implements JsonCallback, JsonCallbackTable<Rich
 
 						final RichGroup object = jso.cast();
 
-						String name, syncEnabled, syncInterval, syncTimestamp, syncSuccessTimestamp, syncState, authGroup, syncTimes, syncSuccessStartTimestamp;
+						String name, syncEnabled, syncInterval, syncStartTimestamp, syncTimestamp, syncSuccessTimestamp, syncState, authGroup, syncTimes, syncSuccessStartTimestamp;
 						name = object.getName();
 						if (object.isSyncEnabled()) {
 							syncEnabled = "enabled";
@@ -231,6 +231,11 @@ public class GetAllRichSubGroups implements JsonCallback, JsonCallbackTable<Rich
 						} else {
 							syncTimestamp = object.getLastSynchronizationTimestamp().split("\\.")[0];
 						}
+						if (object.getStartOfLastSynchronizationTimestamp() == null) {
+							syncStartTimestamp = "N/A";
+						} else {
+							syncStartTimestamp = object.getStartOfLastSynchronizationTimestamp().split("\\.")[0];
+						}
 						if (object.getLastSuccessSynchronizationTimestamp() == null) {
 							syncSuccessTimestamp = "N/A";
 						} else {
@@ -255,7 +260,8 @@ public class GetAllRichSubGroups implements JsonCallback, JsonCallbackTable<Rich
 
 						if (object.isSyncEnabled()) {
 							html += "Last sync. state: <b>"+SafeHtmlUtils.fromString(syncState).asString()+"</b><br>";
-							html += "Last sync. timestamp: <b>"+SafeHtmlUtils.fromString(syncTimestamp).asString()+"</b><br>";
+							html += "Last sync. timestamp (start): <b>"+SafeHtmlUtils.fromString(syncStartTimestamp).asString()+"</b><br>";
+							html += "Last sync. timestamp (end): <b>"+SafeHtmlUtils.fromString(syncTimestamp).asString()+"</b><br>";
 							html += "Last successful sync. timestamp (start): <b>"+SafeHtmlUtils.fromString(syncSuccessStartTimestamp).asString()+"</b><br>";
 							html += "Last successful sync. timestamp (end): <b>"+SafeHtmlUtils.fromString(syncSuccessTimestamp).asString()+"</b><br>";
 						}

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/RichGroup.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/RichGroup.java
@@ -69,6 +69,14 @@ public class RichGroup extends Group {
 		}
 		return null;
 	}-*/;
+	public final native String getStartOfLastSynchronizationTimestamp() /*-{
+		for (var id in this.attributes) {
+			if (this.attributes[id].friendlyName === "startOfLastSynchronization") {
+				return this.attributes[id].value;
+			}
+		}
+		return null;
+	}-*/;
 	public final native String getLastSuccessSynchronizationTimestamp() /*-{
 		for (var id in this.attributes) {
 			if (this.attributes[id].friendlyName === "lastSuccessSynchronizationTimestamp") {

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/GroupsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/GroupsTabItem.java
@@ -124,6 +124,7 @@ public class GroupsTabItem implements TabItem, TabItemWithUrl {
 		attrNames.add("urn:perun:group:attribute-def:def:authoritativeGroup");
 		attrNames.add("urn:perun:group:attribute-def:def:groupSynchronizationTimes");
 		attrNames.add("urn:perun:group:attribute-def:def:startOfLastSuccessfulSynchronization");
+		attrNames.add("urn:perun:group:attribute-def:def:startOfLastSynchronization");
 		final GetAllRichGroups groups = new GetAllRichGroups(voId, attrNames);
 		groups.setCheckable(false);
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/SubgroupsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/SubgroupsTabItem.java
@@ -124,6 +124,7 @@ public class SubgroupsTabItem implements TabItem, TabItemWithUrl{
 		attrNames.add("urn:perun:group:attribute-def:def:authoritativeGroup");
 		attrNames.add("urn:perun:group:attribute-def:def:groupSynchronizationTimes");
 		attrNames.add("urn:perun:group:attribute-def:def:startOfLastSuccessfulSynchronization");
+		attrNames.add("urn:perun:group:attribute-def:def:startOfLastSynchronization");
 
 		final GetAllRichSubGroups subgroups = new GetAllRichSubGroups(groupId, attrNames);
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/vostabs/VoGroupsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/vostabs/VoGroupsTabItem.java
@@ -120,6 +120,7 @@ public class VoGroupsTabItem implements TabItem, TabItemWithUrl{
 		attrNames.add("urn:perun:group:attribute-def:def:authoritativeGroup");
 		attrNames.add("urn:perun:group:attribute-def:def:groupSynchronizationTimes");
 		attrNames.add("urn:perun:group:attribute-def:def:startOfLastSuccessfulSynchronization");
+		attrNames.add("urn:perun:group:attribute-def:def:startOfLastSynchronization");
 		final GetAllRichGroups groups = new GetAllRichGroups(voId, attrNames);
 		final JsonCallbackEvents events = JsonCallbackEvents.refreshTableEvents(groups);
 		if (!session.isVoAdmin(voId)) groups.setCheckable(false);


### PR DESCRIPTION
- When showing-up group sync details, show also timestamp of
  the last synchronization start (since it might not finish
  in one transaction to store end timestamp).