### PR TITLE
Unfilled mail attribute for password reset request

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/PasswordResetMailNotExistsException.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/PasswordResetMailNotExistsException.java
@@ -1,0 +1,22 @@
+package cz.metacentrum.perun.core.api.exceptions;
+
+/**
+ * This exception is thrown when the user doesn't have the chosen attribute for mail set,
+ * where password reset link should be send to.
+ *
+ * @author Radoslav Čerhák <r.cerhak@gmail.com>
+ */
+public class PasswordResetMailNotExistsException extends PerunException {
+
+	public PasswordResetMailNotExistsException(String message) {
+		super(message);
+	}
+
+	public PasswordResetMailNotExistsException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public PasswordResetMailNotExistsException(Throwable cause) {
+		super(cause);
+	}
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/MembersManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/MembersManager.java
@@ -18,6 +18,7 @@ import cz.metacentrum.perun.core.api.exceptions.MemberNotSuspendedException;
 import cz.metacentrum.perun.core.api.exceptions.MemberNotValidYetException;
 import cz.metacentrum.perun.core.api.exceptions.ParentGroupNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.PasswordCreationFailedException;
+import cz.metacentrum.perun.core.api.exceptions.PasswordResetMailNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.PasswordStrengthException;
 import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
 import cz.metacentrum.perun.core.api.exceptions.ResourceNotExistsException;
@@ -1113,8 +1114,9 @@ public interface MembersManager {
 	 * @throws InternalErrorException
 	 * @throws PrivilegeException If not VO admin of member
 	 * @throws MemberNotExistsException If member not exists
+	 * @throws PasswordResetMailNotExistsException If the attribute with stored mail is not filled.
 	 */
-	void sendPasswordResetLinkEmail(PerunSession sess, Member member, String namespace, String url, String mailAttributeUrn, String language) throws PrivilegeException, MemberNotExistsException, UserNotExistsException, AttributeNotExistsException;
+	void sendPasswordResetLinkEmail(PerunSession sess, Member member, String namespace, String url, String mailAttributeUrn, String language) throws PrivilegeException, MemberNotExistsException, UserNotExistsException, AttributeNotExistsException, PasswordResetMailNotExistsException;
 
 	/**
 	 * Creates a new sponsored Member and its User.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/MembersManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/MembersManagerEntry.java
@@ -37,6 +37,7 @@ import cz.metacentrum.perun.core.api.exceptions.MemberNotSuspendedException;
 import cz.metacentrum.perun.core.api.exceptions.MemberNotValidYetException;
 import cz.metacentrum.perun.core.api.exceptions.ParentGroupNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.PasswordCreationFailedException;
+import cz.metacentrum.perun.core.api.exceptions.PasswordResetMailNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.PasswordStrengthException;
 import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
 import cz.metacentrum.perun.core.api.exceptions.ResourceNotExistsException;
@@ -1126,7 +1127,7 @@ public class MembersManagerEntry implements MembersManager {
 	}
 
 	@Override
-	public void sendPasswordResetLinkEmail(PerunSession sess, Member member, String namespace, String url, String mailAttributeUrn, String language) throws PrivilegeException, MemberNotExistsException, UserNotExistsException, AttributeNotExistsException {
+	public void sendPasswordResetLinkEmail(PerunSession sess, Member member, String namespace, String url, String mailAttributeUrn, String language) throws PrivilegeException, MemberNotExistsException, UserNotExistsException, AttributeNotExistsException, PasswordResetMailNotExistsException {
 
 		Utils.checkPerunSession(sess);
 		getMembersManagerBl().checkMemberExists(sess, member);
@@ -1157,9 +1158,12 @@ public class MembersManagerEntry implements MembersManager {
 			throw new InternalErrorException("MailAttribute should not be null.");
 		}
 		String mailAddress = mailAttribute.valueAsString();
+		if (mailAddress == null) {
+			throw new PasswordResetMailNotExistsException("Member " + member.getId() + " doesn't have the attribute " +
+				mailAttributeUrn + " set.");
+		}
 
 		getMembersManagerBl().sendPasswordResetLinkEmail(sess, member, namespace, url, mailAddress, language);
-
 	}
 
 	@Override

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/JsonErrorHandler.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/JsonErrorHandler.java
@@ -762,6 +762,10 @@ public class JsonErrorHandler {
 
 			return "Can't set new password. Old password doesn't match.";
 
+		} else if ("PasswordResetMailNotExistsException".equalsIgnoreCase(errorName)) {
+
+			return "User doesn't have the chosen email attribute set. Choose different attribute.";
+
 		} else if ("PasswordStrengthFailedException".equalsIgnoreCase(errorName)) {
 
 			return "Used password doesn't match required strength constraints.";


### PR DESCRIPTION
- VO manager chooses which user's email attribute should be used for password reset
request. When the user didn't have the  attribute filled, InternalErrorException
was thrown and was displayed as generic error in GUI.
- New PasswordResetMailNotExistsException was created.
- Now this exception is thrown in such case and is displayed with proper message
in GUI.