### PR TITLE
Sponsorship Expiration - cron

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/audit/events/ExpirationNotifScheduler/SponsorshipExpirationInAMonth.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/audit/events/ExpirationNotifScheduler/SponsorshipExpirationInAMonth.java
@@ -1,0 +1,38 @@
+package cz.metacentrum.perun.audit.events.ExpirationNotifScheduler;
+
+import cz.metacentrum.perun.audit.events.AuditEvent;
+import cz.metacentrum.perun.audit.events.EngineIgnoreEvent;
+import cz.metacentrum.perun.core.api.EnrichedSponsorship;
+
+/**
+ * @author Vojtech Sassmann <vojtech.sassmann@gmail.com>
+ */
+public class SponsorshipExpirationInAMonth extends AuditEvent implements EngineIgnoreEvent {
+
+	private EnrichedSponsorship sponsorship;
+	private String message;
+
+	@SuppressWarnings("unused") // used by jackson mapper
+	public SponsorshipExpirationInAMonth() {
+	}
+
+	public SponsorshipExpirationInAMonth(EnrichedSponsorship sponsorship) {
+		this.sponsorship = sponsorship;
+		this.message = formatMessage("Sponsorship of member %s by sponsor %s will expire in a month.",
+				sponsorship.getSponsoredMember(), sponsorship.getSponsor());
+	}
+
+	public EnrichedSponsorship getSponsorship() {
+		return sponsorship;
+	}
+
+	@Override
+	public String getMessage() {
+		return message;
+	}
+
+	@Override
+	public String toString() {
+		return message;
+	}
+}

--- a/perun-base/src/main/java/cz/metacentrum/perun/audit/events/ExpirationNotifScheduler/SponsorshipExpirationInDays.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/audit/events/ExpirationNotifScheduler/SponsorshipExpirationInDays.java
@@ -1,0 +1,45 @@
+package cz.metacentrum.perun.audit.events.ExpirationNotifScheduler;
+
+import cz.metacentrum.perun.audit.events.AuditEvent;
+import cz.metacentrum.perun.audit.events.EngineIgnoreEvent;
+import cz.metacentrum.perun.core.api.EnrichedSponsorship;
+
+/**
+ * @author Vojtech Sassmann <vojtech.sassmann@gmail.com>
+ */
+public class SponsorshipExpirationInDays extends AuditEvent implements EngineIgnoreEvent {
+
+	private EnrichedSponsorship sponsorship;
+	private int days;
+	private String message;
+
+	@SuppressWarnings("unused") // used by jackson mapper
+	public SponsorshipExpirationInDays() {
+	}
+
+	public SponsorshipExpirationInDays(EnrichedSponsorship sponsorship, int days) {
+		this.sponsorship = sponsorship;
+		this.days = days;
+		//TODO
+		this.message = formatMessage("Sponsorship of member %s by sponsor %s will expire in %d days.",
+				sponsorship.getSponsoredMember(), sponsorship.getSponsor(), days);
+	}
+
+	public EnrichedSponsorship getSponsorship() {
+		return sponsorship;
+	}
+
+	public int getDays() {
+		return days;
+	}
+
+	@Override
+	public String getMessage() {
+		return message;
+	}
+
+	@Override
+	public String toString() {
+		return message;
+	}
+}

--- a/perun-base/src/main/java/cz/metacentrum/perun/audit/events/ExpirationNotifScheduler/SponsorshipExpired.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/audit/events/ExpirationNotifScheduler/SponsorshipExpired.java
@@ -1,0 +1,37 @@
+package cz.metacentrum.perun.audit.events.ExpirationNotifScheduler;
+
+import cz.metacentrum.perun.audit.events.AuditEvent;
+import cz.metacentrum.perun.audit.events.EngineIgnoreEvent;
+import cz.metacentrum.perun.core.api.EnrichedSponsorship;
+
+/**
+ * @author Vojtech Sassmann <vojtech.sassmann@gmail.com>
+ */
+public class SponsorshipExpired extends AuditEvent implements EngineIgnoreEvent {
+	private EnrichedSponsorship sponsorship;
+	private String message;
+
+	@SuppressWarnings("unused") // used by jackson mapper
+	public SponsorshipExpired() {
+	}
+
+	public SponsorshipExpired(EnrichedSponsorship sponsorship) {
+		this.sponsorship = sponsorship;
+		this.message = formatMessage("Sponsorship of member %s by sponsor %s has expired.",
+				sponsorship.getSponsoredMember(), sponsorship.getSponsor());
+	}
+
+	public EnrichedSponsorship getSponsorship() {
+		return sponsorship;
+	}
+
+	@Override
+	public String getMessage() {
+		return message;
+	}
+
+	@Override
+	public String toString() {
+		return message;
+	}
+}

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/EnrichedSponsorship.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/EnrichedSponsorship.java
@@ -1,0 +1,73 @@
+package cz.metacentrum.perun.core.api;
+
+import java.time.LocalDate;
+
+/**
+ * @author Vojtech Sassmann <vojtech.sassmann@gmail.com>
+ */
+public class EnrichedSponsorship {
+	private User sponsor;
+	private Member sponsoredMember;
+	private LocalDate validityTo;
+	private boolean active;
+
+	public User getSponsor() {
+		return sponsor;
+	}
+
+	public void setSponsor(User sponsor) {
+		this.sponsor = sponsor;
+	}
+
+	public Member getSponsoredMember() {
+		return sponsoredMember;
+	}
+
+	public void setSponsoredMember(Member sponsoredMember) {
+		this.sponsoredMember = sponsoredMember;
+	}
+
+	public LocalDate getValidityTo() {
+		return validityTo;
+	}
+
+	public void setValidityTo(LocalDate validityTo) {
+		this.validityTo = validityTo;
+	}
+
+	public boolean isActive() {
+		return active;
+	}
+
+	public void setActive(boolean active) {
+		this.active = active;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+
+		EnrichedSponsorship that = (EnrichedSponsorship) o;
+
+		if (getSponsor() != null ? !getSponsor().equals(that.getSponsor()) : that.getSponsor() != null) return false;
+		return getSponsoredMember() != null ? getSponsoredMember().equals(that.getSponsoredMember()) : that.getSponsoredMember() == null;
+	}
+
+	@Override
+	public int hashCode() {
+		int result = getSponsor() != null ? getSponsor().hashCode() : 0;
+		result = 31 * result + (getSponsoredMember() != null ? getSponsoredMember().hashCode() : 0);
+		return result;
+	}
+
+	@Override
+	public String toString() {
+		return "EnrichedSponsorship[" +
+				"sponsor=" + sponsor +
+				", sponsoredMember=" + sponsoredMember +
+				", validityTo=" + validityTo +
+				", active=" + active +
+				']';
+	}
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/MembersManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/MembersManagerBl.java
@@ -1686,4 +1686,15 @@ public interface MembersManagerBl {
 	 * @throws SponsorshipDoesNotExistException if the given user is not sponsor of the given member
 	 */
 	void updateSponsorshipValidity(PerunSession sess, Member sponsoredMember, User sponsor, LocalDate newValidity) throws SponsorshipDoesNotExistException;
+
+	/**
+	 * Returns sponsorship, which have validityTo in range [from, to).
+	 * (from is inclusive, to is exclusive).
+	 *
+	 * @param sess session
+	 * @param from lower validityTo bound (inclusive), use LocalDate.MIN if you don't want to specify the lower bound
+	 * @param to upper validityTo bound (exclusive), use LocalDate.MAX, if you don't want to specify the upper bound
+	 * @return list of sponsorships which have validityTo set in the given range
+	 */
+	List<Sponsorship> getSponsorshipsExpiringInRange(PerunSession sess, LocalDate from, LocalDate to);
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
@@ -2487,6 +2487,13 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 		perunBl.getAuditer().log(sess, new SponsorshipValidityUpdated(sponsoredMember, sponsor, newValidity));
 	}
 
+	@Override
+	public List<Sponsorship> getSponsorshipsExpiringInRange(PerunSession sess, LocalDate from, LocalDate to) {
+		Utils.notNull(from, "from");
+		Utils.notNull(to, "to");
+		return membersManagerImpl.getSponsorshipsExpiringInRange(sess, from, to);
+	}
+
 	/**
 	 * For given member, remove all of his bans on all entities.
 	 *

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/MembersManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/MembersManagerImpl.java
@@ -622,4 +622,11 @@ public class MembersManagerImpl implements MembersManagerImplApi {
 			throw new SponsorshipDoesNotExistException(sponsoredMember, sponsor);
 		}
 	}
+
+	@Override
+	public List<Sponsorship> getSponsorshipsExpiringInRange(PerunSession sess, LocalDate from, LocalDate to) {
+		return jdbc.query("SELECT " + memberSponsorshipSelectQuery + " FROM members_sponsored WHERE active=? AND " +
+						"validity_to >= ? AND validity_to < ?",
+				MEMBER_SPONSORSHIP_MAPPER, true, from, to);
+	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/MembersManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/MembersManagerImplApi.java
@@ -367,4 +367,15 @@ public interface MembersManagerImplApi {
 	 * @throws SponsorshipDoesNotExistException if the given user is not sponsor of the given member
 	 */
 	void updateSponsorshipValidity(PerunSession sess, Member sponsoredMember, User sponsor, LocalDate newValidity) throws SponsorshipDoesNotExistException;
+
+	/**
+	 * Returns sponsorship, which have validityTo in range [from, to).
+	 * (from is inclusive, to is exclusive).
+	 *
+	 * @param sess session
+	 * @param from lower validityTo bound (inclusive), use LocalDate.MIN if you don't want to specify the lower bound
+	 * @param to upper validityTo bound (exclusive), use LocalDate.MAX, if you don't want to specify the upper bound
+	 * @return list of sponsorships which have validityTo set in the given range
+	 */
+	List<Sponsorship> getSponsorshipsExpiringInRange(PerunSession sess, LocalDate from, LocalDate to);
 }


### PR DESCRIPTION
* Implemented expiring of sponsorship. If some sponsorships have
validityTo set in the past and are still active, they will be removed
and a SponsorshipExpired event will me emitted.
* Also, all incoming sponsorship expirations are audited. 1,7, and 14
days before the last day of validity, a SponsorspiExpirationInDays is
emmited. 28 days before the last day of validity, a
SponsorshipExpirationInDays is emitted.