### PR TITLE
Optional expiration for sponsored members

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_vo_attribute_def_def_membershipExpirationRules.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_vo_attribute_def_def_membershipExpirationRules.java
@@ -16,6 +16,8 @@ import java.util.LinkedHashMap;
  */
 public class urn_perun_vo_attribute_def_def_membershipExpirationRules extends AbstractMembershipExpirationRulesModule<Vo> implements VoAttributesModuleImplApi {
 
+	public static final String VO_EXPIRATION_RULES_ATTR = AttributesManager.NS_VO_ATTR_DEF + ":membershipExpirationRules";
+
 	@Override
 	protected boolean isAllowedParameter(String parameter) {
 		if(parameter == null) return false;
@@ -25,7 +27,8 @@ public class urn_perun_vo_attribute_def_def_membershipExpirationRules extends Ab
 				parameter.equals(membershipPeriodLoaKeyName)	||
 				parameter.equals(membershipDoNotAllowLoaKeyName) ||
 				parameter.equals(autoExtensionExtSources) ||
-				parameter.equals(autoExtensionLastLoginPeriod);
+				parameter.equals(autoExtensionLastLoginPeriod) ||
+				parameter.equals(expireSponsoredMembers);
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/AbstractMembershipExpirationRulesModule.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/AbstractMembershipExpirationRulesModule.java
@@ -1,6 +1,7 @@
 package cz.metacentrum.perun.core.implApi.modules.attributes;
 
 import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.PerunBean;
 import cz.metacentrum.perun.core.api.exceptions.ExtSourceNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
@@ -27,6 +28,7 @@ public abstract class AbstractMembershipExpirationRulesModule<T extends PerunBea
 	private static final Pattern loaPattern = Pattern.compile("^(([0-9]+,)|([0-9]+,[ ]))*[0-9]+$");
 	private static final Pattern periodLoaPattern = Pattern.compile("^[0-9]+[|](([0-9]+[.][0-9]+[.])|([+][0-9]+([dmy])))[.]?$");
 	private static final Pattern extSourcesPatter = Pattern.compile("^(\\d+)(,\\d+)*$");
+	private static final Pattern expireSponsoredMembersPattern = Pattern.compile("^(true)|(false)$");
 
 	public static final String membershipGracePeriodKeyName = "gracePeriod";
 	public static final String membershipPeriodKeyName = "period";
@@ -35,6 +37,7 @@ public abstract class AbstractMembershipExpirationRulesModule<T extends PerunBea
 	public static final String membershipDoNotAllowLoaKeyName = "doNotAllowLoa";
 	public static final String autoExtensionLastLoginPeriod = "autoExtensionLastLoginPeriod";
 	public static final String autoExtensionExtSources = "autoExtensionExtSources";
+	public static final String expireSponsoredMembers = "expireSponsoredMembers";
 
 	public void checkAttributeSyntax(PerunSessionImpl sess, T entity, Attribute attribute) throws WrongAttributeValueException {
 		Map<String, String> attrValue;
@@ -132,6 +135,14 @@ public abstract class AbstractMembershipExpirationRulesModule<T extends PerunBea
 				throw new WrongAttributeValueException(attribute, "There is not allowed value for parameter '" +
 						parameter + "': " + attrValue.get(parameter));
 			}
+		}
+
+		parameter = expireSponsoredMembers;
+		if(keys.contains(parameter)) {
+			Matcher expireSponsoredMemberMatcher = expireSponsoredMembersPattern.matcher(attrValue.get(parameter));
+			if(!expireSponsoredMemberMatcher.find())
+				throw new WrongAttributeValueException(attribute, "There is not allowed value for parameter '" +
+					parameter + "': " + attrValue.get(parameter));
 		}
 	}
 

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/MembersManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/MembersManagerEntryIntegrationTest.java
@@ -2,6 +2,7 @@ package cz.metacentrum.perun.core.entry;
 
 import cz.metacentrum.perun.core.AbstractPerunIntegrationTest;
 import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.BeansUtils;
 import cz.metacentrum.perun.core.api.Candidate;
@@ -54,12 +55,15 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import static cz.metacentrum.perun.core.impl.modules.attributes.urn_perun_vo_attribute_def_def_membershipExpirationRules.VO_EXPIRATION_RULES_ATTR;
+import static cz.metacentrum.perun.core.impl.modules.attributes.urn_perun_vo_attribute_def_def_membershipExpirationRules.expireSponsoredMembers;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -1829,6 +1833,32 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 		perun.getMembersManagerBl().unsetSponsorshipForMember(sess, sponsoredMember);
 		members = perun.getMembersManagerBl().findMembers(sess, createdVo, user.getFirstName(), true);
 		assertTrue(members.size() == 0);
+	}
+
+	@Test
+	public void removeLastSponsorWithoutExpiration() throws Exception {
+		System.out.println(CLASS_NAME + "removeLastSponsorWithoutExpiration");
+
+		//Set up sponsor
+		Member sponsorMember = setUpSponsor(createdVo);
+		User sponsorUser = perun.getUsersManagerBl().getUserByMember(sess, sponsorMember);
+		AuthzResolverBlImpl.setRole(sess, sponsorUser, createdVo, Role.SPONSOR);
+		//Set up expiration rule
+		Map<String, String> rulesMap = new LinkedHashMap<>();
+		rulesMap.put(expireSponsoredMembers, "false");
+		Attribute attribute = perun.getAttributesManagerBl().getAttribute(sess, createdVo, VO_EXPIRATION_RULES_ATTR);
+		attribute.setValue(rulesMap);
+		perun.getAttributesManagerBl().setAttribute(sess, createdVo, attribute);
+		//create sponsored member
+		Map<String, String> nameOfUser1 = new HashMap<>();
+		nameOfUser1.put("guestName", "Ing. Jiří Novák, CSc.");
+		Member sponsoredMember = perun.getMembersManagerBl().createSponsoredMember(sess, createdVo, "dummy", nameOfUser1, "secret", sponsorUser, false);
+		//Remove sponsor
+		perun.getMembersManagerBl().removeSponsor(sess, sponsoredMember, sponsorUser);
+		//refresh from DB
+		sponsoredMember = perun.getMembersManagerBl().getMemberById(sess, sponsoredMember.getId());
+
+		assertNotSame("Sponsored member without sponsor cannot expire when expireSponsoredMembers rule is set to false", sponsoredMember.getStatus(), Status.EXPIRED);
 	}
 
 	private Attribute setUpAttribute(String type, String friendlyName, String namespace, Object value) throws Exception {

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_vo_attribute_def_def_membershipExpirationRulesTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_vo_attribute_def_def_membershipExpirationRulesTest.java
@@ -15,6 +15,7 @@ import java.util.Map;
 
 import static cz.metacentrum.perun.core.implApi.modules.attributes.AbstractMembershipExpirationRulesModule.autoExtensionExtSources;
 import static cz.metacentrum.perun.core.implApi.modules.attributes.AbstractMembershipExpirationRulesModule.autoExtensionLastLoginPeriod;
+import static cz.metacentrum.perun.core.implApi.modules.attributes.AbstractMembershipExpirationRulesModule.expireSponsoredMembers;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -79,6 +80,23 @@ public class urn_perun_vo_attribute_def_def_membershipExpirationRulesTest {
 		attributeToCheck.setValue(value);
 		assertThatExceptionOfType(WrongAttributeValueException.class)
 				.isThrownBy(() -> classInstance.checkAttributeSyntax(session, vo, attributeToCheck));
+	}
+
+	@Test
+	public void expireSponsoredMembersCorrectSyntax() throws Exception {
+		Map<String, String> value = new LinkedHashMap<>();
+		value.put(expireSponsoredMembers, "false");
+		attributeToCheck.setValue(value);
+		classInstance.checkAttributeSyntax(session, vo, attributeToCheck);
+	}
+
+	@Test
+	public void expireSponsoredMembersInCorrectSyntax() throws Exception {
+		Map<String, String> value = new LinkedHashMap<>();
+		value.put(expireSponsoredMembers, "wrong value");
+		attributeToCheck.setValue(value);
+		assertThatExceptionOfType(WrongAttributeValueException.class)
+			.isThrownBy(() -> classInstance.checkAttributeSyntax(session, vo, attributeToCheck));
 	}
 
 	// ------------- Semantics ------------- //


### PR DESCRIPTION
- When a sponsored member lost his sponsorship, he automatically expired
  in the VO.
- Now it is possible to add a rule to the vo's membershipExpirationRules
  attribute, which switches off the automatic expiration.
- The rule is called doNotExpireSponsoredMembers and it can be set to
  either true or false (false when not set).