### PR TITLE
Add support for account activation process

### DIFF
--- a/perun-base/src/main/resources/perun-roles.yml
+++ b/perun-base/src/main/resources/perun-roles.yml
@@ -2441,6 +2441,13 @@ perun_policies:
     include_policies:
       - default_policy
 
+  sendAccountActivationLinkEmail_Member_String_String_String_String_policy:
+    policy_roles:
+      - VOADMIN: Vo
+      - SPONSORSHIP: Member
+    include_policies:
+      - default_policy
+
   createSponsoredMember_Vo_String_Map<String_String>_String_User_LocalDate_policy:
     policy_roles:
       - SPONSOR: Vo

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/MembersManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/MembersManager.java
@@ -1119,6 +1119,23 @@ public interface MembersManager {
 	void sendPasswordResetLinkEmail(PerunSession sess, Member member, String namespace, String url, String mailAttributeUrn, String language) throws PrivilegeException, MemberNotExistsException, UserNotExistsException, AttributeNotExistsException, PasswordResetMailNotExistsException;
 
 	/**
+	 * Send mail to user's preferred email address with link for non-authz account activation.
+	 * Correct authz information is stored in link's URL.
+	 *
+	 * @param sess PerunSession
+	 * @param member Member to get user to send link mail to
+	 * @param namespace namespace to activate account in (member must have login in it)
+	 * @param url base URL of Perun instance
+	 * @param mailAttributeUrn urn of the attribute with stored mail
+	 * @param language language of the message
+	 * @throws InternalErrorException
+	 * @throws PrivilegeException If not VO admin of member
+	 * @throws MemberNotExistsException If member not exists
+	 * @throws PasswordResetMailNotExistsException If the attribute with stored mail is not filled.
+	 */
+	void sendAccountActivationLinkEmail(PerunSession sess, Member member, String namespace, String url, String mailAttributeUrn, String language) throws PrivilegeException, MemberNotExistsException, UserNotExistsException, AttributeNotExistsException, PasswordResetMailNotExistsException;
+
+	/**
 	 * Creates a new sponsored Member and its User.
 	 * @param session actor
 	 * @param vo virtual organization  for the member

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/MembersManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/MembersManagerBl.java
@@ -1414,6 +1414,20 @@ public interface MembersManagerBl {
 	void sendPasswordResetLinkEmail(PerunSession sess, Member member, String namespace, String url, String mailAddress, String language);
 
 	/**
+	 * Send mail to user's preferred email address with link for non-authz account activation.
+	 * Correct authz information is stored in link's URL.
+	 *
+	 * @param sess PerunSession
+	 * @param member Member to get user to send link mail to
+	 * @param namespace Namespace to activate account in (member must have login in)
+	 * @param url base URL of Perun instance
+	 * @param mailAddress mail address where email will be sent
+	 * @param language language of the message
+	 * @throws InternalErrorException
+	 */
+	void sendAccountActivationLinkEmail(PerunSession sess, Member member, String namespace, String url, String mailAddress, String language);
+
+	/**
 	 * Creates a new sponsored member.
 	 *
 	 * @param session perun session

--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -8242,6 +8242,23 @@ paths:
         default:
           $ref: '#/components/responses/ExceptionResponse'
 
+  /urlinjsonout/membersManager/sendAccountActivationLinkEmail:
+    post:
+      tags:
+        - MembersManager
+      operationId: sendAccountActivationLinkEmail
+      summary: Send mail to user's preferred email address with link for non-authz account activation. Correct authz information is stored in link's URL.
+      parameters:
+        - $ref: '#/components/parameters/memberId'
+        - $ref: '#/components/parameters/namespace'
+        - { name: emailAttributeURN, schema: { type: string }, in: query, required: true, description: "urn of the attribute with stored mail"}
+        - { name: language, schema: { type: string }, in: query, required: true, description: "language of the message"}
+      responses:
+        '200':
+          $ref: '#/components/responses/VoidResponse'
+        default:
+          $ref: '#/components/responses/ExceptionResponse'
+
   #################################################
   #                                               #
   # FacilitiesManager                             #

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/MembersManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/MembersManagerMethod.java
@@ -1511,6 +1511,29 @@ public enum MembersManagerMethod implements ManagerMethod {
 			return null;
 
 		}
+	},
+
+	/*#
+	 * Send mail to user's preferred email address with link for non-authz account activation.
+	 * Correct authz information is stored in link's URL.
+	 *
+	 * @param member int Member to get user to send link mail to
+	 * @param namespace String Namespace to activate account in (member must have login in it)
+	 * @param emailAttributeURN urn of the attribute with stored mail
+	 * @param language language of the message
+	 */
+	sendAccountActivationLinkEmail {
+		@Override
+		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
+			parms.stateChangingCheck();
+
+			ac.getMembersManager().sendAccountActivationLinkEmail(ac.getSession(), ac.getMemberById(parms.readInt("member")),
+				parms.readString("namespace"), parms.getServletRequest().getRequestURL().toString(),
+				parms.readString("emailAttributeURN"), parms.readString("language"));
+
+			return null;
+
+		}
 	}
 
 }


### PR DESCRIPTION
 - add new method sendAccountActivationLinkEmail (work the same way as
 sendPasswordResetLinkEmail just with different templates for email)
 - if template attribute for subject or object not exists in Perun, do
 not throw en exception, log it instead and continue with default
 predefined templates