### PR TITLE
Perun core - updateSponsorshipValidity fix

### DIFF
--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -2513,19 +2513,12 @@ components:
       in: query
       required: true
 
-    validityTo:
-      name: validityTo
-      description: date in format yyyy-mm-dd
-      schema:
-        type: string
-      in: query
-      required: true
-
     optionalValidityTo:
       name: validityTo
       description: date in format yyyy-mm-dd
       schema:
         type: string
+        nullable: true
       in: query
       required: false
 
@@ -8191,11 +8184,11 @@ paths:
       tags:
         - MembersManager
       operationId: updateSponsorshipValidity
-      summary: Updates sponsorship validity. To change it to FOREVER, pass null in validityTo.
+      summary: Updates sponsorship validity. To change it to FOREVER, don't pass the validityTo param, or pass it as null.
       parameters:
         - $ref: '#/components/parameters/memberId'
         - $ref: '#/components/parameters/sponsorId'
-        - $ref: '#/components/parameters/validityTo'
+        - $ref: '#/components/parameters/optionalValidityTo'
       responses:
         '200':
           $ref: '#/components/responses/VoidResponse'

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/MembersManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/MembersManagerMethod.java
@@ -370,7 +370,7 @@ public enum MembersManagerMethod implements ManagerMethod {
 	 * @param member int id of sponsored member, optional
 	 * @param sponsor int id of sponsoring user that is to be removed
 	 * @param validityTo String the last day, when the sponsorship is active, yyyy-mm-dd format.
-	 *                          can be set to null never expire
+	 *                          if it is not passed, or null, it can be set to never expire
 	 * @throw PrivilegeException insufficient permissions
 	 * @throw SponsorshipDoesNotExistException if the given user is not sponsor of the given member
 	 * @throw MemberNotExistsException if there is no such member
@@ -383,7 +383,10 @@ public enum MembersManagerMethod implements ManagerMethod {
 
 			Member sponsoredMember = ac.getMemberById(params.readInt("member"));
 			User sponsor = ac.getUserById(params.readInt("sponsor"));
-			LocalDate newValidity = params.readLocalDate("validityTo");
+			LocalDate newValidity = null;
+			if (params.contains("validityTo") && params.readString("validityTo") != null) {
+				newValidity = params.readLocalDate("validityTo");
+			}
 
 			ac.getMembersManager().updateSponsorshipValidity(ac.getSession(), sponsoredMember, sponsor, newValidity);
 			return null;


### PR DESCRIPTION
* The updateSponsorshipValidity method used to force the validityTo
parameter. Not, when not specified, it is used with the null value
(which means that the sponsorship will not expire)
* This was changed because the generated open api library in GUI was not
able to pass the validityTo param with null value.