### PR TITLE
Specific users refactorization

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/MembersManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/MembersManagerBl.java
@@ -88,27 +88,26 @@ public interface MembersManagerBl {
 	void deleteAllMembers(PerunSession sess, Vo vo) throws MemberAlreadyRemovedException;
 
 	/**
-	 * Creates a new member from candidate which is prepared for creating specificUser
-	 * In list specificUserOwners can't be specific user, only normal users and sponsored users are allowed.
+	 * Creates a new member from candidate which is prepared for creating service user.
+	 * In list specificUserOwners can't be service user, only normal users are allowed.
 	 * <strong>This method runs WITHOUT synchronization. If validation is needed, need to call concrete validateMember method (validateMemberAsync recommended).</strong>
 	 *
 	 * @param sess
 	 * @param vo
 	 * @param candidate prepared future specificUser
-	 * @param specificUserOwners list of users who own specificUser (can't be empty or contain specific user)
-	 * @param specificUserType type of specific user (service)
-	 * @return newly created member (of specific User)
+	 * @param owners list of users who own the service (can't be empty or contain specific user)
+	 * @return newly created member (of service User)
 	 * @throws InternalErrorException
 	 * @throws WrongAttributeValueException
 	 * @throws WrongReferenceAttributeValueException
 	 * @throws AlreadyMemberException
 	 * @throws ExtendMembershipException
 	 */
-	Member createSpecificMember(PerunSession sess, Vo vo, Candidate candidate, List<User> specificUserOwners, SpecificUserType specificUserType) throws WrongAttributeValueException, WrongReferenceAttributeValueException, AlreadyMemberException, ExtendMembershipException;
+	Member createServiceMember(PerunSession sess, Vo vo, Candidate candidate, List<User> owners) throws WrongAttributeValueException, WrongReferenceAttributeValueException, AlreadyMemberException, ExtendMembershipException;
 
 	/**
-	 * Creates a new member from candidate which is prepared for creating specificUser
-	 * In list specificUserOwners can't be specific user, only normal users and sponsored users are allowed.
+	 * Creates a new member from candidate which is prepared for creating service user.
+	 * In list specificUserOwners can't be service user, only normal users are allowed.
 	 *
 	 * Also add this member to groups in list.
 	 *
@@ -117,8 +116,7 @@ public interface MembersManagerBl {
 	 * @param sess
 	 * @param vo
 	 * @param candidate prepared future specificUser
-	 * @param specificUserOwners list of users who own specificUser (can't be empty or contain specific user)
-	 * @param specificUserType type of specific user (service)
+	 * @param owners list of users who own the service user (can't be empty or contain service user)
 	 * @param groups list of groups where member will be added too
 	 * @return newly created member (of specific User)
 	 * @throws InternalErrorException
@@ -127,7 +125,7 @@ public interface MembersManagerBl {
 	 * @throws AlreadyMemberException
 	 * @throws ExtendMembershipException
 	 */
-	Member createSpecificMember(PerunSession sess, Vo vo, Candidate candidate, List<User> specificUserOwners, SpecificUserType specificUserType, List<Group> groups) throws WrongAttributeValueException, WrongReferenceAttributeValueException, AlreadyMemberException, ExtendMembershipException;
+	Member createServiceMember(PerunSession sess, Vo vo, Candidate candidate, List<User> owners, List<Group> groups) throws WrongAttributeValueException, WrongReferenceAttributeValueException, AlreadyMemberException, ExtendMembershipException;
 
 	/**
 	 * Creates a new member and sets all member's attributes from the candidate.
@@ -301,22 +299,6 @@ public interface MembersManagerBl {
 	 * @see cz.metacentrum.perun.core.bl.MembersManagerBl#createMember(PerunSession, Vo, Candidate)
 	 */
 	Member createMember(PerunSession sess, Vo vo, SpecificUserType specificUserType, Candidate candidate, List<Group> groups, List<String> overwriteUserAttributes) throws WrongAttributeValueException, WrongReferenceAttributeValueException, AlreadyMemberException, ExtendMembershipException;
-
-	/**
-	 * Creates Specific Member.
-	 * This method creates specific member and then validate it <strong>Synchronously</strong>
-	 *
-	 * @see cz.metacentrum.perun.core.bl.MembersManagerBl#createSpecificMember(PerunSession, Vo, Candidate, List<User>)
-	 */
-	Member createSpecificMemberSync(PerunSession sess, Vo vo, Candidate candidate, List<User> serviceUserOwners, SpecificUserType specificUserType) throws WrongAttributeValueException, WrongReferenceAttributeValueException, AlreadyMemberException, ExtendMembershipException;
-
-	/**
-	 * Creates Specific Member and add him also to all groups in list.
-	 * This method creates specific member and then validate it <strong>Synchronously</strong>
-	 *
-	 * @see cz.metacentrum.perun.core.bl.MembersManagerBl#createSpecificMember(PerunSession, Vo, Candidate, List<User>)
-	 */
-	Member createSpecificMemberSync(PerunSession sess, Vo vo, Candidate candidate, List<User> specificUserOwners, SpecificUserType specificUserType, List<Group> groups) throws WrongAttributeValueException, WrongReferenceAttributeValueException, AlreadyMemberException, ExtendMembershipException;
 
 	/**
 	 * Transform non-sponsored member to sponsored one with defined sponsor

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
@@ -257,13 +257,13 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 	}
 
 	@Override
-	public Member createSpecificMember(PerunSession sess, Vo vo, Candidate candidate, List<User> specificUserOwners, SpecificUserType specificUserType) throws WrongAttributeValueException, WrongReferenceAttributeValueException, AlreadyMemberException, ExtendMembershipException {
-		return this.createSpecificMember(sess, vo, candidate, specificUserOwners, specificUserType, null);
+	public Member createServiceMember(PerunSession sess, Vo vo, Candidate candidate, List<User> owners) throws WrongAttributeValueException, WrongReferenceAttributeValueException, AlreadyMemberException, ExtendMembershipException {
+		return this.createServiceMember(sess, vo, candidate, owners, null);
 	}
 
 	@Override
-	public Member createSpecificMember(PerunSession sess, Vo vo, Candidate candidate, List<User> specificUserOwners, SpecificUserType specificUserType, List<Group> groups) throws WrongAttributeValueException, WrongReferenceAttributeValueException, AlreadyMemberException, ExtendMembershipException {
-		if(specificUserType.equals(SpecificUserType.SERVICE)) candidate.setFirstName("(Service)");
+	public Member createServiceMember(PerunSession sess, Vo vo, Candidate candidate, List<User> specificUserOwners, List<Group> groups) throws WrongAttributeValueException, WrongReferenceAttributeValueException, AlreadyMemberException, ExtendMembershipException {
+		candidate.setFirstName("(Service)");
 
 		//Set organization only if user in sessione exists (in tests there is no user in session)
 		if(sess.getPerunPrincipal().getUser() != null) {
@@ -291,7 +291,7 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 		}
 
 		//create member for service user from candidate
-		Member member = createMember(sess, vo, specificUserType, candidate, groups, null);
+		Member member = createMember(sess, vo, SpecificUserType.SERVICE, candidate, groups, null);
 
 		//set specific user owners or sponsors
 		User specificUser = getPerunBl().getUsersManagerBl().getUserByMember(sess, member);
@@ -327,26 +327,6 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 	@Override
 	public Member createMemberSync(PerunSession sess, Vo vo, Candidate candidate, List<Group> groups) throws WrongAttributeValueException, WrongReferenceAttributeValueException, AlreadyMemberException, ExtendMembershipException {
 		return this.createMemberSync(sess, vo, candidate, groups, null);
-	}
-
-	@Override
-	public Member createSpecificMemberSync(PerunSession sess, Vo vo, Candidate candidate, List<User> specificUserOwners, SpecificUserType specificUserType) throws WrongAttributeValueException, WrongReferenceAttributeValueException, AlreadyMemberException, ExtendMembershipException {
-		return this.createSpecificMemberSync(sess, vo, candidate, specificUserOwners, specificUserType, null);
-	}
-
-	@Override
-	public Member createSpecificMemberSync(PerunSession sess, Vo vo, Candidate candidate, List<User> specificUserOwners, SpecificUserType specificUserType, List<Group> groups) throws WrongAttributeValueException, WrongReferenceAttributeValueException, AlreadyMemberException, ExtendMembershipException {
-
-		Member member = createSpecificMember(sess, vo, candidate, specificUserOwners, specificUserType, groups);
-
-		//Validate synchronously
-		try {
-			member = validateMember(sess, member);
-		} catch (AttributeValueException ex) {
-			log.info("Specific Member can't be validated. He stays in invalid state. Cause: " + ex);
-		}
-
-		return member;
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
@@ -173,6 +173,7 @@ public class UsersManagerBlImpl implements UsersManagerBl {
 		this.removeSpecificUserOwner(sess, user, specificUser, false);
 	}
 
+	@Override
 	public void removeSpecificUserOwner(PerunSession sess, User user, User specificUser, boolean forceDelete) throws RelationNotExistsException, SpecificUserOwnerAlreadyRemovedException {
 		if(specificUser.isServiceUser() && specificUser.isSponsoredUser()) throw new InternalErrorException("We don't support specific and sponsored users together yet.");
 		if(specificUser.getMajorSpecificType().equals(SpecificUserType.NORMAL)) throw new InternalErrorException("Incorrect type of specification for specific user!" + specificUser);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/MembersManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/MembersManagerEntry.java
@@ -5,7 +5,6 @@ import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AuthzResolver;
 import cz.metacentrum.perun.core.api.Candidate;
 import cz.metacentrum.perun.core.api.Sponsor;
-import cz.metacentrum.perun.core.api.Sponsorship;
 import cz.metacentrum.perun.core.api.ExtSource;
 import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.Member;
@@ -178,7 +177,7 @@ public class MembersManagerEntry implements MembersManager {
 			}
 		}
 
-		return getMembersManagerBl().createSpecificMember(sess, vo, candidate, specificUserOwners, specificUserType, groups);
+		return getMembersManagerBl().createServiceMember(sess, vo, candidate, specificUserOwners, groups);
 	}
 
 	@Override

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/UsersManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/UsersManagerEntryIntegrationTest.java
@@ -14,7 +14,6 @@ import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.Member;
 import cz.metacentrum.perun.core.api.MemberGroupStatus;
-import cz.metacentrum.perun.core.api.MemberWithSponsors;
 import cz.metacentrum.perun.core.api.Owner;
 import cz.metacentrum.perun.core.api.OwnerType;
 import cz.metacentrum.perun.core.api.Resource;
@@ -175,7 +174,6 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 		List<User> users = usersManager.getSpecificUsers(sess);
 		assertTrue(users.contains(serviceUser1));
 		assertTrue(users.contains(serviceUser2));
-		assertTrue(users.contains(sponsoredUser));
 	}
 
 	@Test
@@ -193,15 +191,6 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 		assertTrue("User should be service user again", user2.isServiceUser());
 		List<User> owners = usersManager.getUsersBySpecificUser(sess, user2);
 		assertTrue("There should be just our owner", owners.size() == 1 && owners.contains(owner));
-	}
-
-	@Test
-	public void getUsersBySponsoredUser() throws Exception {
-		System.out.println(CLASS_NAME + "getUsersBySponsoredUser");
-
-		List<User> users = usersManager.getUsersBySpecificUser(sess, sponsoredUser);
-		assertTrue(users.contains(user));
-		assertTrue(users.size() == 1);
 	}
 
 	@Test
@@ -229,8 +218,7 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 		List<User> users = usersManager.getSpecificUsersByUser(sess, user);
 		assertTrue(users.contains(serviceUser1));
 		assertTrue(users.contains(serviceUser2));
-		assertTrue(users.contains(sponsoredUser));
-		assertTrue(users.size() == 3);
+		assertTrue(users.size() == 2);
 	}
 
 	@Test
@@ -238,7 +226,6 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 		System.out.println(CLASS_NAME + "modifyOwnership");
 
 		usersManager.removeSpecificUserOwner(sess, user, serviceUser1);
-		usersManager.removeSpecificUserOwner(sess, user, sponsoredUser);
 
 		List<User> users = usersManager.getSpecificUsersByUser(sess, user);
 		assertTrue(users.contains(serviceUser2));
@@ -258,13 +245,6 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 		assertTrue(users.contains(serviceUser1));
 		assertTrue(users.contains(serviceUser2));
 		assertTrue(users.size() == 2);
-
-		usersManager.addSpecificUserOwner(sess, user, sponsoredUser);
-		users = usersManager.getSpecificUsersByUser(sess, user);
-		assertTrue(users.contains(serviceUser1));
-		assertTrue(users.contains(serviceUser2));
-		assertTrue(users.contains(sponsoredUser));
-		assertTrue(users.size() == 3);
 	}
 
 	@Test (expected= RelationNotExistsException.class)
@@ -312,7 +292,6 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 		User userOfMember = perun.getUsersManagerBl().getUserByMember(sess, member);
 		assertTrue(!perun.getUsersManagerBl().specificUserOwnershipExists(sess, userOfMember, serviceUser1));
 		assertTrue(!perun.getUsersManagerBl().specificUserOwnershipExists(sess, userOfMember, serviceUser2));
-		assertTrue(!perun.getUsersManagerBl().specificUserOwnershipExists(sess, userOfMember, sponsoredUser));
 
 		usersManager.addSpecificUserOwner(sess, userOfMember, serviceUser1);
 		assertTrue(perun.getUsersManagerBl().specificUserOwnershipExists(sess, userOfMember, serviceUser1));
@@ -320,20 +299,14 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 		usersManager.addSpecificUserOwner(sess, userOfMember, serviceUser2);
 		assertTrue(perun.getUsersManagerBl().specificUserOwnershipExists(sess, userOfMember, serviceUser2));
 
-		usersManager.addSpecificUserOwner(sess, userOfMember, sponsoredUser);
-		assertTrue(perun.getUsersManagerBl().specificUserOwnershipExists(sess, userOfMember, sponsoredUser));
-
 		List<User> specificUsers = usersManager.getSpecificUsersByUser(sess, user);
 		assertTrue(specificUsers.contains(serviceUser1));
 		assertTrue(specificUsers.contains(serviceUser2));
-		assertTrue(specificUsers.contains(sponsoredUser));
-		assertTrue(specificUsers.size() == 3);
+		assertTrue(specificUsers.size() == 2);
 
 		usersManager.removeSpecificUserOwner(sess, user, serviceUser1);
-		usersManager.removeSpecificUserOwner(sess, user, sponsoredUser);
 		assertTrue(perun.getUsersManagerBl().specificUserOwnershipExists(sess, user, serviceUser1));
 		assertTrue(perun.getUsersManagerBl().specificUserOwnershipExists(sess, user, serviceUser2));
-		assertTrue(perun.getUsersManagerBl().specificUserOwnershipExists(sess, user, sponsoredUser));
 		specificUsers = usersManager.getSpecificUsersByUser(sess, user);
 		assertTrue(specificUsers.contains(serviceUser2));
 		assertTrue(specificUsers.size() == 1);
@@ -1536,11 +1509,10 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 
 		perun.getAttributesManagerBl().setAttribute(sess, user, emailAttribute);
 
-		AuthzResolverBlImpl.setRole(sess, user, vo, Role.SPONSOR);
 		Member member = perun.getMembersManagerBl().getMemberByUser(sess, vo, sponsoredUser);
 
 		LocalDate validity = LocalDate.now();
-		perun.getMembersManagerBl().setSponsorshipForMember(sess, member, user, validity);
+		perun.getMembersManagerBl().updateSponsorshipValidity(sess, member, user, validity);
 		Member sponsoredMember = perun.getMembersManagerBl().getMemberByUser(sess, vo, sponsoredUser);
 		List<Sponsor> sponsors = usersManager
 				.getSponsorsForMember(sess, sponsoredMember, Collections.singletonList(URN_ATTR_USER_PREFERRED_MAIL));
@@ -1637,7 +1609,8 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 		List<User> owners = new ArrayList<>();
 		owners.add(user);
 
-		Member serviceMember = perun.getMembersManagerBl().createSpecificMemberSync(sess, vo, candidate, owners, SpecificUserType.SERVICE);
+		Member serviceMember = perun.getMembersManagerBl().createServiceMember(sess, vo, candidate, owners);
+		perun.getMembersManagerBl().validateMember(sess, serviceMember);
 		// set first candidate as member of test VO
 		assertNotNull("No member created", serviceMember);
 		serviceUser1 = usersManager.getUserByMember(sess, serviceMember);
@@ -1650,7 +1623,8 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 		List<User> owners = new ArrayList<>();
 		owners.add(user);
 
-		Member serviceMember = perun.getMembersManagerBl().createSpecificMemberSync(sess, vo, candidate, owners, SpecificUserType.SERVICE);
+		Member serviceMember = perun.getMembersManagerBl().createServiceMember(sess, vo, candidate, owners);
+		perun.getMembersManagerBl().validateMember(sess, serviceMember);
 		// set first candidate as member of test VO
 		assertNotNull("No member created", serviceMember);
 		serviceUser2 = usersManager.getUserByMember(sess, serviceMember);
@@ -1660,10 +1634,10 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 	private void setUpSponsoredUserForVo(Vo vo) throws Exception {
 		Candidate candidate = setUpCandidateForSponsoredUser();
 
-		List<User> sponsors = new ArrayList<>();
-		sponsors.add(user);
-
-		Member sponsoredMember = perun.getMembersManagerBl().createSpecificMemberSync(sess, vo, candidate, sponsors, SpecificUserType.SPONSORED);
+		AuthzResolverBlImpl.setRole(sess, user, vo, Role.SPONSOR);
+		Member sponsoredMember = perun.getMembersManagerBl().createMember(sess, vo, candidate);
+		perun.getMembersManagerBl().setSponsorshipForMember(sess, sponsoredMember, user);
+		perun.getMembersManagerBl().validateMember(sess, sponsoredMember);
 		// set first candidate as member of test VO
 		assertNotNull("No member created", sponsoredMember);
 		sponsoredUser = usersManager.getUserByMember(sess, sponsoredMember);
@@ -1707,7 +1681,8 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 		// assertTrue(candidates.size() > 0);
 
 		Candidate candidate = setUpCandidate();
-		Member member = perun.getMembersManagerBl().createMemberSync(sess, vo, candidate); // candidates.get(0)
+		Member member = perun.getMembersManagerBl().createMember(sess, vo, candidate); // candidates.get(0)
+		perun.getMembersManagerBl().validateMember(sess, member);
 		// set first candidate as member of test VO
 		assertNotNull("No member created", member);
 		usersForDeletion.add(usersManager.getUserByMember(sess, member));


### PR DESCRIPTION
* Some methods working with specific users, were adjusted so it is more
clear, which method to use when working with sponsored and service
members.
* createSpecificMember methods renamed to createServiceMember and now
can create only service members.
* createSpecificMemberSync methods removed since they were used only in
tests and could be replaced by other methods calls.
* Tests were adjusted to the new formats.