### PR TITLE
Sponsor existing user

### DIFF
--- a/perun-base/src/main/resources/perun-roles.yml
+++ b/perun-base/src/main/resources/perun-roles.yml
@@ -2234,6 +2234,12 @@ perun_policies:
     include_policies:
       - default_policy
 
+  setSponsoredMember_Vo_User_String_String_User_policy:
+    policy_roles:
+      - VOADMIN: Vo
+    include_policies:
+      - default_policy
+
   setSponsorshipForMember_Member_User_policy:
     policy_roles: []
     include_policies:

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/MembersManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/MembersManager.java
@@ -1175,6 +1175,32 @@ public interface MembersManager {
 	RichMember createSponsoredMember(PerunSession session, Vo vo, String namespace, Map<String, String> name, String password, User sponsor) throws PrivilegeException, AlreadyMemberException, LoginNotExistsException, PasswordCreationFailedException, ExtendMembershipException, WrongAttributeValueException, ExtSourceNotExistsException, WrongReferenceAttributeValueException, UserNotInRoleException, PasswordStrengthException, InvalidLoginException;
 
 	/**
+	 * Creates a sponsored membership for the given user.
+	 *
+	 * @param session actor
+	 * @param vo virtual organization for the member
+	 * @param userToBeSponsored user, that will be sponsored by sponsor
+	 * @param namespace namespace for selecting password module
+	 * @param password password
+	 * @param sponsor sponsoring user or null for the caller
+	 *
+	 * @return sponsored member
+	 *
+	 * @throws PrivilegeException
+	 * @throws AlreadyMemberException
+	 * @throws LoginNotExistsException
+	 * @throws PasswordCreationFailedException
+	 * @throws ExtendMembershipException
+	 * @throws WrongAttributeValueException
+	 * @throws ExtSourceNotExistsException
+	 * @throws WrongReferenceAttributeValueException
+	 * @throws UserNotInRoleException
+	 * @throws PasswordStrengthException
+	 * @throws InvalidLoginException
+	 */
+	RichMember setSponsoredMember(PerunSession session, Vo vo, User userToBeSponsored, String namespace, String password, User sponsor) throws PrivilegeException, AlreadyMemberException, LoginNotExistsException, PasswordCreationFailedException, ExtendMembershipException, WrongAttributeValueException, ExtSourceNotExistsException, WrongReferenceAttributeValueException, UserNotInRoleException, PasswordStrengthException, InvalidLoginException;
+
+	/**
 	 * Transform non-sponsored member to sponsored one with defined sponsor
 	 *
 	 * @param session perun session

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/MembersManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/MembersManagerBl.java
@@ -1488,6 +1488,30 @@ public interface MembersManagerBl {
 	Member createSponsoredMember(PerunSession session, Vo vo, String namespace, Map<String, String> name, String password, User sponsor, boolean asyncValidation) throws AlreadyMemberException, LoginNotExistsException, PasswordCreationFailedException, ExtendMembershipException, WrongAttributeValueException, ExtSourceNotExistsException, WrongReferenceAttributeValueException, UserNotInRoleException, PasswordStrengthException, InvalidLoginException;
 
 	/**
+	 * Creates a sponsored membership for the given user.
+	 *
+	 * @param session perun session
+	 * @param vo virtual organization
+	 * @param userToBeSponsored user, that will be sponsored by sponsor
+	 * @param namespace used for selecting external system in which guest user account will be created
+	 * @param password password
+	 * @param sponsor sponsoring user
+	 * @param asyncValidation
+	 * @return sponsored member
+	 * @throws AlreadyMemberException
+	 * @throws ExtendMembershipException
+	 * @throws UserNotInRoleException
+	 * @throws PasswordStrengthException
+	 * @throws WrongAttributeValueException
+	 * @throws WrongReferenceAttributeValueException
+	 * @throws LoginNotExistsException
+	 * @throws PasswordCreationFailedException
+	 * @throws InvalidLoginException
+	 * @throws ExtSourceNotExistsException
+	 */
+	Member setSponsoredMember(PerunSession session, Vo vo, User userToBeSponsored, String namespace, String password, User sponsor, boolean asyncValidation) throws AlreadyMemberException, ExtendMembershipException, UserNotInRoleException, PasswordStrengthException, WrongAttributeValueException, WrongReferenceAttributeValueException, LoginNotExistsException, PasswordCreationFailedException, InvalidLoginException, ExtSourceNotExistsException;
+
+	/**
 	 * Links sponsored member and sponsoring user.
 	 * @param session perun session
 	 * @param sponsoredMember member which is sponsored

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
@@ -2312,13 +2312,7 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 	}
 
 	@Override
-	public Member createSponsoredMember(PerunSession session, Vo vo, String namespace, Map<String, String> name, String password, User sponsor, boolean asyncValidation) throws AlreadyMemberException, LoginNotExistsException, PasswordCreationFailedException, ExtendMembershipException, WrongAttributeValueException, ExtSourceNotExistsException, WrongReferenceAttributeValueException, UserNotInRoleException, PasswordStrengthException, InvalidLoginException {
-		//check that sponsoring user has role SPONSOR for the VO
-		if (!getPerunBl().getVosManagerBl().isUserInRoleForVo(session, sponsor, Role.SPONSOR, vo, true)) {
-			throw new UserNotInRoleException("user " + sponsor.getId() + " is not in role SPONSOR for VO " + vo.getId());
-		}
-		String loginAttributeName = PasswordManagerModule.LOGIN_PREFIX + namespace;
-
+	public Member createSponsoredMember(PerunSession session, Vo vo, String namespace, Map<String, String> name, String password, User sponsor, boolean asyncValidation) throws AlreadyMemberException, LoginNotExistsException, PasswordCreationFailedException, ExtendMembershipException, WrongAttributeValueException, ExtSourceNotExistsException, WrongReferenceAttributeValueException, UserNotInRoleException, InvalidLoginException {
 		//create new user
 		User user;
 		if (name.containsKey("guestName")) {
@@ -2328,32 +2322,56 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 		}
 		User sponsoredUser = getPerunBl().getUsersManagerBl().createUser(session, user);
 
-		//create the user account in external system
-		Map<String, String> p = new HashMap<>();
-		p.put(PasswordManagerModule.TITLE_BEFORE_KEY,sponsoredUser.getTitleBefore());
-		p.put(PasswordManagerModule.FIRST_NAME_KEY,sponsoredUser.getFirstName());
-		p.put(PasswordManagerModule.LAST_NAME_KEY,sponsoredUser.getLastName());
-		p.put(PasswordManagerModule.TITLE_AFTER_KEY,sponsoredUser.getTitleAfter());
-		p.put(PasswordManagerModule.PASSWORD_KEY,password);
-		Map<String, String> r = getPerunBl().getUsersManagerBl().generateAccount(session, namespace, p);
-		String login = r.get(loginAttributeName);
-		setLoginToSponsoredUser(session,sponsoredUser,loginAttributeName,login);
+		return setSponsoredMember(session, vo, sponsoredUser, namespace, password, sponsor, asyncValidation);
+	}
+
+	@Override
+	public Member setSponsoredMember(PerunSession session, Vo vo, User userToBeSponsored, String namespace, String password, User sponsor, boolean asyncValidation) throws AlreadyMemberException, ExtendMembershipException, UserNotInRoleException, WrongAttributeValueException, WrongReferenceAttributeValueException, LoginNotExistsException, PasswordCreationFailedException, InvalidLoginException, ExtSourceNotExistsException {
+		//check that sponsoring user has role SPONSOR for the VO
+		if (!getPerunBl().getVosManagerBl().isUserInRoleForVo(session, sponsor, Role.SPONSOR, vo, true)) {
+			throw new UserNotInRoleException("user " + sponsor.getId() + " is not in role SPONSOR for VO " + vo.getId());
+		}
+		String loginAttributeName = PasswordManagerModule.LOGIN_PREFIX + namespace;
+		String attributeValue = getAttributeValueAsString (session, userToBeSponsored, loginAttributeName);
+
+		//create the user account in external system if does not exist yet
+		String login = createUserAccountInExternalSystem (session, userToBeSponsored, namespace, attributeValue, loginAttributeName, password);
 
 		//create the member in Perun
-		Member sponsoredMember = getMembersManagerImpl().createSponsoredMember(session, vo, sponsoredUser, sponsor);
+		Member sponsoredMember = getMembersManagerImpl().createSponsoredMember(session, vo, userToBeSponsored, sponsor);
 		getPerunBl().getAuditer().log(session, new MemberCreated(sponsoredMember));
 		getPerunBl().getAuditer().log(session, new SponsoredMemberSet(sponsoredMember));
 		getPerunBl().getAuditer().log(session, new SponsorshipEstablished(sponsoredMember, sponsor));
 		extendMembership(session, sponsoredMember);
 		insertToMemberGroup(session, sponsoredMember, vo);
-		if(asyncValidation) {
+
+		if (asyncValidation) {
 			validateMemberAsync(session, sponsoredMember);
 		} else {
 			//for unit tests
 			validateMember(session, sponsoredMember);
 		}
-		getPerunBl().getUsersManagerBl().validatePasswordAndSetExtSources(session, sponsoredUser, login, namespace);
+		getPerunBl().getUsersManagerBl().validatePasswordAndSetExtSources(session, userToBeSponsored, login, namespace);
+
 		return sponsoredMember;
+	}
+
+	/**
+	 * Try to get attribute from attribute manager
+	 *
+	 * @param session perun session
+	 * @param userToBeSponsored user, that will be sponsored by sponsor
+	 * @param loginAttributeName login attribute name
+	 * @return attributeValue
+	 */
+	private String getAttributeValueAsString (PerunSession session, User userToBeSponsored, String loginAttributeName) {
+		String attributeValue;
+		try {
+			attributeValue = perunBl.getAttributesManagerBl().getAttribute(session, userToBeSponsored, loginAttributeName).valueAsString();
+		} catch (WrongAttributeAssignmentException | AttributeNotExistsException e) {
+			throw new InternalErrorException(e);
+		}
+		return attributeValue;
 	}
 
 	private void setLoginToSponsoredUser(PerunSession sess, User sponsoredUser, String loginAttributeName, String login) {
@@ -2519,5 +2537,38 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 		this.perunBl = perunBl;
 	}
 
+	/**
+	 * Creates a user account in external system if does not exist yet
+	 *
+	 * @param session perun session
+	 * @param userToBeSponsored user, that will be sponsored by sponsor
+	 * @param namespace namespace
+	 * @param attributeValue attribute value
+	 * @param loginAttributeName login attribute name
+	 * @param password password
+	 * @return login for given user
+	 */
+	private String createUserAccountInExternalSystem (PerunSession session, User userToBeSponsored, String namespace, String attributeValue, String loginAttributeName, String password) {
+		String login;
+		if (attributeValue == null || attributeValue.isEmpty()) {
+			Map<String, String> p = new HashMap<>();
+			p.put(PasswordManagerModule.TITLE_BEFORE_KEY, userToBeSponsored.getTitleBefore());
+			p.put(PasswordManagerModule.FIRST_NAME_KEY, userToBeSponsored.getFirstName());
+			p.put(PasswordManagerModule.LAST_NAME_KEY, userToBeSponsored.getLastName());
+			p.put(PasswordManagerModule.TITLE_AFTER_KEY, userToBeSponsored.getTitleAfter());
+			p.put(PasswordManagerModule.PASSWORD_KEY, password);
+			Map<String, String> r;
+			try {
+				r = getPerunBl().getUsersManagerBl().generateAccount(session, namespace, p);
+			} catch (PasswordStrengthException e) {
+				throw new InternalErrorException("The password fails strength check required by the namespace.");
+			}
+			login = r.get(loginAttributeName);
+			setLoginToSponsoredUser(session, userToBeSponsored, loginAttributeName, login);
+		} else {
+			login = attributeValue;
+		}
+		return login;
+	}
 
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/MembersManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/MembersManagerEntry.java
@@ -8,7 +8,6 @@ import cz.metacentrum.perun.core.api.ExtSource;
 import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.Member;
 import cz.metacentrum.perun.core.api.MembersManager;
-import cz.metacentrum.perun.core.api.PerunBean;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.RichMember;
@@ -56,14 +55,11 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * @author Slavek Licehammer glory@ics.muni.cz
@@ -1221,7 +1217,7 @@ public class MembersManagerEntry implements MembersManager {
 		log.info("createSponsoredMember(vo={},namespace='{}',guestName='{}',sponsor={}", vo.getShortName(), namespace, nameForLog, sponsor == null ? "null" : sponsor.getId());
 
 		if (sponsor == null) {
-			//sponsor is the caller
+			//sponsor is the caller, authorization is checked in Bl
 			sponsor = session.getPerunPrincipal().getUser();
 		} else {
 			//Authorization
@@ -1231,6 +1227,32 @@ public class MembersManagerEntry implements MembersManager {
 		}
 		//create the sponsored member
 		return membersManagerBl.getRichMember(session, membersManagerBl.createSponsoredMember(session, vo, namespace, name, password, sponsor, true));
+	}
+
+	@Override
+	public RichMember setSponsoredMember(PerunSession session, Vo vo, User userToBeSponsored, String namespace, String password, User sponsor)
+		throws PrivilegeException, AlreadyMemberException, LoginNotExistsException, PasswordCreationFailedException,
+		ExtendMembershipException, WrongAttributeValueException, ExtSourceNotExistsException, WrongReferenceAttributeValueException,
+		UserNotInRoleException, PasswordStrengthException, InvalidLoginException {
+		Utils.checkPerunSession(session);
+		Utils.notNull(vo, "vo");
+		Utils.notNull(userToBeSponsored, "userToBeSponsored");
+		Utils.notNull(namespace, "namespace");
+		Utils.notNull(password, "password");
+
+		log.debug("setSponsoredMember(vo={},namespace='{}',displayName='{}',sponsor={}", vo.getShortName(), namespace, userToBeSponsored.getFirstName() + " " + userToBeSponsored.getLastName(), sponsor == null ? "null" : sponsor.getId());
+
+		if (sponsor == null) {
+			//sponsor is the caller, authorization is checked in Bl
+			sponsor = session.getPerunPrincipal().getUser();
+		} else {
+			//Authorization
+			if (!AuthzResolver.authorizedInternal(session, "setSponsoredMember_Vo_User_String_String_User_policy", vo, sponsor)) {
+				throw new PrivilegeException(session, "setSponsoredMember");
+			}
+		}
+		//create the sponsored member
+		return membersManagerBl.getRichMember(session, membersManagerBl.setSponsoredMember(session, vo, userToBeSponsored, namespace, password, sponsor, true));
 	}
 
 	@Override

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/MembersManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/MembersManagerEntryIntegrationTest.java
@@ -1510,6 +1510,22 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 	}
 
 	@Test
+	public void setSponsoredMember() throws Exception {
+		System.out.println(CLASS_NAME + "setSponsoredMember");
+		Candidate candidate = new Candidate();
+		candidate.setFirstName("Jan");
+		candidate.setLastName("Novák");
+		User sponsoredUser = perun.getUsersManagerBl().createUser(sess, candidate);
+		Member sponsorMember = setUpSponsor(createdVo);
+		User sponsor = perun.getUsersManagerBl().getUserByMember(sess, sponsorMember);
+		AuthzResolverBlImpl.setRole(sess, sponsor, createdVo, Role.SPONSOR);
+		Member sponsoredMember = perun.getMembersManagerBl().setSponsoredMember(sess, createdVo, sponsoredUser, "dummy", "password", sponsor, true);
+
+		Member memberFromDb = perun.getMembersManagerBl().getMemberByUser(sess, createdVo, sponsoredUser);
+		assertTrue(memberFromDb.isSponsored());
+	}
+
+	@Test
 	public void setAndUnsetSponsorshipForMember() throws Exception {
 		System.out.println(CLASS_NAME + "setAndUnsetSponsorshipForMember");
 		Member sponsorMember = setUpSponsor(createdVo);

--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -7806,6 +7806,37 @@ paths:
                 sponsor: { type: integer }
                 namespace: { type: string }
 
+  /json/membersManager/setSponsoredMember:
+    post:
+      tags:
+        - MembersManager
+      operationId: setSponsoredMember
+      summary: Creates a sponsored membership for the given user.
+      responses:
+        '200':
+          $ref: '#/components/responses/RichMemberResponse'
+        default:
+          $ref: '#/components/responses/ExceptionResponse'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              title: InputSetSponsoredMember
+              description: "input for setSponsoredMember"
+              type: object
+              required:
+                - userToBeSponsored
+                - password
+                - vo
+                - namespace
+              properties:
+                userToBeSponsored: { type: integer }
+                password: { type: string }
+                vo: { type: integer }
+                sponsor: { type: integer }
+                namespace: { type: string }
+
   /json/membersManager/createSpecificMember:
     post:
       tags:

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/MembersManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/MembersManagerMethod.java
@@ -185,6 +185,52 @@ public enum MembersManagerMethod implements ManagerMethod {
 	},
 
 	/*#
+	 * Creates a sponsored membership for the given user.
+	 *
+	 * Can be called with specific sponsor. If the parameter sponsor is null, then the user
+	 * which called this method will be set as a sponsor.
+	 *
+	 * @param vo int id of virtual organization
+	 * @param userToBeSponsored int id of user, that will be sponsored by sponsor
+	 * @param namespace String used for selecting external system in which guest user account will be created
+	 * @param password String password
+	 * @param sponsor int id of sponsoring user
+	 * @return RichMember sponsored member
+	 */
+	/*#
+	 * Creates a sponsored membership for the given user.
+	 *
+	 * Can be called with specific sponsor. If the parameter sponsor is null, then the user
+	 * which called this method will be set as a sponsor.
+	 *
+	 * @param vo int id of virtual organization
+	 * @param userToBeSponsored int id of user, that will be sponsored by sponsor
+	 * @param namespace String used for selecting external system in which guest user account will be created
+	 * @param password String password
+	 * @return RichMember sponsored member
+	 */
+	setSponsoredMember {
+		@Override
+		public RichMember call(ApiCaller ac, Deserializer params) throws PerunException {
+			params.stateChangingCheck();
+			String password = params.readString("password");
+			Vo vo =  ac.getVoById(params.readInt("vo"));
+			String namespace = params.readString("namespace");
+			User sponsor = null;
+			if(params.contains("sponsor")) {
+				sponsor = ac.getUserById(params.readInt("sponsor"));
+			}
+			User userToBeSponsored;
+			if(params.contains("userToBeSponsored")) {
+				userToBeSponsored = ac.getUserById(params.readInt("userToBeSponsored"));
+			} else {
+				throw new RpcException(RpcException.Type.MISSING_VALUE, "Missing value. The 'userToBeSponsored' must be sent.");
+			}
+			return ac.getMembersManager().setSponsoredMember(ac.getSession(), vo, userToBeSponsored, namespace, password, sponsor);
+		}
+	},
+
+	/*#
 	 * Transform non-sponsored member to sponsored one with defined sponsor
 	 *
 	 * @param sponsoredMember int member's ID


### PR DESCRIPTION
* I split the original method "createSponsoredMember" to two methods. The original method always created user, created member, set user to sponsored user and set sponsor for this user before that, but we want to do some steps separately.
* Now the original method only creates user and the remaining actions does the new method called "setSponsoredMember". Due to this steps I also need to create new policy named "setSponsoredMember_Vo_User_String_String_User_policy".