### PR TITLE
fix messages in PrivilegeException 

### DIFF
--- a/perun-cabinet/src/main/java/cz/metacentrum/perun/cabinet/api/CabinetManager.java
+++ b/perun-cabinet/src/main/java/cz/metacentrum/perun/cabinet/api/CabinetManager.java
@@ -331,9 +331,10 @@ public interface CabinetManager {
 	 *
 	 * @param session PerunSession
 	 * @return List of all Authors of Publications. Empty list of none found.
+	 * @throws PrivilegeException 
 	 * @throws InternalErrorException When implementation fails
 	 */
-	List<Author> getAllAuthors(PerunSession session) throws CabinetException;
+	List<Author> getAllAuthors(PerunSession session) throws PrivilegeException;
 
 	/**
 	 * Return all Authors of Publication specified by its ID. Empty list of none found.
@@ -363,10 +364,11 @@ public interface CabinetManager {
 	 * @param sess  PerunSession for authz
 	 * @param searchString String to search users by
 	 * @return List of new possible authors
-	 * @throws CabinetException
+	 * @throws PrivilegeException 
+	 * @throws CabinetException 
 	 * @throws InternalErrorException
 	 */
-	List<Author> findNewAuthors(PerunSession sess, String searchString) throws CabinetException;
+	List<Author> findNewAuthors(PerunSession sess, String searchString) throws PrivilegeException, CabinetException;
 
 
 	// Publications ----------------------------------

--- a/perun-cabinet/src/main/java/cz/metacentrum/perun/cabinet/api/impl/CabinetManagerImpl.java
+++ b/perun-cabinet/src/main/java/cz/metacentrum/perun/cabinet/api/impl/CabinetManagerImpl.java
@@ -297,7 +297,7 @@ public class CabinetManagerImpl implements CabinetManager {
 				!authorship.getCreatedBy().equalsIgnoreCase(sess.getPerunPrincipal().getActor()) &&
 				!authorship.getUserId().equals(sess.getPerunPrincipal().getUser().getId()) &&
 				authorship.getCreatedByUid() != sess.getPerunPrincipal().getUserId()) {
-			throw new PrivilegeException("You are not allowed to delete authorships you didn't created or which doesn't concern you.");
+			throw new PrivilegeException("deleteAuthorship.");
 		}
 
 		getAuthorshipManagerBl().deleteAuthorship(sess, authorship);
@@ -334,11 +334,11 @@ public class CabinetManagerImpl implements CabinetManager {
 	}
 
 	@Override
-	public List<Author> getAllAuthors(PerunSession sess) throws CabinetException {
+	public List<Author> getAllAuthors(PerunSession sess) throws PrivilegeException {
 
 		//Authorization
 		if (!AuthzResolver.authorizedInternal(sess, "getAllAuthors_policy")) {
-			throw new CabinetException("You are not authorized to list all authors.", NOT_AUTHORIZED);
+			throw new PrivilegeException("getAllAuthors");
 		}
 
 		return getAuthorshipManagerBl().getAllAuthors();
@@ -366,7 +366,7 @@ public class CabinetManagerImpl implements CabinetManager {
 			Publication publication = getPublicationManagerBl().getPublicationById(id);
 			if ((publication.getCreatedByUid() != session.getPerunPrincipal().getUserId()) &&
 					!(Objects.equals(publication.getCreatedBy(), session.getPerunPrincipal().getActor()))) {
-				throw new PrivilegeException("You are not allowed to see authors of publications you didn't created.");
+				throw new PrivilegeException("getAuthorsByPublicationId");
 			}
 		}
 
@@ -380,11 +380,11 @@ public class CabinetManagerImpl implements CabinetManager {
 	}
 
 	@Override
-	public List<Author> findNewAuthors(PerunSession sess, String searchString) throws CabinetException {
+	public List<Author> findNewAuthors(PerunSession sess, String searchString) throws PrivilegeException, CabinetException {
 
 		// Authorization
 		if (!AuthzResolver.authorizedInternal(sess, "findNewAuthors_String_policy")) {
-			throw new CabinetException("You are not authorized to search for new authors.", NOT_AUTHORIZED);
+			throw new PrivilegeException("findNewAuthors");
 		}
 
 		return getAuthorshipManagerBl().findNewAuthors(sess, searchString);
@@ -415,7 +415,7 @@ public class CabinetManagerImpl implements CabinetManager {
 			try {
 				getAuthorsByPublicationId(sess, publication.getId());
 			} catch (PrivilegeException ex) {
-				throw new PrivilegeException("You are not allowed to update publications you didn't created.");
+				throw new PrivilegeException("updatePublication");
 			}
 		}
 
@@ -431,7 +431,7 @@ public class CabinetManagerImpl implements CabinetManager {
 				!publication.getCreatedBy().equalsIgnoreCase(sess.getPerunPrincipal().getActor()) &&
 				publication.getCreatedByUid() != sess.getPerunPrincipal().getUserId()) {
 			// not perun admin or author of record
-			throw new PrivilegeException("You are not allowed to delete publications you didn't created. If you wish, you can remove yourself from authors instead.");
+			throw new PrivilegeException("deletePublication");
 		}
 
 		getPublicationManagerBl().deletePublication(sess, publication);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/AttributesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/AttributesManagerEntry.java
@@ -710,7 +710,7 @@ public class AttributesManagerEntry implements AttributesManager {
 
 		//Authorization - will be later replaced by the new attributes authorization
 		if(!AuthzResolver.authorizedInternal(sess, "getAttributes_String_policy")) {
-			throw new PrivilegeException("For getting entityless attributes principal need to be PerunAdmin or PerunObserver.");
+			throw new PrivilegeException("getAttributes");
 		}
 
 		return getAttributesManagerBl().setWritableTrue(sess, getAttributesManagerBl().getAttributes(sess, key));
@@ -739,7 +739,7 @@ public class AttributesManagerEntry implements AttributesManager {
 
 		//Authorization - will be later replaced by the new attributes authorization
 		if(!AuthzResolver.authorizedInternal(sess, "getEntitylessAttributes_String_policy")) {
-			throw new PrivilegeException("For getting entityless attributes principal need to be PerunAdmin or PerunObserver.");
+			throw new PrivilegeException("getEntitylessAttributes");
 		}
 
 		return getAttributesManagerBl().setWritableTrue(sess, getAttributesManagerBl().getEntitylessAttributes(sess, attrName));
@@ -795,7 +795,7 @@ public class AttributesManagerEntry implements AttributesManager {
 
 		//Authorization - will be later replaced by the new attributes authorization
 		if(!AuthzResolver.authorizedInternal(sess, "getEntitylessKeys_AttributeDefinition_policy")) {
-			throw new PrivilegeException("For getting entityless attributes principal need to be PerunAdmin or PerunObserver.");
+			throw new PrivilegeException("getEntitylessKeys");
 		}
 
 		return getAttributesManagerBl().getEntitylessKeys(sess, attributeDefinition);
@@ -808,7 +808,7 @@ public class AttributesManagerEntry implements AttributesManager {
 
 		//Authorization
 		if(!AuthzResolver.authorizedInternal(sess, "getAttributesByAttributeDefinition_AttributeDefinition_policy", attributeDefinition)) {
-			throw new PrivilegeException("For getting the attributes, you need to be PerunAdmin or PerunObserver.");
+			throw new PrivilegeException("getAttributesByAttributeDefinition");
 		}
 
 		return getAttributesManagerBl().setWritableTrue(sess, getAttributesManagerBl().getAttributesByAttributeDefinition(sess, attributeDefinition));
@@ -1579,7 +1579,7 @@ public class AttributesManagerEntry implements AttributesManager {
 
 		//Authorization - will be later replaced by the new attributes authorization
 		if(!AuthzResolver.authorizedInternal(sess, "setAttribute_String_Attribute_policy")) {
-			throw new PrivilegeException("Only perunAdmin can set entityless attributes.");
+			throw new PrivilegeException("setAttribute");
 		}
 
 		getAttributesManagerBl().setAttribute(sess, key, attribute);
@@ -1602,7 +1602,7 @@ public class AttributesManagerEntry implements AttributesManager {
 
 		//Authorization
 		if(!AuthzResolver.authorizedInternal(sess, "createAttribute_AttributeDefinition_policy")) {
-			throw new PrivilegeException("Only perunAdmin can create new Attribute.");
+			throw new PrivilegeException("createAttribute");
 		}
 
 		if (!attribute.getFriendlyName().matches(AttributesManager.ATTRIBUTES_REGEXP)) {
@@ -1618,7 +1618,7 @@ public class AttributesManagerEntry implements AttributesManager {
 
 		//Authorization
 		if(!AuthzResolver.authorizedInternal(sess, "deleteAttribute_AttributeDefinition_policy", attribute)) {
-			throw new PrivilegeException("Only perunAdmin can delete existing Attribute.");
+			throw new PrivilegeException("deleteAttribute");
 		}
 
 		getAttributesManagerBl().deleteAttribute(sess, attribute);
@@ -1631,7 +1631,7 @@ public class AttributesManagerEntry implements AttributesManager {
 
 		// Authorization
 		if(!AuthzResolver.authorizedInternal(sess, "deleteAttribute_AttributeDefinition_boolean", attributeDefinition)) {
-			throw new PrivilegeException("Only perunAdmin can delete existing Attribute.");
+			throw new PrivilegeException("deleteAttribute");
 		}
 
 		getAttributesManagerBl().deleteAttribute(sess, attributeDefinition, force);
@@ -4446,7 +4446,7 @@ public class AttributesManagerEntry implements AttributesManager {
 
 		// Authorization
 		if(!AuthzResolver.authorizedInternal(perunSession, "updateAttributeDefinition_AttributeDefinition_policy", attributeDefinition)) {
-			throw new PrivilegeException("Only PerunAdmin can update AttributeDefinition");
+			throw new PrivilegeException("updateAttributeDefinition");
 		}
 
 		return getAttributesManagerBl().updateAttributeDefinition(perunSession, attributeDefinition);
@@ -4459,7 +4459,7 @@ public class AttributesManagerEntry implements AttributesManager {
 
 		// Authorization
 		if(!AuthzResolver.authorizedInternal(sess, "doTheMagic_Member_policy", member)) {
-			throw new PrivilegeException("This operation can do only PerunAdmin.");
+			throw new PrivilegeException("doTheMagic");
 		}
 
 		getAttributesManagerBl().doTheMagic(sess, member);
@@ -4472,7 +4472,7 @@ public class AttributesManagerEntry implements AttributesManager {
 
 		// Authorization
 		if(!AuthzResolver.authorizedInternal(sess, "doTheMagic_Member_boolean_policy", member)) {
-			throw new PrivilegeException("This operation can do only PerunAdmin.");
+			throw new PrivilegeException("doTheMagic");
 		}
 
 		getAttributesManagerBl().doTheMagic(sess, member, trueMagic);
@@ -4486,7 +4486,7 @@ public class AttributesManagerEntry implements AttributesManager {
 
 		// Authorization
 		if(!AuthzResolver.authorizedInternal(sess, "getAttributeRights_int_policy")) {
-			throw new PrivilegeException("This operation can be done only by PerunAdmin or PerunObserver.");
+			throw new PrivilegeException("getAttributeRights");
 		}
 
 		return getAttributesManagerBl().getAttributeRights(sess, attributeId);
@@ -4505,7 +4505,7 @@ public class AttributesManagerEntry implements AttributesManager {
 
 		// Authorization
 		if(!AuthzResolver.authorizedInternal(sess, "setAttributeRights_List<AttributeRights>_policy")) {
-			throw new PrivilegeException("This operation can do only PerunAdmin.");
+			throw new PrivilegeException("setAttributeRights");
 		}
 
 		getAttributesManagerBl().setAttributeRights(sess, rights);
@@ -4540,7 +4540,7 @@ public class AttributesManagerEntry implements AttributesManager {
 
 		// Authorization
 		if (!AuthzResolver.authorizedInternal(session, "getModulesDependenciesGraph_GraphTextFormat_policy")) {
-			throw new PrivilegeException("This operation can be done only by PerunAdmin or PerunObserver.");
+			throw new PrivilegeException("getModulesDependenciesGraph");
 		}
 
 		return new GraphDTO(attributesManagerBl.getAttributeModulesDependenciesGraphAsString(session, format), format.name());
@@ -4551,7 +4551,7 @@ public class AttributesManagerEntry implements AttributesManager {
 
 		// Authorization
 		if (!AuthzResolver.authorizedInternal(session, "getModulesDependenciesGraph_GraphTextFormat_String_policy")) {
-			throw new PrivilegeException("This operation can be done only by PerunAdmin or PerunObserver.");
+			throw new PrivilegeException("getModulesDependenciesGraph");
 		}
 
 		AttributeDefinition definition = attributesManagerBl.getAttributeDefinition(session, attributeName);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntry.java
@@ -624,7 +624,7 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 				if(hasRight) continue;
 			}
 
-			throw new PrivilegeException(sess, "You can't add host " + host + ", because you don't have privileges to use this hostName");
+			throw new PrivilegeException(sess, "addHosts(" + host + ")");
 		}
 
 		return getFacilitiesManagerBl().addHosts(sess, hosts, facility);
@@ -676,7 +676,7 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 				if(hasRight) continue;
 			}
 
-			throw new PrivilegeException(sess, "You can't add host " + hostname + ", because you don't have privileges to use this hostName");
+			throw new PrivilegeException(sess, "addHosts(" + hostname + ")");
 		}
 
 		return getFacilitiesManagerBl().addHosts(sess, facility, hosts);
@@ -993,7 +993,7 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 			if(hasRight) return getFacilitiesManagerBl().addHost(sess, host, facility);
 		}
 
-		throw new PrivilegeException(sess, "You can't add host " + host + ", because you don't have privileges to use this hostName");
+		throw new PrivilegeException(sess, "addHost(" + host + ")");
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/GroupsManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/GroupsManagerEntry.java
@@ -924,7 +924,7 @@ public class GroupsManagerEntry implements GroupsManager {
 
 		// Authorization
 		if (!AuthzResolver.authorizedInternal(sess, "getSubGroupsCount_Group_policy", parentGroup)) {
-			throw new PrivilegeException(sess, "getSubGroupsCount for " + parentGroup.getName());
+			throw new PrivilegeException(sess, "getSubGroupsCount");
 				}
 
 		return getGroupsManagerBl().getSubGroupsCount(sess, parentGroup);
@@ -952,7 +952,7 @@ public class GroupsManagerEntry implements GroupsManager {
 
 		// Authorization
 		if (!AuthzResolver.authorizedInternal(sess, "getParentGroupMembers_Group_policy", group)) {
-			throw new PrivilegeException(sess, "getParentGroupMembers for " + group.getName());
+			throw new PrivilegeException(sess, "getParentGroupMembers");
 		}
 
 		return getGroupsManagerBl().getParentGroupMembers(sess, group);
@@ -965,7 +965,7 @@ public class GroupsManagerEntry implements GroupsManager {
 
 		// Authorization
 		if (!AuthzResolver.authorizedInternal(sess, "getParentGroupRichMembers_Group_policy", group)) {
-			throw new PrivilegeException(sess, "getParentGroupRichMembers for " + group.getName());
+			throw new PrivilegeException(sess, "getParentGroupRichMembers");
 		}
 
 		return getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, getGroupsManagerBl().getParentGroupRichMembers(sess, group), group, true);
@@ -978,7 +978,7 @@ public class GroupsManagerEntry implements GroupsManager {
 
 		// Authorization
 		if (!AuthzResolver.authorizedInternal(sess, "getParentGroupMembersWithAttributes_Group_policy", group)) {
-			throw new PrivilegeException(sess, "getParentGroupRichMembers for " + group.getName());
+			throw new PrivilegeException(sess, "getParentGroupRichMembers");
 				}
 
 		return getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, getGroupsManagerBl().getParentGroupRichMembersWithAttributes(sess, group), group, true);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ServicesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ServicesManagerEntry.java
@@ -696,7 +696,7 @@ public class ServicesManagerEntry implements ServicesManager {
 						break;
 					}
 				}
-				if(!hasRight) throw new PrivilegeException("You have no right to add this destination.");
+				if(!hasRight) throw new PrivilegeException("addDestination");
 			}
 
 			if(!facilitiesByDestination.isEmpty()) {
@@ -707,7 +707,7 @@ public class ServicesManagerEntry implements ServicesManager {
 						break;
 					}
 				}
-				if(!hasRight) throw new PrivilegeException("You have no right to add this destination.");
+				if(!hasRight) throw new PrivilegeException("addDestination");
 			}
 				}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
@@ -1320,7 +1320,7 @@ public class UsersManagerEntry implements UsersManager {
 		Utils.notNull(member, "member");
 		// Authorization
 		if (!AuthzResolver.authorizedInternal(sess, "getSponsors_Member_List<String>_policy", member)) {
-			throw new PrivilegeException(sess, "getSponsors can be called only by REGISTRAR");
+			throw new PrivilegeException(sess, "getSponsors");
 		}
 		List<User> sponsors = usersManagerBl.getSponsors(sess, member);
 		if (attrNames == null || attrNames.isEmpty()) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
@@ -362,7 +362,7 @@ public class UsersManagerEntry implements UsersManager {
 		// Authorization
 		if(!AuthzResolver.authorizedInternal(sess, "setSpecificUser_User_SpecificUserType_User_policy", specificUser) &&
 			!AuthzResolver.authorizedInternal(sess, "owner-setSpecificUser_User_SpecificUserType_User_policy", owner)) {
-			throw new PrivilegeException(sess, "Only PerunAdmin should have rights to call this method.");
+			throw new PrivilegeException(sess, "setSpecificUser");
 		}
 
 		//set specific user
@@ -377,7 +377,7 @@ public class UsersManagerEntry implements UsersManager {
 
 		// Authorization
 		if(!AuthzResolver.authorizedInternal(sess, "unsetSpecificUser_User_SpecificUserType_policy", specificUser)) {
-			throw new PrivilegeException(sess, "Only PerunAdmin should have rights to call this method.");
+			throw new PrivilegeException(sess, "unsetSpecificUser");
 		}
 
 		//set specific user


### PR DESCRIPTION
After failed authorizedInternal() check, make sure that the text in PrivilegeException contains only method name.