### PR TITLE
Exceptions for invalid password reset request

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/PasswordResetLinkExpiredException.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/PasswordResetLinkExpiredException.java
@@ -1,0 +1,21 @@
+package cz.metacentrum.perun.core.api.exceptions;
+
+/**
+ * This exception is thrown when password reset link expired (after couple of hours).
+ *
+ * @author Radoslav Čerhák <r.cerhak@gmail.com>
+ */
+public class PasswordResetLinkExpiredException extends PerunException {
+
+	public PasswordResetLinkExpiredException(String message) {
+		super(message);
+	}
+
+	public PasswordResetLinkExpiredException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public PasswordResetLinkExpiredException(Throwable cause) {
+		super(cause);
+	}
+}

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/PasswordResetLinkNotValidException.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/PasswordResetLinkNotValidException.java
@@ -1,0 +1,22 @@
+package cz.metacentrum.perun.core.api.exceptions;
+
+/**
+ * This exception is thrown when password reset link is not valid because it was either
+ * already used or has never existed.
+ *
+ * @author Radoslav Čerhák <r.cerhak@gmail.com>
+ */
+public class PasswordResetLinkNotValidException extends PerunException {
+
+	public PasswordResetLinkNotValidException(String message) {
+		super(message);
+	}
+
+	public PasswordResetLinkNotValidException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public PasswordResetLinkNotValidException(Throwable cause) {
+		super(cause);
+	}
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/UsersManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/UsersManager.java
@@ -15,6 +15,8 @@ import cz.metacentrum.perun.core.api.exceptions.PasswordCreationFailedException;
 import cz.metacentrum.perun.core.api.exceptions.PasswordDeletionFailedException;
 import cz.metacentrum.perun.core.api.exceptions.PasswordDoesntMatchException;
 import cz.metacentrum.perun.core.api.exceptions.PasswordOperationTimeoutException;
+import cz.metacentrum.perun.core.api.exceptions.PasswordResetLinkExpiredException;
+import cz.metacentrum.perun.core.api.exceptions.PasswordResetLinkNotValidException;
 import cz.metacentrum.perun.core.api.exceptions.PasswordStrengthException;
 import cz.metacentrum.perun.core.api.exceptions.PasswordStrengthFailedException;
 import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
@@ -798,6 +800,18 @@ public interface UsersManager {
 	void changePassword(PerunSession sess, User user, String loginNamespace, String oldPassword, String newPassword, boolean checkOldPassword)
 			throws PrivilegeException, UserNotExistsException, LoginNotExistsException, PasswordDoesntMatchException, PasswordChangeFailedException, PasswordOperationTimeoutException, PasswordStrengthFailedException, InvalidLoginException, PasswordStrengthException;
 
+	/**
+	 * Checks if the password reset request based on encrypted parameters is valid.
+	 *
+	 * @param sess
+	 * @param i encrypted user id
+	 * @param m encrypted request id
+	 * @return
+	 * @throws UserNotExistsException
+	 * @throws PasswordResetLinkExpiredException when the reset link expired
+	 * @throws PasswordResetLinkNotValidException when the reset link was already used or has never existed
+	 */
+	void checkPasswordResetRequestIsValid(PerunSession sess, String i, String m) throws UserNotExistsException, PasswordResetLinkExpiredException, PasswordResetLinkNotValidException;
 
 	/**
 	 * Changes user password in defined login-namespace using encrypted parameters.
@@ -811,9 +825,11 @@ public interface UsersManager {
 	 * @throws UserNotExistsException
 	 * @throws LoginNotExistsException
 	 * @throws PasswordChangeFailedException
+	 * @throws PasswordResetLinkNotValidException
+	 * @throws PasswordResetLinkExpiredException
 	 */
 	void changeNonAuthzPassword(PerunSession sess, String i, String m, String password, String lang)
-			throws UserNotExistsException, LoginNotExistsException, PasswordChangeFailedException, PasswordOperationTimeoutException, PasswordStrengthFailedException, InvalidLoginException, PasswordStrengthException;
+		throws UserNotExistsException, LoginNotExistsException, PasswordChangeFailedException, PasswordOperationTimeoutException, PasswordStrengthFailedException, InvalidLoginException, PasswordStrengthException, PasswordResetLinkExpiredException, PasswordResetLinkNotValidException;
 
 	/**
 	 * Reserves random password in external system. User must not exists.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
@@ -31,6 +31,8 @@ import cz.metacentrum.perun.core.api.exceptions.PasswordCreationFailedException;
 import cz.metacentrum.perun.core.api.exceptions.PasswordDeletionFailedException;
 import cz.metacentrum.perun.core.api.exceptions.PasswordDoesntMatchException;
 import cz.metacentrum.perun.core.api.exceptions.PasswordOperationTimeoutException;
+import cz.metacentrum.perun.core.api.exceptions.PasswordResetLinkExpiredException;
+import cz.metacentrum.perun.core.api.exceptions.PasswordResetLinkNotValidException;
 import cz.metacentrum.perun.core.api.exceptions.PasswordStrengthException;
 import cz.metacentrum.perun.core.api.exceptions.PasswordStrengthFailedException;
 import cz.metacentrum.perun.core.api.exceptions.RelationExistsException;
@@ -1301,6 +1303,18 @@ public interface UsersManagerBl {
 	User convertUserEmptyStringsInObjectAttributesIntoNull(User user);
 
 	/**
+	 * Checks if the password reset request link is valid. The request is valid, if it
+	 * was created, never used and hasn't expired yet.
+	 *
+	 * @param sess PerunSession
+	 * @param user user to check request for
+	 * @param m encrypted request id
+	 * @throws PasswordResetLinkExpiredException when the reset link expired
+	 * @throws PasswordResetLinkNotValidException when the reset link was already used or has never existed
+	 */
+	void checkPasswordResetRequestIsValid(PerunSession sess, User user, String m) throws PasswordResetLinkExpiredException, PasswordResetLinkNotValidException;
+
+	/**
 	 * Changes user password in defined login-namespace using encrypted parameters.
 	 *
 	 * @param sess     PerunSession
@@ -1313,9 +1327,11 @@ public interface UsersManagerBl {
 	 * @throws LoginNotExistsException When user doesn't have login in specified namespace
 	 * @throws InvalidLoginException When When login of user has invalid syntax (is not allowed)
 	 * @throws PasswordStrengthException When password doesn't match expected strength by namespace configuration
+	 * @throws PasswordResetLinkExpiredException when the password reset request expired
+	 * @throws PasswordResetLinkNotValidException when the password reset request was already used or has never existed
 	 */
 	void changeNonAuthzPassword(PerunSession sess, User user, String m, String password, String lang)
-			throws LoginNotExistsException, PasswordChangeFailedException, PasswordOperationTimeoutException, PasswordStrengthFailedException, InvalidLoginException, PasswordStrengthException;
+		throws LoginNotExistsException, PasswordChangeFailedException, PasswordOperationTimeoutException, PasswordStrengthFailedException, InvalidLoginException, PasswordStrengthException, PasswordResetLinkExpiredException, PasswordResetLinkNotValidException;
 
 	/**
 	 * Get count of all users.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
@@ -39,6 +39,8 @@ import cz.metacentrum.perun.core.api.exceptions.PasswordCreationFailedException;
 import cz.metacentrum.perun.core.api.exceptions.PasswordDeletionFailedException;
 import cz.metacentrum.perun.core.api.exceptions.PasswordDoesntMatchException;
 import cz.metacentrum.perun.core.api.exceptions.PasswordOperationTimeoutException;
+import cz.metacentrum.perun.core.api.exceptions.PasswordResetLinkExpiredException;
+import cz.metacentrum.perun.core.api.exceptions.PasswordResetLinkNotValidException;
 import cz.metacentrum.perun.core.api.exceptions.PasswordStrengthException;
 import cz.metacentrum.perun.core.api.exceptions.PasswordStrengthFailedException;
 import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
@@ -1269,7 +1271,18 @@ public class UsersManagerEntry implements UsersManager {
 	}
 
 	@Override
-	public void changeNonAuthzPassword(PerunSession sess, String i, String m, String password, String lang) throws UserNotExistsException, LoginNotExistsException, PasswordChangeFailedException, PasswordOperationTimeoutException, PasswordStrengthFailedException, InvalidLoginException, PasswordStrengthException {
+	public void checkPasswordResetRequestIsValid(PerunSession sess, String i, String m) throws UserNotExistsException, PasswordResetLinkExpiredException, PasswordResetLinkNotValidException {
+		Utils.checkPerunSession(sess);
+
+		int userId = Integer.parseInt(Utils.cipherInput(i,true));
+		// this will make also "if exists check"
+		User user = getPerunBl().getUsersManagerBl().getUserById(sess, userId);
+
+		getPerunBl().getUsersManagerBl().checkPasswordResetRequestIsValid(sess, user, m);
+	}
+
+	@Override
+	public void changeNonAuthzPassword(PerunSession sess, String i, String m, String password, String lang) throws UserNotExistsException, LoginNotExistsException, PasswordChangeFailedException, PasswordOperationTimeoutException, PasswordStrengthFailedException, InvalidLoginException, PasswordStrengthException, PasswordResetLinkExpiredException, PasswordResetLinkNotValidException {
 
 		Utils.checkPerunSession(sess);
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/UsersManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/UsersManagerImplApi.java
@@ -16,6 +16,8 @@ import cz.metacentrum.perun.core.api.UserExtSource;
 import cz.metacentrum.perun.core.api.Vo;
 import cz.metacentrum.perun.core.api.exceptions.AlreadyReservedLoginException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.PasswordResetLinkExpiredException;
+import cz.metacentrum.perun.core.api.exceptions.PasswordResetLinkNotValidException;
 import cz.metacentrum.perun.core.api.exceptions.SpecificUserAlreadyRemovedException;
 import cz.metacentrum.perun.core.api.exceptions.SpecificUserOwnerAlreadyRemovedException;
 import cz.metacentrum.perun.core.api.exceptions.UserAlreadyRemovedException;
@@ -692,16 +694,31 @@ public interface UsersManagerImplApi {
 	List<String> getPendingPreferredEmailChanges(PerunSession sess, User user);
 
 	/**
+	 * Checks if the password reset request link is valid. The request is valid, if it
+	 * was created, never used and hasn't expired yet.
+	 *
+	 * @param sess PerunSession
+	 * @param user user to check request for
+	 * @param requestId request id to check
+	 * @throws PasswordResetLinkExpiredException when the password reset request expired
+	 * @throws PasswordResetLinkNotValidException when the password reset request was already used or has never existed
+	 */
+	void checkPasswordResetRequestIsValid(PerunSession sess, User user, int requestId) throws PasswordResetLinkExpiredException, PasswordResetLinkNotValidException;
+
+	/**
 	 * Return only valid password reset requests for selected user and request ID.
 	 * Validity is determined by time since request creation and actual usage (only once).
 	 *
-	 * If no valid entry is found, then NULL is returned. Entry is invalidated once loaded.
+	 * If no valid entry is found, exception is thrown. Entry is invalidated once loaded.
 	 *
+	 * @param sess PerunSession
 	 * @param user user to get requests for
 	 * @param request request ID to get
 	 * @return Pair with "left" = namespace user wants to reset password, "right" = mail used for notification
+	 * @throws PasswordResetLinkExpiredException when the password reset request expired
+	 * @throws PasswordResetLinkNotValidException when the password reset request was already used or has never existed
 	 */
-	Pair<String,String> loadPasswordResetRequest(User user, int request);
+	Pair<String,String> loadPasswordResetRequest(PerunSession sess, User user, int request) throws PasswordResetLinkExpiredException, PasswordResetLinkNotValidException;
 
 	/**
 	 * Removes all password reset requests associated with user.

--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -7712,6 +7712,46 @@ paths:
                 candidate: { $ref: '#/components/schemas/Candidate' }
                 specificUserOwners: { type: array, items: { $ref: "#/components/schemas/User" } }
 
+  /json/usersManager/checkPasswordResetRequestIsValid:
+    get:
+      tags:
+        - UsersManager
+      operationId: checkPasswordResetRequestIsValid
+      summary: Checks if the password reset request based on encrypted input parameters is valid.
+      description: |
+        This method throws PasswordResetLinkExpiredException when the password reset request expired.
+        This method throws PasswordResetLinkNotValidException when the password reset request was already
+        used or has never existed.
+      parameters:
+        - { name: i, description: "encrypted user id", schema: { type: string }, in: query, required: true }
+        - { name: m, description: "encrypted password reset request id", schema: { type: string }, in: query, required: true }
+      responses:
+        '200':
+          $ref: '#/components/responses/VoidResponse'
+        default:
+          $ref: '#/components/responses/ExceptionResponse'
+
+  /urlinjsonout/usersManager/changeNonAuthzPassword:
+    post:
+      tags:
+        - UsersManager
+      operationId: changeNonAuthzPassword
+      summary: Changes user's password in namespace based on encrypted input parameters.
+      description: |
+        This method throws PasswordResetLinkExpiredException when the password reset request expired.
+        This method throws PasswordResetLinkNotValidException when the password reset request was already
+        used or has never existed.
+      parameters:
+        - { name: i, description: "encrypted user id", schema: { type: string }, in: query, required: true }
+        - { name: m, description: "encrypted password reset request id", schema: { type: string }, in: query, required: true }
+        - $ref: '#/components/parameters/password'
+        - { name: lang, description: "language to get notifications in (optional)", schema: { type: string }, in: query, required: false }
+      responses:
+        '200':
+          $ref: '#/components/responses/VoidResponse'
+        default:
+          $ref: '#/components/responses/ExceptionResponse'
+
   /urlinjsonout/usersManager/reservePassword:
     post:
       tags:

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/UsersManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/UsersManagerMethod.java
@@ -1028,6 +1028,23 @@ public enum UsersManagerMethod implements ManagerMethod {
 		}
 	},
 	/*#
+	 * Checks if the password reset request link is valid. The request is valid, if it
+	 * was created, never used and hasn't expired yet.
+	 *
+	 * @param i String first encrypted parameter
+	 * @param m String second encrypted parameter
+	 * @throw PasswordResetLinkExpiredException When the password reset request expired
+	 * @throw PasswordResetLinkNotValidException When the password reset request was already used or has never existed
+	 */
+	checkPasswordResetRequestIsValid {
+		@Override
+		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
+			ac.getUsersManager().checkPasswordResetRequestIsValid(ac.getSession(), parms.readString("i"), parms.readString("m"));
+
+			return null;
+		}
+	},
+	/*#
 	 * Changes user's password in namespace based on encrypted input parameters.
 	 *
 	 * @param i String first encrypted parameter
@@ -1037,6 +1054,8 @@ public enum UsersManagerMethod implements ManagerMethod {
 	 * @throw LoginNotExistsException When user doesn't have login in specified namespace
 	 * @throw InvalidLoginException When login of user has invalid syntax (is not allowed)
 	 * @throw PasswordStrengthException When password doesn't match expected strength by namespace configuration
+	 * @throw PasswordResetLinkExpiredException When the password reset request expired
+	 * @throw PasswordResetLinkNotValidException When the password reset request was already used or has never existed
 	 */
 	changeNonAuthzPassword {
 		@Override


### PR DESCRIPTION
- Method changeNonAuthzPassword() threw InternalErrorExceptions when the
password reset request link has expired or when it never existed.
- Created new exceptions PasswordResetLinkExpired and PasswordResetLinkNotValid
to distuinguish between these two cases.
- Created new method checkPasswordResetRequestIsValid() to check for validity
of the given password reset request, that should be called from GUI before
submitting a new password.