### PR TITLE
Removed subgroups as child elements from getDataWithGroups

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/ServicesManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/ServicesManager.java
@@ -519,7 +519,7 @@ public interface ServicesManager {
 	 * @return attributes in special structure. Facility is in the root, facility children are resources.
 	 *         Resource first child is abstract structure which children are groups.
 	 *         Resource  second chi is abstract structure which children are members.
-	 *         Group first child is abstract structure which children are groups.
+	 *         Group first child is empty structure.
 	 *         Group second chi is abstract structure which children are members.
 	 <pre>
 	 Facility
@@ -549,10 +549,6 @@ public interface ServicesManager {
 	 |              |       |        +-------Attrs
 	 |              |       |        +-------ChildNodes
 	 |              |       |                   +-------()
-	 |              |       |                   |        +---ChildNodes
-	 |              |       |                   |               +------- GROUP (same structure as any other group)
-	 |              |       |                   |               +------- GROUP (same structure as any other group)
-	 |              |       |                   |               +...
 	 |              |       |                   +-------()
 	 |              |       |                            +---ChildNodes
 	 |              |       |                                   +------Member

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/ServicesManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/ServicesManager.java
@@ -518,9 +518,9 @@ public interface ServicesManager {
 	 * @param filterExpiredMembers if true the method does not take members expired in groups into account
 	 * @return attributes in special structure. Facility is in the root, facility children are resources.
 	 *         Resource first child is abstract structure which children are groups.
-	 *         Resource  second chi is abstract structure which children are members.
-	 *         Group first child is empty structure.
-	 *         Group second chi is abstract structure which children are members.
+	 *         Resource  second child is abstract structure which children are members.
+	 *         Group first child is empty structure (services expect members to be second child, here used to be subgroups).
+	 *         Group second child is abstract structure which children are members.
 	 <pre>
 	 Facility
 	 +---Attrs                              ...................................................
@@ -533,10 +533,6 @@ public interface ServicesManager {
 	 |              |       |        +-------Attrs                                     .
 	 |              |       |        +-------ChildNodes                                .
 	 |              |       |                   +-------()                             .
-	 |              |       |                   |        +---ChildNodes                .
-	 |              |       |                   |               +------- GROUP (same structure as any other group)
-	 |              |       |                   |               +------- GROUP (same structure as any other group)
-	 |              |       |                   |               +...
 	 |              |       |                   +-------()
 	 |              |       |                            +---ChildNodes
 	 |              |       |                                   +------Member

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ServicesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ServicesManagerBl.java
@@ -452,10 +452,8 @@ public interface ServicesManagerBl {
 	 * @return attributes in special structure. Facility is in the root, facility children are resources.
 	 *         Resource first child is abstract structure which children are groups.
 	 *         Resource  second chi is abstract structure which children are members.
-	 *         Group first child is abstract structure which children are groups.
+	 *         Group first child is empty structure.
 	 *         Group second chi is abstract structure which children are members.
-	 *
-	 * @throws InternalErrorException
 	 */
 	ServiceAttributes getDataWithGroups(PerunSession perunSession, Service service, Facility facility, boolean filterExpiredMembers);
 	/**

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ServicesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ServicesManagerBl.java
@@ -451,9 +451,9 @@ public interface ServicesManagerBl {
 	 * @param filterExpiredMembers if true the method does not take expired members into account
 	 * @return attributes in special structure. Facility is in the root, facility children are resources.
 	 *         Resource first child is abstract structure which children are groups.
-	 *         Resource  second chi is abstract structure which children are members.
-	 *         Group first child is empty structure.
-	 *         Group second chi is abstract structure which children are members.
+	 *         Resource  second child is abstract structure which children are members.
+	 *         Group first child is empty structure (services expect members to be second child, here used to be subgroups).
+	 *         Group second child is abstract structure which children are members.
 	 */
 	ServiceAttributes getDataWithGroups(PerunSession perunSession, Service service, Facility facility, boolean filterExpiredMembers);
 	/**

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ServicesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ServicesManagerBlImpl.java
@@ -429,14 +429,6 @@ public class ServicesManagerBlImpl implements ServicesManagerBl {
 		} catch (GroupResourceMismatchException ex) {
 			throw new InternalErrorException(ex);
 		}
-		ServiceAttributes groupsSubGroupsElement = new ServiceAttributes();
-		// FIXME Do not get subgroups of the members group
-		if (!group.getName().equals(VosManager.MEMBERS_GROUP)) {
-			List<Group> subGroups = getPerunBl().getGroupsManagerBl().getSubGroups(sess, group);
-			for(Group subGroup : subGroups) {
-				groupsSubGroupsElement.addChildElement(getData(sess, service, facility, resource, subGroup, memberAttributes, filterExpiredMembers));
-			}
-		}
 
 		ServiceAttributes groupsMembersElement = new ServiceAttributes();
 		//Invalid and disabled are not allowed here
@@ -467,7 +459,8 @@ public class ServicesManagerBlImpl implements ServicesManagerBl {
 			groupsMembersElement.addChildElement(tempAttrs);
 		}
 
-		groupServiceAttributes.addChildElement(groupsSubGroupsElement);
+		// Services expect members to be second child element, so we create empty ServiceAttributes where subgroups used to be.
+		groupServiceAttributes.addChildElement(new ServiceAttributes());
 		groupServiceAttributes.addChildElement(groupsMembersElement);
 		return groupServiceAttributes;
 	}

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/ServicesManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/ServicesManagerMethod.java
@@ -902,10 +902,10 @@ public enum ServicesManagerMethod implements ManagerMethod {
 	 * @param service int Service <code>id</code>. You will get attributes reuqired by this service
 	 * @param facility int Facility <code>id</code>. You will get attributes for this facility, resources associated with it and members assigned to the resources
 	 * @return ServiceAttributes Attributes in special structure. Facility is in the root, facility children are resources.
-	 *         Resource first chil is abstract structure which children are groups.
-	 *         Resource  second chi is abstract structure which children are members.
-	 *         Group first chil is abstract structure which children are groups.
-	 *         Group second chi is abstract structure which children are members.
+	 *         Resource first child is abstract structure which children are groups.
+	 *         Resource  second child is abstract structure which children are members.
+	 *         Group first child is empty structure (services expect members to be second child, here used to be subgroups).
+	 *         Group second child is abstract structure which children are members.
 	 <pre>
 	 Facility
 	 +---Attrs                       ...................................................
@@ -918,10 +918,6 @@ public enum ServicesManagerMethod implements ManagerMethod {
 	 |              |       |        +-------Attrs                                     .
 	 |              |       |        +-------ChildNodes                                .
 	 |              |       |                   +-------()                             .
-	 |              |       |                   |        +---ChildNodes                .
-	 |              |       |                   |               +------- GROUP (same structure as any other group)
-	 |              |       |                   |               +------- GROUP (same structure as any other group)
-	 |              |       |                   |               +...
 	 |              |       |                   +-------()
 	 |              |       |                            +---ChildNodes
 	 |              |       |                                   +------Member
@@ -934,10 +930,6 @@ public enum ServicesManagerMethod implements ManagerMethod {
 	 |              |       |        +-------Attrs
 	 |              |       |        +-------ChildNodes
 	 |              |       |                   +-------()
-	 |              |       |                   |        +---ChildNodes
-	 |              |       |                   |               +------- GROUP (same structure as any other group)
-	 |              |       |                   |               +------- GROUP (same structure as any other group)
-	 |              |       |                   |               +...
 	 |              |       |                   +-------()
 	 |              |       |                            +---ChildNodes
 	 |              |       |                                   +------Member


### PR DESCRIPTION
- subgroups are no longer child elements of structure returned by getDataWithGroups, instead there is empty first child element in group part of the structure so current services does not have to be changed