### PR TITLE
engine: WARN state

### DIFF
--- a/perun-auditparser/src/main/java/cz/metacentrum/perun/auditparser/AuditParser.java
+++ b/perun-auditparser/src/main/java/cz/metacentrum/perun/auditparser/AuditParser.java
@@ -536,7 +536,7 @@ public class AuditParser {
 			else if (status.equals("DONE")) st = TaskResultStatus.DONE;
 			else if (status.equals("ERROR")) st = TaskResultStatus.ERROR;
 			else if (status.equals("FATAL_ERROR")) st = TaskResultStatus.FATAL_ERROR;
-			else if (status.equals("WARN")) st = TaskResultStatus.WARN;
+			else if (status.equals("WARNING")) st = TaskResultStatus.WARNING;
 			else st = null;
 		}
 		taskResult.setStatus(st);

--- a/perun-base/src/main/java/cz/metacentrum/perun/taskslib/model/SendTask.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/taskslib/model/SendTask.java
@@ -238,6 +238,6 @@ public class SendTask implements Serializable {
 	 * Represent state in which sending task is
 	 */
 	public static enum SendTaskStatus {
-		SENDING, SENT, ERROR
+		SENDING, SENT, ERROR, WARNING
 	}
 }

--- a/perun-base/src/main/java/cz/metacentrum/perun/taskslib/model/Task.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/taskslib/model/Task.java
@@ -19,7 +19,7 @@ public class Task implements Serializable {
 	private static final long serialVersionUID = -1809998673612582742L;
 
 	public enum TaskStatus {
-		WAITING, PLANNED, GENERATING, GENERROR, GENERATED, SENDING, DONE, SENDERROR, ERROR
+		WAITING, PLANNED, GENERATING, GENERROR, GENERATED, SENDING, DONE, SENDERROR, ERROR, WARNING
 	}
 
 	private int id;

--- a/perun-base/src/main/java/cz/metacentrum/perun/taskslib/model/TaskResult.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/taskslib/model/TaskResult.java
@@ -22,7 +22,7 @@ public class TaskResult extends PerunBean implements Serializable {
 	private static final long serialVersionUID = 5656828750714418582L;
 
 	public static enum TaskResultStatus {
-		DONE, ERROR, FATAL_ERROR, DENIED, WARN
+		DONE, ERROR, FATAL_ERROR, DENIED, WARNING
 	}
 
 	private int taskId;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/TasksManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/TasksManagerImpl.java
@@ -83,6 +83,8 @@ public class TasksManagerImpl implements TasksManagerImplApi {
 			taskResult.setStatus(TaskResult.TaskResultStatus.FATAL_ERROR);
 		} else if (resultSet.getString("tasks_results_status").equalsIgnoreCase(TaskResult.TaskResultStatus.DENIED.toString())) {
 			taskResult.setStatus(TaskResult.TaskResultStatus.DENIED);
+		} else if (resultSet.getString("tasks_results_status").equalsIgnoreCase(TaskResult.TaskResultStatus.WARNING.toString())) {
+			taskResult.setStatus(TaskResult.TaskResultStatus.WARNING);
 		} else {
 			throw new IllegalArgumentException("Unknown TaskResult state.");
 		}
@@ -433,6 +435,8 @@ public class TasksManagerImpl implements TasksManagerImplApi {
 			task.setStatus(Task.TaskStatus.DONE);
 		} else if (resultSet.getString("tasks_status").equalsIgnoreCase(Task.TaskStatus.ERROR.toString())) {
 			task.setStatus(Task.TaskStatus.ERROR);
+		} else if (resultSet.getString("tasks_status").equalsIgnoreCase(Task.TaskStatus.WARNING.toString())) {
+			task.setStatus(Task.TaskStatus.WARNING);
 		} else {
 			throw new IllegalArgumentException("Task status [" + resultSet.getString("tasks_status") + "] unknown");
 		}

--- a/perun-core/src/main/resources/postgresChangelog.txt
+++ b/perun-core/src/main/resources/postgresChangelog.txt
@@ -6,6 +6,13 @@
 -- Directly under version number should be version commands. They will be executed in the order they are written here.
 -- Comments are prefixed with -- and can be written only between version blocks, that means not in the lines with commands. They have to be at the start of the line.
 
+3.1.66
+ALTER TABLE tasks DROP CONSTRAINT task_stat_chk;
+ALTER TABLE tasks ADD CONSTRAINT task_stat_chk check (status in ('WAITING', 'PLANNED', 'GENERATING', 'GENERROR', 'GENERATED', 'SENDING', 'DONE', 'SENDERROR', 'ERROR', 'WARNING'));
+ALTER TABLE tasks_results DROP CONSTRAINT taskres_stat_chk;
+ALTER TABLE tasks_results ADD CONSTRAINT taskres_stat_chk check (status in ('DONE','ERROR','FATAL_ERROR','DENIED', 'WARNING'));
+update configurations set value='3.1.66' where property='DATABASE VERSION';
+
 3.1.65
 ALTER TABLE host_attr_values ALTER COLUMN attr_value TYPE text;
 UPDATE host_attr_values set attr_value=attr_value_text where attr_value is null and attr_value_text is not null;

--- a/perun-db/postgres.sql
+++ b/perun-db/postgres.sql
@@ -1039,7 +1039,7 @@ create table tasks (
   constraint task_u unique (service_id, facility_id),
   constraint task_srv_fk foreign key (service_id) references services(id),
   constraint task_fac_fk foreign key (facility_id) references facilities(id),
-  constraint task_stat_chk check (status in ('WAITING', 'PLANNED', 'GENERATING', 'GENERROR', 'GENERATED', 'SENDING', 'DONE', 'SENDERROR', 'ERROR'))
+  constraint task_stat_chk check (status in ('WAITING', 'PLANNED', 'GENERATING', 'GENERROR', 'GENERATED', 'SENDING', 'DONE', 'SENDERROR', 'ERROR', 'WARNING'))
 );
 
 -- TASKS_RESULTS - contains partial results of tasks (executing, waiting and at near past finished)
@@ -1062,7 +1062,7 @@ create table tasks_results (
 	constraint taskres_pk primary key (id),
 	constraint taskres_task_fk foreign key (task_id) references tasks(id),
   constraint taskres_dest_fk foreign key (destination_id) references destinations(id),
-  constraint taskres_stat_chk check (status in ('DONE','ERROR','FATAL_ERROR','DENIED'))
+  constraint taskres_stat_chk check (status in ('DONE','ERROR','FATAL_ERROR','DENIED', 'WARNING'))
 );
 
 create table auditer_log (
@@ -1712,7 +1712,7 @@ grant all on user_ext_source_attr_u_values to perun;
 grant all on members_sponsored to perun;
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.1.65');
+insert into configurations values ('DATABASE VERSION','3.1.66');
 
 -- insert membership types
 insert into membership_types (id, membership_type, description) values (1, 'DIRECT', 'Member is directly added into group');

--- a/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/scheduling/PropagationMaintainer.java
+++ b/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/scheduling/PropagationMaintainer.java
@@ -92,7 +92,7 @@ public class PropagationMaintainer extends AbstractRunner {
 	/**
 	 * This method runs in own thread as periodic job which:
 	 *
-	 * takes DONE Tasks and reschedule them if source data were updated or Task hasn't run for X hours from the last time.
+	 * takes DONE/WARNING Tasks and reschedule them if source data were updated or Task hasn't run for X hours from the last time.
 	 * takes ERROR Tasks and reschedule them if -- || -- or (end time + (delay * recurrence)) > now
 	 * takes PROCESSING Tasks and switch them to error if we haven`t heard about result for more than 3 hours.
 	 */
@@ -135,7 +135,7 @@ public class PropagationMaintainer extends AbstractRunner {
 
 
 	/**
-	 * Reschedule Tasks in DONE if their
+	 * Reschedule Tasks in DONE/WARNING if their
 	 * - source was updated
 	 * - OR haven't run for X hours
 	 * - or have no end time set
@@ -143,9 +143,9 @@ public class PropagationMaintainer extends AbstractRunner {
 	private void rescheduleDoneTasks() {
 
 		// Reschedule tasks in DONE that haven't been running for quite a while
-		log.info("Checking DONE tasks...");
+		log.info("Checking DONE/WARNING tasks...");
 
-		for (Task task : schedulingPool.getTasksWithStatus(TaskStatus.DONE)) {
+		for (Task task : schedulingPool.getTasksWithStatus(TaskStatus.DONE, TaskStatus.WARNING)) {
 
 			LocalDateTime tooManyHoursAgo = LocalDateTime.now().minusHours(oldRescheduleHours);
 

--- a/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/scheduling/impl/SchedulingPoolImpl.java
+++ b/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/scheduling/impl/SchedulingPoolImpl.java
@@ -390,6 +390,7 @@ public class SchedulingPoolImpl implements SchedulingPool {
 		int sending = getTasksWithStatus(TaskStatus.SENDING).size();
 		int senderror = getTasksWithStatus(TaskStatus.SENDERROR).size();
 		int done = getTasksWithStatus(TaskStatus.DONE).size();
+		int warning = getTasksWithStatus(TaskStatus.WARNING).size();
 		int error = getTasksWithStatus(TaskStatus.ERROR).size();
 
 		return "Dispatcher SchedulingPool Task report:\n" +
@@ -401,6 +402,7 @@ public class SchedulingPoolImpl implements SchedulingPool {
 				"  SENDING:  " + sending +
 				"  SENDEEROR:  " + senderror +
 				"  DONE: " + done +
+				"  WARNING: " + warning + 
 				"  ERROR: " + error;
 	}
 
@@ -430,7 +432,7 @@ public class SchedulingPoolImpl implements SchedulingPool {
 
 			// if service was not in DONE or any kind of ERROR - reschedule now
 			// error/done tasks will be rescheduled later by periodic jobs !!
-			if (!Arrays.asList(TaskStatus.DONE, TaskStatus.ERROR, TaskStatus.GENERROR, TaskStatus.SENDERROR).contains(task.getStatus())) {
+			if (!Arrays.asList(TaskStatus.DONE, TaskStatus.ERROR, TaskStatus.GENERROR, TaskStatus.SENDERROR, TaskStatus.WARNING).contains(task.getStatus())) {
 				if (task.getStatus().equals(TaskStatus.WAITING)) {
 					// if were in WAITING, reset timestamp to now
 					task.setSchedule(LocalDateTime.now());
@@ -452,7 +454,8 @@ public class SchedulingPoolImpl implements SchedulingPool {
 				TaskStatus.PLANNED,
 				TaskStatus.GENERATING,
 				TaskStatus.GENERATED,
-				TaskStatus.SENDING
+				TaskStatus.SENDING,
+				TaskStatus.WARNING
 				);
 
 		// switch all processing tasks to error, remove the engine queue association
@@ -502,6 +505,7 @@ public class SchedulingPoolImpl implements SchedulingPool {
 				task.setSendStartTime(changeDate);
 				break;
 			case DONE:
+			case WARNING:
 			case SENDERROR:
 				task.setSendEndTime(changeDate);
 				task.setEndTime(changeDate);

--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/PropagationMaintainerImpl.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/PropagationMaintainerImpl.java
@@ -283,6 +283,7 @@ public class PropagationMaintainerImpl implements PropagationMaintainer {
 					// TODO   since Task is switched to SENDING before blockingSubmit() of any SendWorker.
 					break;
 
+				case WARNING:
 				case SENDERROR:
 
 					LocalDateTime endTime = task.getSendEndTime();

--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/SendWorkerImpl.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/SendWorkerImpl.java
@@ -15,6 +15,8 @@ import java.util.Date;
 
 import static cz.metacentrum.perun.taskslib.model.SendTask.SendTaskStatus.ERROR;
 import static cz.metacentrum.perun.taskslib.model.SendTask.SendTaskStatus.SENT;
+import static cz.metacentrum.perun.taskslib.model.SendTask.SendTaskStatus.WARNING;
+
 
 /**
  * Implementation of SendWorker, which is used for starting SEND scripts.
@@ -92,14 +94,20 @@ public class SendWorkerImpl extends AbstractWorker<SendTask> implements SendWork
 						task.getId(), getReturnCode(), getStdout(), getStderr());
 
 				sendTask.setStatus(ERROR);
+				// XXX: why exception? There is nothing exceptional about the situation.
 				throw new TaskExecutionException(task, sendTask.getDestination(), getReturnCode(), getStdout(), getStderr());
 
 			} else {
 
-				log.info("[{}] SEND worker finished for Task. Ret code {}, STDOUT: {}, STDERR: {}",
-						sendTask.getTask().getId(), getReturnCode(), getStdout(), getStderr());
+				if(getStderr().isEmpty()) {
+					sendTask.setStatus(SENT);
+				} else {
+					sendTask.setStatus(WARNING);
+				}
 
-				sendTask.setStatus(SENT);
+				log.info("[{}] SEND worker finished for Task with status {}. Ret code {}, STDOUT: {}, STDERR: {}",
+						sendTask.getTask().getId(), sendTask.getStatus(), getReturnCode(), getStdout(), getStderr());
+
 				return sendTask;
 
 			}

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/tasksManager/GetFacilityServicesState.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/tasksManager/GetFacilityServicesState.java
@@ -246,6 +246,9 @@ public class GetFacilityServicesState implements JsonCallback, JsonCallbackTable
 				else if (row.getStatus().equalsIgnoreCase("DONE")){
 					return "rowgreen";
 				}
+				else if (row.getStatus().equalsIgnoreCase("WARNING")){
+					return "rowgreenyellow";
+				}
 				else if (Arrays.asList("GENERROR","SENDERROR","ERROR").contains(row.getStatus())){
 					return "rowred";
 				}

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/tasksManager/GetFacilityState.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/tasksManager/GetFacilityState.java
@@ -176,6 +176,7 @@ public class GetFacilityState implements JsonCallback, JsonCallbackTable<Facilit
 					return "";
 				}
 				else if (row.getState().equalsIgnoreCase("OK")){
+				
 					return "rowgreen";
 				}
 				else if (row.getState().equalsIgnoreCase("PROCESSING")){
@@ -187,7 +188,10 @@ public class GetFacilityState implements JsonCallback, JsonCallbackTable<Facilit
 				else if (row.getState().equalsIgnoreCase("ERROR")){
 					return "rowred";
 				}
-		return "";
+				else if (row.getState().equalsIgnoreCase("WARNING")){
+					return "rowgreenyellow";
+				}
+				return "";
 
 			}
 		});

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/tasksManager/GetRichTaskResultsByTask.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/tasksManager/GetRichTaskResultsByTask.java
@@ -249,7 +249,11 @@ public class GetRichTaskResultsByTask implements JsonCallback, JsonCallbackTable
 				else if (row.getStatus().equalsIgnoreCase("ERROR")){
 					return "roworange";
 				}
-		return "";
+				else if (row.getStatus().equalsIgnoreCase("WARNING")){
+					return "rowgreenyellow";
+				}
+				
+				return "";
 
 			}
 		});

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/tasksManager/GetRichTaskResultsByTaskAndDestination.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/tasksManager/GetRichTaskResultsByTaskAndDestination.java
@@ -267,6 +267,9 @@ public class GetRichTaskResultsByTaskAndDestination implements JsonCallback, Jso
 				else if (row.getStatus().equalsIgnoreCase("ERROR")){
 					return "roworange";
 				}
+				else if (row.getStatus().equalsIgnoreCase("WARNING")){
+					return "rowgreenyellow";
+				}
 				return "";
 
 			}

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/tasksManager/GetTaskResultsByDestinations.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/tasksManager/GetTaskResultsByDestinations.java
@@ -243,7 +243,10 @@ public class GetTaskResultsByDestinations implements JsonCallback, JsonCallbackT
 				else if (row.getStatus().equalsIgnoreCase("ERROR")){
 					return "roworange";
 				}
-		return "";
+				else if (row.getStatus().equalsIgnoreCase("WARNING")){
+					return "rowgreenyellow";
+				}
+				return "";
 
 			}
 		});

--- a/perun-web-gui/src/main/webapp/PerunWeb.css
+++ b/perun-web-gui/src/main/webapp/PerunWeb.css
@@ -1075,6 +1075,12 @@ td div.customTextCell {
 .rowgreen:hover, .rowgreen:hover td {
     background: #9CFFA7 !important;
 }
+.rowgreenyellow, .rowgreenyellow td {
+    background: #ADFF2F !important;
+}
+.rowgreenyellow:hover, .rowgreenyellow:hover td {
+    background: #8DFF0F !important;
+}
 .rowdarkgreen, .rowdarkgreen td {
     background: #8CE696 !important;
 }


### PR DESCRIPTION
Adds WARNING state both to TaskResult and Task, entered in case the send task completes with 0 return code, but not empty error output. The WARNING state is handled in the same way as DONE, but is marked differently in GUI.
The pull request contains:
  - required database changes (constraints changed)
  - core modifications to handle updated db
  - changes to the dispatcher and engine to handle the new state
  - changes to the (old) GUI to display the state