### PR TITLE
Sponsorship ends with last sponsor

### DIFF
--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/MembersManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/MembersManagerEntryIntegrationTest.java
@@ -1413,7 +1413,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 		perun.getGroupsManagerBl().removeMember(sess,sponsors,sponsorMember);
 		//refresh from DB
 		sponsoredMember = perun.getMembersManagerBl().getMemberById(sess,sponsoredMember.getId());
-		assertTrue("sponsored member without sponsors should still have flag sponsored",sponsoredMember.isSponsored());
+		assertFalse("Member's sponsorship should have been removed.",sponsoredMember.isSponsored());
 		assertTrue("sponsored member without sponsors must be expired",sponsoredMember.getStatus()==Status.EXPIRED);
 	}
 


### PR DESCRIPTION
- Method removeSponsor was changed.
  Now when a last member's sponsor is removed, also member's
  sponshorship is removed. Therefore, member expires as a normal member.
- Method deleteMember was also changed.
  Now sponsors of member are always removed. It does
  not matter if the member is sponsored or not. It is because when
  member's sponsorship is set to false, his links to sponsors preserves
  (as inactive). Therefore, it would not be possible to delete member.