### PR TITLE
General getAdmins methods

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/RoleManagementRules.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/RoleManagementRules.java
@@ -5,17 +5,18 @@ import java.util.Map;
 import java.util.Objects;
 
 /**
- * RoleManagementRules represents a set of rules which is used to determine principal's access rights for managing a role.
+ * RoleManagementRules represents a set of rules which is used to determine principal's access rights for managing and reading a role.
  * Moreover, it contains a allowed combinations of object and entity to/from which will be the role un/assigned.
  * Each object and entity also contains a mapping to the specific column in the authz table,
  * so the database query can be created and executed more generally.
  *
  * roleName is role's unique identification which is used in the configuration file perun-roles.yml
- * privilegedRoles is a list of maps where each map entry consists from a role name as a key and a role object as a value.
+ * privilegedRolesToManage is a list of maps where each map entry consists from a role name as a key and a role object as a value.
  *            Relation between each map in the list is logical OR and relation between each entry in the map is logical AND.
  *            Example list - (Map1, Map2...)
  *            Example map - key: VOADMIN ; value: Vo
  *                          key: GROUPADMIN ; value: Group
+ * privilegedRolesToRead is same as the privilegedRolesToManage, but its purpose is to determine which roles have rights to read the roleName.
  * entitiesToManage is a map of entities which can be set to the role. Key is a entity name and value is mapping to the database.
  *            Example entry: key: User; value: user_id
  * assignedObjects is a map of objects which can be assigned with the role. Key is a object name and value is mapping to the database.
@@ -25,13 +26,15 @@ import java.util.Objects;
 public class RoleManagementRules {
 
 	private String roleName;
-	private List<Map<String, String>> privilegedRoles;
+	private List<Map<String, String>> privilegedRolesToManage;
+	private List<Map<String, String>> privilegedRolesToRead;
 	private Map<String, String> entitiesToManage;
 	private Map<String, String> assignedObjects;
 
-	public RoleManagementRules(String roleName, List<Map<String, String>> privilegedRoles, Map<String, String> entitiesToManage, Map<String, String> assignedObjects) {
+	public RoleManagementRules(String roleName, List<Map<String, String>> privilegedRolesToManage, List<Map<String, String>> privilegedRolesToRead, Map<String, String> entitiesToManage, Map<String, String> assignedObjects) {
 		this.roleName = roleName;
-		this.privilegedRoles = privilegedRoles;
+		this.privilegedRolesToManage = privilegedRolesToManage;
+		this.privilegedRolesToRead = privilegedRolesToRead;
 		this.entitiesToManage = entitiesToManage;
 		this.assignedObjects = assignedObjects;
 	}
@@ -44,12 +47,20 @@ public class RoleManagementRules {
 		this.roleName = roleName;
 	}
 
-	public List<Map<String, String>> getPrivilegedRoles() {
-		return privilegedRoles;
+	public List<Map<String, String>> getPrivilegedRolesToManage() {
+		return privilegedRolesToManage;
 	}
 
-	public void setPrivilegedRoles( List<Map<String, String>> privilegedRoles) {
-		this.privilegedRoles = privilegedRoles;
+	public void setPrivilegedRolesToManage( List<Map<String, String>> privilegedRolesToManage) {
+		this.privilegedRolesToManage = privilegedRolesToManage;
+	}
+
+	public List<Map<String, String>> getPrivilegedRolesToRead() {
+		return privilegedRolesToRead;
+	}
+
+	public void setPrivilegedRolesToRead( List<Map<String, String>> privilegedRolesToRead) {
+		this.privilegedRolesToRead = privilegedRolesToRead;
 	}
 
 	public Map<String, String> getEntitiesToManage() {
@@ -74,21 +85,23 @@ public class RoleManagementRules {
 		if (o == null || getClass() != o.getClass()) return false;
 		RoleManagementRules that = (RoleManagementRules) o;
 		return Objects.equals(roleName, that.roleName) &&
-			Objects.equals(privilegedRoles, that.privilegedRoles) &&
+			Objects.equals(privilegedRolesToManage, that.privilegedRolesToManage) &&
+			Objects.equals(privilegedRolesToRead, that.privilegedRolesToRead) &&
 			Objects.equals(entitiesToManage, that.entitiesToManage) &&
 			Objects.equals(assignedObjects, that.assignedObjects);
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(roleName, privilegedRoles, entitiesToManage, assignedObjects);
+		return Objects.hash(roleName, privilegedRolesToManage, privilegedRolesToRead, entitiesToManage, assignedObjects);
 	}
 
 	@Override
 	public String toString() {
 		return "RoleManagementRules{" +
 			"roleName='" + roleName + '\'' +
-			", privilegedRoles=" + privilegedRoles +
+			", privilegedRolesToManage=" + privilegedRolesToManage +
+			", privilegedRolesToRead=" + privilegedRolesToRead +
 			", entitiesToManage=" + entitiesToManage +
 			", assignedObjects=" + assignedObjects +
 			'}';

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/RoleCannotBeManagedException.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/RoleCannotBeManagedException.java
@@ -16,6 +16,12 @@ public class RoleCannotBeManagedException extends PerunException {
 		this.entity = entity;
 	}
 
+	public RoleCannotBeManagedException(String role, Object complementaryObject) {
+		super("Combination of Role: "+ role +" and Object: "+ complementaryObject +" cannot be managed.");
+		this.role = role;
+		this.complementaryObject = complementaryObject;
+	}
+
 	public String getRole() {
 		return role;
 	}

--- a/perun-base/src/main/resources/perun-roles.yml
+++ b/perun-base/src/main/resources/perun-roles.yml
@@ -5819,15 +5819,21 @@ perun_roles_management:
     assign_to_objects: {}
     entities_to_manage:
       User: user_id
-    privileged_roles:
+    privileged_roles_to_manage:
       - PERUNADMIN:
+    privileged_roles_to_read:
+      - PERUNADMIN:
+      - PERUNOBSERVER:
 
   PERUNOBSERVER:
     assign_to_objects: {}
     entities_to_manage:
       User: user_id
-    privileged_roles:
+    privileged_roles_to_manage:
       - PERUNADMIN:
+    privileged_roles_to_read:
+      - PERUNADMIN:
+      - PERUNOBSERVER:
 
   VOADMIN:
     assign_to_objects:
@@ -5835,9 +5841,14 @@ perun_roles_management:
     entities_to_manage:
       User: user_id
       Group: authorized_group_id
-    privileged_roles:
+    privileged_roles_to_manage:
       - PERUNADMIN:
       - VOADMIN: Vo
+    privileged_roles_to_read:
+      - PERUNADMIN:
+      - PERUNOBSERVER:
+      - VOADMIN: Vo
+      - VOOBSERVER: Vo
 
   GROUPADMIN:
     assign_to_objects:
@@ -5846,10 +5857,17 @@ perun_roles_management:
     entities_to_manage:
       User: user_id
       Group: authorized_group_id
-    privileged_roles:
+    privileged_roles_to_manage:
       - PERUNADMIN:
       - VOADMIN: Vo
       - GROUPADMIN: Group
+    privileged_roles_to_read:
+      - PERUNADMIN:
+      - PERUNOBSERVER:
+      - VOADMIN: Vo
+      - VOOBSERVER: Vo
+      - GROUPADMIN: Group
+      - GROUPOBSERVER: Group
 
   GROUPOBSERVER:
     assign_to_objects:
@@ -5858,15 +5876,23 @@ perun_roles_management:
     entities_to_manage:
       User: user_id
       Group: authorized_group_id
-    privileged_roles:
+    privileged_roles_to_manage:
       - PERUNADMIN:
       - VOADMIN: Vo
       - GROUPADMIN: Group
+    privileged_roles_to_read:
+      - PERUNADMIN:
+      - PERUNOBSERVER:
+      - VOADMIN: Vo
+      - VOOBSERVER: Vo
+      - GROUPADMIN: Group
+      - GROUPOBSERVER: Group
 
   SELF:
     assign_to_objects: {}
     entities_to_manage: {}
-    privileged_roles: []
+    privileged_roles_to_manage: []
+    privileged_roles_to_read: []
 
   FACILITYADMIN:
     assign_to_objects:
@@ -5874,9 +5900,14 @@ perun_roles_management:
     entities_to_manage:
       User: user_id
       Group: authorized_group_id
-    privileged_roles:
+    privileged_roles_to_manage:
       - PERUNADMIN:
       - FACILITYADMIN: Facility
+    privileged_roles_to_read:
+      - PERUNADMIN:
+      - PERUNOBSERVER:
+      - FACILITYADMIN: Facility
+      - FACILITYOBSERVER: Facility
 
   FACILITYOBSERVER:
     assign_to_objects:
@@ -5884,9 +5915,14 @@ perun_roles_management:
     entities_to_manage:
       User: user_id
       Group: authorized_group_id
-    privileged_roles:
+    privileged_roles_to_manage:
       - PERUNADMIN:
       - FACILITYADMIN: Facility
+    privileged_roles_to_read:
+      - PERUNADMIN:
+      - PERUNOBSERVER:
+      - FACILITYADMIN: Facility
+      - FACILITYOBSERVER: Facility
 
   TRUSTEDFACILITYADMIN:
     assign_to_objects:
@@ -5894,9 +5930,14 @@ perun_roles_management:
     entities_to_manage:
       User: user_id
       Group: authorized_group_id
-    privileged_roles:
+    privileged_roles_to_manage:
       - PERUNADMIN:
       - VOADMIN: Vo
+    privileged_roles_to_read:
+      - PERUNADMIN:
+      - PERUNOBSERVER:
+      - VOADMIN: Vo
+      - VOOBSERVER: Vo
 
   RESOURCEADMIN:
     assign_to_objects:
@@ -5906,12 +5947,23 @@ perun_roles_management:
     entities_to_manage:
       User: user_id
       Group: authorized_group_id
-    privileged_roles:
+    privileged_roles_to_manage:
       - PERUNADMIN:
       - VOADMIN: Vo
       - RESOURCEADMIN: Resource
       - TRUSTEDFACILITYADMIN: Vo
         FACILITYADMIN: Facility
+    privileged_roles_to_read:
+      - PERUNADMIN:
+      - PERUNOBSERVER:
+      - VOADMIN: Vo
+      - RESOURCEADMIN: Resource
+      - TRUSTEDFACILITYADMIN: Vo
+        FACILITYADMIN: Facility
+      - RESOURCEOBSERVER: Resource
+      - TRUSTEDFACILITYADMIN: Vo
+        FACILITYOBSERVER: Facility
+      - VOOBSERVER: Vo
 
   RESOURCEOBSERVER:
     assign_to_objects:
@@ -5921,12 +5973,23 @@ perun_roles_management:
     entities_to_manage:
       User: user_id
       Group: authorized_group_id
-    privileged_roles:
+    privileged_roles_to_manage:
       - PERUNADMIN:
       - VOADMIN: Vo
       - RESOURCEADMIN: Resource
       - TRUSTEDFACILITYADMIN: Vo
         FACILITYADMIN: Facility
+    privileged_roles_to_read:
+      - PERUNADMIN:
+      - PERUNOBSERVER:
+      - VOADMIN: Vo
+      - RESOURCEADMIN: Resource
+      - TRUSTEDFACILITYADMIN: Vo
+        FACILITYADMIN: Facility
+      - RESOURCEOBSERVER: Resource
+      - TRUSTEDFACILITYADMIN: Vo
+        FACILITYOBSERVER: Facility
+      - VOOBSERVER: Vo
 
   RESOURCESELFSERVICE:
     assign_to_objects:
@@ -5936,37 +5999,53 @@ perun_roles_management:
     entities_to_manage:
       User: user_id
       Group: authorized_group_id
-    privileged_roles:
+    privileged_roles_to_manage:
       - PERUNADMIN:
       - VOADMIN: Vo
       - RESOURCEADMIN: Resource
       - TRUSTEDFACILITYADMIN: Vo
         FACILITYADMIN: Facility
+    privileged_roles_to_read:
+      - PERUNADMIN:
+      - PERUNOBSERVER:
+      - VOADMIN: Vo
+      - RESOURCEADMIN: Resource
+      - TRUSTEDFACILITYADMIN: Vo
+        FACILITYADMIN: Facility
+      - RESOURCEOBSERVER: Resource
+      - TRUSTEDFACILITYADMIN: Vo
+        FACILITYOBSERVER: Facility
+      - VOOBSERVER: Vo
 
   REGISTRAR:
     assign_to_objects: {}
     entities_to_manage: {}
-    privileged_roles: []
+    privileged_roles_to_manage: []
+    privileged_roles_to_read: []
 
   ENGINE:
     assign_to_objects: {}
     entities_to_manage: {}
-    privileged_roles: []
+    privileged_roles_to_manage: []
+    privileged_roles_to_read: []
 
   RPC:
     assign_to_objects: {}
     entities_to_manage: {}
-    privileged_roles: []
+    privileged_roles_to_manage: []
+    privileged_roles_to_read: []
 
   NOTIFICATIONS:
     assign_to_objects: {}
     entities_to_manage: {}
-    privileged_roles: []
+    privileged_roles_to_manage: []
+    privileged_roles_to_read: []
 
   SERVICEUSER:
     assign_to_objects: {}
     entities_to_manage: {}
-    privileged_roles: []
+    privileged_roles_to_manage: []
+    privileged_roles_to_read: []
 
   SPONSOR:
     assign_to_objects:
@@ -5974,9 +6053,14 @@ perun_roles_management:
     entities_to_manage:
       User: user_id
       Group: authorized_group_id
-    privileged_roles:
+    privileged_roles_to_manage:
       - PERUNADMIN:
       - VOADMIN: Vo
+    privileged_roles_to_read:
+      - PERUNADMIN:
+      - PERUNOBSERVER:
+      - VOADMIN: Vo
+      - VOOBSERVER: Vo
 
   VOOBSERVER:
     assign_to_objects:
@@ -5984,9 +6068,14 @@ perun_roles_management:
     entities_to_manage:
       User: user_id
       Group: authorized_group_id
-    privileged_roles:
+    privileged_roles_to_manage:
       - PERUNADMIN:
       - VOADMIN: Vo
+    privileged_roles_to_read:
+      - PERUNADMIN:
+      - PERUNOBSERVER:
+      - VOADMIN: Vo
+      - VOOBSERVER: Vo
 
   TOPGROUPCREATOR:
     assign_to_objects:
@@ -5994,9 +6083,14 @@ perun_roles_management:
     entities_to_manage:
       User: user_id
       Group: authorized_group_id
-    privileged_roles:
+    privileged_roles_to_manage:
       - PERUNADMIN:
       - VOADMIN: Vo
+    privileged_roles_to_read:
+      - PERUNADMIN:
+      - PERUNOBSERVER:
+      - VOADMIN: Vo
+      - VOOBSERVER: Vo
 
   SECURITYADMIN:
     assign_to_objects:
@@ -6004,21 +6098,30 @@ perun_roles_management:
     entities_to_manage:
       User: user_id
       Group: authorized_group_id
-    privileged_roles:
+    privileged_roles_to_manage:
       - PERUNADMIN:
+      - SECURITYADMIN: SecurityTeam
+    privileged_roles_to_read:
+      - PERUNADMIN:
+      - PERUNOBSERVER:
       - SECURITYADMIN: SecurityTeam
 
   CABINETADMIN:
     assign_to_objects: {}
     entities_to_manage:
       User: user_id
-    privileged_roles:
+    privileged_roles_to_manage:
       - PERUNADMIN:
+      - CABINETADMIN:
+    privileged_roles_to_read:
+      - PERUNADMIN:
+      - PERUNOBSERVER:
       - CABINETADMIN:
 
   UNKNOWN:
     assign_to_objects: {}
     entities_to_manage: {}
-    privileged_roles: []
+    privileged_roles_to_manage: []
+    privileged_roles_to_read: []
 
 ...

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
@@ -25,6 +25,7 @@ import cz.metacentrum.perun.core.api.ResourceTag;
 import cz.metacentrum.perun.core.api.RichGroup;
 import cz.metacentrum.perun.core.api.RichMember;
 import cz.metacentrum.perun.core.api.RichResource;
+import cz.metacentrum.perun.core.api.RichUser;
 import cz.metacentrum.perun.core.api.Role;
 import cz.metacentrum.perun.core.api.RoleManagementRules;
 import cz.metacentrum.perun.core.api.SecurityTeam;
@@ -87,6 +88,8 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 	private static AuthzResolverImplApi authzResolverImpl;
 	private static PerunBl perunBl;
 	private final static Set<String> extSourcesWithMultipleIdentifiers = BeansUtils.getCoreConfig().getExtSourcesMultipleIdentifiers();
+	private final static String groupObjectType = "Group";
+	private final static String userObjectType = "User";
 
 	/**
 	 * Prepare necessary structures and resolve access rights for the session's principal.
@@ -147,7 +150,38 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 			mapOfBeans = fetchAllRelatedObjects(Collections.singletonList(object));
 		}
 
-		return resolveAuthorization(sess, rules.getPrivilegedRoles(), mapOfBeans);
+		return resolveAuthorization(sess, rules.getPrivilegedRolesToManage(), mapOfBeans);
+	}
+
+	/**
+	 * Check whether the principal is authorized to read the role on the object.
+	 *
+	 * @param sess principal's perun session
+	 * @param object bounded with the role
+	 * @param roleName which will be managed
+	 * @return true if principal is authorized. False otherwise.
+	 * @throws RoleManagementRulesNotExistsException when the role does not have the management rules.
+	 */
+	public static boolean authorizedToReadRole(PerunSession sess, PerunBean object, String roleName) throws RoleManagementRulesNotExistsException {
+		// We need to load additional information about the principal
+		if (!sess.getPerunPrincipal().isAuthzInitialized()) {
+			refreshAuthz(sess);
+		}
+
+		// If the user has no roles, deny access
+		if (sess.getPerunPrincipal().getRoles() == null) {
+			return false;
+		}
+
+		RoleManagementRules rules = AuthzResolverImpl.getRoleManagementRules(roleName);
+
+		Map <String, Set<Integer>> mapOfBeans = new HashMap<>();
+		if (object != null) {
+			//Fetch super objects like Vo for group etc.
+			mapOfBeans = fetchAllRelatedObjects(Collections.singletonList(object));
+		}
+
+		return resolveAuthorization(sess, rules.getPrivilegedRolesToRead(), mapOfBeans);
 	}
 
 	public static boolean selfAuthorizedForApplication(PerunSession sess, Application app) {
@@ -1020,11 +1054,11 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 	 * @param complementaryObject object for which role will be set
 	 */
 	public static void setRole(PerunSession sess, User user, PerunBean complementaryObject, String role) throws AlreadyAdminException, RoleCannotBeManagedException {
-		if (!objectAndRoleManageableByEntity(user, complementaryObject, role)) {
+		if (!objectAndRoleManageableByEntity(user.getBeanName(), complementaryObject, role)) {
 			throw new RoleCannotBeManagedException(role, complementaryObject, user);
 		}
 
-		Map<String, Integer> mappingOfValues = createMappingOfValues(user, complementaryObject, role);
+		Map<String, Integer> mappingOfValues = createMappingToManageRole(user, complementaryObject, role);
 
 		try {
 			authzResolverImpl.setRole(sess, mappingOfValues, role);
@@ -1052,11 +1086,11 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 	 * @param complementaryObject object for which role will be set
 	 */
 	public static void setRole(PerunSession sess, Group authorizedGroup, PerunBean complementaryObject, String role) throws AlreadyAdminException, RoleCannotBeManagedException {
-		if (!objectAndRoleManageableByEntity(authorizedGroup, complementaryObject, role)) {
+		if (!objectAndRoleManageableByEntity(authorizedGroup.getBeanName(), complementaryObject, role)) {
 			throw new RoleCannotBeManagedException(role, complementaryObject, authorizedGroup);
 		}
 
-		Map<String, Integer> mappingOfValues = createMappingOfValues(authorizedGroup, complementaryObject, role);
+		Map<String, Integer> mappingOfValues = createMappingToManageRole(authorizedGroup, complementaryObject, role);
 
 		try {
 			authzResolverImpl.setRole(sess, mappingOfValues, role);
@@ -1086,11 +1120,11 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 	 * @param complementaryObject object for which role will be unset
 	 */
 	public static void unsetRole(PerunSession sess, User user, PerunBean complementaryObject, String role) throws UserNotAdminException, RoleCannotBeManagedException {
-		if (!objectAndRoleManageableByEntity(user, complementaryObject, role)) {
+		if (!objectAndRoleManageableByEntity(user.getBeanName(), complementaryObject, role)) {
 			throw new RoleCannotBeManagedException(role, complementaryObject, user);
 		}
 
-		Map<String, Integer> mappingOfValues = createMappingOfValues(user, complementaryObject, role);
+		Map<String, Integer> mappingOfValues = createMappingToManageRole(user, complementaryObject, role);
 
 		try {
 			authzResolverImpl.unsetRole(sess, mappingOfValues, role);
@@ -1122,11 +1156,11 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 	 * @param complementaryObject object for which role will be unset
 	 */
 	public static void unsetRole(PerunSession sess, Group authorizedGroup, PerunBean complementaryObject, String role) throws GroupNotAdminException, RoleCannotBeManagedException {
-		if (!objectAndRoleManageableByEntity(authorizedGroup, complementaryObject, role)) {
+		if (!objectAndRoleManageableByEntity(authorizedGroup.getBeanName(), complementaryObject, role)) {
 			throw new RoleCannotBeManagedException(role, complementaryObject, authorizedGroup);
 		}
 
-		Map<String, Integer> mappingOfValues = createMappingOfValues(authorizedGroup, complementaryObject, role);
+		Map<String, Integer> mappingOfValues = createMappingToManageRole(authorizedGroup, complementaryObject, role);
 
 		try {
 			authzResolverImpl.unsetRole(sess, mappingOfValues, role);
@@ -1193,6 +1227,70 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 	 */
 	public static List<PerunPolicy> getAllPolicies() {
 		return AuthzResolverImpl.getAllPolicies();
+	}
+
+	/**
+	 * Get all authorizedGroups for complementary object and role.
+	 *
+	 * @param complementaryObject for which we will get administrator groups
+	 * @param role expected role to filter authorizedGroups by
+	 *
+	 * @return list of authorizedGroups for complementary object and role
+	 */
+	public static List<Group> getAdminGroups(PerunBean complementaryObject, String role) throws RoleCannotBeManagedException {
+
+		if (!objectAndRoleManageableByEntity(groupObjectType, complementaryObject, role)) {
+			throw new RoleCannotBeManagedException(role, complementaryObject);
+		}
+
+		Map<String, Integer> mappingOfValues = createMappingToReadRoleOnObject(complementaryObject, role);
+
+		return authzResolverImpl.getAdminGroups(mappingOfValues);
+	}
+
+	/**
+	 * Get all richUser administrators for complementary object and role with specified attributes.
+	 *
+	 * If <b>onlyDirectAdmins</b> is <b>true</b>, return only direct users of the complementary object for role with specific attributes.
+	 * If <b>allUserAttributes</b> is <b>true</b>, do not specify attributes through list and return them all in objects richUser. Ignoring list of specific attributes.
+	 *
+	 * @param sess perun session
+	 * @param complementaryObject for which we will get administrator
+	 * @param specificAttributes list of specified attributes which are needed in object richUser
+	 * @param role expected role to filter managers by
+	 * @param onlyDirectAdmins if true, get only direct user administrators (if false, get both direct and indirect)
+	 * @param allUserAttributes if true, get all possible user attributes and ignore list of specificAttributes (if false, get only specific attributes)
+	 *
+	 * @return list of richUser administrators for complementary object and role with specified attributes.
+	 */
+	public static List<RichUser> getRichAdmins(PerunSession sess, PerunBean complementaryObject, List<String> specificAttributes, String role, boolean onlyDirectAdmins, boolean allUserAttributes) throws RoleCannotBeManagedException {
+
+		if (!objectAndRoleManageableByEntity(userObjectType, complementaryObject, role)) {
+			throw new RoleCannotBeManagedException(role, complementaryObject);
+		}
+
+		Map<String, Integer> mappingOfValues = createMappingToReadRoleOnObject(complementaryObject, role);
+
+		List<User> admins = authzResolverImpl.getAdmins(mappingOfValues, onlyDirectAdmins);
+		List<RichUser> richAdminsWithAttributes;
+
+		if(allUserAttributes) {
+			try {
+				richAdminsWithAttributes = perunBl.getUsersManagerBl().getRichUsersWithAttributesFromListOfUsers(sess, admins);
+			} catch (UserNotExistsException e) {
+				throw new InternalErrorException(e);
+			}
+		} else {
+			try {
+				List<AttributeDefinition> attrDefinitions = getPerunBl().getAttributesManagerBl().getAttributesDefinition(sess, specificAttributes);
+				List<RichUser> richAdmins = perunBl.getUsersManagerBl().getRichUsersFromListOfUsers(sess, admins);
+				richAdminsWithAttributes = getPerunBl().getUsersManagerBl().convertUsersToRichUsersWithAttributes(sess, richAdmins, attrDefinitions);
+			} catch (AttributeNotExistsException ex) {
+				throw new InternalErrorException("One of the given attributes doesn`t exist.", ex);
+			}
+		}
+
+		return getPerunBl().getUsersManagerBl().filterOnlyAllowedAttributes(sess, richAdminsWithAttributes);
 	}
 
 	public String toString() {
@@ -1967,12 +2065,12 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 	/**
 	 * Checks whether the given parameters satisfies the rules associated with the role.
 	 *
-	 * @param entityToManage to which will be the role set or unset
+	 * @param entityToManage to which will be the role set, unset or read
 	 * @param complementaryObject which will be bounded with the role
 	 * @param role which will be managed
 	 * @return true if all given parameters imply with the associated rule, false otherwise.
 	 */
-	private static boolean objectAndRoleManageableByEntity(PerunBean entityToManage, PerunBean complementaryObject, String role) {
+	private static boolean objectAndRoleManageableByEntity(String entityToManage, PerunBean complementaryObject, String role) {
 		RoleManagementRules rules;
 		try {
 			rules = AuthzResolverImpl.getRoleManagementRules(role);
@@ -1982,7 +2080,7 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 
 		Set<String> necessaryObjects = rules.getAssignedObjects().keySet();
 
-		if (rules.getEntitiesToManage().containsKey(entityToManage.getBeanName())) {
+		if (rules.getEntitiesToManage().containsKey(entityToManage)) {
 			if (complementaryObject == null && necessaryObjects.isEmpty()) {
 				return true;
 			} else if (complementaryObject != null && !necessaryObjects.isEmpty()) {
@@ -2002,9 +2100,7 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 	 * @param role which will be managed
 	 * @return final mapping of values
 	 */
-	private static Map<String, Integer> createMappingOfValues(PerunBean entityToManage, PerunBean complementaryObject, String role) {
-		Map<String, Integer> mapping = new HashMap<>();
-
+	private static Map<String, Integer> createMappingToManageRole(PerunBean entityToManage, PerunBean complementaryObject, String role) {
 		RoleManagementRules rules;
 		try {
 			rules = AuthzResolverImpl.getRoleManagementRules(role);
@@ -2012,9 +2108,42 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 			throw new InternalErrorException("Management rules not exist for the role " + role, e);
 		}
 
+		Map<String, Integer> mapping = createMappingOfValues(complementaryObject, role, rules);
+		mapping.put(rules.getEntitiesToManage().get(entityToManage.getBeanName()), entityToManage.getId());
+
+		return mapping;
+	}
+
+	/**
+	 * Create a mapping of column names and ids which will be used for reading the role.
+	 *
+	 * @param complementaryObject which will be bounded with the role
+	 * @param role which will be managed
+	 * @return final mapping of values
+	 */
+	private static Map<String, Integer> createMappingToReadRoleOnObject(PerunBean complementaryObject, String role) {
+		RoleManagementRules rules;
+		try {
+			rules = AuthzResolverImpl.getRoleManagementRules(role);
+		} catch (RoleManagementRulesNotExistsException e) {
+			throw new InternalErrorException("Management rules not exist for the role " + role, e);
+		}
+
+		return createMappingOfValues(complementaryObject, role, rules);
+	}
+
+	/**
+	 * Create a mapping of column names and ids which will be used to read or manage the role.
+	 *
+	 * @param complementaryObject which will be bounded with the role
+	 * @param role which will be managed
+	 * @return final mapping of values
+	 */
+	private static Map<String, Integer> createMappingOfValues(PerunBean complementaryObject, String role, RoleManagementRules rules) {
+		Map<String, Integer> mapping = new HashMap<>();
+
 		Integer role_id = authzResolverImpl.getRoleId(role);
 		mapping.put("role_id", role_id);
-		mapping.put(rules.getEntitiesToManage().get(entityToManage.getBeanName()), entityToManage.getId());
 
 		Map <String, Set<Integer>> mapOfBeans = new HashMap<>();
 		if (complementaryObject != null) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/PerunRolesLoader.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/PerunRolesLoader.java
@@ -141,25 +141,37 @@ public class PerunRolesLoader {
 		while (roleNames.hasNext()) {
 			String roleName = roleNames.next();
 			JsonNode roleNode = rolesNodes.get(roleName);
-			List<Map<String, String>> privilegedRoles = new ArrayList<>();
-			JsonNode privilegedRolesNode = roleNode.get("privileged_roles");
+			List<Map<String, String>> privilegedRolesToManage = createMapFromPrivilegedRoles(roleNode.get("privileged_roles_to_manage"));
+			List<Map<String, String>> privilegedRolesToRead = createMapFromPrivilegedRoles(roleNode.get("privileged_roles_to_read"));
+			Map<String, String> entitiesToManage = createMapFromJsonNode(roleNode.get("entities_to_manage"));
+			Map<String, String> objectsToAssign = createMapFromJsonNode(roleNode.get("assign_to_objects"));
 
-			//Field privileged_roles is saved as List of maps in the for loop
-			for (JsonNode privilegedRoleNode : privilegedRolesNode) {
-				Map<String, String> innerRoleMap = createmapFromJsonNode(privilegedRoleNode);
-				privilegedRoles.add(innerRoleMap);
-			}
-
-			Map<String, String> entitiesToManage = createmapFromJsonNode(roleNode.get("entities_to_manage"));
-			Map<String, String> objectsToAssign = createmapFromJsonNode(roleNode.get("assign_to_objects"));
-
-			rules.add(new RoleManagementRules(roleName, privilegedRoles, entitiesToManage, objectsToAssign));
+			rules.add(new RoleManagementRules(roleName, privilegedRolesToManage, privilegedRolesToRead, entitiesToManage, objectsToAssign));
 		}
 
 		return rules;
 	}
 
-	private Map<String, String> createmapFromJsonNode(JsonNode node) {
+	/**
+	 * Gathers privileged roles from a JsonNnode and put them into a list of maps.
+	 * Role name is stored as a key and the object for the role is stored as a value.
+	 *
+	 * @param privilegedRolesNode is a JsonNode which contains role privileges
+	 * @return a list of maps representing the role privileges
+	 */
+	private List<Map<String, String>> createMapFromPrivilegedRoles(JsonNode privilegedRolesNode) {
+		List<Map<String, String>> privilegedRoles = new ArrayList<>();
+
+		//Field privileged_roles_to_manage is saved as List of maps in the for loop
+		for (JsonNode privilegedRoleNode : privilegedRolesNode) {
+			Map<String, String> innerRoleMap = createMapFromJsonNode(privilegedRoleNode);
+			privilegedRoles.add(innerRoleMap);
+		}
+
+		return privilegedRoles;
+	}
+
+	private Map<String, String> createMapFromJsonNode(JsonNode node) {
 		Map<String, String> resultMap = new HashMap<>();
 
 		Iterator<String> nodeArrayKeys = node.fieldNames();
@@ -211,7 +223,7 @@ public class PerunRolesLoader {
 
 			//Field policy_roles is saved as List of maps in the for loop
 			for (JsonNode perunRoleNode : perunRolesNode) {
-				Map<String, String> innerRoleMap = createmapFromJsonNode(perunRoleNode);
+				Map<String, String> innerRoleMap = createMapFromJsonNode(perunRoleNode);
 				perunRoles.add(innerRoleMap);
 			}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AuthzResolverImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AuthzResolverImplApi.java
@@ -4,6 +4,7 @@ import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.RichUser;
 import cz.metacentrum.perun.core.api.SecurityTeam;
 import cz.metacentrum.perun.core.api.Service;
 import cz.metacentrum.perun.core.api.User;
@@ -547,4 +548,24 @@ public interface AuthzResolverImplApi {
 	 * @throws RoleNotSetException
 	 */
 	void unsetRole(PerunSession sess, Map<String, Integer> mappingOfValues, String role) throws RoleNotSetException;
+
+	/**
+	 * Get all richUser administrators for complementary object and role with specified attributes.
+	 *
+	 * @param mappingOfValues from which will be the query created (keys are column names and values are their ids)
+	 * @param onlyDirectAdmins if we do not want to include also members of authorized groups.
+	 *
+	 * @return list of user administrators for complementary object and role with specified attributes.
+	 */
+	List<User> getAdmins(Map<String, Integer> mappingOfValues, boolean onlyDirectAdmins);
+
+
+	/**
+	 * Get all authorizedGroups for complementary object and role.
+	 *
+	 * @param mappingOfValues according to which will be the role selected
+	 *
+	 * @return list of authorizedGroups
+	 */
+	List<Group> getAdminGroups(Map<String, Integer> mappingOfValues);
 }


### PR DESCRIPTION
- Methods getAdminGroups and getRichAdmins in AuthzResolver were reworked so it is
  possible to configure the acces rights.
- Access rights are stored in perun-roles.yml under the
  role_management_rules->privileged_roles_to_read.
- Similar methods in other managers were not converted to this general
  approach yet. It will be done in a small separate PR so this one is not
  too complex.