### PR TITLE
Filter of groups where member is direct in addMember moved to entry

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/GroupsManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/GroupsManagerEntry.java
@@ -326,14 +326,20 @@ public class GroupsManagerEntry implements GroupsManager {
 			}
 		}
 
-		// Authorization
+		List<Group> groupsMemberIsNotDirect = new ArrayList<>();
 		for (Group group: groups) {
+			// Authorization
 			if (!AuthzResolver.authorizedInternal(sess, "addMember_List<Group>_Member_policy", group, member)) {
 				throw new PrivilegeException(sess, "addMember");
 			}
+
+			// Filter groups where member is direct member
+			if (!isDirectGroupMember(sess, group, member)) {
+				groupsMemberIsNotDirect.add(group);
+			}
 		}
 
-		getGroupsManagerBl().addMember(sess, groups, member);
+		getGroupsManagerBl().addMember(sess, groupsMemberIsNotDirect, member);
 	}
 
 	@Override

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/GroupsManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/GroupsManagerEntryIntegrationTest.java
@@ -3870,6 +3870,21 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 		}
 	}
 
+	@Test
+	public void addMemberToGroupsFilterDirect() throws Exception {
+		System.out.println(CLASS_NAME + "addMemberToGroupsFilterDirect");
+
+		vo = setUpVo();
+
+		groupsManagerBl.createGroup(sess, vo, group);
+
+		Member member = setUpMember(vo);
+		groupsManager.addMember(sess, group, member);
+		assertTrue("List of members should contain member", groupsManager.isDirectGroupMember(sess, group, member));
+
+		groupsManager.addMember(sess, Collections.singletonList(group), member);
+	}
+
 
 	@Test
 	public void addMembersToGroup() throws Exception {

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/GroupsManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/GroupsManagerMethod.java
@@ -455,16 +455,12 @@ public enum GroupsManagerMethod implements ManagerMethod {
 					throw new RpcException(RpcException.Type.MISSING_VALUE, "Non-empty list of groups not sent.");
 				}
 				List<Group> groups = new ArrayList<>();
-				Member member = ac.getMemberById(parms.readInt("member"));
 				for (Integer groupInt : groupsInts) {
-					Group group = ac.getGroupById(groupInt);
-					if (!ac.getGroupsManager().isDirectGroupMember(ac.getSession(), group, member)) {
-						groups.add(group);
-					}
+					groups.add(ac.getGroupById(groupInt));
 				}
 				ac.getGroupsManager().addMember(ac.getSession(),
 					groups,
-					member);
+					ac.getMemberById(parms.readInt("member")));
 
 			} else {
 				throw new RpcException(RpcException.Type.MISSING_VALUE, "Parameter not provided. 'group' or 'groups' missing.");


### PR DESCRIPTION
- rpc no longer filters groups where member is direct and then sends them to entry in addMember method, but entry layer takes care of the filter
- also added test where all groups are filtered in entry