### PR TITLE
Exclusion of uco based emails from o365 mu attribute modules

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Utils.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Utils.java
@@ -101,6 +101,7 @@ public class Utils {
 	public static final String TITLE_AFTER = "titleAfter";
 	private static Properties properties;
 	public static final Pattern emailPattern = Pattern.compile("^[-_A-Za-z0-9+']+(\\.[-_A-Za-z0-9+']+)*@[-A-Za-z0-9]+(\\.[-A-Za-z0-9]+)*(\\.[A-Za-z]{2,})$");
+	public static final Pattern ucoEmailPattern = Pattern.compile("^[0-9]+@muni\\.cz$");
 
 	private static final Pattern titleBeforePattern = Pattern.compile("^(([\\p{L}]+[.])|(et))$");
 	private static final Pattern firstNamePattern = Pattern.compile("^[\\p{L}-']+$");

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_o365EmailAddresses_o365mu.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_o365EmailAddresses_o365mu.java
@@ -28,6 +28,7 @@ import java.util.stream.Collectors;
 
 import static cz.metacentrum.perun.core.impl.Utils.emailPattern;
 import static cz.metacentrum.perun.core.impl.Utils.hasDuplicate;
+import static cz.metacentrum.perun.core.impl.Utils.ucoEmailPattern;
 
 /**
  * Module for email addresses for Office365 at Masaryk University.
@@ -38,6 +39,7 @@ import static cz.metacentrum.perun.core.impl.Utils.hasDuplicate;
  * <li>type is list</li>
  * <li>all values are email addresses</li>
  * <li>must contain at least one value if urn:perun:group:attribute-def:def:adName:o365mu is set</li>
+ * <li>no uco based emails among the list values</li>
  * <li>no duplicates among the list values</li>
  * <li>no duplicates among all values of this attribute and all values of
  * attribute urn:perun:member:attribute-def:def:o365EmailAddresses:mu</li>
@@ -63,6 +65,9 @@ public class urn_perun_group_attribute_def_def_o365EmailAddresses_o365mu extends
 			Matcher emailMatcher = emailPattern.matcher(email);
 			if (!emailMatcher.matches())
 				throw new WrongAttributeValueException(attribute, group, "Email " + email + " is not in correct form.");
+			Matcher ucoEmailMatcher = ucoEmailPattern.matcher(email);
+			if (ucoEmailMatcher.matches())
+				throw new WrongAttributeValueException(attribute, group, "Email " + email + " is based on UCO which is not supported.");
 		}
 
 		//check for duplicities

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_o365EmailAddresses_mu.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_o365EmailAddresses_mu.java
@@ -29,6 +29,7 @@ import java.util.regex.Matcher;
 
 import static cz.metacentrum.perun.core.impl.Utils.emailPattern;
 import static cz.metacentrum.perun.core.impl.Utils.hasDuplicate;
+import static cz.metacentrum.perun.core.impl.Utils.ucoEmailPattern;
 
 /**
  * Module for email addresses for Office365 at Masaryk University.
@@ -39,6 +40,7 @@ import static cz.metacentrum.perun.core.impl.Utils.hasDuplicate;
  * <li>type is list</li>
  * <li>all values are email addresses</li>
  * <li>must contain at least one value if urn:perun:group-resource:attribute-def:def:adName is set</li>
+ * <li>no uco based emails among the list values</li>
  * <li>no duplicates among the list values</li>
  * <li>no duplicates among all values of this attribute and all values of
  * attribute urn:perun:member:attribute-def:def:o365EmailAddresses:mu</li>
@@ -66,6 +68,9 @@ public class urn_perun_group_resource_attribute_def_def_o365EmailAddresses_mu ex
 			Matcher emailMatcher = emailPattern.matcher(email);
 			if (!emailMatcher.matches())
 				throw new WrongAttributeValueException(attribute, resource, group, "Email " + email + " is not in correct form.");
+			Matcher ucoEmailMatcher = ucoEmailPattern.matcher(email);
+			if (ucoEmailMatcher.matches())
+				throw new WrongAttributeValueException(attribute, resource, group, "Email " + email + " is based on UCO which is not supported.");
 		}
 
 		//check for duplicities

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_o365UserEmailAddresses_mu.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_o365UserEmailAddresses_mu.java
@@ -1,0 +1,65 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Pair;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.bl.AttributesManagerBl;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import cz.metacentrum.perun.core.implApi.modules.attributes.UserAttributesModuleAbstract;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+
+import static cz.metacentrum.perun.core.impl.Utils.emailPattern;
+import static cz.metacentrum.perun.core.impl.Utils.hasDuplicate;
+import static cz.metacentrum.perun.core.impl.Utils.ucoEmailPattern;
+
+public class urn_perun_user_attribute_def_def_o365UserEmailAddresses_mu extends UserAttributesModuleAbstract {
+
+	@Override
+	public void checkAttributeSyntax(PerunSessionImpl perunSession, User user, Attribute attribute) throws InternalErrorException, WrongAttributeValueException {
+		//empty value is valid
+		if(attribute.getValue() == null) return;
+		ArrayList<String> emails = attribute.valueAsList();
+
+		//check syntax of all values
+		for (String email : emails) {
+			Matcher emailMatcher = emailPattern.matcher(email);
+			if (!emailMatcher.matches())
+				throw new WrongAttributeValueException(attribute, user, "Email " + email + " is not in correct form.");
+			Matcher ucoEmailMatcher = ucoEmailPattern.matcher(email);
+			if (ucoEmailMatcher.matches())
+				throw new WrongAttributeValueException(attribute, user, "Email " + email + " is based on UCO which is not supported.");
+		}
+
+		//check for duplicities
+		if (hasDuplicate(emails)) {
+			throw new WrongAttributeValueException(attribute, user, "duplicate values");
+		}
+	}
+
+	@Override
+	public AttributeDefinition getAttributeDefinition() {
+		AttributeDefinition attr = new AttributeDefinition();
+		attr.setNamespace(AttributesManager.NS_USER_ATTR_DEF);
+		attr.setFriendlyName("o365UserEmailAddresses:mu");
+		attr.setDisplayName("User managed email addresses for MU o365");
+		attr.setType(ArrayList.class.getName());
+		attr.setUnique(true);
+		attr.setDescription("User managed email addresses for MU o365");
+		return attr;
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_o365EmailAddresses_o365muTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_o365EmailAddresses_o365muTest.java
@@ -92,6 +92,13 @@ public class urn_perun_group_attribute_def_def_o365EmailAddresses_o365muTest {
 	}
 
 	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckUcoEmailSyntax() throws Exception {
+		System.out.println("testCheckUcoEmailSyntax()");
+		attributeToCheck.setValue(Lists.newArrayList("my@example.com", "451570@muni.cz"));
+		classInstance.checkAttributeSyntax(session, group, attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
 	public void testCheckDuplicates() throws Exception {
 		System.out.println("testCheckDuplicates()");
 		attributeToCheck.setValue(Lists.newArrayList("my@example.com", "aaa@bbb.com", "my@example.com"));

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_o365EmailAddresses_muTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_o365EmailAddresses_muTest.java
@@ -134,6 +134,15 @@ public class urn_perun_group_resource_attribute_def_def_o365EmailAddresses_muTes
 		classInstance.checkAttributeSemantics(session, group, resource, attributeToCheck);
 	}
 
+	@Test(expected = WrongAttributeValueException.class)
+	public void testUcoEmail() throws Exception {
+		System.out.println("testUcoEmail");
+		when(adNameAttr.getValue()).thenReturn(null);
+		when(am.getPerunBeanIdsForUniqueAttributeValue(eq(session),any(Attribute.class))).thenReturn(Sets.newHashSet());
+		attributeToCheck.setValue(Lists.newArrayList("451570@muni.cz"));
+		classInstance.checkAttributeSyntax(session, group, resource, attributeToCheck);
+	}
+
 	@Test
 	public void testUniqItself() throws Exception {
 		System.out.println("testUniqItself");

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_o365UserEmailAddresses_muTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_o365UserEmailAddresses_muTest.java
@@ -1,0 +1,59 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import com.google.common.collect.Lists;
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+
+public class urn_perun_user_attribute_def_def_o365UserEmailAddresses_muTest {
+
+	private urn_perun_user_attribute_def_def_o365UserEmailAddresses_mu classInstance;
+	private PerunSessionImpl session;
+	private Attribute attributeToCheck;
+	private static User user;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_user_attribute_def_def_o365UserEmailAddresses_mu();
+		//prepare mocks
+		session = mock(PerunSessionImpl.class, RETURNS_DEEP_STUBS);
+		user = new User();
+
+		attributeToCheck = new Attribute(classInstance.getAttributeDefinition());
+		attributeToCheck.setId(100);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckEmailSyntax() throws Exception {
+		System.out.println("testCheckEmailSyntax()");
+		attributeToCheck.setValue(Lists.newArrayList("my@example.com", "a/-+"));
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckUcoEmailSyntax() throws Exception {
+		System.out.println("testCheckUcoEmailSyntax()");
+		attributeToCheck.setValue(Lists.newArrayList("my@example.com", "451570@muni.cz"));
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckDuplicates() throws Exception {
+		System.out.println("testCheckDuplicates()");
+		attributeToCheck.setValue(Lists.newArrayList("my@example.com", "aaa@bbb.com", "my@example.com"));
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSyntax() throws Exception {
+		System.out.println("testCorrectSyntax()");
+		attributeToCheck.setValue(Lists.newArrayList("my@example.com"));
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+	}
+}


### PR DESCRIPTION
- the group and group-resource attribute modules check whether email addresses are based on uco and if so throw WrongAttributeValueException
- created new user module for email addresses which also checks syntax of email and exclude uco emails
- also added tests