### PR TITLE
CreateSponsoredMembers - new name format

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/MembersManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/MembersManager.java
@@ -1182,7 +1182,8 @@ public interface MembersManager {
 	 * @param session perun session
 	 * @param vo vo for members
 	 * @param namespace namespace for selecting password module
-	 * @param names a list of names
+	 * @param names names of members to create, single name should have the format {firstName};{lastName} to be
+	 *              parsed well
 	 * @param sponsor sponsoring user or null for the caller
 	 * @param validityTo last day when the sponsorship is active (null means the sponsorship will last forever)
 	 * @return map of names to map of status, login and password

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/MembersManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/MembersManagerBl.java
@@ -1524,7 +1524,8 @@ public interface MembersManagerBl {
 	 * @param session perun session
 	 * @param vo virtual organization to created sponsored members in
 	 * @param namespace used for selecting external system in which guest user account will be created
-	 * @param names full names of members to create
+	 * @param names names of members to create, single name should have the format {firstName};{lastName} to be
+	 *              parsed well
 	 * @param sponsor sponsoring user
 	 * @param asyncValidation switch for easier testing
 	 * @return map of names to map of status, login and password

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
@@ -2250,7 +2250,7 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 		if (name.containsKey("guestName")) {
 			user = Utils.parseUserFromCommonName(name.get("guestName"), true);
 		} else {
-			user = Utils.createUserFromNameMap(name);
+			user = Utils.createUserFromNameMap(name, true);
 		}
 
 		User sponsoredUser = getPerunBl().getUsersManagerBl().createUser(session, user);
@@ -2313,10 +2313,17 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 		PasswordManagerModule module = getPerunBl().getUsersManagerBl().getPasswordManagerModule(sess, namespace);
 
 		for (String name : names) {
-			// generate random password
-			String password = module.generateRandomPassword(sess, null);
 			Map<String, String> mapName = new HashMap<>();
-			mapName.put("guestName", name);
+			if (name.contains(";")) {
+				String[] split = name.split(";", 2);
+				mapName.put("firstName", split[0]);
+				mapName.put("lastName", split[1]);
+			} else {
+				mapName.put("guestName", name);
+			}
+
+			String password = module.generateRandomPassword(sess, null);
+
 			// create sponsored member
 			User user;
 			try {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Utils.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Utils.java
@@ -491,16 +491,25 @@ public class Utils {
 		return s.length() > limit ? s.substring(0, limit) : s;
 	}
 
-	public static User createUserFromNameMap(Map<String, String> name) {
+	public static User createUserFromNameMap(Map<String, String> name, boolean allowEmptyFirstName) {
 		User user = new User();
-		if (name.get(FIRST_NAME) == null || name.get(LAST_NAME) == null || name.get(FIRST_NAME).isEmpty() || name.get(LAST_NAME).isEmpty()) {
-			throw new InternalErrorException("First name/last name is either empty or null when creating user");
+		if (name.get(LAST_NAME) == null || name.get(LAST_NAME).isEmpty()) {
+			throw new InternalErrorException("Last name is either empty or null when creating user");
+		}
+		if (!allowEmptyFirstName && (name.get(FIRST_NAME) == null || name.get(FIRST_NAME).isEmpty())) {
+			throw new InternalErrorException("First name is either empty or null when creating user");
 		}
 		user.setTitleBefore(limit(name.get(TITLE_BEFORE),40));
-		user.setFirstName(limit(name.get(FIRST_NAME),64));
+		if (name.get(FIRST_NAME) != null) {
+			user.setFirstName(limit(name.get(FIRST_NAME),64));
+		}
 		user.setLastName(limit(name.get(LAST_NAME),64));
 		user.setTitleAfter(limit(name.get(TITLE_AFTER),40));
 		return user;
+	}
+
+	public static User createUserFromNameMap(Map<String, String> name) {
+		return createUserFromNameMap(name, false);
 	}
 
 	/**

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/MembersManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/MembersManagerEntryIntegrationTest.java
@@ -1529,8 +1529,8 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 
 
 	@Test(expected=InternalErrorException.class)
-	public void createSponsoredMemberUsingSeparatedNameMissingFirstNameFail() throws Exception {
-		System.out.println(CLASS_NAME + "createSponsoredMemberUsingSeparatedName");
+	public void createSponsoredMemberUsingSeparatedNameMissingLastNameFail() throws Exception {
+		System.out.println(CLASS_NAME + "createSponsoredMemberUsingSeparatedNameMissingLastNameFail");
 		//create user in group sponsors with role SPONSOR
 		Member sponsorMember = setUpSponsor(createdVo);
 		User sponsorUser = perun.getUsersManagerBl().getUserByMember(sess, sponsorMember);
@@ -1541,7 +1541,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 		//create guest
 		assertTrue("user must have SPONSOR role", perun.getVosManagerBl().isUserInRoleForVo(sess, sponsorUser, Role.SPONSOR, createdVo, true));
 		Map<String, String> nameOfUser1 = new HashMap<>();
-		nameOfUser1.put("lastName", "Morgan");
+		nameOfUser1.put("firstName", "Morgan");
 		nameOfUser1.put("titleBefore", "prof. RNDr.");
 		nameOfUser1.put("titleAfter", "Ph.D.");
 		Member sponsoredMember = perun.getMembersManagerBl().createSponsoredMember(sess, createdVo, "dummy", nameOfUser1, "TB", null, sponsorUser, false);
@@ -1582,6 +1582,32 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 			assertNotNull("login should not be null", loginAndPassword.get(name).get("login"));
 			assertNotNull("password should not be null", loginAndPassword.get(name).get("password"));
 		}
+	}
+
+	@Test
+	public void createSponsoredMembersParseSemicolon() throws Exception {
+		System.out.println(CLASS_NAME + "createSponsoredMembersParseSemicolon");
+		//create user in group sponsors with role SPONSOR
+		Member sponsorMember = setUpSponsor(createdVo);
+		User sponsorUser = perun.getUsersManagerBl().getUserByMember(sess, sponsorMember);
+		AuthzResolverBlImpl.setRole(sess, sponsorUser, createdVo, Role.SPONSOR);
+
+		String firstName = "John";
+		String lastName = "Doe1";
+
+		//create guests
+		Map<String, Map<String, String>> loginAndPassword = perun.getMembersManagerBl().createSponsoredMembers(sess,
+				createdVo, "dummy", Collections.singletonList(firstName + ";" + lastName), sponsorUser, null, false);
+
+		assertThat(loginAndPassword).hasSize(1);
+
+		extSource = perun.getExtSourcesManagerBl().getExtSourceByName(sess, "https://dummy");
+		UserExtSource ues = new UserExtSource(extSource,
+				loginAndPassword.values().iterator().next().get("login") + "@dummy");
+
+		User createdUser = perun.getUsersManagerBl().getUserByUserExtSource(sess, ues);
+		assertThat(createdUser.getFirstName()).isEqualTo(firstName);
+		assertThat(createdUser.getLastName()).isEqualTo(lastName);
 	}
 
 	@Test

--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -8041,7 +8041,7 @@ paths:
                 - sponsor
                 - namespace
               properties:
-                guestNames : { type: array, items: { type: string } }
+                guestNames : { type: array, items: { type: string }, description: "names of members to create, single name should have the format {firstName};{lastName} to be parsed well" }
                 vo: { type: integer }
                 sponsor: { type: integer }
                 namespace: { type: string }

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/MembersManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/MembersManagerMethod.java
@@ -240,7 +240,8 @@ public enum MembersManagerMethod implements ManagerMethod {
 	 * "status" has as its value either "OK" or message of exception which was thrown during creation of the member.
 	 * "login" contains login (e.g. učo) if status is OK, "password" contains password if status is OK.
 	 *
-	 * @param guestNames List<String> identification of sponsored accounts, e.g. "John Doe" or "conference member 1"
+	 * @param guestNames List<String> names of members to create, single name should have the format
+	 *                                {firstName};{lastName} to be parsed well
 	 * @param vo int VO ID
 	 * @param namespace String namespace selecting remote system for storing the password
 	 * @param sponsor int sponsor's ID


### PR DESCRIPTION
* The createSponsoredMembers now supports a new format of the names -
[firstName];[lastName]. This way, we can decide, which part of the given
value should be used as a first name and as a last name. It also
supports the old behaviour - if there is no comma, it will try to parse
the given value as a common name.