### PR TITLE
Core - Member mapper rework

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/GroupsManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/GroupsManagerImpl.java
@@ -326,7 +326,7 @@ public class GroupsManagerImpl implements GroupsManagerImplApi {
 	public List<Member> getGroupMembers(PerunSession sess, Group group) {
 		try {
 			return jdbc.query("select " + MembersManagerImpl.groupsMembersMappingSelectQuery + " from groups_members join members on members.id=groups_members.member_id " +
-					"where groups_members.group_id=?", MembersManagerImpl.MEMBER_MAPPER, group.getId());
+					"where groups_members.group_id=?", MembersManagerImpl.MEMBER_MAPPER_WITH_GROUP, group.getId());
 		} catch (EmptyResultDataAccessException e) {
 			return new ArrayList<>();
 		} catch (RuntimeException e) {
@@ -341,7 +341,7 @@ public class GroupsManagerImpl implements GroupsManagerImplApi {
 					" from groups_members" +
 					" join members on members.id=groups_members.member_id" +
 					" and groups_members.group_id=? " +
-					" and members.id=?", MembersManagerImpl.MEMBER_MAPPER, group.getId(), id);
+					" and members.id=?", MembersManagerImpl.MEMBER_MAPPER_WITH_GROUP, group.getId(), id);
 		} catch (EmptyResultDataAccessException e) {
 			return new ArrayList<>();
 		} catch (RuntimeException e) {
@@ -353,7 +353,7 @@ public class GroupsManagerImpl implements GroupsManagerImplApi {
 	public List<Member> getGroupMembersByMembership(PerunSession sess, Group group, MembershipType membershipType) {
 		try {
 			return jdbc.query("select " + MembersManagerImpl.groupsMembersMappingSelectQuery + " from groups_members join members on members.id=groups_members.member_id " +
-					"where groups_members.group_id=? and groups_members.membership_type=?", MembersManagerImpl.MEMBER_MAPPER, group.getId(), membershipType.getCode());
+					"where groups_members.group_id=? and groups_members.membership_type=?", MembersManagerImpl.MEMBER_MAPPER_WITH_GROUP, group.getId(), membershipType.getCode());
 		} catch (EmptyResultDataAccessException e) {
 			return new ArrayList<>();
 		} catch (RuntimeException e) {
@@ -376,12 +376,12 @@ public class GroupsManagerImpl implements GroupsManagerImplApi {
 				// Exclude members with one of the status
 				return this.namedParameterJdbcTemplate.query("select " + MembersManagerImpl.groupsMembersMappingSelectQuery +
 						" from groups_members join members on members.id=groups_members.member_id " +
-						"where groups_members.group_id=:group_id and members.status not in (:statuses)", parameters, MembersManagerImpl.MEMBER_MAPPER);
+						"where groups_members.group_id=:group_id and members.status not in (:statuses)", parameters, MembersManagerImpl.MEMBER_MAPPER_WITH_GROUP);
 			} else {
 				// Include members with one of the status
 				return this.namedParameterJdbcTemplate.query("select " + MembersManagerImpl.groupsMembersMappingSelectQuery +
 						" from groups_members join members on members.id=groups_members.member_id " +
-						"where groups_members.group_id=:group_id and members.status in (:statuses)", parameters, MembersManagerImpl.MEMBER_MAPPER);
+						"where groups_members.group_id=:group_id and members.status in (:statuses)", parameters, MembersManagerImpl.MEMBER_MAPPER_WITH_GROUP);
 			}
 		} catch (EmptyResultDataAccessException e) {
 			return new ArrayList<>();

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ResourcesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ResourcesManagerImpl.java
@@ -47,6 +47,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static cz.metacentrum.perun.core.impl.MembersManagerImpl.MEMBER_MAPPER;
+
 /**
  *
  * @author Slavek Licehammer glory@ics.muni.cz
@@ -376,13 +378,12 @@ public class ResourcesManagerImpl implements ResourcesManagerImplApi {
 	@Override
 	public List<Member> getAllowedMembers(PerunSession sess, Resource resource) {
 		try  {
-			// we do include all group statuses for such members
 			return jdbc.query("select distinct " + MembersManagerImpl.memberMappingSelectQuery + " from groups_resources" +
 							" join groups on groups_resources.group_id=groups.id" +
 							" join groups_members on groups.id=groups_members.group_id" +
 							" join members on groups_members.member_id=members.id" +
 							" where groups_resources.resource_id=? and members.status!=? and members.status!=?",
-					MembersManagerImpl.MEMBERS_WITH_GROUP_STATUSES_SET_EXTRACTOR, resource.getId(),
+					MEMBER_MAPPER, resource.getId(),
 					Status.INVALID.getCode(), Status.DISABLED.getCode());
 		} catch (EmptyResultDataAccessException e) {
 			return new ArrayList<>();


### PR DESCRIPTION
* The old implementation of MEMBER_MAPPER could be used to load also
member's group statuses. But, it the query didn't return these columns,
it used to throw an Exception. This exception has been catched and the
mapper just skipped the group-specific columns. This caused a
performance issues because exception handling has a high cost
(especially when it was thrown for every row).
* The MEMBER_MAPPER has been split into two mappers - MEMBER_MAPPER
which can be used to load only member fields and
MEMBER_MAPPER_WITH_GROUP which can be used to load also member's group
statuses.