### PR TITLE
RPC: Removed unused password property form method API

### DIFF
--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/MembersManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/MembersManagerMethod.java
@@ -241,7 +241,6 @@ public enum MembersManagerMethod implements ManagerMethod {
 		@Override
 		public Map<String, Map<String, String>> call(ApiCaller ac, Deserializer params) throws PerunException {
 			params.stateChangingCheck();
-			String password = params.readString("password");
 			Vo vo =  ac.getVoById(params.readInt("vo"));
 			String namespace = params.readString("namespace");
 			LocalDate validityTo = null;


### PR DESCRIPTION
- Removed unused password property in API method
  membersManager/createSponsoredMembers(). It was
  throwing exceptions for correct calls.