### PR TITLE
Fix policies for sponsor methods

### DIFF
--- a/perun-base/src/main/resources/perun-roles.yml
+++ b/perun-base/src/main/resources/perun-roles.yml
@@ -2471,9 +2471,15 @@ perun_policies:
     include_policies:
       - default_policy
 
-  sponsorMember_Member_User_LocalDate_policy:
+  sponsored-sponsorMember_Member_User_LocalDate_policy:
     policy_roles:
-      - VOADMIN:
+      - SPONSOR: Vo
+    include_policies:
+      - default_policy
+
+  sponsor-sponsorMember_Member_User_LocalDate_policy:
+    policy_roles:
+      - SELF: User
     include_policies:
       - default_policy
 
@@ -2535,9 +2541,15 @@ perun_policies:
     include_policies:
       - default_policy
 
-  removeSponsor_Member_User_policy:
+  sponsored-removeSponsor_Member_User_policy:
     policy_roles:
-      - VOADMIN: Vo
+      - SPONSORSHIP: Member
+    include_policies:
+      - default_policy
+
+  sponsor-removeSponsor_Member_User_policy:
+    policy_roles:
+      - SELF: User
     include_policies:
       - default_policy
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/MembersManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/MembersManagerEntry.java
@@ -1283,7 +1283,8 @@ public class MembersManagerEntry implements MembersManager {
 		log.debug("sponsorMember(sponsored={},sponsor={}", sponsored.getId(), sponsor.getId());
 
 		//Authorization
-		if (!AuthzResolver.authorizedInternal(session, "sponsorMember_Member_User_LocalDate_policy", sponsored)) {
+		if (!AuthzResolver.authorizedInternal(session, "sponsored-sponsorMember_Member_User_LocalDate_policy", sponsored) ||
+		    !AuthzResolver.authorizedInternal(session, "sponsor-sponsorMember_Member_User_LocalDate_policy", sponsor)) {
 			throw new PrivilegeException(session, "sponsorMember");
 		}
 		//create the link between sponsored and sponsoring users
@@ -1403,7 +1404,8 @@ public class MembersManagerEntry implements MembersManager {
 		Vo vo = membersManagerBl.getMemberVo(sess, sponsoredMember);
 
 		//Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "removeSponsor_Member_User_policy", sponsoredMember)) {
+		if (!AuthzResolver.authorizedInternal(sess, "sponsored-removeSponsor_Member_User_policy", sponsoredMember) ||
+		    !AuthzResolver.authorizedInternal(sess, "sponsor-removeSponsor_Member_User_policy", sponsorToRemove)) {
 			throw new PrivilegeException(sess, "removeSponsor");
 		}
 


### PR DESCRIPTION
* We wanted sponsors to be able call methods `removeSponsor` and
`sponsorMember`. We also don't want VoAdmins to do this, this is
job for sponsors.
* However, the policy for the removeSponsor method has to be duplicated.
One will be resolved with the sponsor and the other one with the sponored
member. Only this way we can define roles which should be relevant only
to one of them.