### PR TITLE
Methods for convertion of sponsored users

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/VosManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/VosManager.java
@@ -549,4 +549,25 @@ public interface VosManager {
 	 * @throws VoNotExistsException if there is no vo with given id
 	 */
 	List<BanOnVo> getBansForVo(PerunSession sess, int voId) throws PrivilegeException, VoNotExistsException;
+
+	/**
+	 * For the given vo, creates sponsored members for each sponsored user who is a member
+	 * of the given vo. Original sponsors of the users will be set to the sponsored members.
+	 *
+	 * @param sess session
+	 * @param vo vo where members will be converted
+	 */
+	void convertSponsoredUsers(PerunSession sess, Vo vo) throws PrivilegeException;
+
+
+	/**
+	 * For the given vo, creates sponsored members for each sponsored user who is a member
+	 * of the given vo. The sponsored members will be sponsored by the given user, not by its
+	 * original sponsors.
+	 *
+	 * @param sess session
+	 * @param vo vo where members will be converted
+	 * @param newSponsor user, who will be set as a sponsor to the sponsored members
+	 */
+	void convertSponsoredUsersWithNewSponsor(PerunSession sess, Vo vo, User newSponsor) throws PrivilegeException;
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/VosManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/VosManagerBl.java
@@ -504,4 +504,24 @@ public interface VosManagerBl {
 	 * @return true, if member with given id is banned, false otherwise
 	 */
 	boolean isMemberBanned(PerunSession sess, int memberId);
+
+	/**
+	 * For the given vo, creates sponsored members for each sponsored user who is a member
+	 * of the given vo. Original sponsors of the users will be set to the sponsored members.
+	 *
+	 * @param sess session
+	 * @param vo vo where members will be converted
+	 */
+	void convertSponsoredUsers(PerunSession sess, Vo vo);
+
+	/**
+	 * For the given vo, creates sponsored members for each sponsored user who is a member
+	 * of the given vo. The sponsored members will be sponsored by the given user, not by its
+	 * original sponsors.
+	 *
+	 * @param sess session
+	 * @param vo vo where members will be converted
+	 * @param newSponsor user, who will be set as a sponsor to the sponsored members
+	 */
+	void convertSponsoredUsersWithNewSponsor(PerunSession sess, Vo vo, User newSponsor);
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/VosManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/VosManagerEntry.java
@@ -655,6 +655,24 @@ public class VosManagerEntry implements VosManager {
 		return vosManagerBl.getBansForVo(sess, voId);
 	}
 
+	@Override
+	public void convertSponsoredUsers(PerunSession sess, Vo vo) throws PrivilegeException {
+		if (!AuthzResolver.authorizedInternal(sess, "default_policy")) {
+			throw new PrivilegeException("convertSponsoredUsers");
+		}
+
+		vosManagerBl.convertSponsoredUsers(sess, vo);
+	}
+
+	@Override
+	public void convertSponsoredUsersWithNewSponsor(PerunSession sess, Vo vo, User newSponsor) throws PrivilegeException {
+		if (!AuthzResolver.authorizedInternal(sess, "default_policy")) {
+			throw new PrivilegeException("convertSponsoredUsersWithNewSponsor");
+		}
+
+		vosManagerBl.convertSponsoredUsersWithNewSponsor(sess, vo, newSponsor);
+	}
+
 	/**
 	 * Gets the perunBl for this instance.
 	 *

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/VosManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/VosManagerMethod.java
@@ -699,5 +699,37 @@ public enum VosManagerMethod implements ManagerMethod {
 			return ac.getVosManager().getBansForVo(ac.getSession(),
 					parms.readInt("vo"));
 		}
+	},
+
+	/*#
+	 * For the given vo, creates sponsored members for each sponsored user who is a member
+	 * of the given vo. Original sponsors of the users will be set to the sponsored members.
+	 *
+	 * @param vo int vo id
+	 */
+	convertSponsoredUsers {
+		@Override
+		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
+			ac.getVosManager().convertSponsoredUsers(ac.getSession(), ac.getVoById(parms.readInt("vo")));
+
+			return null;
+		}
+	},
+
+	/*#
+	 * For the given vo, creates sponsored members for each sponsored user who is a member
+	 * of the given vo. The sponsored members will be sponsored by the given user, not by its
+	 * original sponsors.
+	 *
+	 * @param vo int vo where members will be converted
+	 * @param newSponsor int user, who will be set as a sponsor to the sponsored members
+	 */
+	convertSponsoredUsersWithNewSponsor {
+		@Override
+		public Object call(ApiCaller ac, Deserializer parms) throws PerunException {
+			ac.getVosManager().convertSponsoredUsersWithNewSponsor(ac.getSession(),
+					ac.getVoById(parms.readInt("vo")), ac.getUserById(parms.readInt("user")));
+			return null;
+		}
 	}
 }


### PR DESCRIPTION
* Created two new methods that can be used to convert sponsored users.
* Method `convertSponsoredUsers` can be used to create sponsored members
for all sponsored users who are members of the given vo. All sponsors
are kept, if they were not sponsors in the given, the role is set for
them.
* Method `convertSponsoredUsersWithNewSponsor` can also be used for the
conversion. The difference is, that this method sets a given users as a
sponsor of all members. Old sponsors will be not set.
* Once all conversions are done, we have to consider how to remove all
of the user sponsorships. This is not handled by these two methods.