### PR TITLE
Fix roles management

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
@@ -2138,19 +2138,11 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 			throw new InternalErrorException("Management rules not exist for the role " + role, e);
 		}
 
-		//For reading a role it is enough to know role and the primary object.
-		//No need to fetch all related objects
-		Map<String, Integer> mapping = new HashMap<>();
-		Integer roleId = authzResolverImpl.getRoleId(role);
-		mapping.put("role_id", roleId);
-		String objectColumnName = rules.getAssignedObjects().get(complementaryObject.getBeanName());
-		mapping.put(objectColumnName, complementaryObject.getId());
-
-		return mapping;
+		return createMappingOfValues(complementaryObject, role, rules);
 	}
 
 	/**
-	 * Create a mapping of column names and ids which will be used to manage the role.
+	 * Create a mapping of column names and ids which will be used to read or manage the role.
 	 *
 	 * @param complementaryObject which will be bounded with the role
 	 * @param role which will be managed

--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -2817,7 +2817,6 @@ paths:
               required:
                 - role
                 - users
-                - complementaryObject
               properties:
                 role: {type: string, nullable: false}
                 users:
@@ -2850,7 +2849,6 @@ paths:
               required:
                 - role
                 - users
-                - complementaryObject
               properties:
                 role: {type: string, nullable: false}
                 users:
@@ -2884,7 +2882,6 @@ paths:
               required:
                 - role
                 - authorizedGroups
-                - complementaryObject
               properties:
                 role: {type: string, nullable: false}
                 authorizedGroups:
@@ -2917,7 +2914,6 @@ paths:
               required:
                 - role
                 - authorizedGroups
-                - complementaryObject
               properties:
                 role: {type: string, nullable: false}
                 authorizedGroups:

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/ApiCaller.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/ApiCaller.java
@@ -11,6 +11,7 @@ import cz.metacentrum.perun.cabinet.model.Category;
 import cz.metacentrum.perun.cabinet.model.Publication;
 import cz.metacentrum.perun.cabinet.model.PublicationSystem;
 import cz.metacentrum.perun.cabinet.model.Thanks;
+import cz.metacentrum.perun.core.api.PerunBean;
 import cz.metacentrum.perun.core.api.PerunClient;
 import cz.metacentrum.perun.core.api.TasksManager;
 import cz.metacentrum.perun.registrar.model.Application;
@@ -494,5 +495,61 @@ public class ApiCaller {
 
 		return listOfObjects.subList(fromIndex, toIndex);
 
+	}
+
+	/**
+	 * Fetch PerunBean from the Perun database
+	 *
+	 * IMPORTANT: Actually are supported only objects, that can be connected with some user/authorizedGroup role!!!
+	 *
+	 * @param object according to which will be the real object retrieved
+	 * @return real PerunBean object from the database
+	 * @throws PerunException
+	 */
+	public PerunBean fetchPerunBean(PerunBean object) throws PerunException {
+		if (object == null) throw new InternalErrorException("PerunBean cannot be null while fetching the real object from the database.");
+		return getBeanFromDatabase(object);
+	}
+
+	/**
+	 * Fetch PerunBeans from the Perun database
+	 *
+	 * IMPORTANT: Actually are supported only objects, that can be connected with some user/authorizedGroup role!!!
+	 *
+	 * @param objects according to which will be real objects retrieved
+	 * @return list of real PerunBean objects from the database
+	 * @throws PerunException
+	 */
+	public List<PerunBean> fetchPerunBeans(List<PerunBean> objects) throws PerunException {
+		if (objects == null) throw new InternalErrorException("PerunBeans cannot be null while fetching the real objects from the database.");
+		List<PerunBean> result = new ArrayList<>();
+		for (PerunBean object: objects) {
+			result.add(fetchPerunBean(object));
+		}
+		return result;
+	}
+
+	/**
+	 * Method which fetch the object from the database according to object name and its id
+	 *
+	 * @param object according to which will be real object retrieved
+	 * @return real PerunBean object from the database
+	 * @throws PerunException
+	 */
+	private PerunBean getBeanFromDatabase(PerunBean object) throws PerunException {
+		switch(object.getBeanName()) {
+			case "Group":
+				return getGroupById(object.getId());
+			case "Vo":
+				return getVoById(object.getId());
+			case "Resource":
+				return getResourceById(object.getId());
+			case "Facility":
+				return getFacilityById(object.getId());
+			case "SecurityTeam":
+				return getSecurityTeamById(object.getId());
+			default:
+				throw new RpcException(RpcException.Type.WRONG_PARAMETER, "Object " + object.getBeanName() + " is not supported.");
+		}
 	}
 }


### PR DESCRIPTION
- getAdminGroups and getRichAdmins use only simple perun bean consisting
  only from its name and id. However, to properly resolve authorization,
  we need also information about connected objects like vo id for group etc.
- Second issue is that methods setRole and unsetRole are composing
  PerunBeans only from information recieved from input. Therefore, someone
  can fake information about the connected objects like fake vo id for
  group. This way it would be possible to setRole on object without proper
  rights.
- Solution for these issues was to fetch the real object from database
  according to bean name and its id. This way the final object will have
  correct all its values. For this purpose were implemented methods
  fetchPerunBean and fetchPerunBeans. They suppport only objects which
  can be managed for now. It will be extended later. These methods are
  now used in RPC methods setRole, unsetRole, getAdminGroups and
  getRichAdmins.
- While fixing these problems, we have realized that it is not possible
  to call set and unset role methods without complementary object.
  However the underlying logic allows to operate with null complementary
  object. Therefore, this option was added to these RPC methods.