### PR TITLE
fix forgotten tasks in WAITING state

### DIFF
--- a/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/scheduling/PropagationMaintainer.java
+++ b/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/scheduling/PropagationMaintainer.java
@@ -135,7 +135,7 @@ public class PropagationMaintainer extends AbstractRunner {
 
 
 	/**
-	 * Reschedule Tasks in DONE/WARNING if their
+	 * Reschedule Tasks in DONE/WARNING/WAITING state if their
 	 * - source was updated
 	 * - OR haven't run for X hours
 	 * - or have no end time set
@@ -143,9 +143,9 @@ public class PropagationMaintainer extends AbstractRunner {
 	private void rescheduleDoneTasks() {
 
 		// Reschedule tasks in DONE that haven't been running for quite a while
-		log.info("Checking DONE/WARNING tasks...");
+		log.info("Checking DONE/WARNING/WAITING tasks...");
 
-		for (Task task : schedulingPool.getTasksWithStatus(TaskStatus.DONE, TaskStatus.WARNING)) {
+		for (Task task : schedulingPool.getTasksWithStatus(TaskStatus.DONE, TaskStatus.WARNING, TaskStatus.WAITING)) {
 
 			LocalDateTime tooManyHoursAgo = LocalDateTime.now().minusHours(oldRescheduleHours);
 


### PR DESCRIPTION
Adds periodic scheduling of tasks in WAITING state (the same way as DONE tasks are scheduled):
  * WAITING tasks stay in that state most often because there are no destinations or service is blocked,
  * these tasks should be scheduled when the service is unblocked or destinations added, as indicated by
    audit message,
  * the same mechanism is used for DONE tasks - flag is set indicating new data and the task is rescheduled,
  * if the task is still not eligible for scheduling, it stays in the WAITING state until switched to ERROR, when time limit expires.