### PR TITLE
Core - auto extension of members

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Utils.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Utils.java
@@ -1515,6 +1515,36 @@ public class Utils {
 	}
 
 	/**
+	 * Shortens the given date by the given period.
+	 *
+	 * @param localDate date to be shortened
+	 * @param period string of format ([0-9]+)([dmy])
+	 * @return shortened date
+	 */
+	public static LocalDate shortenDateByPeriod(LocalDate localDate, String period) {
+		Pattern p = Pattern.compile("([0-9]+)([dmy])");
+		Matcher m = p.matcher(period);
+		if (m.matches()) {
+			String countString = m.group(1);
+			int amount = Integer.parseInt(countString);
+
+			String dmyString = m.group(2);
+			switch (dmyString) {
+				case "d":
+					return localDate.minusDays(amount);
+				case "m":
+					return localDate.minusMonths(amount);
+				case "y":
+					return localDate.minusYears(amount);
+				default:
+					throw new InternalErrorException("Wrong format of period. Period: " + period);
+			}
+		} else {
+			throw new InternalErrorException("Wrong format of period. Period: " + period);
+		}
+	}
+
+	/**
 	 * Returns closest future LocalDate based on values given by matcher.
 	 * If returned value should fall to 29. 2. of non-leap year, the date is extended to 28. 2. instead.
 	 *

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_vo_attribute_def_def_membershipExpirationRules.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_vo_attribute_def_def_membershipExpirationRules.java
@@ -4,6 +4,7 @@ import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.Vo;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.AbstractMembershipExpirationRulesModule;
 import cz.metacentrum.perun.core.implApi.modules.attributes.VoAttributesModuleImplApi;
@@ -22,7 +23,9 @@ public class urn_perun_vo_attribute_def_def_membershipExpirationRules extends Ab
 				parameter.equals(membershipDoNotExtendLoaKeyName) ||
 				parameter.equals(membershipGracePeriodKeyName) ||
 				parameter.equals(membershipPeriodLoaKeyName)	||
-				parameter.equals(membershipDoNotAllowLoaKeyName);
+				parameter.equals(membershipDoNotAllowLoaKeyName) ||
+				parameter.equals(autoExtensionExtSources) ||
+				parameter.equals(autoExtensionLastLoginPeriod);
 	}
 
 	@Override
@@ -33,6 +36,11 @@ public class urn_perun_vo_attribute_def_def_membershipExpirationRules extends Ab
 	@Override
 	public Attribute fillAttribute(PerunSessionImpl sess, Vo vo, AttributeDefinition attribute) {
 		return new Attribute(attribute);
+	}
+
+	@Override
+	public void checkAttributeSemantics(PerunSessionImpl perunSession, Vo entity, Attribute attribute) throws WrongReferenceAttributeValueException {
+		super.checkAttributeSemantics(perunSession, entity, attribute);
 	}
 
 	@Override

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_vo_attribute_def_def_membershipExpirationRulesTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_vo_attribute_def_def_membershipExpirationRulesTest.java
@@ -1,0 +1,116 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.ExtSource;
+import cz.metacentrum.perun.core.api.Vo;
+import cz.metacentrum.perun.core.api.exceptions.ExtSourceNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static cz.metacentrum.perun.core.implApi.modules.attributes.AbstractMembershipExpirationRulesModule.autoExtensionExtSources;
+import static cz.metacentrum.perun.core.implApi.modules.attributes.AbstractMembershipExpirationRulesModule.autoExtensionLastLoginPeriod;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class urn_perun_vo_attribute_def_def_membershipExpirationRulesTest {
+
+	private static urn_perun_vo_attribute_def_def_membershipExpirationRules classInstance;
+	private static PerunSessionImpl session = mock(PerunSessionImpl.class, RETURNS_DEEP_STUBS);
+	private static Attribute attributeToCheck;
+	private static Vo vo;
+
+	@Before
+	public void setUp() {
+		classInstance = new urn_perun_vo_attribute_def_def_membershipExpirationRules();
+		attributeToCheck = new Attribute();
+		vo = new Vo();
+	}
+
+	// ------------- Syntax ------------- //
+
+	@Test
+	public void autoExtensionLastLoginPeriodCorrectSyntax() throws Exception {
+		Map<String, String> value = new LinkedHashMap<>();
+		value.put(autoExtensionLastLoginPeriod, "3m");
+		attributeToCheck.setValue(value);
+		classInstance.checkAttributeSyntax(session, vo, attributeToCheck);
+	}
+
+	@Test
+	public void autoExtensionLastLoginPeriodInCorrectSyntax() throws Exception {
+		Map<String, String> value = new LinkedHashMap<>();
+		value.put(autoExtensionLastLoginPeriod, "-3m");
+		attributeToCheck.setValue(value);
+		assertThatExceptionOfType(WrongAttributeValueException.class)
+				.isThrownBy(() -> classInstance.checkAttributeSyntax(session, vo, attributeToCheck));
+	}
+
+	@Test
+	public void autoExtensionExtSourcesCorrectSyntax() throws Exception {
+		Map<String, String> value = new LinkedHashMap<>();
+		value.put(autoExtensionExtSources, "2,3");
+		attributeToCheck.setValue(value);
+		classInstance.checkAttributeSyntax(session, vo, attributeToCheck);
+	}
+
+	@Test
+	public void autoExtensionExtSourcesInCorrectSyntax() throws Exception {
+		Map<String, String> value = new LinkedHashMap<>();
+		value.put(autoExtensionExtSources, "3,");
+		attributeToCheck.setValue(value);
+		assertThatExceptionOfType(WrongAttributeValueException.class)
+				.isThrownBy(() -> classInstance.checkAttributeSyntax(session, vo, attributeToCheck));
+	}
+
+	@Test
+	public void autoExtensionExtSourcesInCorrectSyntaxCommaPrefix() throws Exception {
+		Map<String, String> value = new LinkedHashMap<>();
+		value.put(autoExtensionExtSources, ",3");
+		attributeToCheck.setValue(value);
+		assertThatExceptionOfType(WrongAttributeValueException.class)
+				.isThrownBy(() -> classInstance.checkAttributeSyntax(session, vo, attributeToCheck));
+	}
+
+	// ------------- Semantics ------------- //
+
+	@Test
+	public void autoExtensionLastLoginPeriodCorrectSemantics() throws Exception {
+		Map<String, String> value = new LinkedHashMap<>();
+		when(session.getPerunBl().getExtSourcesManagerBl().getExtSourceById(any(), anyInt()))
+				.thenReturn(new ExtSource());
+		value.put(autoExtensionExtSources, "3");
+		attributeToCheck.setValue(value);
+		classInstance.checkAttributeSemantics(session, vo, attributeToCheck);
+	}
+
+	@Test
+	public void autoExtensionExtSourcesInCorrectSemantics() throws Exception {
+		Map<String, String> value = new LinkedHashMap<>();
+		when(session.getPerunBl().getExtSourcesManagerBl().getExtSourceById(any(), anyInt()))
+				.thenThrow(ExtSourceNotExistsException.class);
+		value.put(autoExtensionExtSources, "3");
+		attributeToCheck.setValue(value);
+		assertThatExceptionOfType(WrongReferenceAttributeValueException.class)
+				.isThrownBy(() -> classInstance.checkAttributeSemantics(session, vo, attributeToCheck));
+	}
+
+	@Test
+	public void autoExtensionMultipleExtSourcesCorrectSemantics() throws Exception {
+		Map<String, String> value = new LinkedHashMap<>();
+		when(session.getPerunBl().getExtSourcesManagerBl().getExtSourceById(any(), anyInt()))
+				.thenReturn(new ExtSource());
+		value.put(autoExtensionExtSources, "3,2");
+		attributeToCheck.setValue(value);
+		classInstance.checkAttributeSemantics(session, vo, attributeToCheck);
+	}
+}

--- a/perun-registrar-lib/src/test/java/cz/metacentrum/perun/registrar/ExpirationNotifSchedulerTest.java
+++ b/perun-registrar-lib/src/test/java/cz/metacentrum/perun/registrar/ExpirationNotifSchedulerTest.java
@@ -10,6 +10,7 @@ import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.Member;
 import cz.metacentrum.perun.core.api.MemberGroupStatus;
 import cz.metacentrum.perun.core.api.Status;
+import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.UserExtSource;
 import cz.metacentrum.perun.core.api.Vo;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
@@ -17,11 +18,24 @@ import cz.metacentrum.perun.registrar.impl.ExpirationNotifScheduler;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcPerunTemplate;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDate;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 
+import static cz.metacentrum.perun.core.implApi.modules.attributes.AbstractMembershipExpirationRulesModule.autoExtensionExtSources;
+import static cz.metacentrum.perun.core.implApi.modules.attributes.AbstractMembershipExpirationRulesModule.autoExtensionLastLoginPeriod;
+import static cz.metacentrum.perun.core.implApi.modules.attributes.AbstractMembershipExpirationRulesModule.membershipPeriodKeyName;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 /**
  * Tests for Synchronizer component.
@@ -34,10 +48,15 @@ public class ExpirationNotifSchedulerTest extends RegistrarBaseIntegrationTest {
 
 	private final static String EXPIRATION_URN = "urn:perun:member:attribute-def:def:membershipExpiration";
 	private final static String GROUP_EXPIRATION_URN = "urn:perun:member_group:attribute-def:def:groupMembershipExpiration";
+	private final static String VO_MEMBERSHIP_RULES_URN = "urn:perun:vo:attribute-def:def:membershipExpirationRules";
+	private final static String MEMBER_EXPIRATION_URN = "urn:perun:member:attribute-def:def:membershipExpiration";
 	private ExtSource extSource = new ExtSource(0, "testExtSource", ExtSourcesManager.EXTSOURCE_INTERNAL);
 	private Vo vo = new Vo(0, "SynchronizerTestVo", "SyncTestVo");
 
 	private ExpirationNotifScheduler scheduler;
+	private ExpirationNotifScheduler spyScheduler;
+
+	private JdbcPerunTemplate jdbc;
 
 	public ExpirationNotifScheduler getScheduler() {
 		return scheduler;
@@ -46,11 +65,12 @@ public class ExpirationNotifSchedulerTest extends RegistrarBaseIntegrationTest {
 	@Autowired
 	public void setScheduler(ExpirationNotifScheduler scheduler) {
 		this.scheduler = scheduler;
+		this.spyScheduler = spy(scheduler);
 	}
 
 	@Before
 	public void setUp() throws Exception {
-
+		jdbc = (JdbcPerunTemplate) ReflectionTestUtils.getField(scheduler, "jdbc");
 		setUpExtSource();
 		setUpVo();
 
@@ -319,6 +339,143 @@ public class ExpirationNotifSchedulerTest extends RegistrarBaseIntegrationTest {
 		MemberGroupStatus memberGroupStatus = perun.getGroupsManagerBl().getDirectMemberGroupStatus(session, member2, group);
 
 		assertEquals("Member should not be expired!", MemberGroupStatus.VALID, memberGroupStatus);
+	}
+
+	@Test
+	public void testAutoExtensionExtendsMemberWithLastAccess() throws Exception {
+		System.out.println(CLASS_NAME + "testAutoExtensionExtendsMemberWithLastAccess");
+
+		autoExpirationTest(
+				voRules -> {
+					voRules.put(membershipPeriodKeyName, "+3m");
+					voRules.put(autoExtensionLastLoginPeriod, "3m");
+				},
+				userExtSources -> {
+					for (UserExtSource userExtSource : userExtSources) {
+						jdbc.update("update user_ext_sources set last_access='1996-01-01 00:00:00.1' where id=?",
+								userExtSource.getId());
+					}
+				},
+				(oldExpiration, newExpiration) -> assertThat(newExpiration).isAfter(oldExpiration));
+	}
+
+	@Test
+	public void testAutoExtensionDoesNotExtendMemberWithoutLastAccess() throws Exception {
+		System.out.println(CLASS_NAME + "testAutoExtensionDoesNotExtendMemberWithoutLastAccess");
+
+		autoExpirationTest(
+				voRules -> {
+					voRules.put(membershipPeriodKeyName, "+3m");
+					voRules.put(autoExtensionLastLoginPeriod, "3m");
+				},
+				userExtSources -> {
+					for (UserExtSource userExtSource : userExtSources) {
+						jdbc.update("update user_ext_sources set last_access='1995-01-01 00:00:00.1' where id=?",
+								userExtSource.getId());
+					}
+				},
+				(oldExpiration, newExpiration) -> assertThat(newExpiration).isEqualTo(oldExpiration));
+	}
+
+	@Test
+	public void testAutoExtensionDoesNotExtendForUnspecifiedExtSource() throws Exception {
+		System.out.println(CLASS_NAME + "testAutoExtensionDoesNotExtendForUnspecifiedExtSource");
+
+		autoExpirationTest(
+				voRules -> {
+					voRules.put(autoExtensionExtSources, String.valueOf(extSource.getId()));
+					voRules.put(membershipPeriodKeyName, "+3m");
+					voRules.put(autoExtensionLastLoginPeriod, "3m");
+				},
+				userExtSources -> {
+					for (UserExtSource userExtSource : userExtSources) {
+						if (userExtSource.getExtSource().equals(extSource)) {
+							jdbc.update("update user_ext_sources set last_access='1995-01-01 00:00:00.1' where id=?",
+									userExtSource.getId());
+						} else {
+							jdbc.update("update user_ext_sources set last_access='1996-01-01 00:00:00.1' where id=?",
+									userExtSource.getId());
+						}
+					}
+				},
+				(oldExpiration, newExpiration) -> assertThat(newExpiration).isEqualTo(oldExpiration));
+	}
+
+	@Test
+	public void testAutoExtensionExtendForSpecifiedExtSource() throws Exception {
+		System.out.println(CLASS_NAME + "testAutoExtensionExtendForSpecifiedExtSource");
+
+		autoExpirationTest(
+				voRules -> {
+					voRules.put(autoExtensionExtSources, String.valueOf(extSource.getId()));
+					voRules.put(membershipPeriodKeyName, "+3m");
+					voRules.put(autoExtensionLastLoginPeriod, "3m");
+				},
+				userExtSources -> {
+					for (UserExtSource userExtSource : userExtSources) {
+						if (userExtSource.getExtSource().equals(extSource)) {
+							jdbc.update("update user_ext_sources set last_access='1996-01-01 00:00:00.1' where id=?",
+									userExtSource.getId());
+						} else {
+							jdbc.update("update user_ext_sources set last_access='1995-01-01 00:00:00.1' where id=?",
+									userExtSource.getId());
+						}
+					}
+				},
+				(oldExpiration, newExpiration) -> assertThat(newExpiration).isAfter(oldExpiration));
+	}
+
+	/**
+	 * Perform autoExpiration test.
+	 *
+	 * @param voExpirationRulesModifier takes vo's member expiration rules attribute value, can be used to modify the
+	 *                                  vo's expiration rules
+	 * @param uesModifier takes a list of userExtSources of the tested user, can be used to modify them
+	 * @param expirationVerifier takes the expirationDate before the auto extension, and after the extension.
+	 *                           Can be used to test how the expiration is changed.
+	 */
+	private void autoExpirationTest(Consumer<Map<String, String>> voExpirationRulesModifier,
+	                                Consumer<List<UserExtSource>> uesModifier,
+	                                BiConsumer<LocalDate, LocalDate> expirationVerifier) throws Exception {
+		System.out.println(CLASS_NAME + "testAutoExtensionDoesNotExtendsMemberWithoutLastAccess");
+
+		LocalDate today = LocalDate.of(1996, 2, 12);
+		when(spyScheduler.getCurrentLocalDate())
+				.thenReturn(today);
+
+		setUpVoExpirationRulesAttribute(voExpirationRulesModifier);
+
+		Member member = setUpMember();
+
+		LocalDate oldExpiration = today.plusDays(7);
+		Attribute memberExpiration =
+				new Attribute(perun.getAttributesManager().getAttributeDefinition(session, MEMBER_EXPIRATION_URN));
+		memberExpiration.setValue(oldExpiration.toString());
+		perun.getAttributesManager().setAttribute(session, member, memberExpiration);
+
+		User user = perun.getUsersManagerBl().getUserByMember(session, member);
+
+		List<UserExtSource> userExtSources = perun.getUsersManagerBl().getUserExtSources(session, user);
+
+		uesModifier.accept(userExtSources);
+
+		List<Vo> vos = perun.getVosManagerBl().getVos(session);
+		ReflectionTestUtils.invokeMethod(spyScheduler, "performAutoExtension", vos);
+
+		Attribute newMemberExpAttr = perun.getAttributesManager().getAttribute(session, member, MEMBER_EXPIRATION_URN);
+
+		LocalDate newExpirationDate = LocalDate.parse(newMemberExpAttr.valueAsString());
+		expirationVerifier.accept(oldExpiration, newExpirationDate);
+	}
+
+	private void setUpVoExpirationRulesAttribute(Consumer<Map<String, String>> voExpirationRulesModifier) throws Exception {
+		Attribute voRulesAttribute = new Attribute(
+				perun.getAttributesManagerBl().getAttributeDefinition(session, VO_MEMBERSHIP_RULES_URN));
+		Map<String, String> value = new LinkedHashMap<>();
+		voExpirationRulesModifier.accept(value);
+		voRulesAttribute.setValue(value);
+
+		perun.getAttributesManagerBl().setAttribute(session, vo, voRulesAttribute);
 	}
 
 	// ----------------- PRIVATE METHODS -------------------------------------------


### PR DESCRIPTION
* The vo's memberExpirationRules attribute can now have two new values
which can be used to automatically extend its members.
* The value of `autoExtensionLastLoginPeriod` has format `^[0-9]+([dmy])$`.
If any user has accessed the Perun at this period at the latest, he
will be extended by the vo's rules, if they have the `period` defined.
* The value of `autoExtensionExtSources` has format of extSource ids
split by commas - `^(\d+)?(,\d+)*$`. If these ids are specified, they
will be used to limit the extSources used to check the last access.