### PR TITLE
Add missing attributes for namespace to initialization

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -7791,6 +7791,25 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 			rights = new ArrayList<>();
 			attributes.put(attr, rights);
 
+			attr = new AttributeDefinition();
+			attr.setNamespace(AttributesManager.NS_ENTITYLESS_ATTR_DEF);
+			attr.setType(String.class.getName());
+			attr.setFriendlyName("nonAuthzAccActivationMailSubject:"+namespace);
+			attr.setDisplayName("Non-Authz Acc Activation Mail Subject");
+			attr.setDescription("Non authz account activation mail subject for "+namespace+".");
+
+			rights = new ArrayList<>();
+			attributes.put(attr, rights);
+
+			attr = new AttributeDefinition();
+			attr.setNamespace(AttributesManager.NS_ENTITYLESS_ATTR_DEF);
+			attr.setType(String.class.getName());
+			attr.setFriendlyName("nonAuthzAccActivationMailTemplate:"+namespace);
+			attr.setDisplayName("Non-Authz Acc Activation Mail Template");
+			attr.setDescription("Non authz account activation mail template for "+namespace+".");
+
+			rights = new ArrayList<>();
+			attributes.put(attr, rights);
 		}
 
 		if (perunBl.isPerunReadOnly()) log.debug("Loading attributes manager init in readOnly version.");


### PR DESCRIPTION
 - add account activation attributes (subject and template) for all
 namespace to initialization when missing attribute are auto-created