### PR TITLE
Fixed calling of authorization

### DIFF
--- a/perun-cabinet/src/main/java/cz/metacentrum/perun/cabinet/api/impl/CabinetManagerImpl.java
+++ b/perun-cabinet/src/main/java/cz/metacentrum/perun/cabinet/api/impl/CabinetManagerImpl.java
@@ -487,8 +487,10 @@ public class CabinetManagerImpl implements CabinetManager {
 		}
 
 		//Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "lockPublications_boolean_List<Publication>_policy", new ArrayList<>(publications))) {
-			throw new PrivilegeException("lockPublications");
+		for (Publication publication: publications) {
+			if (!AuthzResolver.authorizedInternal(sess, "lockPublications_boolean_List<Publication>_policy", publication)) {
+				throw new PrivilegeException("lockPublications");
+			}
 		}
 
 		getPublicationManagerBl().lockPublications(lockState, publications);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntry.java
@@ -225,10 +225,10 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 		}
 
 		// Authorization
-		List<PerunBean> beans = new ArrayList<>(owners);
-		beans.add(facility);
-		if (!AuthzResolver.authorizedInternal(sess, "setOwners_Facility_List<Owner>_policy", beans)) {
-			throw new PrivilegeException(sess, "setOwners");
+		for (Owner owner: owners) {
+			if (!AuthzResolver.authorizedInternal(sess, "setOwners_Facility_List<Owner>_policy", owner, facility)) {
+				throw new PrivilegeException(sess, "setOwners");
+			}
 		}
 
 		getFacilitiesManagerBl().setOwners(sess, facility, owners);
@@ -272,7 +272,8 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 		getFacilitiesManagerBl().checkFacilityExists(sess, destinationFacility);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "copyOwners_Facility_Facility_policy", Arrays.asList(sourceFacility, destinationFacility))) {
+		if (!AuthzResolver.authorizedInternal(sess, "copyOwners_Facility_Facility_policy", sourceFacility) ||
+			!AuthzResolver.authorizedInternal(sess, "copyOwners_Facility_Facility_policy", destinationFacility)) {
 			throw new PrivilegeException(sess, "copyOwners");
 		}
 
@@ -441,14 +442,11 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 		Utils.checkPerunSession(sess);
 		getPerunBl().getGroupsManagerBl().checkGroupExists(sess, group);
 
-		List<Facility> facilities = getFacilitiesManagerBl().getAssignedFacilities(sess, group);
-
 		// Authorization
-		List<PerunBean> beans = new ArrayList<>(facilities);
-		beans.add(group);
-		if (!AuthzResolver.authorizedInternal(sess, "getAssignedFacilities_Group_policy", beans)) {
+		if (!AuthzResolver.authorizedInternal(sess, "getAssignedFacilities_Group_policy", group)) {
 			throw new PrivilegeException(sess, "getAssignedFacilities");
 		}
+		List<Facility> facilities = getFacilitiesManagerBl().getAssignedFacilities(sess, group);
 		facilities.removeIf(facility -> !AuthzResolver.authorizedInternal(sess, "filter-getAssignedFacilities_Group_policy", Arrays.asList(facility, group)));
 
 		return facilities;
@@ -459,14 +457,11 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 		Utils.checkPerunSession(sess);
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
 
-		List<Facility> facilities = getFacilitiesManagerBl().getAssignedFacilities(sess, member);
-
 		// Authorization
-		List<PerunBean> beans = new ArrayList<>(facilities);
-		beans.add(member);
-		if (!AuthzResolver.authorizedInternal(sess, "getAssignedFacilities_Member_policy", beans)) {
+		if (!AuthzResolver.authorizedInternal(sess, "getAssignedFacilities_Member_policy", member)) {
 			throw new PrivilegeException(sess, "getAssignedFacilities");
 		}
+		List<Facility> facilities = getFacilitiesManagerBl().getAssignedFacilities(sess, member);
 		facilities.removeIf(facility -> !AuthzResolver.authorizedInternal(sess, "filter-getAssignedFacilities_Member_policy", Arrays.asList(facility, member)));
 
 		return facilities;
@@ -477,14 +472,11 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 		Utils.checkPerunSession(sess);
 		getPerunBl().getUsersManagerBl().checkUserExists(sess, user);
 
-		List<Facility> facilities = getFacilitiesManagerBl().getAssignedFacilities(sess, user);
-
 		// Authorization
-		List<PerunBean> beans = new ArrayList<>(facilities);
-		beans.add(user);
-		if (!AuthzResolver.authorizedInternal(sess, "getAssignedFacilities_User_policy", beans)) {
+		if (!AuthzResolver.authorizedInternal(sess, "getAssignedFacilities_User_policy", user)) {
 			throw new PrivilegeException(sess, "getAssignedFacilities");
 		}
+		List<Facility> facilities = getFacilitiesManagerBl().getAssignedFacilities(sess, user);
 		facilities.removeIf(facility -> !AuthzResolver.authorizedInternal(sess, "filter-getAssignedFacilities_User_policy", Arrays.asList(facility, user)));
 
 		return facilities;
@@ -495,14 +487,11 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 		Utils.checkPerunSession(sess);
 		getPerunBl().getServicesManagerBl().checkServiceExists(sess, service);
 
-		List<Facility> facilities = getFacilitiesManagerBl().getAssignedFacilities(sess, service);
-
 		// Authorization
-		List<PerunBean> beans = new ArrayList<>(facilities);
-		beans.add(service);
-		if (!AuthzResolver.authorizedInternal(sess, "getAssignedFacilities_Service_policy", beans)) {
+		if (!AuthzResolver.authorizedInternal(sess, "getAssignedFacilities_Service_policy", service)) {
 			throw new PrivilegeException(sess, "getAssignedFacilities");
 		}
+		List<Facility> facilities = getFacilitiesManagerBl().getAssignedFacilities(sess, service);
 		facilities.removeIf(facility -> !AuthzResolver.authorizedInternal(sess, "filter-getAssignedFacilities_Service_policy", Arrays.asList(facility, service)));
 
 		return facilities;
@@ -513,14 +502,11 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 		Utils.checkPerunSession(sess);
 		getPerunBl().getSecurityTeamsManagerBl().checkSecurityTeamExists(sess, securityTeam);
 
-		List<Facility> facilities = getFacilitiesManagerBl().getAssignedFacilities(sess, securityTeam);
-
 		// Authorization
-		List<PerunBean> beans = new ArrayList<>(facilities);
-		beans.add(securityTeam);
-		if (!AuthzResolver.authorizedInternal(sess, "getAssignedFacilities_SecurityTeam_policy", beans)) {
+		if (!AuthzResolver.authorizedInternal(sess, "getAssignedFacilities_SecurityTeam_policy", securityTeam)) {
 			throw new PrivilegeException(sess, "getAssignedFacilities");
 		}
+		List<Facility> facilities = getFacilitiesManagerBl().getAssignedFacilities(sess, securityTeam);
 		facilities.removeIf(facility -> !AuthzResolver.authorizedInternal(sess, "filter-getAssignedFacilities_SecurityTeam_policy", Arrays.asList(securityTeam, facility)));
 
 		return facilities;
@@ -704,10 +690,10 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 		getFacilitiesManagerBl().checkFacilityExists(sess, facility);
 
 		// Authorization
-		List<PerunBean> beans = new ArrayList<>(hosts);
-		beans.add(facility);
-		if (!AuthzResolver.authorizedInternal(sess, "removeHosts_List<Host>_Facility_policy", beans)) {
-			throw new PrivilegeException(sess, "removeHosts");
+		for (Host host: hosts) {
+			if (!AuthzResolver.authorizedInternal(sess, "removeHosts_List<Host>_Facility_policy", host, facility)) {
+				throw new PrivilegeException(sess, "removeHosts");
+			}
 		}
 
 		getFacilitiesManagerBl().removeHosts(sess, hosts, facility);
@@ -928,8 +914,9 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 		getFacilitiesManagerBl().checkFacilityExists(sess, sourceFacility);
 		getFacilitiesManagerBl().checkFacilityExists(sess, destinationFacility);
 
-		// Authorization - facility admin of the both facilities required
-		if (!AuthzResolver.authorizedInternal(sess, "copyManagers_Facility_Facility_policy", Arrays.asList(sourceFacility, destinationFacility))) {
+		// Authorization
+		if (!AuthzResolver.authorizedInternal(sess, "copyManagers_Facility_Facility_policy", sourceFacility) ||
+			!AuthzResolver.authorizedInternal(sess, "copyManagers_Facility_Facility_policy", destinationFacility)) {
 			throw new PrivilegeException(sess, "copyManager");
 		}
 
@@ -943,8 +930,9 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 		getFacilitiesManagerBl().checkFacilityExists(sess, sourceFacility);
 		getFacilitiesManagerBl().checkFacilityExists(sess, destinationFacility);
 
-		// Authorization - facility admin of the both facilities required
-		if (!AuthzResolver.authorizedInternal(sess, "copyAttributes_Facility_Facility_policy", Arrays.asList(sourceFacility, destinationFacility))) {
+		// Authorization
+		if (!AuthzResolver.authorizedInternal(sess, "copyAttributes_Facility_Facility_policy", sourceFacility) ||
+			!AuthzResolver.authorizedInternal(sess, "copyAttributes_Facility_Facility_policy", destinationFacility)) {
 			throw new PrivilegeException(sess, "copyAttributes");
 		}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/GroupsManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/GroupsManagerEntry.java
@@ -188,9 +188,11 @@ public class GroupsManagerEntry implements GroupsManager {
 			}
 		}
 
-		//test of privileges on groups
-		if(!AuthzResolver.authorizedInternal(perunSession, "deleteGroups_List<Group>_boolean_policy", new ArrayList<>(groups))) {
-			throw new PrivilegeException(perunSession, "deleteGroups");
+		//Authorization
+		for (Group group: groups) {
+			if(!AuthzResolver.authorizedInternal(perunSession, "deleteGroups_List<Group>_boolean_policy", group)) {
+				throw new PrivilegeException(perunSession, "deleteGroups");
+			}
 		}
 
 		getGroupsManagerBl().deleteGroups(perunSession, groups, forceDelete);
@@ -208,7 +210,7 @@ public class GroupsManagerEntry implements GroupsManager {
 		// Authorization
 		if (!AuthzResolver.authorizedInternal(sess, "updateGroup_Group_policy", group)) {
 			throw new PrivilegeException(sess, "updateGroup");
-				}
+		}
 
 		return getGroupsManagerBl().updateGroup(sess, group);
 	}
@@ -252,7 +254,7 @@ public class GroupsManagerEntry implements GroupsManager {
 		Group group = getGroupsManagerBl().getGroupById(sess, id);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getGroupById_int_policy")) {
+		if (!AuthzResolver.authorizedInternal(sess, "getGroupById_int_policy", group)) {
 			throw new PrivilegeException(sess, "getGroupById");
 		}
 
@@ -272,7 +274,7 @@ public class GroupsManagerEntry implements GroupsManager {
 		// Authorization
 		if (!AuthzResolver.authorizedInternal(sess, "getGroupByName_Vo_String_policy", Arrays.asList(vo, group))) {
 			throw new PrivilegeException(sess, "getGroupByName");
-				}
+		}
 
 		return group;
 	}
@@ -291,10 +293,10 @@ public class GroupsManagerEntry implements GroupsManager {
 		}
 
 		// Authorization
-		ArrayList<PerunBean> beans = new ArrayList<>(members);
-		beans.add(group);
-		if (!AuthzResolver.authorizedInternal(sess, "addMembers_Group_List<Member>_policy", beans)) {
-			throw new PrivilegeException(sess, "addMembers");
+		for (Member member: members) {
+			if (!AuthzResolver.authorizedInternal(sess, "addMembers_Group_List<Member>_policy", member, group)) {
+				throw new PrivilegeException(sess, "addMembers");
+			}
 		}
 
 		// Check if the group is externally synchronized
@@ -325,10 +327,10 @@ public class GroupsManagerEntry implements GroupsManager {
 		}
 
 		// Authorization
-		List<PerunBean> beans = new ArrayList<>(groups);
-		beans.add(member);
-		if (!AuthzResolver.authorizedInternal(sess, "addMember_List<Group>_Member_policy", beans)) {
-			throw new PrivilegeException(sess, "addMember");
+		for (Group group: groups) {
+			if (!AuthzResolver.authorizedInternal(sess, "addMember_List<Group>_Member_policy", group, member)) {
+				throw new PrivilegeException(sess, "addMember");
+			}
 		}
 
 		getGroupsManagerBl().addMember(sess, groups, member);
@@ -404,10 +406,10 @@ public class GroupsManagerEntry implements GroupsManager {
 		}
 
 		// Authorization
-		ArrayList<PerunBean> beans = new ArrayList<>(members);
-		beans.add(group);
-		if (!AuthzResolver.authorizedInternal(sess, "removeMembers_Group_List<Member>_policy", beans)) {
-			throw new PrivilegeException(sess, "removeMembers");
+		for (Member member: members) {
+			if (!AuthzResolver.authorizedInternal(sess, "removeMembers_Group_List<Member>_policy", member, group)) {
+				throw new PrivilegeException(sess, "removeMembers");
+			}
 		}
 
 		// Check if the group is externally synchronized
@@ -433,10 +435,10 @@ public class GroupsManagerEntry implements GroupsManager {
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
 
 		// Authorization
-		List<PerunBean> beans = new ArrayList<>(groups);
-		beans.add(member);
-		if (!AuthzResolver.authorizedInternal(sess, "removeMember_Member_List<Group>_policy", beans)) {
-			throw new PrivilegeException(sess, "removeMember");
+		for (Group group: groups) {
+			if (!AuthzResolver.authorizedInternal(sess, "removeMember_Member_List<Group>_policy", member, group)) {
+				throw new PrivilegeException(sess, "removeMember");
+			}
 		}
 
 		getGroupsManagerBl().removeMember(sess, groups, member);
@@ -450,7 +452,7 @@ public class GroupsManagerEntry implements GroupsManager {
 		// Authorization
 		if (!AuthzResolver.authorizedInternal(sess, "getGroupMembers_Group_policy", group)) {
 			throw new PrivilegeException(sess, "getGroupMembers");
-				}
+		}
 
 		return getGroupsManagerBl().getGroupMembers(sess, group);
 	}
@@ -1291,7 +1293,8 @@ public class GroupsManagerEntry implements GroupsManager {
 		}
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "createGroupUnion_Group_Group_policy", Arrays.asList(resultGroup, operandGroup))) {
+		if (!AuthzResolver.authorizedInternal(sess, "createGroupUnion_Group_Group_policy", resultGroup) ||
+			!AuthzResolver.authorizedInternal(sess, "createGroupUnion_Group_Group_policy", operandGroup)) {
 			throw new PrivilegeException(sess, "createGroupUnion");
 		}
 
@@ -1309,7 +1312,8 @@ public class GroupsManagerEntry implements GroupsManager {
 		}
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "removeGroupUnion_Group_Group_policy", Arrays.asList(resultGroup, operandGroup))) {
+		if (!AuthzResolver.authorizedInternal(sess, "removeGroupUnion_Group_Group_policy", resultGroup) ||
+			!AuthzResolver.authorizedInternal(sess, "removeGroupUnion_Group_Group_policy", operandGroup)) {
 			throw new PrivilegeException(sess, "removeGroupUnion");
 		}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/MembersManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/MembersManagerEntry.java
@@ -110,8 +110,10 @@ public class MembersManagerEntry implements MembersManager {
 		}
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "deleteMembers_List<Member>_policy", new ArrayList<>(members))) {
-			throw new PrivilegeException(sess, "deleteMembers");
+		for (Member member: members) {
+			if (!AuthzResolver.authorizedInternal(sess, "deleteMembers_List<Member>_policy", member)) {
+				throw new PrivilegeException(sess, "deleteMembers");
+			}
 		}
 
 		getMembersManagerBl().deleteMembers(sess, members);
@@ -165,11 +167,16 @@ public class MembersManagerEntry implements MembersManager {
 		}
 
 		// Authorization
-		ArrayList<PerunBean> beans = new ArrayList<>();
-		beans.add(vo);
-		if (groups != null) beans.addAll(groups);
-		if (!AuthzResolver.authorizedInternal(sess, "createSpecificMember_Vo_Candidate_List<User>_SpecificUserType_List<Group>_policy", beans)) {
-			throw new PrivilegeException(sess, "createSpecificMember (Specific User) - from candidate");
+		if (groups != null && !groups.isEmpty()) {
+			for (Group group: groups) {
+				if (!AuthzResolver.authorizedInternal(sess, "createSpecificMember_Vo_Candidate_List<User>_SpecificUserType_List<Group>_policy", vo, group)) {
+					throw new PrivilegeException("createSpecificMember");
+				}
+			}
+		} else {
+			if (!AuthzResolver.authorizedInternal(sess, "createSpecificMember_Vo_Candidate_List<User>_SpecificUserType_List<Group>_policy", vo)) {
+				throw new PrivilegeException("createSpecificMember");
+			}
 		}
 
 		return getMembersManagerBl().createSpecificMember(sess, vo, candidate, specificUserOwners, specificUserType, groups);
@@ -226,11 +233,16 @@ public class MembersManagerEntry implements MembersManager {
 		}
 
 		// Authorization
-		ArrayList<PerunBean> beans = new ArrayList<>();
-		beans.add(vo);
-		if (groups != null) beans.addAll(groups);
-		if (!AuthzResolver.authorizedInternal(sess, "createMember_Vo_Candidate_List<Group>_policy", beans)) {
-			throw new PrivilegeException(sess, "createMember - from candidate");
+		if (groups != null && !groups.isEmpty()) {
+			for (Group group: groups) {
+				if (!AuthzResolver.authorizedInternal(sess, "createMember_Vo_Candidate_List<Group>_policy", vo, group)) {
+					throw new PrivilegeException("createMember");
+				}
+			}
+		} else {
+			if (!AuthzResolver.authorizedInternal(sess, "createMember_Vo_Candidate_List<Group>_policy", vo)) {
+				throw new PrivilegeException("createMember");
+			}
 		}
 
 		return getMembersManagerBl().createMember(sess, vo, candidate, groups);
@@ -265,11 +277,16 @@ public class MembersManagerEntry implements MembersManager {
 		}
 
 		// Authorization
-		ArrayList<PerunBean> beans = new ArrayList<>();
-		beans.add(vo);
-		if (groups != null) beans.addAll(groups);
-		if (!AuthzResolver.authorizedInternal(sess, "createMember_Vo_String_String_String_Candidate_List<Group>_policy", beans)) {
-			throw new PrivilegeException(sess, "createMember - from candidate");
+		if (groups != null && !groups.isEmpty()) {
+			for (Group group: groups) {
+				if (!AuthzResolver.authorizedInternal(sess, "createMember_Vo_String_String_String_Candidate_List<Group>_policy", vo, group)) {
+					throw new PrivilegeException("createMember");
+				}
+			}
+		} else {
+			if (!AuthzResolver.authorizedInternal(sess, "createMember_Vo_String_String_String_Candidate_List<Group>_policy", vo)) {
+				throw new PrivilegeException("createMember");
+			}
 		}
 
 		return getMembersManagerBl().createMember(sess, vo, extSourceName, extSourceType, login, candidate, groups);
@@ -305,11 +322,16 @@ public class MembersManagerEntry implements MembersManager {
 		Utils.checkMaxLength("TitleAfter", candidate.getTitleAfter(), 40);
 
 		// Authorization
-		ArrayList<PerunBean> beans = new ArrayList<>();
-		beans.add(vo);
-		if (groups != null) beans.addAll(groups);
-		if (!AuthzResolver.authorizedInternal(sess, "createMember_Vo_String_String_int_String_Candidate_List<Group>_policy", beans)) {
-			throw new PrivilegeException(sess, "createMember - from candidate");
+		if (groups != null && !groups.isEmpty()) {
+			for (Group group: groups) {
+				if (!AuthzResolver.authorizedInternal(sess, "createMember_Vo_String_String_int_String_Candidate_List<Group>_policy", vo, group)) {
+					throw new PrivilegeException("createMember");
+				}
+			}
+		} else {
+			if (!AuthzResolver.authorizedInternal(sess, "createMember_Vo_String_String_int_String_Candidate_List<Group>_policy", vo)) {
+				throw new PrivilegeException("createMember");
+			}
 		}
 
 		return getMembersManagerBl().createMember(sess, vo, extSourceName, extSourceType, extSourceLoa, login, candidate, groups);
@@ -337,12 +359,16 @@ public class MembersManagerEntry implements MembersManager {
 		}
 
 		// Authorization
-		ArrayList<PerunBean> beans = new ArrayList<>();
-		beans.add(vo);
-		beans.add(user);
-		if (groups != null) beans.addAll(groups);
-		if (!AuthzResolver.authorizedInternal(sess, "createMember_Vo_User_List<Group>_policy", beans)) {
-			throw new PrivilegeException(sess, "createMember - from user");
+		if (groups != null && !groups.isEmpty()) {
+			for (Group group: groups) {
+				if (!AuthzResolver.authorizedInternal(sess, "createMember_Vo_User_List<Group>_policy", vo, group, user)) {
+					throw new PrivilegeException("createMember");
+				}
+			}
+		} else {
+			if (!AuthzResolver.authorizedInternal(sess, "createMember_Vo_User_List<Group>_policy", vo, user)) {
+				throw new PrivilegeException("createMember");
+			}
 		}
 
 		return getMembersManagerBl().createMember(sess, vo, user, groups);
@@ -373,8 +399,10 @@ public class MembersManagerEntry implements MembersManager {
 		if (!AuthzResolver.authorizedInternal(sess, "createMember_Vo_ExtSource_String_List<Group>_policy", Arrays.asList(vo, extSource))) {
 			//also group admin of all affected groups is ok
 			if (groups != null && !groups.isEmpty()) {
-				if (!AuthzResolver.authorizedInternal(sess, "createMember_Vo_ExtSource_String_List<Group>_policy", new ArrayList<>(groups))) {
-					throw new PrivilegeException(sess, "createMember - from login and extSource");
+				for (Group group: groups) {
+					if (!AuthzResolver.authorizedInternal(sess, "createMember_Vo_ExtSource_String_List<Group>_policy", group)) {
+						throw new PrivilegeException(sess, "createMember - from login and extSource");
+					}
 				}
 				//ExtSource has to be assigned to at least one of the groups
 				boolean groupContainsExtSource = groups.stream()

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ResourcesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ResourcesManagerEntry.java
@@ -148,7 +148,8 @@ public class ResourcesManagerEntry implements ResourcesManager {
 		getResourcesManagerBl().checkResourceExists(sess, templateResource);
 
 		//Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "copyResource_Resource_Resource_boolean_policy", Arrays.asList(templateResource, destinationResource))) {
+		if (!AuthzResolver.authorizedInternal(sess, "copyResource_Resource_Resource_boolean_policy", templateResource) ||
+			!AuthzResolver.authorizedInternal(sess, "copyResource_Resource_Resource_boolean_policy", destinationResource)) {
 			throw new PrivilegeException(sess, "copyResource");
 		}
 
@@ -157,7 +158,8 @@ public class ResourcesManagerEntry implements ResourcesManager {
 				throw new InternalErrorException("Resources are not from the same VO.");
 			}
 
-			if(!AuthzResolver.authorizedInternal(sess, "withGroups-copyResource_Resource_Resource_boolean_policy", Arrays.asList(templateResource, destinationResource))) {
+			if(!AuthzResolver.authorizedInternal(sess, "withGroups-copyResource_Resource_Resource_boolean_policy", templateResource) ||
+				!AuthzResolver.authorizedInternal(sess, "withGroups-copyResource_Resource_Resource_boolean_policy", destinationResource)) {
 				throw new PrivilegeException(sess, "copyResource");
 			}
 		}
@@ -306,10 +308,10 @@ public class ResourcesManagerEntry implements ResourcesManager {
 		getResourcesManagerBl().checkResourceExists(perunSession, resource);
 
 		// Authorization
-		List<PerunBean> beans = new ArrayList<>(groups);
-		beans.add(resource);
-		if (!AuthzResolver.authorizedInternal(perunSession, "assignGroupsToResource_List<Group>_Resource_policy", beans)) {
-			throw new PrivilegeException(perunSession, "assignGroupsToResource");
+		for (Group group: groups) {
+			if (!AuthzResolver.authorizedInternal(perunSession, "assignGroupsToResource_List<Group>_Resource_policy", group, resource)) {
+				throw new PrivilegeException(perunSession, "assignGroupsToResource");
+			}
 		}
 
 		getResourcesManagerBl().assignGroupsToResource(perunSession, groups, resource);
@@ -325,10 +327,10 @@ public class ResourcesManagerEntry implements ResourcesManager {
 		}
 
 		// Authorization
-		List<PerunBean> beans = new ArrayList<>(resources);
-		beans.add(group);
-		if (!AuthzResolver.authorizedInternal(perunSession, "assignGroupToResources_Group_List<Resource>_policy", beans)) {
-			throw new PrivilegeException(perunSession, "assignGroupToResources");
+		for (Resource resource: resources) {
+			if (!AuthzResolver.authorizedInternal(perunSession, "assignGroupToResources_Group_List<Resource>_policy", resource, group)) {
+				throw new PrivilegeException(perunSession, "assignGroupToResources");
+			}
 		}
 
 		getResourcesManagerBl().assignGroupToResources(perunSession, group, resources);
@@ -358,10 +360,10 @@ public class ResourcesManagerEntry implements ResourcesManager {
 		}
 
 		// Authorization
-		List<PerunBean> beans = new ArrayList<>(groups);
-		beans.add(resource);
-		if (!AuthzResolver.authorizedInternal(perunSession, "removeGroupsFromResource_List<Group>_Resource_policy", beans)) {
-			throw new PrivilegeException(perunSession, "removeGroupsFromResource");
+		for (Group group: groups) {
+			if (!AuthzResolver.authorizedInternal(perunSession, "removeGroupsFromResource_List<Group>_Resource_policy", group, resource)) {
+				throw new PrivilegeException(perunSession, "removeGroupsFromResource");
+			}
 		}
 
 		getResourcesManagerBl().removeGroupsFromResource(perunSession, groups, resource);
@@ -377,10 +379,10 @@ public class ResourcesManagerEntry implements ResourcesManager {
 		}
 
 		// Authorization
-		List<PerunBean> beans = new ArrayList<>(resources);
-		beans.add(group);
-		if (!AuthzResolver.authorizedInternal(perunSession, "removeGroupFromResources_Group_List<Resource>_policy", beans)) {
-			throw new PrivilegeException(perunSession, "removeGroupFromResources");
+		for (Resource resource: resources) {
+			if (!AuthzResolver.authorizedInternal(perunSession, "removeGroupFromResources_Group_List<Resource>_policy", resource, group)) {
+				throw new PrivilegeException(perunSession, "removeGroupFromResources");
+			}
 		}
 
 		getResourcesManagerBl().removeGroupFromResources(perunSession, group, resources);
@@ -467,10 +469,10 @@ public class ResourcesManagerEntry implements ResourcesManager {
 		}
 
 		// Authorization
-		List<PerunBean> beans = new ArrayList<>(services);
-		beans.add(resource);
-		if(!AuthzResolver.authorizedInternal(sess, "assignServices_Resource_List<Service>_policy", beans)){
-			throw new PrivilegeException(sess, "assignServices");
+		for (Service service: services) {
+			if(!AuthzResolver.authorizedInternal(sess, "assignServices_Resource_List<Service>_policy", service, resource)){
+				throw new PrivilegeException(sess, "assignServices");
+			}
 		}
 
 		getResourcesManagerBl().assignServices(sess, resource, services);
@@ -515,10 +517,10 @@ public class ResourcesManagerEntry implements ResourcesManager {
 		}
 
 		// Authorization
-		List<PerunBean> beans = new ArrayList<>(services);
-		beans.add(resource);
-		if(!AuthzResolver.authorizedInternal(sess, "removeServices_Resource_List<Service>_policy", beans)){
-			throw new PrivilegeException(sess, "removeServices");
+		for (Service service: services) {
+			if(!AuthzResolver.authorizedInternal(sess, "removeServices_Resource_List<Service>_policy", service, resource)){
+				throw new PrivilegeException(sess, "removeServices");
+			}
 		}
 
 		getResourcesManagerBl().removeServices(sess, resource, services);
@@ -842,7 +844,8 @@ public class ResourcesManagerEntry implements ResourcesManager {
 		getResourcesManagerBl().checkResourceExists(sess, destinationResource);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "copyAttributes_Resource_Resource_policy", Arrays.asList(sourceResource, destinationResource))) {
+		if (!AuthzResolver.authorizedInternal(sess, "copyAttributes_Resource_Resource_policy", sourceResource) ||
+			!AuthzResolver.authorizedInternal(sess, "copyAttributes_Resource_Resource_policy", destinationResource)) {
 			throw new PrivilegeException(sess, "copyAttributes");
 		}
 
@@ -857,7 +860,8 @@ public class ResourcesManagerEntry implements ResourcesManager {
 		getResourcesManagerBl().checkResourceExists(sess, destinationResource);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "copyServices_Resource_Resource_policy", Arrays.asList(sourceResource, destinationResource))) {
+		if (!AuthzResolver.authorizedInternal(sess, "copyServices_Resource_Resource_policy", sourceResource) ||
+			!AuthzResolver.authorizedInternal(sess, "copyServices_Resource_Resource_policy", destinationResource)) {
 			throw new PrivilegeException(sess, "copyServices");
 		}
 
@@ -872,7 +876,8 @@ public class ResourcesManagerEntry implements ResourcesManager {
 		getResourcesManagerBl().checkResourceExists(sess, destinationResource);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "copyGroups_Resource_Resource_policy", Arrays.asList(sourceResource, destinationResource))) {
+		if (!AuthzResolver.authorizedInternal(sess, "copyGroups_Resource_Resource_policy", sourceResource) ||
+			!AuthzResolver.authorizedInternal(sess, "copyGroups_Resource_Resource_policy", destinationResource)) {
 			throw new PrivilegeException(sess, "copyGroups");
 		}
 
@@ -918,8 +923,6 @@ public class ResourcesManagerEntry implements ResourcesManager {
 			throw new PrivilegeException(sess, "getResourcesWhereUserIsAdmin");
 		}
 
-		getPerunBl().getUsersManagerBl().checkUserExists(sess, user);
-
 		return getResourcesManagerBl().getResourcesWhereUserIsAdmin(sess, user);
 	}
 
@@ -930,14 +933,11 @@ public class ResourcesManagerEntry implements ResourcesManager {
 		getPerunBl().getVosManagerBl().checkVoExists(sess, vo);
 		getPerunBl().getUsersManagerBl().checkUserExists(sess, authorizedUser);
 
-		List<Resource> resources = getResourcesManagerBl().getResourcesWhereUserIsAdmin(sess, facility, vo, authorizedUser);
-
 		//Authorization
-		List<PerunBean> beans = new ArrayList<>(resources);
-		beans.addAll(Arrays.asList(facility, vo, authorizedUser));
-		if(!AuthzResolver.authorizedInternal(sess, "getResourcesWhereUserIsAdmin_Facility_Vo_User_policy", beans)){
+		if(!AuthzResolver.authorizedInternal(sess, "getResourcesWhereUserIsAdmin_Facility_Vo_User_policy", facility, vo, authorizedUser)){
 			throw new PrivilegeException(sess, "getResourcesByResourceManager");
 		}
+		List<Resource> resources = getResourcesManagerBl().getResourcesWhereUserIsAdmin(sess, facility, vo, authorizedUser);
 		resources.removeIf(resource -> !AuthzResolver.authorizedInternal(sess, "filter-getResourcesWhereUserIsAdmin_Facility_Vo_User_policy", Arrays.asList(vo, facility, resource, authorizedUser)));
 
 		return resources;
@@ -949,14 +949,11 @@ public class ResourcesManagerEntry implements ResourcesManager {
 		getPerunBl().getVosManagerBl().checkVoExists(sess, vo);
 		getPerunBl().getUsersManagerBl().checkUserExists(sess, authorizedUser);
 
-		List<Resource> resources = getResourcesManagerBl().getResourcesWhereUserIsAdmin(sess, vo, authorizedUser);
-
 		//Authorization
-		List<PerunBean> beans = new ArrayList<>(resources);
-		beans.addAll(Arrays.asList( vo, authorizedUser));
-		if(!AuthzResolver.authorizedInternal(sess, "getResourcesWhereUserIsAdmin_Vo_User_policy", beans)){
+		if(!AuthzResolver.authorizedInternal(sess, "getResourcesWhereUserIsAdmin_Vo_User_policy", vo, authorizedUser)){
 			throw new PrivilegeException(sess, "getResourcesWhereUserIsAdmin");
 		}
+		List<Resource> resources = getResourcesManagerBl().getResourcesWhereUserIsAdmin(sess, vo, authorizedUser);
 		resources.removeIf(resource -> !AuthzResolver.authorizedInternal(sess, "filter-getResourcesWhereUserIsAdmin_Vo_User_policy", Arrays.asList(vo, resource, authorizedUser)));
 
 		return resources;
@@ -969,13 +966,12 @@ public class ResourcesManagerEntry implements ResourcesManager {
 		getPerunBl().getVosManagerBl().checkVoExists(sess, vo);
 		getPerunBl().getGroupsManagerBl().checkGroupExists(sess, authorizedGroup);
 
-		List<Resource> resources = getResourcesManagerBl().getResourcesWhereGroupIsAdmin(sess, facility, vo, authorizedGroup);
-
 		//Authorization
 		if(!AuthzResolver.authorizedInternal(sess, "getResourcesWhereGroupIsAdmin_Facility_Vo_Group_policy", Arrays.asList(facility, vo)) &&
-		!AuthzResolver.authorizedInternal(sess, "authorizedGroup-getResourcesWhereGroupIsAdmin_Facility_Vo_Group_policy", authorizedGroup)){
+			!AuthzResolver.authorizedInternal(sess, "authorizedGroup-getResourcesWhereGroupIsAdmin_Facility_Vo_Group_policy", authorizedGroup)){
 			throw new PrivilegeException(sess, "getResourcesByResourceManager");
 		}
+		List<Resource> resources = getResourcesManagerBl().getResourcesWhereGroupIsAdmin(sess, facility, vo, authorizedGroup);
 		resources.removeIf(resource -> !AuthzResolver.authorizedInternal(sess, "filter-getResourcesWhereGroupIsAdmin_Facility_Vo_Group_policy", Arrays.asList(vo, resource, facility)) &&
 			!AuthzResolver.authorizedInternal(sess, "filter_authorizedGroup-getResourcesWhereGroupIsAdmin_Facility_Vo_Group_policy", authorizedGroup));
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ServicesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ServicesManagerEntry.java
@@ -956,18 +956,17 @@ public class ServicesManagerEntry implements ServicesManager {
 		Utils.checkPerunSession(perunSession);
 		Utils.notNull(services, "services");
 
-		// Auhtorization
-		List<PerunBean> beans = new ArrayList<>(services);
-		beans.add(facility);
-		if (!AuthzResolver.authorizedInternal(perunSession, "addDestinationsDefinedByHostsOnFacility_List<Services>_Facility_policy", beans)) {
-			throw new PrivilegeException(perunSession, "addDestinationsDefinedByHostsOnFacility");
-		}
-
 		for(Service s: services) {
 			getServicesManagerBl().checkServiceExists(perunSession, s);
 		}
-
 		getPerunBl().getFacilitiesManagerBl().checkFacilityExists(perunSession, facility);
+
+		// Authorization
+		for (Service service: services) {
+			if (!AuthzResolver.authorizedInternal(perunSession, "addDestinationsDefinedByHostsOnFacility_List<Services>_Facility_policy", service, facility)) {
+				throw new PrivilegeException(perunSession, "addDestinationsDefinedByHostsOnFacility");
+			}
+		}
 
 		return getServicesManagerBl().addDestinationsDefinedByHostsOnFacility(perunSession, services, facility);
 	}

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/MailManagerImpl.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/MailManagerImpl.java
@@ -335,7 +335,8 @@ public class MailManagerImpl implements MailManager {
 		perun.getVosManagerBl().checkVoExists(sess, toVo);
 
 		//Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "copyMailsFromVoToVo_Vo_Vo_policy", Arrays.asList(fromVo, toVo))) {
+		if (!AuthzResolver.authorizedInternal(sess, "copyMailsFromVoToVo_Vo_Vo_policy", fromVo) ||
+			!AuthzResolver.authorizedInternal(sess, "copyMailsFromVoToVo_Vo_Vo_policy", toVo)) {
 			throw new PrivilegeException(sess, "copyMailsFromVoToVo");
 		}
 
@@ -350,7 +351,8 @@ public class MailManagerImpl implements MailManager {
 		perun.getGroupsManagerBl().checkGroupExists(sess, toGroup);
 
 		//Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "copyMailsFromVoToGroup_Vo_Group_boolean_policy", Arrays.asList(fromVo, toGroup))) {
+		if (!AuthzResolver.authorizedInternal(sess, "copyMailsFromVoToGroup_Vo_Group_boolean_policy", fromVo) ||
+			!AuthzResolver.authorizedInternal(sess, "copyMailsFromVoToGroup_Vo_Group_boolean_policy", toGroup)) {
 			throw new PrivilegeException(sess, "copyMailsFromVoToGroup");
 		}
 
@@ -373,7 +375,8 @@ public class MailManagerImpl implements MailManager {
 		perun.getGroupsManagerBl().checkGroupExists(sess, toGroup);
 
 		//Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "copyMailsFromGroupToGroup_Group_Group_policy", Arrays.asList(fromGroup, toGroup))) {
+		if (!AuthzResolver.authorizedInternal(sess, "copyMailsFromGroupToGroup_Group_Group_policy", fromGroup) ||
+			!AuthzResolver.authorizedInternal(sess, "copyMailsFromGroupToGroup_Group_Group_policy", toGroup)) {
 			throw new PrivilegeException(sess, "copyMailsFromGroupToGroup");
 		}
 

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
@@ -2453,7 +2453,8 @@ public class RegistrarManagerImpl implements RegistrarManager {
 		vosManager.checkVoExists(sess, toVo);
 
 		//Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "copyFormFromVoToVo_Vo_Vo_policy", Arrays.asList(fromVo, toVo))) {
+		if (!AuthzResolver.authorizedInternal(sess, "copyFormFromVoToVo_Vo_Vo_policy", fromVo) ||
+			!AuthzResolver.authorizedInternal(sess, "copyFormFromVoToVo_Vo_Vo_policy", toVo)) {
 			throw new PrivilegeException(sess, "copyFormFromVoToVo");
 		}
 


### PR DESCRIPTION
- We have realized that the new authorization would not work 100%
  correctly when there are passed more objects of the same type.
  It is because it check whether you have role on all objects on the
  same type. It does not check whteher you have some role on one part of
  these objects and another role on the second part.
- One solution was to reimplement the authorization algorithm but it
  would be dificult because of the AND clauses which would bring great
  complexity to such solution.
- Therefore, the change was made on the side of authorization call.
  Methods which need to check rights on more objects of the same type were
  reworked so these object are passed into the authorization in separate
  calls.
- The result is that the authorization should allow UNION of role rights
  but it does not change nothing else.