### PR TITLE
Core - bug fix

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/MembersManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/MembersManagerImpl.java
@@ -505,7 +505,7 @@ public class MembersManagerImpl implements MembersManagerImplApi {
 		String sponsoredQueryString = "";
 		if(onlySponsored) {
 			//only sponsored members
-			sponsoredQueryString+=" members.sponsored=1 and ";
+			sponsoredQueryString+=" members.sponsored=true and ";
 		}
 
 		String userNameQueryString = Utils.prepareUserSearchQuerySimilarMatch();


### PR DESCRIPTION
* There was an invalid value for the sponsored column when finding
members. The column is of type boolean and the passed value was `1`
which postgres cannot convert to true.