### PR TITLE
REGISTRAR: Support editing submitted form by user

### DIFF
--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -13009,6 +13009,32 @@ paths:
         default:
           $ref: '#/components/responses/ExceptionResponse'
 
+  /json/registrarManager/updateFormItemsData:
+    post:
+      tags:
+        - RegistrarManager
+      operationId: updateFormItemsData
+      summary: Update application form items data, which was originally submitted by the User.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              title: InputFormItemData
+              description: "input to updateFormItemsData"
+              type: object
+              required:
+                - appId
+                - data
+              properties:
+                appId: { type: integer, description: "application id" }
+                data: { type: array, items: { $ref: '#/components/schemas/ApplicationFormItemData' } }
+      responses:
+        '200':
+          $ref: '#/components/responses/VoidResponse'
+        default:
+          $ref: '#/components/responses/ExceptionResponse'
+
   /json/registrarManager/submitApplication:
     post:
       tags:

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/RegistrarManager.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/RegistrarManager.java
@@ -484,7 +484,17 @@ public interface RegistrarManager {
 	 * @throws PrivilegeException
 	 * @throws RegistrarException
 	 */
+	@Deprecated
 	void updateFormItemData(PerunSession session, int applicationId, ApplicationFormItemData data) throws PrivilegeException, RegistrarException;
+
+	/**
+	 * Updated data stored for specific application and its form items
+	 *
+	 * @param session
+	 * @param applicationId ID of submitted application
+	 * @param data List of form items data to update
+	 */
+	void updateFormItemsData(PerunSession session, int applicationId, List<ApplicationFormItemData> data) throws PerunException;
 
 	/**
 	 * Getter for Mail manager used for notifications

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/RegistrarManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/RegistrarManagerMethod.java
@@ -1280,6 +1280,7 @@ public enum RegistrarManagerMethod implements ManagerMethod {
 	 *
 	 * @param appId int ID of Application this data belongs to.
 	 * @param data ApplicationFormItemData Form item data to be updated by its ID.
+	 * @deprecated Only for old GUI, see updateFormItemsData(appId, data)
 	 */
 	updateFormItemData {
 
@@ -1287,6 +1288,29 @@ public enum RegistrarManagerMethod implements ManagerMethod {
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
 			parms.stateChangingCheck();
 			ac.getRegistrarManager().updateFormItemData(ac.getSession(), parms.readInt("appId"), parms.read("data", ApplicationFormItemData.class));
+			return null;
+		}
+
+	},
+
+	/*#
+	 * Update data of application form items, which were originally submitted by the user.
+	 * Only user who submitted the application can use this. Only applications in NEW or VERIFIED state can have form items updated.
+	 * Form items of types: FROM_FEDERATION_HIDDEN, FROM_FEDERATION_SHOW, USERNAME, PASSWORD, HEADING, HTML_COMMENT,
+	 * SUBMIT_BUTTON and AUTO_SUBMIT_BUTTON are not updatable by this method.
+	 *
+	 * If VALIDATED_EMAIL is changed to non-verified value, it will change application state from VERIFIED to NEW
+	 * and trigger new verification and auto approval (if possible).
+	 *
+	 * @param appId int ID of Application this data belongs to.
+	 * @param data List<ApplicationFormItemData> Form items data to be updated by their IDs.
+	 */
+	updateFormItemsData {
+
+		@Override
+		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
+			parms.stateChangingCheck();
+			ac.getRegistrarManager().updateFormItemsData(ac.getSession(), parms.readInt("appId"), parms.readList("data", ApplicationFormItemData.class));
 			return null;
 		}
 


### PR DESCRIPTION
- Added updateFormItemsData() which will update form items
  data with new values by its IDs. Only application submitter
  can use this.
- Updating form items sets application state to NEW
  and starts verification and auto-approval if possible.
- Method updateFormItemData() used from old GUI is now
  marked as deprecated.