### PR TITLE
Removed functionality for creating sponsored users

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/MembersManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/MembersManager.java
@@ -93,7 +93,7 @@ public interface MembersManager {
 	 * @param vo
 	 * @param candidate prepared future specificUser
 	 * @param specificUserOwners list of users who own specificUser (can't be empty or contain specificUser)
-	 * @param specificUserType type of specific user (service or sponsored)
+	 * @param specificUserType type of specific user (service)
 	 * @return newly created member (of specificUser)
 	 * @throws InternalErrorException
 	 * @throws WrongAttributeValueException
@@ -119,7 +119,7 @@ public interface MembersManager {
 	 * @param vo
 	 * @param candidate prepared future specificUser
 	 * @param specificUserOwners list of users who own specificUser (can't be empty or contain specificUser)
-	 * @param specificUserType type of specific user (service or sponsored)
+	 * @param specificUserType type of specific user (service)
 	 * @param groups list of groups where member will be added too
 	 * @return newly created member (of specific User)
 	 * @throws InternalErrorException
@@ -231,25 +231,6 @@ public interface MembersManager {
 	 * @throws GroupNotExistsException
 	 */
 	Member createMember(PerunSession sess, Vo vo, String extSourceName, String extSourceType, int extSourceLoa, String login, Candidate candidate, List<Group> groups) throws WrongAttributeValueException, WrongReferenceAttributeValueException, AlreadyMemberException, PrivilegeException, ExtendMembershipException, GroupNotExistsException;
-
-	/**
-	 * Creates a new sponsored member in given namespace and external source.
-	 * Owner of the member must be specified in params map under key "sponsor"
-	 *
-	 * @param sess session
-	 * @param params Map containing parameters about user that will be created, will be used to create Candidate,
-	 *               must contain key "sponsor" with value of user login in given namespace that will be owner of created member
-	 * @param namespace namespace to generate account in
-	 * @param extSource external source
-	 * @param extSourcePostfix login postfix if external source uses postfix after login from given namespace, e.g. "@muni.cz"
-	 * @param vo VO in which user will be created
-	 * @param loa level of assurance
-	 * @return newly created sponsored member
-	 *
-	 * @deprecated replaced by {@link #createSponsoredMember(PerunSession, Vo, String, String, String, User)}
-	 */
-	@Deprecated
-	Member createSponsoredAccount(PerunSession sess, Map<String, String> params, String namespace, ExtSource extSource, String extSourcePostfix, Vo vo, int loa) throws PrivilegeException, UserNotExistsException, ExtSourceNotExistsException, UserExtSourceNotExistsException, WrongReferenceAttributeValueException, LoginNotExistsException, PasswordCreationFailedException, ExtendMembershipException, AlreadyMemberException, PasswordStrengthFailedException, PasswordOperationTimeoutException, WrongAttributeValueException, PasswordStrengthException, InvalidLoginException;
 
 	/**
 	 * Creates a new member from candidate returned by the method VosManager.findCandidates which fills Candidate.userExtSource.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/MembersManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/MembersManagerBl.java
@@ -94,7 +94,7 @@ public interface MembersManagerBl {
 	 * @param vo
 	 * @param candidate prepared future specificUser
 	 * @param specificUserOwners list of users who own specificUser (can't be empty or contain specific user)
-	 * @param specificUserType type of specific user (service or sponsored)
+	 * @param specificUserType type of specific user (service)
 	 * @return newly created member (of specific User)
 	 * @throws InternalErrorException
 	 * @throws WrongAttributeValueException
@@ -116,7 +116,7 @@ public interface MembersManagerBl {
 	 * @param vo
 	 * @param candidate prepared future specificUser
 	 * @param specificUserOwners list of users who own specificUser (can't be empty or contain specific user)
-	 * @param specificUserType type of specific user (service or sponsored)
+	 * @param specificUserType type of specific user (service)
 	 * @param groups list of groups where member will be added too
 	 * @return newly created member (of specific User)
 	 * @throws InternalErrorException
@@ -286,7 +286,7 @@ public interface MembersManagerBl {
 	 * @param sess
 	 * @param vo
 	 * @param candidate
-	 * @param SpecificUserType (Normal or service or sponsored)
+	 * @param specificUserType (Normal or service or sponsored)
 	 * @param groups list of groups where member will be added too
 	 * @param overwriteUserAttributes list of user attributes names which will be overwrite instead of merged
 	 *
@@ -343,25 +343,6 @@ public interface MembersManagerBl {
 	 * @throws InternalErrorException if something unexpected happend
 	 */
 	Member unsetSponsorshipForMember(PerunSession session, Member sponsoredMember) throws MemberNotSponsoredException;
-
-	/**
-	 * Generates account with params in given namespace, which is used to create a new Candidate for MembersManager.createSpecificMember
-	 * with SPONSORED type and is asynchronously validated after that
-	 *
-	 * @param sess session
-	 * @param params map with parameters for generating account in namespace
-	 * @param namespace namespace to generate account in
-	 * @param extSource external source
-	 * @param extSourcePostfix login postfix if external source uses postfix after login from given namespace, e.g. "@muni.cz"
-	 * @param owner owner of newly created member
-	 * @param vo vo to create member in
-	 * @param loa level of assurance
-	 * @return newly created Member
-	 *
-	 * @deprecated replaced by {@link #createSponsoredMember(PerunSession, Vo, String, String, String, User, boolean)}
-	 */
-	@Deprecated
-	Member createSponsoredAccount(PerunSession sess, Map<String, String> params, String namespace, ExtSource extSource, String extSourcePostfix, User owner, Vo vo, int loa) throws PasswordCreationFailedException, PasswordOperationTimeoutException, PasswordStrengthFailedException, ExtendMembershipException, AlreadyMemberException, WrongReferenceAttributeValueException, WrongAttributeValueException, UserNotExistsException, ExtSourceNotExistsException, LoginNotExistsException, PasswordStrengthException, InvalidLoginException;
 
 	/**
 	 * Creates member. Runs synchronously.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
@@ -309,33 +309,6 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 	}
 
 	@Override
-	@Deprecated
-	public Member createSponsoredAccount(PerunSession sess, Map<String, String> params, String namespace, ExtSource extSource, String extSourcePostfix, User owner, Vo vo, int loa) throws PasswordCreationFailedException, PasswordOperationTimeoutException, PasswordStrengthFailedException, ExtendMembershipException, AlreadyMemberException, WrongReferenceAttributeValueException, WrongAttributeValueException, UserNotExistsException, ExtSourceNotExistsException, LoginNotExistsException, PasswordStrengthException, InvalidLoginException {
-		String loginNamespaceUri = AttributesManager.NS_USER_ATTR_DEF + ":login-namespace:" + namespace;
-		boolean passwordPresent = params.get("password") != null;
-		if (params.get(loginNamespaceUri) == null) {
-			Map<String, String> generatedParams = getPerunBl().getUsersManagerBl().generateAccount(sess, namespace, params);
-			params.putAll(generatedParams);
-		} else if (passwordPresent) {
-			getPerunBl().getUsersManagerBl().reservePassword(sess, params.get(loginNamespaceUri), namespace, params.get("password"));
-		} else {
-			throw new InternalErrorException("If login for new account is provided, password must be provided also");
-		}
-		// remove non-valid entries from map for Candidate otherwise it would fail to create member
-		params.keySet().removeIf(next -> !next.startsWith("urn:perun:user") && !next.startsWith("urn:perun:member"));
-		String extSourceLogin = params.get(loginNamespaceUri) + extSourcePostfix;
-		UserExtSource userExtSource = new UserExtSource(extSource, loa, extSourceLogin);
-		Candidate candidate = new Candidate(userExtSource, params);
-		Member member = this.createSpecificMember(sess, vo, candidate, Collections.singletonList(owner), SpecificUserType.SPONSORED);
-		this.validateMemberAsync(sess, member);
-		if (passwordPresent) {
-			User user = getPerunBl().getUsersManagerBl().getUserById(sess, member.getUserId());
-			getPerunBl().getUsersManagerBl().validatePasswordAndSetExtSources(sess, user, params.get(loginNamespaceUri), namespace);
-		}
-		return member;
-	}
-
-	@Override
 	public Member createMemberSync(PerunSession sess, Vo vo, Candidate candidate) throws WrongAttributeValueException, WrongReferenceAttributeValueException, AlreadyMemberException, ExtendMembershipException {
 		return this.createMemberSync(sess, vo, candidate, null);
 	}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
@@ -251,8 +251,8 @@ public class UsersManagerBlImpl implements UsersManagerBl {
 
 	@Override
 	public User setSpecificUser(PerunSession sess, User specificUser, SpecificUserType specificUserType, User owner) throws RelationExistsException {
-		if(specificUser.isServiceUser() && specificUser.isSponsoredUser()) {
-			throw new InternalErrorException("We don't support specific and sponsored users together yet.");
+		if(specificUserType.equals(SpecificUserType.SPONSORED)) {
+			throw new InternalErrorException("We don't support sponsored users anymore.");
 		}
 
 		if(specificUser.getMajorSpecificType().equals(specificUserType)) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/MembersManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/MembersManagerEntry.java
@@ -153,9 +153,8 @@ public class MembersManagerEntry implements MembersManager {
 			getPerunBl().getUsersManagerBl().checkUserExists(sess, u);
 		}
 
-		//normal type is not allowed when creating specific member
-		if (specificUserType.equals(SpecificUserType.NORMAL))
-			throw new InternalErrorException("Type of specific user must be defined.");
+		if (!specificUserType.equals(SpecificUserType.SERVICE))
+			throw new InternalErrorException("Only service user type is allowed.");
 
 		// if any group is not from the vo, throw an exception
 		if (groups != null) {
@@ -180,29 +179,6 @@ public class MembersManagerEntry implements MembersManager {
 		}
 
 		return getMembersManagerBl().createSpecificMember(sess, vo, candidate, specificUserOwners, specificUserType, groups);
-	}
-
-	@Override
-	@Deprecated
-	public Member createSponsoredAccount(PerunSession sess, Map<String, String> params, String namespace, ExtSource extSource, String extSourcePostfix, Vo vo, int loa) throws PrivilegeException, UserNotExistsException, ExtSourceNotExistsException, UserExtSourceNotExistsException, WrongReferenceAttributeValueException, LoginNotExistsException, PasswordCreationFailedException, ExtendMembershipException, AlreadyMemberException, PasswordStrengthFailedException, PasswordOperationTimeoutException, WrongAttributeValueException, PasswordStrengthException, InvalidLoginException {
-		Utils.checkPerunSession(sess);
-		Utils.notNull(extSource, "extSource");
-		Utils.notNull(namespace, "namespace");
-		Utils.notNull(vo, "vo");
-		Utils.notNull(extSourcePostfix, "extSourcePostfix");
-
-		if (!AuthzResolver.isAuthorized(sess, Role.REGISTRAR)) {
-			throw new PrivilegeException(sess, "createSponsoredAccount");
-		}
-
-		if (params.containsKey("sponsor")) {
-			String sponsorLogin = params.get("sponsor");
-			User owner = getPerunBl().getUsersManager().getUserByExtSourceNameAndExtLogin(sess, extSource.getName(), sponsorLogin + extSourcePostfix);
-
-			return getPerunBl().getMembersManagerBl().createSponsoredAccount(sess, params, namespace, extSource, extSourcePostfix, owner, vo, loa);
-		} else {
-			throw new InternalErrorException("sponsor cannot be null");
-		}
 	}
 
 	@Override

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/UsersManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/UsersManagerEntryIntegrationTest.java
@@ -162,16 +162,6 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 		setUpUser();
 		User owner = user;
 
-		assertTrue("User should be sponsored", sponsoredUser.isSponsoredUser());
-		usersManager.unsetSpecificUser(sess, sponsoredUser, SpecificUserType.SPONSORED);
-		User user1 = usersManager.getUserById(sess, sponsoredUser.getId());
-		assertTrue("User shouldn't be sponsored", !user1.isSponsoredUser());
-		usersManager.setSpecificUser(sess, user1, SpecificUserType.SPONSORED, owner);
-		user1 = usersManager.getUserById(sess, user1.getId());
-		assertTrue("User should be sponsored again", user1.isSponsoredUser());
-		List<User> owners = usersManager.getUsersBySpecificUser(sess, user1);
-		assertTrue("There should be just our owner", owners.size() == 1 && owners.contains(owner));
-
 		assertTrue("User should be service user", serviceUser1.isServiceUser());
 		usersManager.unsetSpecificUser(sess, serviceUser1, SpecificUserType.SERVICE);
 		User user2 = usersManager.getUserById(sess, serviceUser1.getId());
@@ -179,7 +169,7 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 		usersManager.setSpecificUser(sess, user2, SpecificUserType.SERVICE, owner);
 		user2 = usersManager.getUserById(sess, user2.getId());
 		assertTrue("User should be service user again", user2.isServiceUser());
-		owners = usersManager.getUsersBySpecificUser(sess, user2);
+		List<User> owners = usersManager.getUsersBySpecificUser(sess, user2);
 		assertTrue("There should be just our owner", owners.size() == 1 && owners.contains(owner));
 	}
 

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/MembersManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/MembersManagerMethod.java
@@ -102,34 +102,6 @@ public enum MembersManagerMethod implements ManagerMethod {
 	},
 
 	/*#
-	 * Creates a new SPONSORED member from given parameters map.
-	 *
-	 * @param parameters Map<String,String> Map containing all parameters, must contain at least:
-	 *                   "sponsor" - uco of sponsor for new created account
-	 * @param namespace String namespace
-	 * @param extSource int extSource ID
-	 * @param extSourcePostfix String extSource login postfix, e.g. "@muni.cz"
-	 * @param vo int VO ID
-	 * @param loa int Level of assurance (0,1,2)
-	 * @return Member newly created sponsored member
-	 */
-	@Deprecated
-	createSponsoredAccount {
-		@SuppressWarnings("unchecked")
-		@Override
-		public Member call(ApiCaller ac, Deserializer parms) throws PerunException {
-			parms.stateChangingCheck();
-			return ac.getMembersManager().createSponsoredAccount(ac.getSession(),
-					parms.read("parameters", HashMap.class),
-					parms.readString("namespace"),
-					ac.getExtSourceById(parms.readInt("extSource")),
-					parms.readString("extSourcePostfix"),
-					ac.getVoById(parms.readInt("vo")),
-					parms.readInt("loa"));
-		}
-	},
-
-	/*#
 	 * Creates a new sponsored member in a given VO and namespace.
 	 *
 	 * Can be called either by a user with role SPONSOR, in that case the user becomes the sponsor,

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/CreateServiceMemberInVoTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/CreateServiceMemberInVoTabItem.java
@@ -123,9 +123,7 @@ public class CreateServiceMemberInVoTabItem implements TabItem, TabItemWithUrl {
 		final ExtendedTextBox certDN = new ExtendedTextBox();
 		final ExtendedTextBox cacertDN = new ExtendedTextBox();
 
-		final ListBox userType = new ListBox();
-		userType.addItem("Service", "SERVICE");
-		userType.addItem("Sponsored", "SPONSORED");
+		final String serviceType = "SERVICE";
 
 		serviceUserPassword.getTextBox().setWidth("200px");
 		serviceUserPassword2.getTextBox().setWidth("200px");
@@ -360,10 +358,6 @@ public class CreateServiceMemberInVoTabItem implements TabItem, TabItemWithUrl {
 		layout.setWidget(6, 1, certDN);
 		layout.setHTML(7, 0, "<strong>Issuer DN: </strong>");
 		layout.setWidget(7, 1, cacertDN);
-		if (session.isPerunAdmin()) {
-			layout.setHTML(8, 0, "<strong>User type: </strong>");
-			layout.setWidget(8, 1, userType);
-		}
 
 		final FlexTable firstTabLayout = new FlexTable();
 		firstTabLayout.setSize("100%", "100%");
@@ -409,10 +403,6 @@ public class CreateServiceMemberInVoTabItem implements TabItem, TabItemWithUrl {
 				final FindUsersInVo callback = new FindUsersInVo();
 				// Service users can't own another Service or Guest (Sponsored) account.
 				callback.hideService(true);
-				if (userType.getSelectedValue().equals("SPONSORED")) {
-					// Sponsored account can't sponsor another !
-					callback.setHideSponsored(true);
-				}
 
 				// HORIZONTAL MENU
 				TabMenu tabMenu = new TabMenu();
@@ -675,7 +665,7 @@ public class CreateServiceMemberInVoTabItem implements TabItem, TabItemWithUrl {
 								serviceUserLogin.getTextBox().getValue().trim(),
 								certDN.getTextBox().getValue().trim(),
 								cacertDN.getTextBox().getValue().trim(),
-								userType.getSelectedValue()
+								serviceType
 						);
 
 					}


### PR DESCRIPTION
- We want to use new functionality for sponsored members. We don't want
  to Create sponsored users anymore.
- Therefore, all places where it could be called from outside were
  removed or forbiden.
- We do not want to remove all logic around sponsored users (old way) for now,
  because there are still users which are set this way.