### PR TITLE
Bump version to 3.12.0-SNAPSHOT

### DIFF
--- a/perun-auditparser/pom.xml
+++ b/perun-auditparser/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<artifactId>perun</artifactId>
 		<groupId>cz.metacentrum</groupId>
-		<version>3.10.0-SNAPSHOT</version>
+		<version>3.12.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>cz.metacentrum.perun</groupId>

--- a/perun-base/pom.xml
+++ b/perun-base/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<artifactId>perun</artifactId>
 		<groupId>cz.metacentrum</groupId>
-		<version>3.10.0-SNAPSHOT</version>
+		<version>3.12.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>cz.metacentrum.perun</groupId>

--- a/perun-cabinet/pom.xml
+++ b/perun-cabinet/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<artifactId>perun</artifactId>
 		<groupId>cz.metacentrum</groupId>
-		<version>3.10.0-SNAPSHOT</version>
+		<version>3.12.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>cz.metacentrum.perun</groupId>

--- a/perun-cli-java/pom.xml
+++ b/perun-cli-java/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<artifactId>perun</artifactId>
 		<groupId>cz.metacentrum</groupId>
-		<version>3.10.0-SNAPSHOT</version>
+		<version>3.12.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>cz.metacentrum.perun</groupId>

--- a/perun-cli/Perun/Agent.pm
+++ b/perun-cli/Perun/Agent.pm
@@ -1,6 +1,6 @@
 package Perun::Agent;
 my $agentVersionMajor = '3';
-my $agentVersionMinor = '10';
+my $agentVersionMinor = '12';
 my $agentVersionPatch = '0';
 my $agentVersion = $agentVersionMajor . "." . $agentVersionMinor . "." . $agentVersionPatch;
 

--- a/perun-core/pom.xml
+++ b/perun-core/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<artifactId>perun</artifactId>
 		<groupId>cz.metacentrum</groupId>
-		<version>3.10.0-SNAPSHOT</version>
+		<version>3.12.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>cz.metacentrum.perun</groupId>

--- a/perun-dispatcher/pom.xml
+++ b/perun-dispatcher/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<artifactId>perun</artifactId>
 		<groupId>cz.metacentrum</groupId>
-		<version>3.10.0-SNAPSHOT</version>
+		<version>3.12.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>cz.metacentrum.perun</groupId>

--- a/perun-engine/pom.xml
+++ b/perun-engine/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<artifactId>perun</artifactId>
 		<groupId>cz.metacentrum</groupId>
-		<version>3.10.0-SNAPSHOT</version>
+		<version>3.12.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>cz.metacentrum.perun</groupId>

--- a/perun-ldapc/pom.xml
+++ b/perun-ldapc/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<artifactId>perun</artifactId>
 		<groupId>cz.metacentrum</groupId>
-		<version>3.10.0-SNAPSHOT</version>
+		<version>3.12.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>cz.metacentrum.perun</groupId>

--- a/perun-notification/pom.xml
+++ b/perun-notification/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<artifactId>perun</artifactId>
 		<groupId>cz.metacentrum</groupId>
-		<version>3.10.0-SNAPSHOT</version>
+		<version>3.12.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>cz.metacentrum.perun</groupId>

--- a/perun-openapi/pom.xml
+++ b/perun-openapi/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<artifactId>perun</artifactId>
 		<groupId>cz.metacentrum</groupId>
-		<version>3.10.0-SNAPSHOT</version>
+		<version>3.12.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>cz.metacentrum.perun</groupId>

--- a/perun-registrar-lib/pom.xml
+++ b/perun-registrar-lib/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<artifactId>perun</artifactId>
 		<groupId>cz.metacentrum</groupId>
-		<version>3.10.0-SNAPSHOT</version>
+		<version>3.12.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>cz.metacentrum.perun</groupId>

--- a/perun-rpc/pom.xml
+++ b/perun-rpc/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<artifactId>perun</artifactId>
 		<groupId>cz.metacentrum</groupId>
-		<version>3.10.0-SNAPSHOT</version>
+		<version>3.12.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>cz.metacentrum.perun</groupId>

--- a/perun-scim/pom.xml
+++ b/perun-scim/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<artifactId>perun</artifactId>
 		<groupId>cz.metacentrum</groupId>
-		<version>3.10.0-SNAPSHOT</version>
+		<version>3.12.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>cz.metacentrum.perun</groupId>

--- a/perun-voot/pom.xml
+++ b/perun-voot/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<artifactId>perun</artifactId>
 		<groupId>cz.metacentrum</groupId>
-		<version>3.10.0-SNAPSHOT</version>
+		<version>3.12.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>cz.metacentrum.perun</groupId>

--- a/perun-web-gui/pom.xml
+++ b/perun-web-gui/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<artifactId>perun</artifactId>
 		<groupId>cz.metacentrum</groupId>
-		<version>3.10.0-SNAPSHOT</version>
+		<version>3.12.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>cz.metacentrum.perun</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	<!-- PERUN -->
 	<groupId>cz.metacentrum</groupId>
 	<artifactId>perun</artifactId>
-	<version>3.10.0-SNAPSHOT</version>
+	<version>3.12.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<!-- Spring Boot Starter Parent as parent project - this project inherits versions of dependencies and plugins -->


### PR DESCRIPTION
- Start new development cycle. We skip 3.11.0, since
  it will be done the old way in own branch.