### PR TITLE
CreateSponsoredMember - return attributes

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/MembersManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/MembersManagerEntry.java
@@ -1190,7 +1190,7 @@ public class MembersManagerEntry implements MembersManager {
 			}
 		}
 		//create the sponsored member
-		return membersManagerBl.getRichMember(session, membersManagerBl.createSponsoredMember(session, vo, namespace, name, password, email, sponsor, validityTo, true));
+		return membersManagerBl.getRichMemberWithAttributes(session, membersManagerBl.createSponsoredMember(session, vo, namespace, name, password, email, sponsor, validityTo, true));
 	}
 
 	@Override

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/MembersManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/MembersManagerMethod.java
@@ -144,7 +144,7 @@ public enum MembersManagerMethod implements ManagerMethod {
 			Vo vo =  ac.getVoById(params.readInt("vo"));
 			String namespace = params.readString("namespace");
 			String email = null;
-			if (params.contains("mail")) {
+			if (params.contains("email")) {
 				email = params.readString("email");
 			}
 			if (email != null && !Utils.emailPattern.matcher(email).matches()) {


### PR DESCRIPTION
* We need to be able to return all member and user attributes for the
newly created member, so we can e.g. display generated login etc.
* These attributes must not be filtered, since users with only SPONSOR
role might not have privileges to display them.