### PR TITLE
GUI - new format of audit messages

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/AuditMessage.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/AuditMessage.java
@@ -71,14 +71,6 @@ public class AuditMessage {
 		this.createdByUid = createdByUid;
 	}
 
-	public String getUIMessage() {
-		if (event != null) {
-			return BeansUtils.eraseEscaping(BeansUtils.replaceEscapedNullByStringNull(BeansUtils.replacePointyBracketsByApostrophe(event.getMessage())));
-		} else {
-			return null;
-		}
-	}
-
 	@Override
 	public String toString() {
 		StringBuilder ret = new StringBuilder();

--- a/perun-base/src/main/java/cz/metacentrum/perun/rpc/deserializer/JsonDeserializer.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/rpc/deserializer/JsonDeserializer.java
@@ -49,9 +49,6 @@ public class JsonDeserializer extends Deserializer {
 	@JsonIgnoreProperties({"commonName", "displayName", "beanName", "specificUser", "majorSpecificType"})
 	private interface UserMixIn {}
 
-	@JsonIgnoreProperties({"uimessage"})
-	private interface AuditMessageMixIn {}
-
 	@JsonIgnoreProperties({"beanName"})
 	private interface PerunBeanMixIn {}
 
@@ -105,7 +102,6 @@ public class JsonDeserializer extends Deserializer {
 		mixinMap.put(AttributeDefinition.class, AttributeDefinitionMixIn.class);
 		mixinMap.put(User.class, UserMixIn.class);
 		mixinMap.put(Member.class, MemberMixIn.class);
-		mixinMap.put(AuditMessage.class, AuditMessageMixIn.class);
 		mixinMap.put(PerunBean.class, PerunBeanMixIn.class);
 		mixinMap.put(Candidate.class, CandidateMixIn.class);
 		mixinMap.put(PerunException.class, PerunExceptionMixIn.class);

--- a/perun-base/src/main/java/cz/metacentrum/perun/rpclib/impl/JsonDeserializer.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/rpclib/impl/JsonDeserializer.java
@@ -49,9 +49,6 @@ public class JsonDeserializer extends Deserializer {
 	@JsonIgnoreProperties({"commonName", "displayName", "beanName", "specificUser", "majorSpecificType"})
 	public interface UserMixIn {}
 
-	@JsonIgnoreProperties({"uimessage"})
-	public interface AuditMessageMixIn {}
-
 	@JsonIgnoreProperties({"beanName"})
 	public interface PerunBeanMixIn {}
 
@@ -103,7 +100,6 @@ public class JsonDeserializer extends Deserializer {
 		mixinMap.put(AttributeDefinition.class, AttributeDefinitionMixIn.class);
 		mixinMap.put(User.class, UserMixIn.class);
 		mixinMap.put(Member.class, MemberMixIn.class);
-		mixinMap.put(AuditMessage.class, AuditMessageMixIn.class);
 		mixinMap.put(PerunBean.class, PerunBeanMixIn.class);
 		mixinMap.put(Candidate.class, CandidateMixIn.class);
 		mixinMap.put(PerunException.class, PerunExceptionMixIn.class);

--- a/perun-base/src/main/java/cz/metacentrum/perun/rpclib/impl/JsonSerializer.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/rpclib/impl/JsonSerializer.java
@@ -38,10 +38,6 @@ public final class JsonSerializer implements Serializer {
 	private interface UserMixIn {
 	}
 
-	@JsonIgnoreProperties({"uimessage"})
-	private interface AuditMessageMixIn {
-	}
-
 	private static final ObjectMapper mapper = new ObjectMapper();
 	private static final Map<Class<?>,Class<?>> mixinMap = new HashMap<>();
 
@@ -49,7 +45,6 @@ public final class JsonSerializer implements Serializer {
 		mixinMap.put(Attribute.class, AttributeMixIn.class);
 		mixinMap.put(AttributeDefinition.class, AttributeDefinitionMixIn.class);
 		mixinMap.put(User.class, UserMixIn.class);
-		mixinMap.put(AuditMessage.class, AuditMessageMixIn.class);
 
 		mapper.setMixIns(mixinMap);
 	}

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/AuditMessage.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/AuditMessage.java
@@ -29,13 +29,26 @@ public class AuditMessage extends JavaScriptObject {
 			return this.event;
 		}-*/;
 
-	/**
-	 * Get message
-	 * @return message
-	 */
-	public final native String getMessage() /*-{
-		if (!this.uimessage) return "";
-		return this.uimessage;
+	public final native String getEventName() /*-{
+        if (!this.event) return "";
+        return this.event.name;
+    }-*/;
+
+	public final native String getAuditEventObjectsMessage() /*-{
+    	if (!this.event) return "";
+    	var keys = Object.keys(this.event);
+    	var message = "";
+    	for (i = 0; i < keys.length; i++) {
+    	    var key = keys[i];
+    	    if (key !== "message" && key !== "name") {
+    	        if (message !== "") {
+    	            message += "\n\n";
+	            }
+    	        message += key + ":";
+    	        message += JSON.stringify(this.event[key]);
+		    }
+	    }
+    	return message;
 	}-*/;
 
 		/**


### PR DESCRIPTION
* We will get rid of the field message in the audit messages and
therefor the gui cannot use it anymore.
* The audit messages table has been reimplemented so it uses only the
new audit message fileds.
* Also, the GetUiMessage getter was removed from the perun-base model,
since it is not needed anymore.