### PR TITLE
GetAdminGroups - allow SPONSOR role

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/AuthzResolver.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/AuthzResolver.java
@@ -973,7 +973,7 @@ public class AuthzResolver {
 	 * @param sess perun session
 	 * @param complementaryObjectId id of object for which we will get richUser administrators
 	 * @param complementaryObjectName name of object for which we will get richUser administrators
-	 * @param role expected role to filter authorizedGroups by (PERUNADMIN | VOADMIN | GROUPADMIN | SELF | FACILITYADMIN | VOOBSERVER | TOPGROUPCREATOR | RESOURCEADMIN)
+	 * @param role expected role to filter authorizedGroups by (PERUNADMIN | VOADMIN | GROUPADMIN | SPONSOR | SELF | FACILITYADMIN | VOOBSERVER | TOPGROUPCREATOR | RESOURCEADMIN)
 	 *
 	 * @return list of authorizedGroups for complementary object and role
 	 */

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/VosManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/VosManager.java
@@ -307,7 +307,7 @@ public interface VosManager {
 	/**
 	 * Get list of group administrators of the given VO.
 	 *
-	 * Supported roles: VOOBSERVER, TOPGROUPCREATOR, VOADMIN
+	 * Supported roles: VOOBSERVER, TOPGROUPCREATOR, VOADMIN, SPONSOR
 	 *
 	 * @param perunSession
 	 * @param vo

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/VosManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/VosManagerEntry.java
@@ -380,8 +380,9 @@ public class VosManagerEntry implements VosManager {
 		//Role can be only supported one (TopGroupCreator, VoAdmin or VoObserver)
 		if(!role.equals(Role.TOPGROUPCREATOR) &&
 						!role.equals(Role.VOADMIN) &&
+						!role.equals(Role.SPONSOR) &&
 						!role.equals(Role.VOOBSERVER)) {
-			throw new RoleNotSupportedException("Supported roles are VoAdmin, VoObserver and TopGroupCreator.", role);
+			throw new RoleNotSupportedException("Supported roles are VoAdmin, VoObserver, Sponsor and TopGroupCreator.", role);
 		}
 
 		// Authorization

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/VosManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/VosManagerMethod.java
@@ -465,7 +465,7 @@ public enum VosManagerMethod implements ManagerMethod {
 	/*#
 	 * Get list of administrator groups of the given VO.
 	 *
-	 * Supported roles: VOOBSERVER, TOPGROUPCREATOR, VOADMIN
+	 * Supported roles: VOOBSERVER, TOPGROUPCREATOR, VOADMIN, SPONSOR
 	 *
 	 * @param vo int VO <code>id</code>
 	 * @param role String Role name


### PR DESCRIPTION
* We need to be able to return groups which have the SPONSOR role set
for given vo. This is a temporary fix as more complex changes will be
done in the future.