### PR TITLE
CreateSponsoredMember - email

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/MembersManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/MembersManager.java
@@ -1123,6 +1123,7 @@ public interface MembersManager {
 	 * @param namespace namespace for selecting password module
 	 * @param name a map containing the full name or its parts (mandatory: firstName, lastName; optionally: titleBefore, titleAfter)
 	 * @param password  password
+	 * @param email (optional) preferred email that will be set to the created user
 	 * @param sponsor sponsoring user or null for the caller
 	 * @param validityTo last day when the sponsorship is active (null means the sponsorship will last forever)
 	 * @return new Member in the Vo
@@ -1137,7 +1138,7 @@ public interface MembersManager {
 	 * @throws WrongReferenceAttributeValueException
 	 * @throws UserNotInRoleException
 	 */
-	RichMember createSponsoredMember(PerunSession session, Vo vo, String namespace, Map<String, String> name, String password, User sponsor, LocalDate validityTo) throws PrivilegeException, AlreadyMemberException, LoginNotExistsException, PasswordCreationFailedException, ExtendMembershipException, WrongAttributeValueException, ExtSourceNotExistsException, WrongReferenceAttributeValueException, UserNotInRoleException, PasswordStrengthException, InvalidLoginException;
+	RichMember createSponsoredMember(PerunSession session, Vo vo, String namespace, Map<String, String> name, String password, String email, User sponsor, LocalDate validityTo) throws PrivilegeException, AlreadyMemberException, LoginNotExistsException, PasswordCreationFailedException, ExtendMembershipException, WrongAttributeValueException, ExtSourceNotExistsException, WrongReferenceAttributeValueException, UserNotInRoleException, PasswordStrengthException, InvalidLoginException;
 
 	/**
 	 * Creates a sponsored membership for the given user.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/MembersManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/MembersManagerBl.java
@@ -1420,6 +1420,7 @@ public interface MembersManagerBl {
 	 * @param namespace used for selecting external system in which guest user account will be created
 	 * @param name a map containing the full name or its parts (mandatory: firstName, lastName; optionally: titleBefore, titleAfter)
 	 * @param password password
+	 * @param email (optional) preferred email that will be set to the created user
 	 * @param sponsor sponsoring user
 	 * @param asyncValidation
 	 * @return created member
@@ -1433,7 +1434,7 @@ public interface MembersManagerBl {
 	 * @throws WrongReferenceAttributeValueException
 	 * @throws UserNotInRoleException if the member is not in required role
 	 */
-	Member createSponsoredMember(PerunSession session, Vo vo, String namespace, Map<String, String> name, String password, User sponsor, boolean asyncValidation) throws AlreadyMemberException, LoginNotExistsException, PasswordCreationFailedException, ExtendMembershipException, WrongAttributeValueException, ExtSourceNotExistsException, WrongReferenceAttributeValueException, UserNotInRoleException, PasswordStrengthException, InvalidLoginException;
+	Member createSponsoredMember(PerunSession session, Vo vo, String namespace, Map<String, String> name, String password, String email, User sponsor, boolean asyncValidation) throws AlreadyMemberException, LoginNotExistsException, PasswordCreationFailedException, ExtendMembershipException, WrongAttributeValueException, ExtSourceNotExistsException, WrongReferenceAttributeValueException, UserNotInRoleException, PasswordStrengthException, InvalidLoginException;
 
 	/**
 	 * Creates a new sponsored member.
@@ -1443,6 +1444,7 @@ public interface MembersManagerBl {
 	 * @param namespace used for selecting external system in which guest user account will be created
 	 * @param name a map containing the full name or its parts (mandatory: firstName, lastName; optionally: titleBefore, titleAfter)
 	 * @param password password
+	 * @param email (optional) preferred email that will be set to the created user
 	 * @param sponsor sponsoring user
 	 * @param validityTo last day when the sponsorship is active (null means the sponsorship will last forever)
 	 * @param asyncValidation
@@ -1457,7 +1459,7 @@ public interface MembersManagerBl {
 	 * @throws WrongReferenceAttributeValueException
 	 * @throws UserNotInRoleException if the member is not in required role
 	 */
-	Member createSponsoredMember(PerunSession session, Vo vo, String namespace, Map<String, String> name, String password, User sponsor, LocalDate validityTo, boolean asyncValidation) throws AlreadyMemberException, LoginNotExistsException, PasswordCreationFailedException, ExtendMembershipException, WrongAttributeValueException, ExtSourceNotExistsException, WrongReferenceAttributeValueException, UserNotInRoleException, PasswordStrengthException, InvalidLoginException;
+	Member createSponsoredMember(PerunSession session, Vo vo, String namespace, Map<String, String> name, String password, String email, User sponsor, LocalDate validityTo, boolean asyncValidation) throws AlreadyMemberException, LoginNotExistsException, PasswordCreationFailedException, ExtendMembershipException, WrongAttributeValueException, ExtSourceNotExistsException, WrongReferenceAttributeValueException, UserNotInRoleException, PasswordStrengthException, InvalidLoginException;
 
 	/**
 	 * Creates a sponsored membership for the given user.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
@@ -120,6 +120,7 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 	final static Logger log = LoggerFactory.getLogger(MembersManagerBlImpl.class);
 
 	private static final String EXPIRATION = AttributesManager.NS_MEMBER_ATTR_DEF + ":membershipExpiration";
+	private static final String A_U_PREF_MAIL = AttributesManager.NS_USER_ATTR_DEF + ":preferredMail";
 
 	private final MembersManagerImplApi membersManagerImpl;
 	private PerunBl perunBl;
@@ -2233,14 +2234,17 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 
 
 	@Override
-	public Member createSponsoredMember(PerunSession session, Vo vo, String namespace, Map<String, String> name, String password, User sponsor, boolean asyncValidation) throws AlreadyMemberException, LoginNotExistsException, PasswordCreationFailedException, ExtendMembershipException, WrongAttributeValueException, ExtSourceNotExistsException, WrongReferenceAttributeValueException, UserNotInRoleException, InvalidLoginException {
-		return createSponsoredMember(session, vo, namespace, name, password, sponsor, null, asyncValidation);
+	public Member createSponsoredMember(PerunSession session, Vo vo, String namespace, Map<String, String> name, String password, String email, User sponsor, boolean asyncValidation) throws AlreadyMemberException, LoginNotExistsException, PasswordCreationFailedException, ExtendMembershipException, WrongAttributeValueException, ExtSourceNotExistsException, WrongReferenceAttributeValueException, UserNotInRoleException, InvalidLoginException {
+		return createSponsoredMember(session, vo, namespace, name, password, email, sponsor, null, asyncValidation);
 	}
 
 	@Override
 	public Member createSponsoredMember(PerunSession session, Vo vo, String namespace, Map<String, String> name,
-		String password, User sponsor, LocalDate validityTo, boolean asyncValidation) throws AlreadyMemberException, LoginNotExistsException, PasswordCreationFailedException, ExtendMembershipException, WrongAttributeValueException, ExtSourceNotExistsException, WrongReferenceAttributeValueException, UserNotInRoleException, InvalidLoginException {
+		String password, String email, User sponsor, LocalDate validityTo, boolean asyncValidation) throws AlreadyMemberException, LoginNotExistsException, PasswordCreationFailedException, ExtendMembershipException, WrongAttributeValueException, ExtSourceNotExistsException, WrongReferenceAttributeValueException, UserNotInRoleException, InvalidLoginException {
 
+		if (email != null && !Utils.emailPattern.matcher(email).matches()) {
+			throw new InternalErrorException("Email has an invalid format: " + email);
+		}
 		//create new user
 		User user;
 		if (name.containsKey("guestName")) {
@@ -2248,7 +2252,20 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 		} else {
 			user = Utils.createUserFromNameMap(name);
 		}
+
 		User sponsoredUser = getPerunBl().getUsersManagerBl().createUser(session, user);
+
+		if (email != null) {
+			try {
+				Attribute mailAttr = getPerunBl().getAttributesManagerBl().getAttribute(session, user, A_U_PREF_MAIL);
+
+				mailAttr.setValue(email);
+
+				getPerunBl().getAttributesManagerBl().setAttribute(session, user, mailAttr);
+			} catch (WrongAttributeAssignmentException | AttributeNotExistsException e) {
+				throw new InternalErrorException(e);
+			}
+		}
 
 		return setSponsoredMember(session, vo, sponsoredUser, namespace, password, sponsor, validityTo, asyncValidation);
 	}
@@ -2304,7 +2321,7 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 			User user;
 			try {
 				user = perunBl.getUsersManagerBl().getUserByMember(sess,
-						createSponsoredMember(sess, vo, namespace, mapName, password, sponsor, validityTo, asyncValidation));
+						createSponsoredMember(sess, vo, namespace, mapName, password, null, sponsor, validityTo, asyncValidation));
 				// get login to return
 				String login = perunBl.getAttributesManagerBl().getAttribute(sess, user, PasswordManagerModule.LOGIN_PREFIX + namespace).valueAsString();
 				Map<String, String> statusWithLogin = new HashMap<>();

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/MembersManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/MembersManagerEntry.java
@@ -1164,7 +1164,7 @@ public class MembersManagerEntry implements MembersManager {
 
 	@Override
 	public RichMember createSponsoredMember(PerunSession session, Vo vo, String namespace, Map<String, String> name,
-	                                        String password, User sponsor, LocalDate validityTo)
+	                                        String password, String email, User sponsor, LocalDate validityTo)
 			throws PrivilegeException, AlreadyMemberException, LoginNotExistsException, PasswordCreationFailedException,
 			ExtendMembershipException, WrongAttributeValueException, ExtSourceNotExistsException, WrongReferenceAttributeValueException,
 			UserNotInRoleException, PasswordStrengthException, InvalidLoginException {
@@ -1190,7 +1190,7 @@ public class MembersManagerEntry implements MembersManager {
 			}
 		}
 		//create the sponsored member
-		return membersManagerBl.getRichMember(session, membersManagerBl.createSponsoredMember(session, vo, namespace, name, password, sponsor, validityTo, true));
+		return membersManagerBl.getRichMember(session, membersManagerBl.createSponsoredMember(session, vo, namespace, name, password, email, sponsor, validityTo, true));
 	}
 
 	@Override

--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -7978,6 +7978,7 @@ paths:
                 titleBefore: { type: string}
                 titleAfter: { type: string }
                 password: { type: string }
+                email: { type: string }
                 vo: { type: integer }
                 sponsor: { type: integer }
                 namespace: { type: string }

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/MembersManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/MembersManagerMethod.java
@@ -3,6 +3,7 @@ package cz.metacentrum.perun.rpc.methods;
 import cz.metacentrum.perun.core.api.*;
 import cz.metacentrum.perun.core.api.exceptions.PerunException;
 import cz.metacentrum.perun.core.api.exceptions.RpcException;
+import cz.metacentrum.perun.core.impl.Utils;
 import cz.metacentrum.perun.rpc.ApiCaller;
 import cz.metacentrum.perun.rpc.ManagerMethod;
 import cz.metacentrum.perun.rpc.deserializer.Deserializer;
@@ -114,6 +115,7 @@ public enum MembersManagerMethod implements ManagerMethod {
 	 * @param vo int VO ID
 	 * @param namespace String namespace selecting remote system for storing the password
 	 * @param sponsor int sponsor's ID
+	 * @param email String email that will be set to the created user
 	 * @return RichMember newly created sponsored member
 	 */
 	/*#
@@ -130,6 +132,7 @@ public enum MembersManagerMethod implements ManagerMethod {
 	 * @param vo int VO ID
 	 * @param namespace String namespace selecting remote system for storing the password
 	 * @param sponsor int sponsor's ID
+	 * @param email String email that will be set to the created user
 	 * @param validityTo (Optional) String the last day, when the sponsorship is active, yyyy-mm-dd format.
 	 * @return RichMember newly created sponsored member
 	 */
@@ -140,6 +143,13 @@ public enum MembersManagerMethod implements ManagerMethod {
 			String password = params.readString("password");
 			Vo vo =  ac.getVoById(params.readInt("vo"));
 			String namespace = params.readString("namespace");
+			String email = null;
+			if (params.contains("mail")) {
+				email = params.readString("email");
+			}
+			if (email != null && !Utils.emailPattern.matcher(email).matches()) {
+				throw new RpcException(RpcException.Type.WRONG_PARAMETER, "Email has an invalid format.");
+			}
 			User sponsor = null;
 			LocalDate validityTo = null;
 			if (params.contains("validityTo")) {
@@ -159,7 +169,7 @@ public enum MembersManagerMethod implements ManagerMethod {
 			} else {
 				throw new RpcException(RpcException.Type.MISSING_VALUE, "Missing value. Either 'guestName' or ('firstName' and 'lastName') must be sent.");
 			}
-			return ac.getMembersManager().createSponsoredMember(ac.getSession(), vo, namespace, name, password, sponsor, validityTo);
+			return ac.getMembersManager().createSponsoredMember(ac.getSession(), vo, namespace, name, password, email, sponsor, validityTo);
 		}
 	},
 


### PR DESCRIPTION
* Added email parameter to the createSponsoredMember because users need
to be able to set it during the creation of the sponsored member. Later
on, they might not have the necessary privileges.