### PR TITLE
Registrar - name widget

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/registrar/model/ApplicationFormItem.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/registrar/model/ApplicationFormItem.java
@@ -194,7 +194,12 @@ public class ApplicationFormItem {
 		/**
 		 * Special item with pre-defined Timezone selection. Value is autoselected in GUI using Google's API
 		 */
-		TIMEZONE
+		TIMEZONE,
+		/**
+		 * Special item which allows user to set his first name, middle name, last name and titles manually in
+		 * application form.
+		 */
+		NAME_WIDGET
 	}
 
 	public static class ItemTexts {

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/CreateFormItemTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/CreateFormItemTabItem.java
@@ -77,6 +77,7 @@ public class CreateFormItemTabItem implements TabItem {
 		aMap.put("TIMEZONE", "Selection of timezone");
 		aMap.put("FROM_FEDERATION_HIDDEN", "Hidden input text pre-filled from external source");
 		aMap.put("FROM_FEDERATION_SHOW", "Input text field pre-filled from external source");
+		aMap.put("NAME_WIDGET", "Input text fields for names and titles");
 		inputTypes = Collections.unmodifiableMap(aMap);
 	}
 


### PR DESCRIPTION
* There was a problem, that we were not able to parse names and titles from displayName always correctly.
* I created a back-end part of a new feature called name widget, that allows user to put names and titles to application manually, but correctly.