### PR TITLE
CORE: Fixed possible null pointer

### DIFF
--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/exceptions/TaskExecutionException.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/exceptions/TaskExecutionException.java
@@ -82,7 +82,7 @@ public class TaskExecutionException extends EngineException {
 	}
 
 	public String getStdout() {
-		return stdout;
+		return (this.stdout == null) ? "" : this.stdout;
 	}
 
 	public void setStdout(String stdout) {
@@ -90,7 +90,7 @@ public class TaskExecutionException extends EngineException {
 	}
 
 	public String getStderr() {
-		return stderr;
+		return (this.stderr == null) ? "" : this.stderr;
 	}
 
 	public void setStderr(String stderr) {

--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/SchedulingPoolImpl.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/SchedulingPoolImpl.java
@@ -200,8 +200,8 @@ public class SchedulingPoolImpl implements SchedulingPool {
 		taskResult.setErrorMessage(stderr);
 		taskResult.setStandardMessage(stdout);
 		taskResult.setReturnCode(returnCode);
-		taskResult.setStatus(returnCode == 0 ? 
-				(stderr.isEmpty() ? TaskResult.TaskResultStatus.DONE : TaskResult.TaskResultStatus.WARNING) 
+		taskResult.setStatus(returnCode == 0 ?
+				((stderr == null || stderr.isEmpty()) ? TaskResult.TaskResultStatus.DONE : TaskResult.TaskResultStatus.WARNING)
 				: TaskResult.TaskResultStatus.ERROR);
 		taskResult.setTimestamp(new Date(System.currentTimeMillis()));
 		taskResult.setService(service);


### PR DESCRIPTION
- Make sure we return non-null string for stdout/stderr
  when getting it from TaskExecutionException.
- When creating TaskResult handle also null stderr.