### PR TITLE
CORE: Fixed search for standard users

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Utils.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Utils.java
@@ -1787,7 +1787,7 @@ public class Utils {
 	public static MapSqlParameterSource getMapSqlParameterSourceToSearchUsersOrMembers(String searchString, Map<String, List<String>> attributesToSearchBy) {
 		MapSqlParameterSource namedParams = new MapSqlParameterSource();
 		namedParams.addValue("searchString", searchString);
-		namedParams.addValue("nameString", Utils.utftoasci(searchString.toLowerCase()));
+		namedParams.addValue("nameString", Utils.utftoasci(searchString.toLowerCase().replaceAll(" ", "")));
 		namedParams.addValue("memberAttributes", attributesToSearchBy.get("memberAttributes"));
 		namedParams.addValue("userAttributes", attributesToSearchBy.get("userAttributes"));
 		namedParams.addValue("uesAttributes", attributesToSearchBy.get("uesAttributes"));


### PR DESCRIPTION
- We must remove spaces from the "nameString"
  used when searching for users, since its
  usually in the input and that doesn't match
  joined column values from the DB.
- This is mostly quickfix, since it prevents
  specific users to be found, where space can be
  part of the lastName (single column value).