### PR TITLE
Rewrite isCesnetEligibleLastSeen to user attribute

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_ues_attribute_def_def_isCesnetEligibleLastSeen.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_ues_attribute_def_def_isCesnetEligibleLastSeen.java
@@ -1,0 +1,101 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.UserExtSource;
+import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.ConsistencyErrorException;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import cz.metacentrum.perun.core.implApi.modules.attributes.UserExtSourceAttributesModuleAbstract;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+/**
+ * Attribute module for isCesnetEligibleLastSeen, value is String representing timestamp.
+ *
+ * @author Radoslav Čerhák <r.cerhak@gmail.com>
+ */
+public class urn_perun_ues_attribute_def_def_isCesnetEligibleLastSeen extends UserExtSourceAttributesModuleAbstract {
+
+	private static final String A_USER_DEF_IS_CESNET_ELIGIBLE_LAST_SEEN = AttributesManager.NS_USER_ATTR_DEF + ":isCesnetEligibleLastSeen";
+	private static final Logger log = LoggerFactory.getLogger(urn_perun_ues_attribute_def_def_isCesnetEligibleLastSeen.class);
+
+	@Override
+	public void checkAttributeSyntax(PerunSessionImpl perunSession, UserExtSource ues, Attribute attribute) throws WrongAttributeValueException {
+		if (attribute.getValue() == null) return;
+
+		DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+		dateFormat.setLenient(false);
+		try {
+			dateFormat.parse(attribute.valueAsString());
+		} catch (ParseException ex) {
+			throw new WrongAttributeValueException(attribute, "Format of timestamp is not correct, it should be 'yyyy-MM-dd HH:mm:ss'", ex);
+		}
+	}
+
+	/**
+	 * When isCesnetEligibleLastSeen of a user's ext source is set, check if it is
+	 * more recent than the user's current isCesnetEligibleLastSeen. If so, update it.
+	 *
+	 * @param session
+	 * @param ues
+	 * @param attribute
+	 */
+	@Override
+	public void changedAttributeHook(PerunSessionImpl session, UserExtSource ues, Attribute attribute) {
+		if (attribute.getValue() == null) return;
+
+		User user;
+		try {
+			user = session.getPerunBl().getUsersManagerBl().getUserById(session, ues.getUserId());
+		} catch (UserNotExistsException ex) {
+			throw new ConsistencyErrorException(ex);
+		}
+
+		Attribute userIsCesnetEligible;
+		try {
+			userIsCesnetEligible = session.getPerunBl().getAttributesManagerBl().getAttribute(session, user, A_USER_DEF_IS_CESNET_ELIGIBLE_LAST_SEEN);
+		} catch (AttributeNotExistsException ex) {
+			log.warn("Attribute {} doesn't exist.", A_USER_DEF_IS_CESNET_ELIGIBLE_LAST_SEEN);
+			return;
+		} catch (WrongAttributeAssignmentException ex) {
+			throw new InternalErrorException(ex);
+		}
+
+		DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+		dateFormat.setLenient(false);
+		try {
+			Date uesTimestamp = dateFormat.parse(attribute.valueAsString());
+			// if user's isCesnetEligibleLastSeen is null or earlier than new value of ues isCesnetEligibleLastSeen, update it
+			if (userIsCesnetEligible.getValue() == null || uesTimestamp.after(dateFormat.parse(userIsCesnetEligible.valueAsString()))) {
+				userIsCesnetEligible.setValue(attribute.getValue());
+				session.getPerunBl().getAttributesManagerBl().setAttribute(session, user, userIsCesnetEligible);
+			}
+		} catch (ParseException | WrongAttributeAssignmentException | WrongAttributeValueException | WrongReferenceAttributeValueException ex) {
+			throw new InternalErrorException(ex);
+		}
+	}
+
+	@Override
+	public AttributeDefinition getAttributeDefinition() {
+		AttributeDefinition attr = new AttributeDefinition();
+		attr.setNamespace(AttributesManager.NS_UES_ATTR_DEF);
+		attr.setFriendlyName("isCesnetEligibleLastSeen");
+		attr.setDisplayName("isCesnetEligibleLastSeen");
+		attr.setType(String.class.getName());
+		attr.setDescription("isCesnetEligibleLastSeen");
+		return attr;
+	}
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_isCesnetEligibleLastSeen.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_isCesnetEligibleLastSeen.java
@@ -1,0 +1,32 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import cz.metacentrum.perun.core.implApi.modules.attributes.UserAttributesModuleAbstract;
+
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+
+/**
+ * Attribute module for isCesnetEligibleLastSeen, value is String representing timestamp.
+ *
+ * @author Radoslav Čerhák <r.cerhak@gmail.com>
+ */
+public class urn_perun_user_attribute_def_def_isCesnetEligibleLastSeen extends UserAttributesModuleAbstract {
+
+	@Override
+	public void checkAttributeSyntax(PerunSessionImpl perunSession, User user, Attribute attribute) throws WrongAttributeValueException {
+		if (attribute.getValue() == null) return;
+
+		DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+		dateFormat.setLenient(false);
+		try {
+			dateFormat.parse(attribute.valueAsString());
+		} catch (ParseException ex) {
+			throw new WrongAttributeValueException(attribute, "Format of timestamp is not correct, it should be 'yyyy-MM-dd HH:mm:ss'", ex);
+		}
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_ues_attribute_def_def_isCesnetEligibleLastSeenTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_ues_attribute_def_def_isCesnetEligibleLastSeenTest.java
@@ -1,0 +1,165 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.AbstractPerunIntegrationTest;
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.UserExtSource;
+import cz.metacentrum.perun.core.api.exceptions.AttributeDefinitionExistsException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+
+public class urn_perun_ues_attribute_def_def_isCesnetEligibleLastSeenTest extends AbstractPerunIntegrationTest {
+	private urn_perun_ues_attribute_def_def_isCesnetEligibleLastSeen classInstance;
+	private Attribute uesAttribute;
+	private User user;
+	private PerunSessionImpl mockedSession;
+	private UserExtSource userExtSource;
+	private static final String A_USER_DEF_IS_CESNET_ELIGIBLE_LAST_SEEN = AttributesManager.NS_USER_ATTR_DEF + ":isCesnetEligibleLastSeen";
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_ues_attribute_def_def_isCesnetEligibleLastSeen();
+		mockedSession = mock(PerunSessionImpl.class);
+		uesAttribute = new Attribute();
+		setUpUser();
+		userExtSource = new UserExtSource();
+		userExtSource.setUserId(user.getId());
+
+		AttributeDefinition def = new AttributeDefinition();
+		def.setNamespace(AttributesManager.NS_USER_ATTR_DEF);
+		def.setType(String.class.getName());
+		def.setDescription("isCesnetEligibleLastSeen");
+		def.setDisplayName("isCesnetEligibleLastSeen");
+		def.setFriendlyName("isCesnetEligibleLastSeen");
+		try {
+			perun.getAttributesManagerBl().createAttribute(sess, def);
+		} catch (AttributeDefinitionExistsException ex) {
+			// OK
+		}
+	}
+
+	@Test
+	public void testCheckAttributeSyntaxCorrect() throws Exception {
+		System.out.println("testCheckAttributeSyntaxCorrect()");
+
+		uesAttribute.setValue("2019-06-17 17:18:28");
+
+		classInstance.checkAttributeSyntax(mockedSession, userExtSource, uesAttribute);
+	}
+
+	@Test
+	public void testCheckAttributeSyntaxCorrectWithMilliseconds() throws Exception {
+		System.out.println("testCheckAttributeSyntaxCorrectWithMilliseconds()");
+
+		uesAttribute.setValue("2019-06-17 17:18:28.22");
+
+		classInstance.checkAttributeSyntax(mockedSession, userExtSource, uesAttribute);
+	}
+
+	@Test
+	public void testCheckAttributeSyntaxNull() throws Exception {
+		System.out.println("testCheckAttributeSyntaxNull()");
+
+		uesAttribute.setValue(null);
+
+		classInstance.checkAttributeSyntax(mockedSession, userExtSource, uesAttribute);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckAttributeSyntaxIncorrect() throws Exception {
+		System.out.println("testCheckAttributeSyntaxIncorrect()");
+
+		uesAttribute.setValue("incorrect");
+
+		classInstance.checkAttributeSyntax(mockedSession, userExtSource, uesAttribute);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckAttributeSyntaxIncorrectMonths() throws Exception {
+		System.out.println("testCheckAttributeSyntaxIncorrectMonths()");
+
+		uesAttribute.setValue("2019-13-17 17:18:28");
+
+		classInstance.checkAttributeSyntax(mockedSession, userExtSource, uesAttribute);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckAttributeSyntaxIncorrectMinutes() throws Exception {
+		System.out.println("testCheckAttributeSyntaxIncorrectMinutes()");
+
+		uesAttribute.setValue("2019-12-17 17:68:28");
+
+		classInstance.checkAttributeSyntax(mockedSession, userExtSource, uesAttribute);
+	}
+
+	@Test
+	public void testChangedAttributeHookUserAttributeHasNullValue() throws Exception {
+		System.out.println("testChangedAttributeHookUserAttributeHasNullValue()");
+
+		uesAttribute.setValue("2019-06-17 17:18:28.5");
+
+		classInstance.changedAttributeHook((PerunSessionImpl) sess, userExtSource, uesAttribute);
+		Attribute userAttribute = perun.getAttributesManagerBl().getAttribute(sess, user, A_USER_DEF_IS_CESNET_ELIGIBLE_LAST_SEEN);
+		assertEquals(userAttribute.getValue(), uesAttribute.getValue());
+	}
+
+	@Test
+	public void testChangedAttributeHookAttributeWasRemoved() throws Exception {
+		System.out.println("testChangedAttributeHookAttributeWasRemoved()");
+
+		uesAttribute.setValue(null); // attribute was removed
+		String timestamp = "2019-06-17 17:18:28";
+		setUpUserIsCesnetEligibleAttribute(timestamp);
+
+		classInstance.changedAttributeHook((PerunSessionImpl) sess, userExtSource, uesAttribute);
+		Attribute userAttribute = perun.getAttributesManagerBl().getAttribute(sess, user, A_USER_DEF_IS_CESNET_ELIGIBLE_LAST_SEEN);
+		assertEquals(userAttribute.getValue(), timestamp);
+	}
+
+	@Test
+	public void testChangedAttributeHookValueIsMoreRecent() throws Exception {
+		System.out.println("testChangedAttributeHookValueIsMoreRecent()");
+
+		uesAttribute.setValue("2020-06-17 17:18:28");
+		setUpUserIsCesnetEligibleAttribute("2019-06-17 17:18:28");
+
+		classInstance.changedAttributeHook((PerunSessionImpl) sess, userExtSource, uesAttribute);
+		Attribute userAttribute = perun.getAttributesManagerBl().getAttribute(sess, user, A_USER_DEF_IS_CESNET_ELIGIBLE_LAST_SEEN);
+		assertEquals(userAttribute.getValue(), uesAttribute.getValue());
+	}
+
+	@Test
+	public void testChangedAttributeHookValueIsNotMoreRecent() throws Exception {
+		System.out.println("testChangedAttributeHookValueIsNotMoreRecent()");
+
+		uesAttribute.setValue("2018-06-17 17:18:28");
+		String timestamp = "2019-06-17 17:18:28";
+		setUpUserIsCesnetEligibleAttribute(timestamp);
+
+		classInstance.changedAttributeHook((PerunSessionImpl) sess, userExtSource, uesAttribute);
+		Attribute userAttribute = perun.getAttributesManagerBl().getAttribute(sess, user, A_USER_DEF_IS_CESNET_ELIGIBLE_LAST_SEEN);
+		assertEquals(userAttribute.getValue(), timestamp);
+	}
+
+	private void setUpUser() {
+		user = new User();
+		user.setFirstName("Firstname");
+		user.setLastName("Lastname");
+		user = perun.getUsersManagerBl().createUser(sess, user);
+		assertNotNull(user);
+	}
+
+	private void setUpUserIsCesnetEligibleAttribute(String value) throws Exception {
+		Attribute attr = new Attribute(perun.getAttributesManagerBl().getAttributeDefinition(sess, AttributesManager.NS_USER_ATTR_DEF + ":isCesnetEligibleLastSeen"));
+		attr.setValue(value);
+		perun.getAttributesManagerBl().setAttribute(sess, user, attr);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_isCesnetEligibleLastSeenTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_isCesnetEligibleLastSeenTest.java
@@ -1,0 +1,79 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+
+public class urn_perun_user_attribute_def_def_isCesnetEligibleLastSeenTest {
+	private urn_perun_user_attribute_def_def_isCesnetEligibleLastSeen classInstance;
+	private Attribute attributeToCheck;
+	private User user;
+	private PerunSessionImpl session;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_user_attribute_def_def_isCesnetEligibleLastSeen();
+		session = mock(PerunSessionImpl.class);
+		attributeToCheck = new Attribute();
+		user = new User();
+	}
+
+	@Test
+	public void testCheckAttributeSyntaxCorrect() throws Exception {
+		System.out.println("testCheckAttributeSyntaxCorrect()");
+
+		attributeToCheck.setValue("2019-06-17 17:18:28");
+
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+	}
+
+	@Test
+	public void testCheckAttributeSyntaxCorrectWithMilliseconds() throws Exception {
+		System.out.println("testCheckAttributeSyntaxCorrectWithMilliseconds()");
+
+		attributeToCheck.setValue("2019-06-17 17:18:28.22");
+
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+	}
+
+	@Test
+	public void testCheckAttributeSyntaxNull() throws Exception {
+		System.out.println("testCheckAttributeSyntaxNull()");
+
+		attributeToCheck.setValue(null);
+
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckAttributeSyntaxIncorrect() throws Exception {
+		System.out.println("testCheckAttributeSyntaxIncorrect()");
+
+		attributeToCheck.setValue("incorrect");
+
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckAttributeSyntaxIncorrectMonths() throws Exception {
+		System.out.println("testCheckAttributeSyntaxIncorrectMonths()");
+
+		attributeToCheck.setValue("2019-13-17 17:18:28");
+
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckAttributeSyntaxIncorrectMinutes() throws Exception {
+		System.out.println("testCheckAttributeSyntaxIncorrectMinutes()");
+
+		attributeToCheck.setValue("2019-12-17 17:68:28");
+
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+	}
+}


### PR DESCRIPTION
- Attribute ues:def:isCesnetEligibleLastSeen has String value representing
timestamp. When the value is set, user version of this attribute should be
updated if ues attribute’s value is more recent timestamp.
- Created module ues:def:isCesnetEligibleLastSeen and implemented its method
changedAttributeHook.