### PR TITLE
Fixed usage of LocalDate in audit messages

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/audit/events/MembersManagerEvents/SponsorshipEstablished.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/audit/events/MembersManagerEvents/SponsorshipEstablished.java
@@ -11,7 +11,7 @@ public class SponsorshipEstablished extends AuditEvent {
 	private Member sponsoredMember;
 	private User sponsor;
 	private String message;
-	private LocalDate validity;
+	private String validity;
 
 	@SuppressWarnings("unused") // used by jackson mapper
 	public SponsorshipEstablished() {
@@ -20,9 +20,9 @@ public class SponsorshipEstablished extends AuditEvent {
 	public SponsorshipEstablished(Member sponsoredMember, User sponsor, LocalDate validityTo) {
 		this.sponsoredMember = sponsoredMember;
 		this.sponsor = sponsor;
-		this.validity = validityTo;
+		this.validity = (validityTo == null) ? "FOREVER" : validityTo.toString();
 		this.message = formatMessage("Sponsorship of %s by %s established with validity to %s.",
-				sponsoredMember, sponsor, validityTo == null ? "FOREVER" : validityTo.toString());
+				sponsoredMember, sponsor, validity);
 	}
 
 	@Override
@@ -38,7 +38,7 @@ public class SponsorshipEstablished extends AuditEvent {
 		return sponsor;
 	}
 
-	public LocalDate getValidity() {
+	public String getValidity() {
 		return validity;
 	}
 

--- a/perun-base/src/main/java/cz/metacentrum/perun/audit/events/MembersManagerEvents/SponsorshipValidityUpdated.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/audit/events/MembersManagerEvents/SponsorshipValidityUpdated.java
@@ -44,4 +44,10 @@ public class SponsorshipValidityUpdated extends AuditEvent {
 	public String getValidity() {
 		return validity;
 	}
+
+	@Override
+	public String toString() {
+		return message;
+	}
+
 }

--- a/perun-base/src/main/java/cz/metacentrum/perun/audit/events/MembersManagerEvents/SponsorshipValidityUpdated.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/audit/events/MembersManagerEvents/SponsorshipValidityUpdated.java
@@ -14,7 +14,7 @@ public class SponsorshipValidityUpdated extends AuditEvent {
 	private Member sponsoredMember;
 	private User sponsor;
 	private String message;
-	private LocalDate validity;
+	private String validity;
 
 	@SuppressWarnings("unused") // used by jackson mapper
 	public SponsorshipValidityUpdated() {
@@ -23,9 +23,9 @@ public class SponsorshipValidityUpdated extends AuditEvent {
 	public SponsorshipValidityUpdated(Member sponsoredMember, User sponsor, LocalDate validityTo) {
 		this.sponsoredMember = sponsoredMember;
 		this.sponsor = sponsor;
-		this.validity = validityTo;
+		this.validity = (validityTo == null) ? "FOREVER" : validityTo.toString();
 		this.message = formatMessage("Validity of sponsorship of %s by %s changed to %s.",
-				sponsoredMember, sponsor, validityTo == null ? "FOREVER" : validityTo.toString());
+				sponsoredMember, sponsor, validity);
 	}
 
 	@Override
@@ -41,7 +41,7 @@ public class SponsorshipValidityUpdated extends AuditEvent {
 		return sponsor;
 	}
 
-	public LocalDate getValidity() {
+	public String getValidity() {
 		return validity;
 	}
 }


### PR DESCRIPTION
- We cannot instantiate LocalDate when reading back
  SponsorshipEstablished and SponsorshipValidityUpdated
  messages.
- It is now converted to String instead.
- Added missing toString() in SponsorshipValidityUpdated.