### PR TITLE
Searching for users by strings with spaces

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Utils.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Utils.java
@@ -1682,9 +1682,9 @@ public class Utils {
 	 */
 	public static String prepareUserSearchQueryExactMatch() {
 		if (Compatibility.isPostgreSql()) {
-			return " replace(lower("+Compatibility.convertToAscii("COALESCE(users.first_name,'') || COALESCE(users.middle_name,'') || COALESCE(users.last_name,'')")+"), ' ', '')=:nameString";
+			return " replace(lower("+Compatibility.convertToAscii("COALESCE(users.first_name,'') || COALESCE(users.middle_name,'') || COALESCE(users.last_name,'')")+"), ' ', '')=replace(lower(:nameString), ' ', '')";
 		} else if (Compatibility.isHSQLDB()) {
-			return " replace(lower("+Compatibility.convertToAscii("COALESCE(users.first_name,'') || COALESCE(users.middle_name,'') || COALESCE(users.last_name,'')")+"), ' ', '')=:nameString";
+			return " replace(lower("+Compatibility.convertToAscii("COALESCE(users.first_name,'') || COALESCE(users.middle_name,'') || COALESCE(users.last_name,'')")+"), ' ', '')=replace(lower(:nameString), ' ', '')";
 		} else {
 			throw new InternalErrorException("Unsupported db type");
 		}
@@ -1697,11 +1697,11 @@ public class Utils {
 	 */
 	public static String prepareUserSearchQuerySimilarMatch() {
 		if (Compatibility.isPostgreSql()) {
-			return " strpos(replace(lower(" + Compatibility.convertToAscii("COALESCE(users.first_name,'') || COALESCE(users.middle_name,'') || COALESCE(users.last_name,'')") + "), ' ', ''),:nameString) > 0 or " +
-				   " strpos(replace(lower(" + Compatibility.convertToAscii("COALESCE(users.last_name,'') || COALESCE(users.middle_name,'') || COALESCE(users.first_name,'')") + "), ' ', ''),:nameString) > 0 ";
+			return " strpos(replace(lower(" + Compatibility.convertToAscii("COALESCE(users.first_name,'') || COALESCE(users.middle_name,'') || COALESCE(users.last_name,'')") + "), ' ', ''),replace(lower(:nameString), ' ', '')) > 0 or " +
+				   " strpos(replace(lower(" + Compatibility.convertToAscii("COALESCE(users.last_name,'') || COALESCE(users.middle_name,'') || COALESCE(users.first_name,'')") + "), ' ', ''),replace(lower(:nameString), ' ', '')) > 0 ";
 		} else if (Compatibility.isHSQLDB()) {
-			return " replace(lower(" + Compatibility.convertToAscii("COALESCE(users.first_name,'') || COALESCE(users.middle_name,'') || COALESCE(users.last_name,'')") + "), ' ', '') like '%' || :nameString || '%' or " +
-				   " replace(lower(" + Compatibility.convertToAscii("COALESCE(users.last_name,'') || COALESCE(users.middle_name,'') || COALESCE(users.first_name,'')") + "), ' ', '') like '%' || :nameString || '%' ";
+			return " replace(lower(" + Compatibility.convertToAscii("COALESCE(users.first_name,'') || COALESCE(users.middle_name,'') || COALESCE(users.last_name,'')") + "), ' ', '') like '%' || replace(lower(:nameString), ' ', '') || '%' or " +
+				   " replace(lower(" + Compatibility.convertToAscii("COALESCE(users.last_name,'') || COALESCE(users.middle_name,'') || COALESCE(users.first_name,'')") + "), ' ', '') like '%' || replace(lower(:nameString), ' ', '') || '%' ";
 		} else {
 			throw new InternalErrorException("Unsupported db type");
 		}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Utils.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Utils.java
@@ -1682,9 +1682,9 @@ public class Utils {
 	 */
 	public static String prepareUserSearchQueryExactMatch() {
 		if (Compatibility.isPostgreSql()) {
-			return " lower("+Compatibility.convertToAscii("COALESCE(users.first_name,'') || COALESCE(users.middle_name,'') || COALESCE(users.last_name,'')")+")=:nameString";
+			return " replace(lower("+Compatibility.convertToAscii("COALESCE(users.first_name,'') || COALESCE(users.middle_name,'') || COALESCE(users.last_name,'')")+"), ' ', '')=:nameString";
 		} else if (Compatibility.isHSQLDB()) {
-			return " lower("+Compatibility.convertToAscii("COALESCE(users.first_name,'') || COALESCE(users.middle_name,'') || COALESCE(users.last_name,'')")+")=:nameString";
+			return " replace(lower("+Compatibility.convertToAscii("COALESCE(users.first_name,'') || COALESCE(users.middle_name,'') || COALESCE(users.last_name,'')")+"), ' ', '')=:nameString";
 		} else {
 			throw new InternalErrorException("Unsupported db type");
 		}
@@ -1697,9 +1697,11 @@ public class Utils {
 	 */
 	public static String prepareUserSearchQuerySimilarMatch() {
 		if (Compatibility.isPostgreSql()) {
-			return " strpos(lower(" + Compatibility.convertToAscii("COALESCE(users.first_name,'') || COALESCE(users.middle_name,'') || COALESCE(users.last_name,'')") + "),:nameString) > 0 ";
+			return " strpos(replace(lower(" + Compatibility.convertToAscii("COALESCE(users.first_name,'') || COALESCE(users.middle_name,'') || COALESCE(users.last_name,'')") + "), ' ', ''),:nameString) > 0 or " +
+				   " strpos(replace(lower(" + Compatibility.convertToAscii("COALESCE(users.last_name,'') || COALESCE(users.middle_name,'') || COALESCE(users.first_name,'')") + "), ' ', ''),:nameString) > 0 ";
 		} else if (Compatibility.isHSQLDB()) {
-			return " lower(" + Compatibility.convertToAscii("COALESCE(users.first_name,'') || COALESCE(users.middle_name,'') || COALESCE(users.last_name,'')") + ") like '%' || :nameString || '%' ";
+			return " replace(lower(" + Compatibility.convertToAscii("COALESCE(users.first_name,'') || COALESCE(users.middle_name,'') || COALESCE(users.last_name,'')") + "), ' ', '') like '%' || :nameString || '%' or " +
+				   " replace(lower(" + Compatibility.convertToAscii("COALESCE(users.last_name,'') || COALESCE(users.middle_name,'') || COALESCE(users.first_name,'')") + "), ' ', '') like '%' || :nameString || '%' ";
 		} else {
 			throw new InternalErrorException("Unsupported db type");
 		}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/MembersManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/MembersManagerEntryIntegrationTest.java
@@ -1680,6 +1680,31 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 		members = perun.getMembersManagerBl().findMembers(sess, createdVo, user.getLastName(), false);
 		assertTrue(members.size() == 1);
 		assertEquals(member, members.get(0));
+		members = perun.getMembersManagerBl().findMembers(sess, createdVo, user.getLastName() + " " + user.getFirstName(), false);
+		assertTrue(members.size() == 1);
+		assertEquals(member, members.get(0));
+
+		// New member to test searching with space in first name
+		Candidate candidate2 = new Candidate();
+		// Different first name from the default candidate in the test, contains a space
+		candidate2.setFirstName(new StringBuilder(candidate.getFirstName()).append('2').insert(candidate.getFirstName().length() / 2, ' ').toString());
+		candidate2.setId(0);
+		candidate2.setMiddleName("");
+		candidate2.setLastName(candidate.getLastName());
+		candidate2.setTitleBefore("");
+		candidate2.setTitleAfter("");
+		// Different ext login from the default candidate in the test
+		UserExtSource ues2 = new UserExtSource(extSource, candidate.getUserExtSource().getLogin() + "2");
+		candidate2.setUserExtSource(ues2);
+		candidate2.setAttributes(new HashMap<>());
+
+		Member member2 = perun.getMembersManagerBl().createMemberSync(sess, createdVo, candidate2);
+		usersForDeletion.add(perun.getUsersManager().getUserByMember(sess, member2));
+		assertNotNull("No member created", member2);
+
+		members = perun.getMembersManagerBl().findMembers(sess, createdVo, candidate2.getFirstName(), false);
+		assertTrue(members.size() == 1);
+		assertEquals(member2, members.get(0));
 	}
 
 	@Test

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/UsersManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/UsersManagerEntryIntegrationTest.java
@@ -982,9 +982,10 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 
 		// Create second user
 		User user2 = new User();
-		user2.setFirstName(userFirstName+"2");
+		// Different first name from the default user in the test, contains a space
+		user2.setFirstName(new StringBuilder(userFirstName).append('2').insert(userFirstName.length() / 2, ' ').toString());
 		user2.setMiddleName("");
-		user2.setLastName(userLastName); // Different last name from the default user in the test
+		user2.setLastName(userLastName);
 		user2.setTitleBefore("");
 		user2.setTitleAfter("");
 		assertNotNull(perun.getUsersManagerBl().createUser(sess, user2));
@@ -992,7 +993,7 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 		usersForDeletion.add(user2);
 		// save user for deletion after testing
 
-		List<User> users = usersManager.findUsers(sess, userFirstName+""+userLastName);
+		List<User> users = usersManager.findUsers(sess, userFirstName + " " + userLastName);
 		// This search must contain at least one result
 		assertTrue("results must contain at least one user", users.size() >= 1);
 		// And must contain the user
@@ -1002,6 +1003,17 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 		// This search must contain at least two results
 		assertTrue("results must contain at least two users", users.size() >= 2);
 		assertTrue("results must contain user and user2", users.contains(user) && users.contains(user2));
+
+		users = usersManager.findUsers(sess, userLastName + " " + userFirstName);
+		// This search must contain at least one result
+		assertTrue("results must contain at least one user", users.size() >= 1);
+		assertTrue("results must contain user", users.contains(user));
+
+		// Search with a space in first name
+		users = usersManager.findUsers(sess, user2.getFirstName());
+		// This search must contain at least one result
+		assertTrue("results must contain at least one user", users.size() >= 1);
+		assertTrue("results must contain user2", users.contains(user2));
 	}
 
 	@Test
@@ -1109,13 +1121,30 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 	public void findRichUsersWithAttributesByExactMatch() throws Exception {
 		System.out.println(CLASS_NAME + "findRichUsersWithAttributesByExactMatch");
 
+		// Create second user
+		User user2 = new User();
+		// Different first name from the default user in the test, contains a space
+		user2.setFirstName(new StringBuilder(userFirstName).append('2').insert(userFirstName.length() / 2, ' ').toString());
+		user2.setMiddleName("");
+		user2.setLastName(userLastName);
+		user2.setTitleBefore("");
+		user2.setTitleAfter("");
+		assertNotNull(perun.getUsersManagerBl().createUser(sess, user2));
+		// create new user in database
+		usersForDeletion.add(user2);
+		// save user for deletion after testing
+
 		ArrayList<String> attrNames = new ArrayList<>();
 		attrNames.add("urn:perun:user:attribute-def:def:preferredMail");
 
-		String searchString = user.getFirstName()+user.getLastName();
+		String searchString = user.getFirstName() + " " + user.getLastName();
 		List<RichUser> users = perun.getUsersManager().findRichUsersWithAttributesByExactMatch(sess, searchString, attrNames);
 		assertTrue("No users found for exact match!", !users.isEmpty());
 
+		searchString = user2.getFirstName() + " " + user2.getLastName();
+		users = perun.getUsersManager().findRichUsersWithAttributesByExactMatch(sess, searchString, attrNames);
+		assertTrue("Results must contain user2!", users.contains(user2));
+		assertTrue("Results can't contain user!", !users.contains(user));
 	}
 
 	@Test


### PR DESCRIPTION
- This is fix for outcome of quickfix in #2915. Quickfix caused that when
searching for users, who have a space in one part of name (e.g. in lastName),
they were not found.
- Also when searching for user by his name in reverse order, the user was not
found.
- Now when searching by similar match, both issues were fixed.
- When searching by exact match, only the bug with spaces in one part of name
was fixed.
- Tests for searching by string with a space were added too.