### PR TITLE
check quota path syntax acccording to regex, not URI

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ModulesUtilsBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ModulesUtilsBlImpl.java
@@ -37,6 +37,7 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.file.Paths;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
@@ -784,11 +785,10 @@ public class ModulesUtilsBlImpl implements ModulesUtilsBl {
 
 			//testing if path is unique
 			String canonicalPath;
-			try {
-				canonicalPath = new URI(path).normalize().getPath();
-				//path should not end on '/' (problem with some systems as GPFS)
-				if(!canonicalPath.equals("/") && canonicalPath.endsWith("/")) canonicalPath = canonicalPath.substring(0, canonicalPath.length() - 1);
-			} catch (URISyntaxException ex) {
+			canonicalPath = Paths.get(path).normalize().toString();
+			//path should not end on '/' (problem with some systems as GPFS)
+			if(!canonicalPath.equals("/") && canonicalPath.endsWith("/")) canonicalPath = canonicalPath.substring(0, canonicalPath.length() - 1);
+			if(!canonicalPath.matches("^[-a-zA-Z.0-9_/:=,]+$")) {
 				throw new WrongAttributeValueException(quotasAttribute, firstPlaceholder, secondPlaceholder, "Path '" + path + "' is not correct form.");
 			}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ModulesUtilsBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ModulesUtilsBlImpl.java
@@ -35,8 +35,6 @@ import org.slf4j.LoggerFactory;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.math.BigDecimal;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.nio.file.Paths;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
@@ -77,10 +75,11 @@ public class ModulesUtilsBlImpl implements ModulesUtilsBl {
 	//Often used patterns
 	public static final Pattern quotaWithMetricsPattern = Pattern.compile("^([0-9]+([.][0-9]+)?[KMGTPE]?):([0-9]+([.][0-9]+)?[KMGTPE]?)$");
 	public static final Pattern quotaWithoutMetricsPattern = Pattern.compile("^([0-9]+)(:)([0-9]+)$");
+	public static final Pattern quotaPathPattern = Pattern.compile("^[-a-zA-Z.0-9_/:=,]+$");
 	public static final Pattern numberPattern = Pattern.compile("[0-9]+([.][0-9]+)?");
 	public static final Pattern letterPattern = Pattern.compile("[A-Z]");
 	public static final Pattern fqdnPattern = Pattern.compile("^((?!-)[a-zA-Z0-9-]{1,63}(?<!-)\\.)+[a-zA-Z]{2,63}\\.?$");
-
+	
 	//previous regex ^/[-a-zA-Z0-9_/]*$"
 	public static final Pattern shellPattern = Pattern.compile("^(/[-_a-zA-Z0-9]+)+$");
 
@@ -784,11 +783,10 @@ public class ModulesUtilsBlImpl implements ModulesUtilsBl {
 			if(path == null || path.isEmpty()) throw new WrongAttributeValueException(quotasAttribute, firstPlaceholder, secondPlaceholder, "The path of some volume where quota should be set is null.");
 
 			//testing if path is unique
-			String canonicalPath;
-			canonicalPath = Paths.get(path).normalize().toString();
+			String canonicalPath = Paths.get(path).normalize().toString();
 			//path should not end on '/' (problem with some systems as GPFS)
 			if(!canonicalPath.equals("/") && canonicalPath.endsWith("/")) canonicalPath = canonicalPath.substring(0, canonicalPath.length() - 1);
-			if(!canonicalPath.matches("^[-a-zA-Z.0-9_/:=,]+$")) {
+			if(!quotaPathPattern.matcher(canonicalPath).matches()) {
 				throw new WrongAttributeValueException(quotasAttribute, firstPlaceholder, secondPlaceholder, "Path '" + path + "' is not correct form.");
 			}
 

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ModulesUtilsEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ModulesUtilsEntryIntegrationTest.java
@@ -715,6 +715,15 @@ public class ModulesUtilsEntryIntegrationTest extends AbstractPerunIntegrationTe
 		modulesUtilsBl.checkAndTransferQuotas(dataQuotasAttribute, resource, null, true);
 	}
 
+	@Test(expected=WrongAttributeValueException.class)
+	public void checkQuotasErrorInPath() throws Exception {
+		System.out.println(CLASS_NAME + "WrongAttributeValueException");
+		Resource resource = new Resource(10, "test", "test", 10, 10);
+		Attribute dataQuotasAttribute = getDataQuotasAttribute();
+		((LinkedHashMap) dataQuotasAttribute.getValue()).put("/!new/path", "10:10");
+		modulesUtilsBl.checkAndTransferQuotas(dataQuotasAttribute, resource, null, true);
+	}
+
 	@Test(expected= QuotaNotInAllowedLimitException.class)
 	public void checkIfQuotasContainsDifferentPathThanMaxQuotas() throws Exception {
 		System.out.println(CLASS_NAME + "checkIfQuotasContainsDifferentPathThanMaxQuotas");

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ModulesUtilsEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ModulesUtilsEntryIntegrationTest.java
@@ -708,7 +708,7 @@ public class ModulesUtilsEntryIntegrationTest extends AbstractPerunIntegrationTe
 
 	@Test(expected=WrongAttributeValueException.class)
 	public void checkQuotasErrorInValue() throws Exception {
-		System.out.println(CLASS_NAME + "WrongAttributeValueException");
+		System.out.println(CLASS_NAME + "checkQuotasErrorInValue");
 		Resource resource = new Resource(10, "test", "test", 10, 10);
 		Attribute dataQuotasAttribute = getDataQuotasAttribute();
 		((LinkedHashMap) dataQuotasAttribute.getValue()).put("/new/path", "b20:1");
@@ -717,7 +717,7 @@ public class ModulesUtilsEntryIntegrationTest extends AbstractPerunIntegrationTe
 
 	@Test(expected=WrongAttributeValueException.class)
 	public void checkQuotasErrorInPath() throws Exception {
-		System.out.println(CLASS_NAME + "WrongAttributeValueException");
+		System.out.println(CLASS_NAME + "checkQuotasErrorInPath");
 		Resource resource = new Resource(10, "test", "test", 10, 10);
 		Attribute dataQuotasAttribute = getDataQuotasAttribute();
 		((LinkedHashMap) dataQuotasAttribute.getValue()).put("/!new/path", "10:10");


### PR DESCRIPTION
- The changes concern all quota attributes and methods validating their content.
- The original URI syntax checks allowed for transformations changing the path meaning,
  which is undesirable.