### PR TITLE
RPC: Add commented option for timeout

### DIFF
--- a/perun-rpc/pom.xml
+++ b/perun-rpc/pom.xml
@@ -47,6 +47,9 @@
 							<!-- Force running against real DB -->
 							<spring.profiles.active>production</spring.profiles.active>
 						</systemProperties>
+						<!-- uncomment in case that dispatcher init takes too long
+						<timeout>600000</timeout>
+						 -->
 					</container>
 					<configuration>
 						<home>${basedir}/target/cargo/tomcat8x</home>


### PR DESCRIPTION
- If we run Perun locally by cargo plugin, there might
  be too short default timeout for app deployment, if
  dispatcher initialization takes too long (remote db).
- Added commented option with new timeout, so that we
  can uncomment it when needed.