### PR TITLE
NotfScheduler - bug fix

### DIFF
--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/ExpirationNotifScheduler.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/ExpirationNotifScheduler.java
@@ -470,7 +470,7 @@ public class ExpirationNotifScheduler {
 	 * @param vos vos where the auto extension will be performed
 	 */
 	private void performAutoExtension(Collection<Vo> vos) {
-		LocalDate nextMonth = getCurrentLocalDate().plusMonths(1);
+		LocalDate nextMonth = getCurrentLocalDate().plusDays(28);
 
 		List<Member> soonExpiringMembers = perun.getSearcherBl().getMembersByExpiration(sess, "<=", nextMonth);
 
@@ -708,7 +708,7 @@ public class ExpirationNotifScheduler {
 	 * @throws InternalErrorException internal error
 	 */
 	private void auditIncomingExpirations(List<Status> allowedStatuses, Map<Integer, Vo> vosMap) {
-		LocalDate nextMonth = getCurrentLocalDate().plusMonths(1);
+		LocalDate nextMonth = getCurrentLocalDate().plusDays(28);
 
 		// log message for all members which will expire in 30 days
 		auditInfoAboutIncomingMembersExpirationInGivenTime(allowedStatuses, vosMap, nextMonth, ExpirationPeriod.MONTH);
@@ -734,7 +734,7 @@ public class ExpirationNotifScheduler {
 	 * @throws InternalErrorException internal error
 	 */
 	private void auditIncomingGroupExpirations(List<Status> allowedStatuses, Group group) {
-		LocalDate nextMonth = getCurrentLocalDate().plusMonths(1);
+		LocalDate nextMonth = getCurrentLocalDate().plusDays(28);
 
 		// log message for all members which will expire in 30 days
 		auditInfoAboutIncomingGroupMembersExpirationInGivenTime(allowedStatuses, group, nextMonth, GroupExpirationPeriod.MONTH);


### PR DESCRIPTION
* When resolving incoming expirations, to calculate expirations in a
month, we need to use some fixed number of days, instead of plus month.
If we use plusMonth, multiple days might resolve to the same day. Or,
some days might not even be resolved and because of that, some users
might not get the one month notification. E.g. 28-1-2000 + month ->
28-2-2000 but 29-1-2000 + month -> 28-2-2000 as well. And for
expirations on 31-3-2000 there will be no notification.