### PR TITLE
REGISTRAR: Reworked Metacentrum registration module

### DIFF
--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/RegistrarModule.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/RegistrarModule.java
@@ -97,9 +97,10 @@ public interface RegistrarModule {
 	 * Custom logic for checking method before application submission (retrieval of registration form) from GUI
 	 *
 	 * @param session who approves the application
+	 * @param appType INITIAL or EXTENSION application
 	 * @param params custom params
 	 */
-	void canBeSubmitted(PerunSession session, Map<String, String> params) throws PerunException;
+	void canBeSubmitted(PerunSession session, Application.AppType appType, Map<String, String> params) throws PerunException;
 
 	/**
 	 * Custom logic for processing pre-filled form item data before they are returned from Perun to GUI

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
@@ -2122,7 +2122,7 @@ public class RegistrarManagerImpl implements RegistrarManager {
 		Map<String, String> federValues = sess.getPerunPrincipal().getAdditionalInformations();
 
 		RegistrarModule module = getRegistrarModule(form);
-		if (module != null) module.canBeSubmitted(sess, federValues);
+		if (module != null) module.canBeSubmitted(sess, appType, federValues);
 
 		// throws exception if user couldn't submit application - no reason to get form
 		checkDuplicateRegistrationAttempt(sess, appType, form);

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/DefaultRegistrarModule.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/DefaultRegistrarModule.java
@@ -74,7 +74,7 @@ public class DefaultRegistrarModule implements RegistrarModule {
 	}
 
 	@Override
-	public void canBeSubmitted(PerunSession session, Map<String, String> params) throws PerunException {
+	public void canBeSubmitted(PerunSession session, Application.AppType appType, Map<String, String> params) throws PerunException {
 
 	}
 

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/Du.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/Du.java
@@ -79,7 +79,7 @@ public class Du extends DefaultRegistrarModule {
 	}
 
 	@Override
-	public void canBeSubmitted(PerunSession session, Map<String, String> params) throws PerunException {
+	public void canBeSubmitted(PerunSession session, Application.AppType appType, Map<String, String> params) throws PerunException {
 
 		String eligibleString = params.get("isCesnetEligibleLastSeen");
 

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/EduGain.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/EduGain.java
@@ -5,7 +5,6 @@ import cz.metacentrum.perun.core.api.exceptions.AlreadyAdminException;
 import cz.metacentrum.perun.core.api.exceptions.GroupNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.InvalidGroupNameException;
-import cz.metacentrum.perun.core.api.exceptions.PerunException;
 import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
 import cz.metacentrum.perun.core.api.exceptions.RoleCannotBeManagedException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
@@ -13,8 +12,6 @@ import cz.metacentrum.perun.core.api.exceptions.VoNotExistsException;
 import cz.metacentrum.perun.registrar.model.Application;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.Map;
 
 /**
  * Application module for EduGain purpose
@@ -46,26 +43,6 @@ public class EduGain extends DefaultRegistrarModule {
 		}
 
 		return app;
-
-	}
-
-	@Override
-	public Application rejectApplication(PerunSession session, Application app, String reason) throws PerunException {
-		return app;
-	}
-
-	@Override
-	public Application beforeApprove(PerunSession session, Application app) {
-		return app;
-	}
-
-	@Override
-	public void canBeApproved(PerunSession session, Application app) throws PerunException {
-
-	}
-
-	@Override
-	public void canBeSubmitted(PerunSession session, Map<String, String> params) throws PerunException {
 
 	}
 

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/ElixirBonaFideStatus.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/ElixirBonaFideStatus.java
@@ -105,7 +105,7 @@ public class ElixirBonaFideStatus extends DefaultRegistrarModule {
 	 * Validate if the user meets criteria for applying to group.
 	 */
 	@Override
-	public void canBeSubmitted(PerunSession session, Map<String, String> params) throws PerunException {
+	public void canBeSubmitted(PerunSession session, Application.AppType appType, Map<String, String> params) throws PerunException {
 		User user = session.getPerunPrincipal().getUser();
 		if (user == null) {
 			throw new CantBeSubmittedException("This module can be set only for registration to Group.");

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/Metacentrum.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/Metacentrum.java
@@ -53,6 +53,7 @@ public class Metacentrum extends DefaultRegistrarModule {
 	private final static String A_GROUP_STATISTIC_GROUP_AUTOFILL = AttributesManager.NS_GROUP_ATTR_DEF+":statisticGroupAutoFill";
 	private final static String A_USER_IS_CESNET_ELIGIBLE_LAST_SEEN = AttributesManager.NS_USER_ATTR_DEF+":isCesnetEligibleLastSeen";
 	private final static String A_MEMBER_MEMBERSHIP_EXPIRATION = AttributesManager.NS_MEMBER_ATTR_DEF+":membershipExpiration";
+	protected final static String METACENTRUM_IDP = "https://login.ics.muni.cz/idp/shibboleth";
 
 	/**
 	 * Add all new Metacentrum members to "storage" group.
@@ -157,6 +158,12 @@ public class Metacentrum extends DefaultRegistrarModule {
 
 	@Override
 	public void canBeSubmitted(PerunSession session, Application.AppType appType, Map<String, String> params) throws PerunException {
+
+		if (METACENTRUM_IDP.equals(session.getPerunPrincipal().getExtSourceName())) {
+			throw new CantBeSubmittedException("You are currently logged-in using Metacentrum IdP." +
+					"It can't be used to register or extend membership in Metacentrum. Please close browser and log-in using different identity provider.",
+					"NOT_ELIGIBLE", null, null);
+		}
 
 		if (Application.AppType.EXTENSION.equals(appType)) {
 

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/Metacentrum.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/Metacentrum.java
@@ -9,8 +9,6 @@ import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.MemberNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.PerunException;
 import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
-import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
-import cz.metacentrum.perun.core.api.exceptions.VoNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
@@ -25,8 +23,10 @@ import org.slf4j.LoggerFactory;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
@@ -40,21 +40,29 @@ public class Metacentrum extends DefaultRegistrarModule {
 
 	private final static Logger log = LoggerFactory.getLogger(Metacentrum.class);
 
+	private final static String A_USER_RESEARCH_GROUP_STATISTICS = AttributesManager.NS_USER_ATTR_DEF+":researchGroupStatistic";
+	private final static String A_GROUP_STATISTIC_GROUP = AttributesManager.NS_GROUP_ATTR_DEF+":statisticGroup";
+	private final static String A_GROUP_STATISTIC_GROUP_AUTOFILL = AttributesManager.NS_GROUP_ATTR_DEF+":statisticGroupAutoFill";
+	private final static String A_USER_IS_CESNET_ELIGIBLE_LAST_SEEN = AttributesManager.NS_USER_ATTR_DEF+":isCesnetEligibleLastSeen";
+	private final static String A_MEMBER_MEMBERSHIP_EXPIRATION = AttributesManager.NS_MEMBER_ATTR_DEF+":membershipExpiration";
+
 	/**
 	 * Add all new Metacentrum members to "storage" group.
+	 * Sort them in the statistics groups.
+	 * Set shorter expiration to users, which are not eligible for CESNET services.
 	 */
 	@Override
-	public Application approveApplication(PerunSession session, Application app) throws PrivilegeException, VoNotExistsException, GroupNotExistsException, UserNotExistsException, MemberNotExistsException, ExternallyManagedException, WrongAttributeAssignmentException, AttributeNotExistsException, WrongReferenceAttributeValueException, WrongAttributeValueException, RegistrarException {
+	public Application approveApplication(PerunSession session, Application app) throws PrivilegeException, GroupNotExistsException, MemberNotExistsException, ExternallyManagedException, WrongAttributeAssignmentException, AttributeNotExistsException, WrongReferenceAttributeValueException, WrongAttributeValueException, RegistrarException {
 
-		// get perun from session
 		PerunBl perun = (PerunBl)session.getPerun();
+		Vo vo = app.getVo();
+		User user = app.getUser();
+		Member mem = perun.getMembersManagerBl().getMemberByUser(session, vo, user);
 
+		// Add new members to "storage" group
 		if (Application.AppType.INITIAL.equals(app.getType())) {
 
-			Vo vo = app.getVo();
-			User user = app.getUser();
 			Group group = perun.getGroupsManagerBl().getGroupByName(session, vo, "storage");
-			Member mem = perun.getMembersManagerBl().getMemberByUser(session, vo, user);
 
 			try  {
 				perun.getGroupsManager().addMember(session, group, mem);
@@ -68,7 +76,7 @@ public class Metacentrum extends DefaultRegistrarModule {
 
 		List<ApplicationFormItemData> formData = registrar.getApplicationDataById(session, app.getId());
 		for (ApplicationFormItemData item : formData) {
-			if (Objects.equals("urn:perun:user:attribute-def:def:researchGroupStatistic", item.getFormItem().getPerunDestinationAttribute())) {
+			if (Objects.equals(A_USER_RESEARCH_GROUP_STATISTICS, item.getFormItem().getPerunDestinationAttribute())) {
 				statisticGroupName = item.getValue();
 				break;
 			}
@@ -83,22 +91,45 @@ public class Metacentrum extends DefaultRegistrarModule {
 				return app;
 			}
 
-
-			Attribute isStatisticGroup = perun.getAttributesManagerBl().getAttribute(session, group, "urn:perun:group:attribute-def:def:statisticGroup");
-			Attribute isStatisticGroupAutoFill = perun.getAttributesManagerBl().getAttribute(session, group, "urn:perun:group:attribute-def:def:statisticGroupAutoFill");
+			Attribute isStatisticGroup = perun.getAttributesManagerBl().getAttribute(session, group, A_GROUP_STATISTIC_GROUP);
+			Attribute isStatisticGroupAutoFill = perun.getAttributesManagerBl().getAttribute(session, group, A_GROUP_STATISTIC_GROUP_AUTOFILL);
 
 			boolean statisticGroup = (isStatisticGroup.getValue() != null) ? (Boolean)isStatisticGroup.getValue() : false;
 			boolean statisticGroupAutoFill = (isStatisticGroupAutoFill.getValue() != null) ? (Boolean)isStatisticGroupAutoFill.getValue() : false;
 
 			if (statisticGroup && statisticGroupAutoFill) {
 				try  {
-					Member mem = perun.getMembersManagerBl().getMemberByUser(session, app.getVo(), app.getUser());
 					perun.getGroupsManager().addMember(session, group, mem);
-				} catch (AlreadyMemberException ex) {
+				} catch (AlreadyMemberException ignored) {
 
 				}
 			}
 		}
+
+		// SET EXPIRATION BASED ON "isCesnetEligibleLastSeen"
+		boolean eligibleUser = isCesnetEligibleLastSeen(getIsCesnetEligibleLastSeenFromUser(session, app));
+		boolean eligibleApplication = isCesnetEligibleLastSeen(getIsCesnetEligibleLastSeenFromApplication(session, app));
+
+		if (!eligibleUser && !eligibleApplication) {
+
+			Attribute expirationAttribute = perun.getAttributesManagerBl().getAttribute(session, mem, A_MEMBER_MEMBERSHIP_EXPIRATION);
+
+			// only if member already has some expiration set !!
+			if (expirationAttribute.getValue() != null) {
+				LocalDate date = null;
+				if (Application.AppType.INITIAL.equals(app.getType())) {
+					// set 3 months from now (since generic logic already set wrong expiration to the member)
+					date = LocalDate.now().plusMonths(3);
+				} else {
+					// set 3 months from current expiration
+					date = LocalDate.parse(expirationAttribute.valueAsString(), DateTimeFormatter.ISO_LOCAL_DATE).plusMonths(3);
+				}
+				expirationAttribute.setValue(date.toString());
+				perun.getAttributesManagerBl().setAttribute(session, mem, expirationAttribute);
+			}
+
+		}
+
 		return app;
 
 	}
@@ -106,18 +137,22 @@ public class Metacentrum extends DefaultRegistrarModule {
 	@Override
 	public void canBeApproved(PerunSession session, Application app) throws PerunException {
 
-		// allow only Education & Research community members
-		List<ApplicationFormItemData> data = registrar.getApplicationDataById(session, app.getId());
-		String eligibleString = "";
+		boolean eligibleUser = isCesnetEligibleLastSeen(getIsCesnetEligibleLastSeenFromUser(session, app));
+		boolean eligibleApplication = isCesnetEligibleLastSeen(getIsCesnetEligibleLastSeenFromApplication(session, app));
 
-		for (ApplicationFormItemData item : data) {
-			if (item.getFormItem() != null && Objects.equals("isCesnetEligibleLastSeen", item.getFormItem().getFederationAttribute())) {
-				if (item.getValue() != null && !item.getValue().trim().isEmpty()) {
-					eligibleString = item.getValue();
-					break;
-				}
-			}
+		if (!eligibleUser && !eligibleApplication) {
+			throw new CantBeApprovedException("User is not eligible for CESNET services.", "NOT_ELIGIBLE", null, null, true);
 		}
+
+	}
+
+	/**
+	 * Check whether passed eligible timestamp is valid and not older than 1 year. If so, user is eligible for CESNET services.
+	 *
+	 * @param eligibleString Timestamp to check
+	 * @return TRUE if eligible, FALSE if not
+	 */
+	private boolean isCesnetEligibleLastSeen(String eligibleString) {
 
 		if (eligibleString != null && !eligibleString.isEmpty()) {
 
@@ -131,7 +166,7 @@ public class Metacentrum extends DefaultRegistrarModule {
 
 				// compare
 				if (LocalDateTime.now().isBefore(timeInOneYear)) {
-					return;
+					return true;
 				}
 
 			} catch (ParseException e) {
@@ -139,7 +174,66 @@ public class Metacentrum extends DefaultRegistrarModule {
 			}
 		}
 
-		throw new CantBeApprovedException("User is not eligible for CESNET services.", "NOT_ELIGIBLE", null, null, true);
+		return false;
+
+	}
+
+	/**
+	 * Get value of "isCesnetEligibleLastSeen" form item (first item with this source federation attribute).
+	 * Return empty string if not found or it somehow fails.
+	 *
+	 * @param session PerunSession
+	 * @param app Application to get form items from
+	 * @return Timestamp (yyyy-MM-dd HH:mm:ss) value or empty string.
+	 */
+	private String getIsCesnetEligibleLastSeenFromApplication(PerunSession session, Application app) {
+
+		String eligibleString = "";
+
+		try {
+			List<ApplicationFormItemData> data = registrar.getApplicationDataById(session, app.getId());
+
+			for (ApplicationFormItemData item : data) {
+				if (item.getFormItem() != null && Objects.equals("isCesnetEligibleLastSeen", item.getFormItem().getFederationAttribute())) {
+					if (item.getValue() != null && !item.getValue().trim().isEmpty()) {
+						eligibleString = item.getValue();
+						break;
+					}
+				}
+			}
+		} catch (PrivilegeException | RegistrarException e) {
+			log.error("Unable to get 'isCesnetEligibleLastSeen' from application.", e);
+		}
+
+		return eligibleString;
+
+	}
+
+	/**
+	 * Get value of "user:def:isCesnetEligibleLastSeen" attribute.
+	 * If application has no associated user or we anyhow fail to get the value, empty string is returned.
+	 *
+	 * @param session PerunSession
+	 * @param app Application to get user from
+	 * @return Timestamp (yyyy-MM-dd HH:mm:ss) value or empty string.
+	 */
+	private String getIsCesnetEligibleLastSeenFromUser(PerunSession session, Application app) {
+
+		String eligibleString = "";
+		if (app.getUser() != null) {
+			try {
+				PerunBl perun = (PerunBl) session.getPerun();
+				User user = app.getUser();
+				Attribute attribute = perun.getAttributesManagerBl().getAttribute(session, user, A_USER_IS_CESNET_ELIGIBLE_LAST_SEEN);
+				if (attribute.getValue() != null)  {
+					eligibleString = attribute.valueAsString();
+				}
+			} catch (Exception ex) {
+				log.error("Unable to get 'isCesnetEligibleLastSeen' from user.", ex);
+			}
+		}
+
+		return eligibleString;
 
 	}
 

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/MetacentrumSocial.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/MetacentrumSocial.java
@@ -11,13 +11,19 @@ import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ConsistencyErrorException;
 import cz.metacentrum.perun.core.api.exceptions.MemberGroupMismatchException;
 import cz.metacentrum.perun.core.api.exceptions.MemberNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.PerunException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.registrar.exceptions.CantBeSubmittedException;
 import cz.metacentrum.perun.registrar.model.Application;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+import static cz.metacentrum.perun.registrar.modules.Metacentrum.METACENTRUM_IDP;
 
 /**
  * Module for "Social" group within the Metacentrum VO.
@@ -54,6 +60,17 @@ public class MetacentrumSocial extends DefaultRegistrarModule {
 			throw new ConsistencyErrorException("Member and group should be from the same VO.", e);
 		}
 		return app;
+
+	}
+
+	@Override
+	public void canBeSubmitted(PerunSession session, Application.AppType appType, Map<String, String> params) throws PerunException {
+
+		if (METACENTRUM_IDP.equals(session.getPerunPrincipal().getExtSourceName())) {
+			throw new CantBeSubmittedException("You are currently logged-in using Metacentrum IdP." +
+					"It can't be used to register or extend membership in Metacentrum. Please close browser and log-in using different identity provider.",
+					"NOT_ELIGIBLE", null, null);
+		}
 
 	}
 

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/MetacentrumSocial.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/MetacentrumSocial.java
@@ -1,0 +1,60 @@
+package cz.metacentrum.perun.registrar.modules;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.Member;
+import cz.metacentrum.perun.core.api.PerunSession;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.Vo;
+import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.ConsistencyErrorException;
+import cz.metacentrum.perun.core.api.exceptions.MemberGroupMismatchException;
+import cz.metacentrum.perun.core.api.exceptions.MemberNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.registrar.model.Application;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Module for "Social" group within the Metacentrum VO.
+ *
+ * @author Pavel Zlamal <zlamal@cesnet.cz>
+ */
+public class MetacentrumSocial extends DefaultRegistrarModule {
+
+	private final static Logger log = LoggerFactory.getLogger(MetacentrumSocial.class);
+
+	private final static String A_MEMBER_MEMBERSHIP_EXPIRATION = AttributesManager.NS_MEMBER_ATTR_DEF+":membershipExpiration";
+	private final static String A_MEMBER_GROUP_MEMBERSHIP_EXPIRATION = AttributesManager.NS_MEMBER_GROUP_ATTR_DEF+":groupMembershipExpiration";
+
+	/**
+	 * Set GROUP MEMBERSHIP EXPIRATION based on the current VO MEMBERSHIP EXPIRATION
+	 */
+	@Override
+	public Application approveApplication(PerunSession session, Application app) throws MemberNotExistsException, WrongAttributeAssignmentException, AttributeNotExistsException, WrongAttributeValueException, WrongReferenceAttributeValueException {
+
+		PerunBl perun = (PerunBl)session.getPerun();
+		Vo vo = app.getVo();
+		User user = app.getUser();
+		Member member = perun.getMembersManagerBl().getMemberByUser(session, vo, user);
+		Group group = app.getGroup();
+		Attribute voExpiration = perun.getAttributesManagerBl().getAttribute(session, member, A_MEMBER_MEMBERSHIP_EXPIRATION);
+		try {
+			Attribute groupExpiration = perun.getAttributesManagerBl().getAttribute(session, member, group, A_MEMBER_GROUP_MEMBERSHIP_EXPIRATION);
+			groupExpiration.setValue(voExpiration.getValue());
+			perun.getAttributesManagerBl().setAttribute(session, member, group, groupExpiration);
+			log.debug("{} expiration in Group {} aligned with the VO {} expiration: {}",
+					member, group.getName(), vo.getName(), groupExpiration.valueAsString());
+		} catch (MemberGroupMismatchException e) {
+			log.error("Member and group should be from the same VO.", e);
+			throw new ConsistencyErrorException("Member and group should be from the same VO.", e);
+		}
+		return app;
+
+	}
+
+}


### PR DESCRIPTION
- Metacentrum no longer uses LoA and works with
  isCesnetEligibleLastSeen only.
- We now check both application form and user attribute for the
  value of isCesnetEligibleLastSeen.
  If at least one of them is OK, application can be approved
  and members expiration is not modified (fixed date 2.2.).
  If none of them is OK, then admin is warned before approval
  and members expiration is modified to "+3m" from now() or
  current expiration value (former LoA behaviour).
- Use constants for attribute names.
- Shared logic moved to the private methods.