### PR TITLE
Unique sponsorship between member and user

### DIFF
--- a/perun-base/src/test/resources/test-schema.sql
+++ b/perun-base/src/test/resources/test-schema.sql
@@ -2,7 +2,7 @@ set database sql syntax PGS true;
 -- fix unique index on authz, since PGS compatibility doesn't allow coalesce call in index and treats nulls in columns as different values.
 SET DATABASE SQL UNIQUE NULLS FALSE;
 
--- database version 3.1.69 (don't forget to update insert statement at the end of file)
+-- database version 3.1.70 (don't forget to update insert statement at the end of file)
 
 -- VOS - virtual organizations
 create table vos (
@@ -1406,7 +1406,8 @@ CREATE TABLE members_sponsored (
 	modified_by longvarchar default user not null,
 	modified_by_uid integer,
 	constraint memspons_mem_fk foreign key (sponsored_id) references members(id),
-	constraint memspons_usr_fk foreign key (sponsor_id) references users(id)
+	constraint memspons_usr_fk foreign key (sponsor_id) references users(id),
+	constraint memspons_mem_usr_u unique (sponsored_id, sponsor_id)
 );
 
 -- AUTHZ - assigned roles to users/groups/VOs/other entities...
@@ -1643,7 +1644,7 @@ CREATE INDEX ufauv_idx ON user_facility_attr_u_values (user_id, facility_id, att
 CREATE INDEX vauv_idx ON vo_attr_u_values (vo_id, attr_id) ;
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.1.69');
+insert into configurations values ('DATABASE VERSION','3.1.70');
 insert into membership_types (id, membership_type, description) values (1, 'DIRECT', 'Member is directly added into group');
 insert into membership_types (id, membership_type, description) values (2, 'INDIRECT', 'Member is added indirectly through UNION relation');
 insert into action_types (id, action_type, description) values (nextval('action_types_seq'), 'read', 'Can read value.');

--- a/perun-core/src/main/resources/hsqldbChangelog.txt
+++ b/perun-core/src/main/resources/hsqldbChangelog.txt
@@ -3,6 +3,9 @@
 
 -- this update is not supported on hsql since its used only as in-memory db
 
+3.1.70
+update configurations set value='3.1.70' where property='DATABASE VERSION';
+
 3.1.69
 update configurations set value='3.1.69' where property='DATABASE VERSION';
 

--- a/perun-core/src/main/resources/postgresChangelog.txt
+++ b/perun-core/src/main/resources/postgresChangelog.txt
@@ -6,6 +6,10 @@
 -- Directly under version number should be version commands. They will be executed in the order they are written here.
 -- Comments are prefixed with -- and can be written only between version blocks, that means not in the lines with commands. They have to be at the start of the line.
 
+3.1.70
+ALTER TABLE members_sponsored ADD CONSTRAINT memspons_mem_usr_u unique (sponsored_id, sponsor_id);
+UPDATE configurations SET value='3.1.70' WHERE property='DATABASE VERSION';
+
 3.1.69
 alter table members_sponsored ADD COLUMN validity_to timestamp default null;
 UPDATE configurations SET value='3.1.69' WHERE property='DATABASE VERSION';

--- a/perun-db/postgres.sql
+++ b/perun-db/postgres.sql
@@ -1,4 +1,4 @@
--- database version 3.1.69 (don't forget to update insert statement at the end of file)
+-- database version 3.1.70 (don't forget to update insert statement at the end of file)
 
 -- VOS - virtual organizations
 create table vos (
@@ -1401,7 +1401,8 @@ CREATE TABLE members_sponsored (
 	modified_by varchar default user not null,
 	modified_by_uid integer,
 	constraint memspons_mem_fk foreign key (sponsored_id) references members(id),
-  constraint memspons_usr_fk foreign key (sponsor_id) references users(id)
+  constraint memspons_usr_fk foreign key (sponsor_id) references users(id),
+  constraint memspons_mem_usr_u unique (sponsored_id, sponsor_id)
 );
 
 -- AUTHZ - assigned roles to users/groups/VOs/other entities...
@@ -1737,7 +1738,7 @@ grant all on user_ext_source_attr_u_values to perun;
 grant all on members_sponsored to perun;
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.1.69');
+insert into configurations values ('DATABASE VERSION','3.1.70');
 
 -- insert membership types
 insert into membership_types (id, membership_type, description) values (1, 'DIRECT', 'Member is directly added into group');


### PR DESCRIPTION
- Sponsorship between a user and a member should be unique.
- Unique constraint was added to table members_sponsored.
- Now before inserting a sponsorship to the table, it is checked if it is not
already there. If it is in the table, it is updated (reactivated) instead of
inserted.