### PR TITLE
We don't want to let VoAdmin to set direct sponsorship

### DIFF
--- a/perun-base/src/main/resources/perun-roles.yml
+++ b/perun-base/src/main/resources/perun-roles.yml
@@ -2442,7 +2442,6 @@ perun_policies:
 
   createSponsoredMember_Vo_String_Map<String_String>_String_User_LocalDate_policy:
     policy_roles:
-      - VOADMIN: Vo
       - SPONSOR: Vo
         SELF: User
     include_policies:
@@ -2450,7 +2449,6 @@ perun_policies:
 
   setSponsoredMember_Vo_User_String_String_User_LocalDate_policy:
     policy_roles:
-      - VOADMIN: Vo
       - SPONSOR: Vo
         SELF: User
     include_policies:
@@ -2458,7 +2456,6 @@ perun_policies:
 
   createSponsoredMembers_Vo_String_List<String>_User_policy:
     policy_roles:
-      - VOADMIN: Vo
       - SPONSOR: Vo
         SELF: User
     include_policies:


### PR DESCRIPTION
 - VoAdmin shouldn't be able to set someone to sponsor someone else. He
 is there only to set role SPONSOR to some person who is then able to
 sponsor other users to this VO. VoAdmin could be also sponsor in his
 VO, then he will have a way to do this for himself too.

```# Please enter the commit message for your changes. Lines starting