### PR TITLE
Sponsorship expiration

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/audit/events/MembersManagerEvents/SponsorshipValidityUpdated.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/audit/events/MembersManagerEvents/SponsorshipValidityUpdated.java
@@ -6,7 +6,10 @@ import cz.metacentrum.perun.core.api.User;
 
 import java.time.LocalDate;
 
-public class SponsorshipEstablished extends AuditEvent {
+/**
+ * @author Vojtech Sassmann <vojtech.sassmann@gmail.com>
+ */
+public class SponsorshipValidityUpdated extends AuditEvent {
 
 	private Member sponsoredMember;
 	private User sponsor;
@@ -14,14 +17,14 @@ public class SponsorshipEstablished extends AuditEvent {
 	private LocalDate validity;
 
 	@SuppressWarnings("unused") // used by jackson mapper
-	public SponsorshipEstablished() {
+	public SponsorshipValidityUpdated() {
 	}
 
-	public SponsorshipEstablished(Member sponsoredMember, User sponsor, LocalDate validityTo) {
+	public SponsorshipValidityUpdated(Member sponsoredMember, User sponsor, LocalDate validityTo) {
 		this.sponsoredMember = sponsoredMember;
 		this.sponsor = sponsor;
 		this.validity = validityTo;
-		this.message = formatMessage("Sponsorship of %s by %s established with validity to %s.",
+		this.message = formatMessage("Validity of sponsorship of %s by %s changed to %s.",
 				sponsoredMember, sponsor, validityTo == null ? "FOREVER" : validityTo.toString());
 	}
 
@@ -40,10 +43,5 @@ public class SponsorshipEstablished extends AuditEvent {
 
 	public LocalDate getValidity() {
 		return validity;
-	}
-
-	@Override
-	public String toString() {
-		return message;
 	}
 }

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/MemberWithSponsors.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/MemberWithSponsors.java
@@ -10,7 +10,7 @@ import java.util.Objects;
  */
 public class MemberWithSponsors {
 	private RichMember member;
-	private List<User> sponsors;
+	private List<Sponsor> sponsors;
 
 	/**
 	 * Constructor
@@ -33,11 +33,11 @@ public class MemberWithSponsors {
 		this.member = member;
 	}
 
-	public List<User> getSponsors() {
+	public List<Sponsor> getSponsors() {
 		return sponsors;
 	}
 
-	public void setSponsors(List<User> sponsors) {
+	public void setSponsors(List<Sponsor> sponsors) {
 		this.sponsors = sponsors;
 	}
 

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/Sponsor.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/Sponsor.java
@@ -1,0 +1,95 @@
+package cz.metacentrum.perun.core.api;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import cz.metacentrum.perun.rpc.stdserializers.LocalDateSerializer;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * Class representing a Sponsor for some specific member. This object contains information
+ * about the validity of this sponsorship for the specific member. It also contains additional
+ * information about the sponsor so it can be obtained in one API call.
+ *
+ * @author Vojtech Sassmann <vojtech.sassmann@gmail.com>
+ */
+public class Sponsor {
+	private final User user;
+	@JsonSerialize(using = LocalDateSerializer.class)
+	private LocalDate validityTo;
+	private boolean active;
+	private List<UserExtSource> userExtSources;
+	private List<Attribute> userAttributes;
+
+	public Sponsor(User user) {
+		this.user = user;
+	}
+
+	public Sponsor(RichUser user) {
+		this.user = user;
+		this.userAttributes = user.getUserAttributes();
+		this.userExtSources = user.getUserExtSources();
+	}
+
+	public LocalDate getValidityTo() {
+		return validityTo;
+	}
+
+	public void setValidityTo(LocalDate validityTo) {
+		this.validityTo = validityTo;
+	}
+
+	public boolean isActive() {
+		return active;
+	}
+
+	public void setActive(boolean active) {
+		this.active = active;
+	}
+
+	public List<UserExtSource> getUserExtSources() {
+		return userExtSources;
+	}
+
+	public void setUserExtSources(List<UserExtSource> userExtSources) {
+		this.userExtSources = userExtSources;
+	}
+
+	public List<Attribute> getUserAttributes() {
+		return userAttributes;
+	}
+
+	public void setUserAttributes(List<Attribute> userAttributes) {
+		this.userAttributes = userAttributes;
+	}
+
+	public User getUser() {
+		return user;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+
+		Sponsor sponsor = (Sponsor) o;
+
+		return user != null ? user.equals(sponsor.user) : sponsor.user == null;
+	}
+
+	@Override
+	public int hashCode() {
+		return user != null ? user.hashCode() : 0;
+	}
+
+	@Override
+	public String toString() {
+		return "Sponsor[" +
+				"user=" + user +
+				", validityTo=" + validityTo +
+				", active=" + active +
+				", userExtSources=" + userExtSources +
+				", userAttributes=" + userAttributes +
+				']';
+	}
+}

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/Sponsorship.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/Sponsorship.java
@@ -1,0 +1,76 @@
+package cz.metacentrum.perun.core.api;
+
+import java.time.LocalDate;
+
+/**
+ * Class representing relationship between a sponsor (User id)
+ * and sponsored member (Member id).
+ *
+ * @author Vojtech Sassmann <vojtech.sassmann@gmail.com>
+ */
+public class Sponsorship {
+	int sponsoredId;
+	int sponsorId;
+	LocalDate validityTo;
+	boolean active;
+
+	public int getSponsoredId() {
+		return sponsoredId;
+	}
+
+	public void setSponsoredId(int sponsoredId) {
+		this.sponsoredId = sponsoredId;
+	}
+
+	public int getSponsorId() {
+		return sponsorId;
+	}
+
+	public void setSponsorId(int sponsorId) {
+		this.sponsorId = sponsorId;
+	}
+
+	public LocalDate getValidityTo() {
+		return validityTo;
+	}
+
+	public void setValidityTo(LocalDate validityTo) {
+		this.validityTo = validityTo;
+	}
+
+	public boolean isActive() {
+		return active;
+	}
+
+	public void setActive(boolean active) {
+		this.active = active;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+
+		Sponsorship that = (Sponsorship) o;
+
+		if (getSponsoredId() != that.getSponsoredId()) return false;
+		return getSponsorId() == that.getSponsorId();
+	}
+
+	@Override
+	public int hashCode() {
+		int result = (int) (getSponsoredId() ^ (getSponsoredId() >>> 32));
+		result = 31 * result + (int) (getSponsorId() ^ (getSponsorId() >>> 32));
+		return result;
+	}
+
+	@Override
+	public String toString() {
+		return "Sponsorship[" +
+				"sponsoredId=" + sponsoredId +
+				", sponsorId=" + sponsorId +
+				", validityTo=" + validityTo +
+				", active=" + active +
+				']';
+	}
+}

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/SponsorshipDoesNotExistException.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/SponsorshipDoesNotExistException.java
@@ -1,0 +1,25 @@
+package cz.metacentrum.perun.core.api.exceptions;
+
+import cz.metacentrum.perun.core.api.Member;
+import cz.metacentrum.perun.core.api.User;
+
+/**
+ * @author Vojtech Sassmann <vojtech.sassmann@gmail.com>
+ */
+public class SponsorshipDoesNotExistException extends PerunException {
+	public SponsorshipDoesNotExistException(Member sponsoredMember, User sponsor) {
+		super(sponsoredMember + " is not sponsored by: " + sponsor);
+	}
+
+	public SponsorshipDoesNotExistException(String s) {
+		super(s);
+	}
+
+	public SponsorshipDoesNotExistException(String s, Throwable throwable) {
+		super(s, throwable);
+	}
+
+	public SponsorshipDoesNotExistException(Throwable throwable) {
+		super(throwable);
+	}
+}

--- a/perun-base/src/main/java/cz/metacentrum/perun/rpc/deserializer/Deserializer.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/rpc/deserializer/Deserializer.java
@@ -4,6 +4,7 @@ import cz.metacentrum.perun.core.api.PerunBean;
 import cz.metacentrum.perun.core.api.exceptions.RpcException;
 
 import javax.servlet.http.HttpServletRequest;
+import java.time.LocalDate;
 import java.util.List;
 
 /**
@@ -53,6 +54,16 @@ public abstract class Deserializer {
 	 * @throws RpcException if the specified value cannot be parsed as {@code int} or if it is not supplied
 	 */
 	public abstract int readInt(String name);
+
+	/**
+	 * Reads LocalDate value with the specified name. Expected ISO-8601 format. (yyyy-MM-dd)
+	 *
+	 * @param name name of the localDate value
+	 * @return parsed local date
+	 */
+	public LocalDate readLocalDate(String name) {
+		return LocalDate.parse(readString(name));
+	}
 
 	public int[] readArrayOfInts(String name) {
 		throw new UnsupportedOperationException("readArrayOfInts(String name)");

--- a/perun-base/src/main/java/cz/metacentrum/perun/rpc/stdserializers/LocalDateSerializer.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/rpc/stdserializers/LocalDateSerializer.java
@@ -1,0 +1,26 @@
+package cz.metacentrum.perun.rpc.stdserializers;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Serializer that can be used to serialize a LocalDate into format 'yyyy-MM-dd'
+ *
+ * @author Vojtech Sassmann <vojtech.sassmann@gmail.com>
+ */
+public class LocalDateSerializer extends StdSerializer<LocalDate> {
+
+	public LocalDateSerializer() {
+		super(LocalDate.class);
+	}
+
+	@Override
+	public void serialize(LocalDate value, JsonGenerator generator, SerializerProvider provider) throws IOException {
+		generator.writeString(value.format(DateTimeFormatter.ISO_LOCAL_DATE));
+	}
+}

--- a/perun-base/src/main/resources/perun-roles.yml
+++ b/perun-base/src/main/resources/perun-roles.yml
@@ -2256,14 +2256,14 @@ perun_policies:
     include_policies:
       - default_policy
 
-  createSponsoredMember_Vo_String_Map<String_String>_String_User_policy:
+  createSponsoredMember_Vo_String_Map<String_String>_String_User_LocalDate_policy:
     policy_roles:
       - VOADMIN: Vo
       - SPONSOR: Vo
     include_policies:
       - default_policy
 
-  setSponsoredMember_Vo_User_String_String_User_policy:
+  setSponsoredMember_Vo_User_String_String_User_LocalDate_policy:
     policy_roles:
       - VOADMIN: Vo
       - SPONSOR: Vo
@@ -2277,7 +2277,7 @@ perun_policies:
     include_policies:
       - default_policy
 
-  setSponsorshipForMember_Member_User_policy:
+  setSponsorshipForMember_Member_User_LocalDate_policy:
     policy_roles: []
     include_policies:
       - default_policy
@@ -2287,7 +2287,7 @@ perun_policies:
     include_policies:
       - default_policy
 
-  sponsorMember_Member_User_policy:
+  sponsorMember_Member_User_LocalDate_policy:
     policy_roles:
       - VOADMIN:
     include_policies:
@@ -2351,6 +2351,13 @@ perun_policies:
   removeSponsor_Member_User_policy:
     policy_roles:
       - VOADMIN: Vo
+    include_policies:
+      - default_policy
+
+  updateSponsorshipValidity_Member_User_LocalDate:
+    policy_roles:
+      - VOADMIN: Vo
+      - SELF: User
     include_policies:
       - default_policy
 
@@ -4469,6 +4476,16 @@ perun_policies:
 
   getSponsors_Member_List<String>_policy:
     policy_roles:
+      - PERUNOBSERVER:
+      - REGISTRAR:
+    include_policies:
+      - default_policy
+
+  getSponsorsForMember_Member_List<String>_policy:
+    policy_roles:
+      - VOADMIN: Vo
+      - VOOBSERVER: Vo
+      - SPONSOR: Vo
       - PERUNOBSERVER:
       - REGISTRAR:
     include_policies:

--- a/perun-base/src/test/resources/test-schema.sql
+++ b/perun-base/src/test/resources/test-schema.sql
@@ -2,7 +2,7 @@ set database sql syntax PGS true;
 -- fix unique index on authz, since PGS compatibility doesn't allow coalesce call in index and treats nulls in columns as different values.
 SET DATABASE SQL UNIQUE NULLS FALSE;
 
--- database version 3.1.68 (don't forget to update insert statement at the end of file)
+-- database version 3.1.69 (don't forget to update insert statement at the end of file)
 
 -- VOS - virtual organizations
 create table vos (
@@ -1398,6 +1398,7 @@ CREATE TABLE members_sponsored (
 	active boolean default true not null,
 	sponsored_id INTEGER NOT NULL,
 	sponsor_id INTEGER NOT NULL,
+	validity_to timestamp default null,
 	created_at timestamp default now() not null,
 	created_by longvarchar default user not null,
 	created_by_uid integer,
@@ -1642,7 +1643,7 @@ CREATE INDEX ufauv_idx ON user_facility_attr_u_values (user_id, facility_id, att
 CREATE INDEX vauv_idx ON vo_attr_u_values (vo_id, attr_id) ;
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.1.68');
+insert into configurations values ('DATABASE VERSION','3.1.69');
 insert into membership_types (id, membership_type, description) values (1, 'DIRECT', 'Member is directly added into group');
 insert into membership_types (id, membership_type, description) values (2, 'INDIRECT', 'Member is added indirectly through UNION relation');
 insert into action_types (id, action_type, description) values (nextval('action_types_seq'), 'read', 'Can read value.');

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/MembersManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/MembersManager.java
@@ -18,19 +18,18 @@ import cz.metacentrum.perun.core.api.exceptions.MemberNotSuspendedException;
 import cz.metacentrum.perun.core.api.exceptions.MemberNotValidYetException;
 import cz.metacentrum.perun.core.api.exceptions.ParentGroupNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.PasswordCreationFailedException;
-import cz.metacentrum.perun.core.api.exceptions.PasswordOperationTimeoutException;
 import cz.metacentrum.perun.core.api.exceptions.PasswordStrengthException;
-import cz.metacentrum.perun.core.api.exceptions.PasswordStrengthFailedException;
 import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
 import cz.metacentrum.perun.core.api.exceptions.ResourceNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.SponsorshipDoesNotExistException;
 import cz.metacentrum.perun.core.api.exceptions.UserExtSourceNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotInRoleException;
 import cz.metacentrum.perun.core.api.exceptions.VoNotExistsException;
-import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 
+import java.time.LocalDate;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -1125,6 +1124,7 @@ public interface MembersManager {
 	 * @param name a map containing the full name or its parts (mandatory: firstName, lastName; optionally: titleBefore, titleAfter)
 	 * @param password  password
 	 * @param sponsor sponsoring user or null for the caller
+	 * @param validityTo last day when the sponsorship is active (null means the sponsorship will last forever)
 	 * @return new Member in the Vo
 	 * @throws InternalErrorException if given parameters are invalid
 	 * @throws PrivilegeException if not REGISTRAR or VOADMIN
@@ -1137,7 +1137,7 @@ public interface MembersManager {
 	 * @throws WrongReferenceAttributeValueException
 	 * @throws UserNotInRoleException
 	 */
-	RichMember createSponsoredMember(PerunSession session, Vo vo, String namespace, Map<String, String> name, String password, User sponsor) throws PrivilegeException, AlreadyMemberException, LoginNotExistsException, PasswordCreationFailedException, ExtendMembershipException, WrongAttributeValueException, ExtSourceNotExistsException, WrongReferenceAttributeValueException, UserNotInRoleException, PasswordStrengthException, InvalidLoginException;
+	RichMember createSponsoredMember(PerunSession session, Vo vo, String namespace, Map<String, String> name, String password, User sponsor, LocalDate validityTo) throws PrivilegeException, AlreadyMemberException, LoginNotExistsException, PasswordCreationFailedException, ExtendMembershipException, WrongAttributeValueException, ExtSourceNotExistsException, WrongReferenceAttributeValueException, UserNotInRoleException, PasswordStrengthException, InvalidLoginException;
 
 	/**
 	 * Creates a sponsored membership for the given user.
@@ -1148,6 +1148,7 @@ public interface MembersManager {
 	 * @param namespace namespace for selecting password module
 	 * @param password password
 	 * @param sponsor sponsoring user or null for the caller
+	 * @param validityTo last day when the sponsorship is active (null means the sponsorship will last forever)
 	 *
 	 * @return sponsored member
 	 *
@@ -1163,7 +1164,7 @@ public interface MembersManager {
 	 * @throws PasswordStrengthException
 	 * @throws InvalidLoginException
 	 */
-	RichMember setSponsoredMember(PerunSession session, Vo vo, User userToBeSponsored, String namespace, String password, User sponsor) throws PrivilegeException, AlreadyMemberException, LoginNotExistsException, PasswordCreationFailedException, ExtendMembershipException, WrongAttributeValueException, ExtSourceNotExistsException, WrongReferenceAttributeValueException, UserNotInRoleException, PasswordStrengthException, InvalidLoginException;
+	RichMember setSponsoredMember(PerunSession session, Vo vo, User userToBeSponsored, String namespace, String password, User sponsor, LocalDate validityTo) throws PrivilegeException, AlreadyMemberException, LoginNotExistsException, PasswordCreationFailedException, ExtendMembershipException, WrongAttributeValueException, ExtSourceNotExistsException, WrongReferenceAttributeValueException, UserNotInRoleException, PasswordStrengthException, InvalidLoginException;
 
 	/**
 	 * Creates new sponsored Members (with random generated passwords).
@@ -1182,10 +1183,11 @@ public interface MembersManager {
 	 * @param namespace namespace for selecting password module
 	 * @param names a list of names
 	 * @param sponsor sponsoring user or null for the caller
+	 * @param validityTo last day when the sponsorship is active (null means the sponsorship will last forever)
 	 * @return map of names to map of status, login and password
 	 * @throws PrivilegeException
 	 */
-	Map<String, Map<String, String>> createSponsoredMembers(PerunSession session, Vo vo, String namespace, List<String> names, User sponsor) throws PrivilegeException;
+	Map<String, Map<String, String>> createSponsoredMembers(PerunSession session, Vo vo, String namespace, List<String> names, User sponsor, LocalDate validityTo) throws PrivilegeException;
 
 	/**
 	 * Transform non-sponsored member to sponsored one with defined sponsor
@@ -1193,6 +1195,7 @@ public interface MembersManager {
 	 * @param session perun session
 	 * @param sponsoredMember member who will be set as sponsored one
 	 * @param sponsor new sponsor of this member
+	 * @param validityTo last day when the sponsorship is active (null means the sponsorship will last forever)
 	 *
 	 * @return sponsored member
 	 *
@@ -1202,7 +1205,7 @@ public interface MembersManager {
 	 * @throws UserNotInRoleException if sponsor hasn't right role in the same vo
 	 * @throws PrivilegeException if not PerunAdmin
 	 */
-	RichMember setSponsorshipForMember(PerunSession session, Member sponsoredMember, User sponsor) throws MemberNotExistsException, AlreadySponsoredMemberException, UserNotInRoleException, PrivilegeException;
+	RichMember setSponsorshipForMember(PerunSession session, Member sponsoredMember, User sponsor, LocalDate validityTo) throws MemberNotExistsException, AlreadySponsoredMemberException, UserNotInRoleException, PrivilegeException;
 
 	/**
 	 * Transform sponsored member to non-sponsored one. Delete all his sponsors.
@@ -1224,6 +1227,7 @@ public interface MembersManager {
 	 * @param session actor
 	 * @param sponsored existing member that needs sponsoring
 	 * @param sponsor sponsoring user or null for the caller
+	 * @param validityTo last day when the sponsorship is active (null means the sponsorship will last forever)
 	 * @return existing Member
 	 * @throws InternalErrorException
 	 * @throws PrivilegeException
@@ -1231,7 +1235,7 @@ public interface MembersManager {
 	 * @throws AlreadySponsorException
 	 * @throws UserNotInRoleException
 	 */
-	RichMember sponsorMember(PerunSession session, Member sponsored, User sponsor) throws PrivilegeException, MemberNotSponsoredException, AlreadySponsorException, UserNotInRoleException;
+	RichMember sponsorMember(PerunSession session, Member sponsored, User sponsor, LocalDate validityTo) throws PrivilegeException, MemberNotSponsoredException, AlreadySponsorException, UserNotInRoleException;
 
 	/**
 	 * Get all sponsored RichMembers with attributes by list of attribute names for specific User and Vo.
@@ -1305,4 +1309,17 @@ public interface MembersManager {
 	 */
 	void removeSponsor(PerunSession sess, Member sponsoredMember, User sponsorToRemove) throws PrivilegeException;
 
+	/**
+	 * Update the sponsorship of given member for given sponsor.
+	 *
+	 * @param sess session
+	 * @param sponsoredMember sponsored member
+	 * @param sponsor sponsor
+	 * @param newValidity new validity, can be set to null never expire
+	 * @throws PrivilegeException insufficient permissions
+	 * @throws SponsorshipDoesNotExistException if the given user is not sponsor of the given member
+	 * @throws MemberNotExistsException if there is no such member
+	 * @throws UserNotExistsException if there is no such user
+	 */
+	void updateSponsorshipValidity(PerunSession sess, Member sponsoredMember, User sponsor, LocalDate newValidity) throws PrivilegeException, SponsorshipDoesNotExistException, MemberNotExistsException, UserNotExistsException;
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/UsersManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/UsersManager.java
@@ -1151,6 +1151,7 @@ public interface UsersManager {
 	/**
 	 * Gets list of users that sponsor the member, with attributes.
 	 *
+	 * @deprecated - use getSponsorsForMember
 	 * @param sess Perun session
 	 * @param member member which is sponsored
 	 * @param attrNames list of attributes. if null or empty, returns all attributes
@@ -1159,7 +1160,19 @@ public interface UsersManager {
 	 * @throws UserNotExistsException
 	 * @return list of users which sponsor the member
 	 */
+	@Deprecated
 	List<RichUser> getSponsors(PerunSession sess, Member member, List<String> attrNames) throws PrivilegeException, UserNotExistsException;
+
+	/**
+	 * Gets list of users that sponsor the member, with attributes.
+	 *
+	 * @param sess Perun session
+	 * @param member member which is sponsored
+	 * @param attrNames list of attributes. if null or empty, returns all attributes
+	 * @throws PrivilegeException insufficient permissions
+	 * @return list of users which sponsor the member
+	 */
+	List<Sponsor> getSponsorsForMember(PerunSession sess, Member member, List<String> attrNames) throws PrivilegeException;
 
 	/**
 	 * Generates new random password for given user and returns String representing HTML

--- a/perun-core/src/main/resources/hsqldbChangelog.txt
+++ b/perun-core/src/main/resources/hsqldbChangelog.txt
@@ -3,6 +3,9 @@
 
 -- this update is not supported on hsql since its used only as in-memory db
 
+3.1.69
+update configurations set value='3.1.69' where property='DATABASE VERSION';
+
 3.1.68
 update configurations set value='3.1.68' where property='DATABASE VERSION';
 

--- a/perun-core/src/main/resources/postgresChangelog.txt
+++ b/perun-core/src/main/resources/postgresChangelog.txt
@@ -6,6 +6,10 @@
 -- Directly under version number should be version commands. They will be executed in the order they are written here.
 -- Comments are prefixed with -- and can be written only between version blocks, that means not in the lines with commands. They have to be at the start of the line.
 
+3.1.69
+alter table members_sponsored ADD COLUMN validity_to timestamp default null;
+UPDATE configurations SET value='3.1.69' WHERE property='DATABASE VERSION';
+
 3.1.68
 CREATE TABLE vos_bans (id integer not null, member_id integer not null, vo_id integer not null, description varchar, banned_to timestamp default '2999-01-01 00:00:00' not null, created_at timestamp default statement_timestamp() not null, created_by varchar default user not null, modified_at timestamp default statement_timestamp() not null, modified_by varchar default user not null, created_by_uid integer, modified_by_uid integer, constraint vos_bans_pk primary key (id), constraint vos_bans_u unique (member_id), constraint vos_bans_mem_fk foreign key (member_id) references members (id), constraint vos_bans_vo_fk foreign key (vo_id) references vos (id));
 CREATE SEQUENCE "vos_bans_id_seq";

--- a/perun-db/postgres.sql
+++ b/perun-db/postgres.sql
@@ -1,4 +1,4 @@
--- database version 3.1.68 (don't forget to update insert statement at the end of file)
+-- database version 3.1.69 (don't forget to update insert statement at the end of file)
 
 -- VOS - virtual organizations
 create table vos (
@@ -1393,6 +1393,7 @@ CREATE TABLE members_sponsored (
 	active boolean default true not null,
 	sponsored_id INTEGER NOT NULL,
 	sponsor_id INTEGER NOT NULL,
+	validity_to timestamp default null,
 	created_at timestamp default statement_timestamp() not null,
 	created_by varchar default user not null,
 	created_by_uid integer,
@@ -1736,7 +1737,7 @@ grant all on user_ext_source_attr_u_values to perun;
 grant all on members_sponsored to perun;
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.1.68');
+insert into configurations values ('DATABASE VERSION','3.1.69');
 
 -- insert membership types
 insert into membership_types (id, membership_type, description) values (1, 'DIRECT', 'Member is directly added into group');

--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -114,6 +114,21 @@ components:
       discriminator:
         propertyName: beanName
 
+    Sponsor:
+      type: object
+      properties:
+        user: { $ref: '#/components/schemas/User' }
+        userExtSources: { type: array, items: { $ref: '#/components/schemas/UserExtSource' } }
+        userAttributes: { type: array, items: { $ref: '#/components/schemas/Attribute' } }
+        validityTo: { type: string, description: 'Date in format yyyy-MM-dd}' }
+        active: { type: boolean }
+      required:
+        - user
+        - userExtSources
+        - userAttributes
+        - validityTo
+        - active
+
     Member:
       allOf:
         - $ref: '#/components/schemas/Auditable'
@@ -928,7 +943,7 @@ components:
       type: object
       properties:
         member: { $ref: '#/components/schemas/RichMember' }
-        sponsors: { type: array, items: { $ref: '#/components/schemas/User' }}
+        sponsors: { type: array, items: { $ref: '#/components/schemas/Sponsor' }}
 
     RTMessage:
       type: object
@@ -1063,6 +1078,15 @@ components:
             type: array
             items:
               $ref: "#/components/schemas/RichUser"
+
+    ListOfSponsorsResponse:
+      description: 'returns List<Sponsor>'
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/Sponsor"
 
     MemberResponse:
       description: returns Member
@@ -2448,6 +2472,22 @@ components:
         type: integer
       in: query
       required: true
+
+    validityTo:
+      name: validityTo
+      description: date in format yyyy-mm-dd
+      schema:
+        type: string
+      in: query
+      required: true
+
+    optionalValidityTo:
+      name: validityTo
+      description: date in format yyyy-mm-dd
+      schema:
+        type: string
+      in: query
+      required: false
 
     onlySponsored:
       name: onlySponsored
@@ -7192,6 +7232,38 @@ paths:
         default:
           $ref: '#/components/responses/ExceptionResponse'
 
+  /json/usersManager/getSponsorsForMember/member:
+    get:
+      tags:
+        - UsersManager
+      operationId: getSponsorsForMember
+      summary: Gets sponsors for given member with optional attribute names.
+      parameters:
+        - $ref: '#/components/parameters/memberId'
+        - $ref: '#/components/parameters/attrNamesOptional'
+      responses:
+        '200':
+          $ref: '#/components/responses/ListOfSponsorsResponse'
+        default:
+          $ref: '#/components/responses/ExceptionResponse'
+
+  /json/usersManager/getSponsorsForMember/vo:
+    get:
+      tags:
+        - UsersManager
+      operationId: getSponsorsForMemberByVoAndLogin
+      summary: Gets sponsors for member specified by VO, extSourceName and extLogin with optional attribute names.
+      parameters:
+        - $ref: '#/components/parameters/voId'
+        - $ref: '#/components/parameters/extSourceName'
+        - $ref: '#/components/parameters/extLogin'
+        - $ref: '#/components/parameters/attrNamesOptional'
+      responses:
+        '200':
+          $ref: '#/components/responses/ListOfSponsorsResponse'
+        default:
+          $ref: '#/components/responses/ExceptionResponse'
+
   /json/usersManager/getUserByExtSourceNameAndExtLogin:
     get:
       tags:
@@ -7909,6 +7981,7 @@ paths:
                 vo: { type: integer }
                 sponsor: { type: integer }
                 namespace: { type: string }
+                validityTo: { type: string }
 
   /json/membersManager/setSponsoredMember:
     post:
@@ -7940,6 +8013,7 @@ paths:
                 vo: { type: integer }
                 sponsor: { type: integer }
                 namespace: { type: string }
+                validityTo: { type: string }
 
   /json/membersManager/createSponsoredMembers:
     post:
@@ -7970,6 +8044,7 @@ paths:
                 vo: { type: integer }
                 sponsor: { type: integer }
                 namespace: { type: string }
+                validityTo: { type: string }
 
   /json/membersManager/createSpecificMember:
     post:
@@ -8011,6 +8086,22 @@ paths:
       parameters:
         - $ref: '#/components/parameters/memberId'
         - $ref: '#/components/parameters/sponsorId'
+      responses:
+        '200':
+          $ref: '#/components/responses/VoidResponse'
+        default:
+          $ref: '#/components/responses/ExceptionResponse'
+
+  /urlinjsonout/membersManager/updateSponsorshipValidity:
+    post:
+      tags:
+        - MembersManager
+      operationId: updateSponsorshipValidity
+      summary: Updates sponsorship validity. To change it to FOREVER, pass null in validityTo.
+      parameters:
+        - $ref: '#/components/parameters/memberId'
+        - $ref: '#/components/parameters/sponsorId'
+        - $ref: '#/components/parameters/validityTo'
       responses:
         '200':
           $ref: '#/components/responses/VoidResponse'

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/MembersManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/MembersManagerMethod.java
@@ -8,7 +8,9 @@ import cz.metacentrum.perun.rpc.ManagerMethod;
 import cz.metacentrum.perun.rpc.deserializer.Deserializer;
 
 import java.text.ParseException;
+import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -128,6 +130,7 @@ public enum MembersManagerMethod implements ManagerMethod {
 	 * @param vo int VO ID
 	 * @param namespace String namespace selecting remote system for storing the password
 	 * @param sponsor int sponsor's ID
+	 * @param validityTo (Optional) String the last day, when the sponsorship is active, yyyy-mm-dd format.
 	 * @return RichMember newly created sponsored member
 	 */
 	createSponsoredMember {
@@ -138,6 +141,10 @@ public enum MembersManagerMethod implements ManagerMethod {
 			Vo vo =  ac.getVoById(params.readInt("vo"));
 			String namespace = params.readString("namespace");
 			User sponsor = null;
+			LocalDate validityTo = null;
+			if (params.contains("validityTo")) {
+				validityTo = params.readLocalDate("validityTo");
+			}
 			if(params.contains("sponsor")) {
 				sponsor = ac.getUserById(params.readInt("sponsor"));
 			}
@@ -152,7 +159,7 @@ public enum MembersManagerMethod implements ManagerMethod {
 			} else {
 				throw new RpcException(RpcException.Type.MISSING_VALUE, "Missing value. Either 'guestName' or ('firstName' and 'lastName') must be sent.");
 			}
-			return ac.getMembersManager().createSponsoredMember(ac.getSession(), vo, namespace, name, password, sponsor);
+			return ac.getMembersManager().createSponsoredMember(ac.getSession(), vo, namespace, name, password, sponsor, validityTo);
 		}
 	},
 
@@ -167,6 +174,7 @@ public enum MembersManagerMethod implements ManagerMethod {
 	 * @param namespace String used for selecting external system in which guest user account will be created
 	 * @param password String password
 	 * @param sponsor int id of sponsoring user
+	 * @param validityTo (Optional) String the last day, when the sponsorship is active, yyyy-mm-dd format.
 	 * @return RichMember sponsored member
 	 */
 	/*#
@@ -179,6 +187,7 @@ public enum MembersManagerMethod implements ManagerMethod {
 	 * @param userToBeSponsored int id of user, that will be sponsored by sponsor
 	 * @param namespace String used for selecting external system in which guest user account will be created
 	 * @param password String password
+	 * @param validityTo (Optional) String the last day, when the sponsorship is active, yyyy-mm-dd format.
 	 * @return RichMember sponsored member
 	 */
 	setSponsoredMember {
@@ -188,6 +197,10 @@ public enum MembersManagerMethod implements ManagerMethod {
 			String password = params.readString("password");
 			Vo vo =  ac.getVoById(params.readInt("vo"));
 			String namespace = params.readString("namespace");
+			LocalDate validityTo = null;
+			if (params.contains("validityTo")) {
+				validityTo = params.readLocalDate("validityTo");
+			}
 			User sponsor = null;
 			if(params.contains("sponsor")) {
 				sponsor = ac.getUserById(params.readInt("sponsor"));
@@ -198,7 +211,7 @@ public enum MembersManagerMethod implements ManagerMethod {
 			} else {
 				throw new RpcException(RpcException.Type.MISSING_VALUE, "Missing value. The 'userToBeSponsored' must be sent.");
 			}
-			return ac.getMembersManager().setSponsoredMember(ac.getSession(), vo, userToBeSponsored, namespace, password, sponsor);
+			return ac.getMembersManager().setSponsoredMember(ac.getSession(), vo, userToBeSponsored, namespace, password, sponsor, validityTo);
 		}
 	},
 
@@ -221,6 +234,7 @@ public enum MembersManagerMethod implements ManagerMethod {
 	 * @param vo int VO ID
 	 * @param namespace String namespace selecting remote system for storing the password
 	 * @param sponsor int sponsor's ID
+	 * @param validityTo (Optional) String the last day, when the sponsorship is active, yyyy-mm-dd format.
 	 * @return Map<String, Map<String, String> newly created sponsored member, their password and status of creation
 	 */
 	createSponsoredMembers {
@@ -230,6 +244,10 @@ public enum MembersManagerMethod implements ManagerMethod {
 			String password = params.readString("password");
 			Vo vo =  ac.getVoById(params.readInt("vo"));
 			String namespace = params.readString("namespace");
+			LocalDate validityTo = null;
+			if (params.contains("validityTo")) {
+				validityTo = params.readLocalDate("validityTo");
+			}
 			User sponsor = null;
 			if(params.contains("sponsor")) {
 				sponsor = ac.getUserById(params.readInt("sponsor"));
@@ -240,7 +258,7 @@ public enum MembersManagerMethod implements ManagerMethod {
 			} else {
 				throw new RpcException(RpcException.Type.MISSING_VALUE, "Missing value: 'guestNames' must be sent.");
 			}
-			return ac.getMembersManager().createSponsoredMembers(ac.getSession(), vo, namespace, names, sponsor);
+			return ac.getMembersManager().createSponsoredMembers(ac.getSession(), vo, namespace, names, sponsor, validityTo);
 		}
 	},
 
@@ -249,6 +267,7 @@ public enum MembersManagerMethod implements ManagerMethod {
 	 *
 	 * @param sponsoredMember int member's ID
 	 * @param sponsor int sponsor's ID
+	 * @param validityTo (Optional) String the last day, when the sponsorship is active, yyyy-mm-dd format.
 	 * @return RichMember sponsored member which was newly set
 	 */
 	setSponsorshipForMember {
@@ -257,10 +276,14 @@ public enum MembersManagerMethod implements ManagerMethod {
 			params.stateChangingCheck();
 			Member sponsoredMember = ac.getMemberById(params.readInt("sponsoredMember"));
 			User sponsor = null;
+			LocalDate validityTo = null;
+			if (params.contains("validityTo")) {
+				validityTo = params.readLocalDate("validityTo");
+			}
 			if (params.contains("sponsor")) {
 				sponsor = ac.getUserById(params.readInt("sponsor"));
 			}
-			return ac.getMembersManager().setSponsorshipForMember(ac.getSession(), sponsoredMember, sponsor);
+			return ac.getMembersManager().setSponsorshipForMember(ac.getSession(), sponsoredMember, sponsor, validityTo);
 		}
 	},
 
@@ -287,6 +310,7 @@ public enum MembersManagerMethod implements ManagerMethod {
 	 *
 	 * @param member int id of sponsored member, optional
 	 * @param sponsor int id of sponsoring user, optional
+	 * @param validityTo (Optional) String the last day, when the sponsorship is active, yyyy-mm-dd format.
 	 * @return RichMember sponsored member
 	 */
 	sponsorMember {
@@ -295,7 +319,11 @@ public enum MembersManagerMethod implements ManagerMethod {
 			params.stateChangingCheck();
 			Member sponsored = ac.getMemberById(params.readInt("member"));
 			User sponsor = ac.getUserById(params.readInt("sponsor"));
-			return ac.getMembersManager().sponsorMember(ac.getSession(), sponsored, sponsor);
+			LocalDate validityTo = null;
+			if (params.contains("validityTo")) {
+				validityTo = params.readLocalDate("validityTo");
+			}
+			return ac.getMembersManager().sponsorMember(ac.getSession(), sponsored, sponsor, validityTo);
 		}
 	},
 
@@ -314,6 +342,32 @@ public enum MembersManagerMethod implements ManagerMethod {
 			Member sponsoredMember = ac.getMemberById(params.readInt("member"));
 			User sponsorToRemove = ac.getUserById(params.readInt("sponsor"));
 			ac.getMembersManager().removeSponsor(ac.getSession(), sponsoredMember, sponsorToRemove);
+			return null;
+		}
+	},
+
+	/*#
+	 * Update the sponsorship of given member for given sponsor.
+	 *
+	 * @param member int id of sponsored member, optional
+	 * @param sponsor int id of sponsoring user that is to be removed
+	 * @param validityTo String the last day, when the sponsorship is active, yyyy-mm-dd format.
+	 *                          can be set to null never expire
+	 * @throw PrivilegeException insufficient permissions
+	 * @throw SponsorshipDoesNotExistException if the given user is not sponsor of the given member
+	 * @throw MemberNotExistsException if there is no such member
+	 * @throw UserNotExistsException if there is no such user
+	 */
+	updateSponsorshipValidity {
+		@Override
+		public Void call(ApiCaller ac, Deserializer params) throws PerunException {
+			params.stateChangingCheck();
+
+			Member sponsoredMember = ac.getMemberById(params.readInt("member"));
+			User sponsor = ac.getUserById(params.readInt("sponsor"));
+			LocalDate newValidity = params.readLocalDate("validityTo");
+
+			ac.getMembersManager().updateSponsorshipValidity(ac.getSession(), sponsoredMember, sponsor, newValidity);
 			return null;
 		}
 	},
@@ -390,13 +444,15 @@ public enum MembersManagerMethod implements ManagerMethod {
 		@Override
 		public List<MemberWithSponsors> call(ApiCaller ac, Deserializer params) throws PerunException {
 			Vo vo = ac.getVoById(params.readInt("vo"));
-			List<String> attrNames = params.contains("attrNames") ? params.readList("attrNames",String.class) : null;
+			List<String> attrNames = params.contains("attrNames") ? params.readList("attrNames",String.class) : Collections.emptyList();
 			return ac.getMembersManager().getSponsoredMembersAndTheirSponsors(ac.getSession(), vo, attrNames);
 		}
 	},
 
 	/*#
 	 * Gets users sponsoring a given user in a VO.
+	 *
+	 * @deprecated - use usersManager/getSponsorsForMember
 	 *
 	 * Can be called by user in role REGISTRAR.
 	 *
@@ -406,6 +462,8 @@ public enum MembersManagerMethod implements ManagerMethod {
 	 */
 	/*#
 	 * Gets users sponsoring a given user in a VO.
+	 *
+	 * @deprecated - use usersManager/getSponsorsForMember
 	 *
 	 * Can be called by user in role REGISTRAR.
 	 *

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/UsersManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/UsersManagerMethod.java
@@ -93,6 +93,38 @@ public enum UsersManagerMethod implements ManagerMethod {
 	},
 
 	/*#
+	 * Gets users sponsoring a given user in a VO.
+	 *
+	 * @param member int member id
+	 * @param attrNames List<String> names of attributes to return, empty to return all attributes
+	 * @return List<Sponsor> sponsors
+	 */
+	/*#
+	 * Gets users sponsoring a given user in a VO.
+	 *
+	 * @param vo int VO ID
+	 * @param extSourceName String external source name, usually SAML IdP entityID
+	 * @param extLogin String external source login, usually eduPersonPrincipalName
+	 * @param attrNames List<String> names of attributes to return, empty to return all attributes
+	 * @return List<Sponsor> sponsors
+	 */
+	getSponsorsForMember {
+		@Override
+		public List<Sponsor> call(ApiCaller ac, Deserializer params) throws PerunException {
+			Member member = null;
+			if (params.contains("member")) {
+				member = ac.getMemberById(params.readInt("member"));
+			} else if (params.contains("vo") && params.contains("extSourceName") && params.contains("extLogin")) {
+				Vo vo = ac.getVoById(params.readInt("vo"));
+				User user = ac.getUsersManager().getUserByExtSourceNameAndExtLogin(ac.getSession(), params.readString("extSourceName"), params.readString("extLogin"));
+				member = ac.getMembersManager().getMemberByUser(ac.getSession(), vo, user);
+			}
+			List<String> attrNames = params.contains("attrNames") ? params.readList("attrNames",String.class) : null;
+			return ac.getUsersManager().getSponsorsForMember(ac.getSession(), member, attrNames);
+		}
+	},
+
+	/*#
 	 * Return all specific users who are owned by the user.
 	 *
 	 * @param user int User <code>id</code>


### PR DESCRIPTION
* For deployment:
  * New DB version with changelog
* From now, it is possible to specify the validity of the sponsorship.
The validity is in format yyyy-mm-dd and it is meant to define the
last day when the sponsorship is active. After this day, it will turn
inactive. (NOT PART OF THIS COMMIT)
* Updated existing methods that returned users as sponsors. Now these
methods returns new Sponsor object. It had to be done so it is possible
to also return information about the sponsorship (activeness and
validity). The Sponsor object has the same format as the RichUser, so it
should not cause any incompatibility with our RPC API.
* Created method `updateSponsorshipValidity` which can be used to update
validity of a sponsorship relation.
* Updated policy of the `getSponsors` method so it can be called by
appropriate users.
* BUGFIXES:
  * MembersManagerImpl/getSponsoredMembers - there was a missing
DISTINCT keyword which caused duplicit members being returned if they
had multiple sponsors.
  * MembersManagerMethod/getSponsoredMembersAndTheirSponsors - if no
attrNames were specified, the method used a null which caused
NullPointerException.