### PR TITLE
New methods getObjectWhereUserIsInRoles

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/Role.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/Role.java
@@ -10,7 +10,7 @@ public class Role {
 	public static final String PERUNOBSERVER = "PERUNOBSERVER";
 	public static final String VOADMIN = "VOADMIN";
 	public static final String GROUPADMIN = "GROUPADMIN";
-	public static final String GROUPOBSERVER = "GROUPOBSERER";
+	public static final String GROUPOBSERVER = "GROUPOBSERVER";
 	public static final String SELF = "SELF";
 	public static final String FACILITYADMIN = "FACILITYADMIN";
 	public static final String FACILITYOBSERVER = "FACILITYOBSERVER";

--- a/perun-base/src/main/resources/perun-roles.yml
+++ b/perun-base/src/main/resources/perun-roles.yml
@@ -346,6 +346,42 @@ perun_policies:
     include_policies:
       - default_policy
 
+  getVosWhereUserIsInRoles_User_List<String>_policy:
+    policy_roles:
+      - SELF: User
+    include_policies:
+      - default_policy
+
+  getFacilitiesWhereUserIsInRoles_User_List<String>_policy:
+    policy_roles:
+      - SELF: User
+    include_policies:
+      - default_policy
+
+  getResourcesWhereUserIsInRoles_User_List<String>_policy:
+    policy_roles:
+      - SELF: User
+    include_policies:
+      - default_policy
+
+  getGroupsWhereUserIsInRoles_User_List<String>_policy:
+    policy_roles:
+      - SELF: User
+    include_policies:
+      - default_policy
+
+  getMembersWhereUserIsInRoles_User_List<String>_policy:
+    policy_roles:
+      - SELF: User
+    include_policies:
+      - default_policy
+
+  getSecurityTeamsWhereUserIsInRoles_User_List<String>_policy:
+    policy_roles:
+      - SELF: User
+    include_policies:
+      - default_policy
+
   #DatabaseManagerEntry
   getCurrentDatabaseVersion_policy:
     policy_roles:

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/AuthzResolver.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/AuthzResolver.java
@@ -25,6 +25,7 @@ import cz.metacentrum.perun.core.impl.Privileges;
 import cz.metacentrum.perun.core.impl.Utils;
 import cz.metacentrum.perun.registrar.model.Application;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -1110,5 +1111,175 @@ public class AuthzResolver {
 	 */
 	public static List<RoleManagementRules> getAllRolesManagementRules() {
 		return AuthzResolverBlImpl.getAllRolesManagementRules();
+	}
+
+	/**
+	 * Get all Vos where the given user has set one of the given roles
+	 * or the given user is a member of an authorized group with such roles.
+	 * If user parameter is null then Vos are retrieved for the given principal.
+	 *
+	 * @param sess Perun session
+	 * @param user for who Vos are retrieved
+	 * @param roles for which Vos are retrieved
+	 * @return List of Vos
+	 *
+	 * @throws PrivilegeException when the principal is not authorized.
+	 */
+	public static List<Vo> getVosWhereUserIsInRoles(PerunSession sess, User user, List<String> roles) throws PrivilegeException {
+		Utils.checkPerunSession(sess);
+		Utils.notNull(roles, "roles");
+
+		if (user == null) {
+			user = sess.getPerunPrincipal().getUser();
+		} else {
+			//Authorization
+			if (!authorizedInternal(sess, "getVosWhereUserIsInRoles_User_List<String>_policy", user)) {
+				throw new PrivilegeException(sess, "getVosWhereUserIsInRoles");
+			}
+		}
+
+		return AuthzResolverBlImpl.getVosWhereUserIsInRoles(sess, user, roles);
+	}
+
+	/**
+	 * Get all Facilities where the given user has set one of the given roles
+	 * or the given user is a member of an authorized group with such roles.
+	 * If user parameter is null then Facilities are retrieved for the given principal.
+	 *
+	 * @param sess Perun session
+	 * @param user for who Facilities are retrieved
+	 * @param roles for which Facilities are retrieved
+	 * @return List of Facilities
+	 *
+	 * @throws PrivilegeException when the principal is not authorized.
+	 */
+	public static List<Facility> getFacilitiesWhereUserIsInRoles(PerunSession sess, User user, List<String> roles) throws PrivilegeException {
+		Utils.checkPerunSession(sess);
+		Utils.notNull(roles, "roles");
+
+		if (user == null) {
+			user = sess.getPerunPrincipal().getUser();
+		} else {
+			//Authorization
+			if (!authorizedInternal(sess, "getFacilitiesWhereUserIsInRoles_User_List<String>_policy", user)) {
+				throw new PrivilegeException(sess, "getFacilitiesWhereUserIsInRoles");
+			}
+		}
+
+		return AuthzResolverBlImpl.getFacilitiesWhereUserIsInRoles(sess, user, roles);
+	}
+
+	/**
+	 * Get all Resources where the given user has set one of the given roles
+	 * or the given user is a member of an authorized group with such roles.
+	 * If user parameter is null then Resources are retrieved for the given principal.
+	 *
+	 * @param sess Perun session
+	 * @param user for who Resources are retrieved
+	 * @param roles for which Resources are retrieved
+	 * @return List of Resources
+	 *
+	 * @throws PrivilegeException when the principal is not authorized.
+	 */
+	public static List<Resource> getResourcesWhereUserIsInRoles(PerunSession sess, User user, List<String> roles) throws PrivilegeException {
+		Utils.checkPerunSession(sess);
+		Utils.notNull(roles, "roles");
+
+		if (user == null) {
+			user = sess.getPerunPrincipal().getUser();
+		} else {
+			//Authorization
+			if (!authorizedInternal(sess, "getResourcesWhereUserIsInRoles_User_List<String>_policy", user)) {
+				throw new PrivilegeException(sess, "getResourcesWhereUserIsInRoles");
+			}
+		}
+
+		return AuthzResolverBlImpl.getResourcesWhereUserIsInRoles(sess, user, roles);
+	}
+
+	/**
+	 * Get all Groups where the given user has set one of the given roles
+	 * or the given user is a member of an authorized group with such roles.
+	 * If user parameter is null then Groups are retrieved for the given principal.
+	 *
+	 * Method does not return subgroups of the fetched groups.
+	 *
+	 * @param sess Perun session
+	 * @param user for who Groups are retrieved
+	 * @param roles for which Groups are retrieved
+	 * @return List of Groups
+	 *
+	 * @throws PrivilegeException when the principal is not authorized.
+	 */
+	public static List<Group> getGroupsWhereUserIsInRoles(PerunSession sess, User user, List<String> roles) throws PrivilegeException {
+		Utils.checkPerunSession(sess);
+		Utils.notNull(roles, "roles");
+
+		if (user == null) {
+			user = sess.getPerunPrincipal().getUser();
+		} else {
+			//Authorization
+			if (!authorizedInternal(sess, "getGroupsWhereUserIsInRoles_User_List<String>_policy", user)) {
+				throw new PrivilegeException(sess, "getGroupsWhereUserIsInRoles");
+			}
+		}
+
+		return AuthzResolverBlImpl.getGroupsWhereUserIsInRoles(sess, user, roles);
+	}
+
+	/**
+	 * Get all Members where the given user has set one of the given roles
+	 * or the given user is a member of an authorized group with such roles.
+	 * If user parameter is null then Members are retrieved for the given principal.
+	 *
+	 * @param sess Perun session
+	 * @param user for who Members are retrieved
+	 * @param roles for which Members are retrieved
+	 * @return List of Members
+	 *
+	 * @throws PrivilegeException when the principal is not authorized.
+	 */
+	public static List<Member> getMembersWhereUserIsInRoles(PerunSession sess, User user, List<String> roles) throws PrivilegeException {
+		Utils.checkPerunSession(sess);
+		Utils.notNull(roles, "roles");
+
+		if (user == null) {
+			user = sess.getPerunPrincipal().getUser();
+		} else {
+			//Authorization
+			if (!authorizedInternal(sess, "getMembersWhereUserIsInRoles_User_List<String>_policy", user)) {
+				throw new PrivilegeException(sess, "getMembersWhereUserIsInRoles");
+			}
+		}
+
+		return AuthzResolverBlImpl.getMembersWhereUserIsInRoles(sess, user, roles);
+	}
+
+	/**
+	 * Get all SecurityTeams where the given user has set one of the given roles
+	 * or the given user is a member of an authorized group with such roles.
+	 * If user parameter is null then SecurityTeams are retrieved for the given principal.
+	 *
+	 * @param sess Perun session
+	 * @param user for who SecurityTeams are retrieved
+	 * @param roles for which SecurityTeams are retrieved
+	 * @return List of SecurityTeams
+	 *
+	 * @throws PrivilegeException when the principal is not authorized.
+	 */
+	public static List<SecurityTeam> getSecurityTeamsWhereUserIsInRoles(PerunSession sess, User user, List<String> roles) throws PrivilegeException {
+		Utils.checkPerunSession(sess);
+		Utils.notNull(roles, "roles");
+
+		if (user == null) {
+			user = sess.getPerunPrincipal().getUser();
+		} else {
+			//Authorization
+			if (!authorizedInternal(sess, "getSecurityTeamsWhereUserIsInRoles_User_List<String>_policy", user)) {
+				throw new PrivilegeException(sess, "getSecurityTeamsWhereUserIsInRoles");
+			}
+		}
+
+		return AuthzResolverBlImpl.getSecurityTeamsWhereUserIsInRoles(sess, user, roles);
 	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
@@ -1843,6 +1843,128 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 		return perunBl;
 	}
 
+	/**
+	 * Get all Vos where the given user has set one of the given roles
+	 * or the given user is a member of an authorized group with such roles.
+	 *
+	 * @param sess Perun session
+	 * @param user for who Vos are retrieved
+	 * @param roles for which Vos are retrieved
+	 * @return List of Vos
+	 */
+	public static List<Vo> getVosWhereUserIsInRoles(PerunSession sess, User user, List<String> roles) {
+		for (String role: roles) {
+			if (!roleExists(role)) {
+				throw new InternalErrorException("Role: "+ role +" does not exists.");
+			}
+		}
+
+		return new ArrayList<>(authzResolverImpl.getVosWhereUserIsInRoles(user, roles));
+	}
+
+	/**
+	 * Get all Facilities where the given user has set one of the given roles
+	 * or the given user is a member of an authorized group with such roles.
+	 *
+	 * @param sess Perun session
+	 * @param user for who Facilities are retrieved
+	 * @param roles for which Facilities are retrieved
+	 * @return List of Facilities
+	 */
+	public static List<Facility> getFacilitiesWhereUserIsInRoles(PerunSession sess, User user, List<String> roles) {
+		for (String role: roles) {
+			if (!roleExists(role)) {
+				throw new InternalErrorException("Role: "+ role +" does not exists.");
+			}
+		}
+
+		return new ArrayList<>(authzResolverImpl.getFacilitiesWhereUserIsInRoles(user, roles));
+	}
+
+	/**
+	 * Get all Resources where the given user has set one of the given roles
+	 * or the given user is a member of an authorized group with such roles.
+	 *
+	 * @param sess Perun session
+	 * @param user for who Resources are retrieved
+	 * @param roles for which Resources are retrieved
+	 * @return List of Resources
+	 */
+	public static List<Resource> getResourcesWhereUserIsInRoles(PerunSession sess, User user, List<String> roles) {
+		for (String role: roles) {
+			if (!roleExists(role)) {
+				throw new InternalErrorException("Role: "+ role +" does not exists.");
+			}
+		}
+
+		return new ArrayList<>(authzResolverImpl.getResourcesWhereUserIsInRoles(user, roles));
+	}
+
+	/**
+	 * Get all Groups where the given user has set one of the given roles
+	 * or the given user is a member of an authorized group with such roles.
+	 *
+	 * Method does not return subgroups of the fetched groups.
+	 *
+	 * @param sess Perun session
+	 * @param user for who Groups are retrieved
+	 * @param roles for which Groups are retrieved
+	 * @return List of Groups
+	 */
+	public static List<Group> getGroupsWhereUserIsInRoles(PerunSession sess, User user, List<String> roles) {
+		for (String role: roles) {
+			if (!roleExists(role)) {
+				throw new InternalErrorException("Role: "+ role +" does not exists.");
+			}
+		}
+
+		return new ArrayList<>(authzResolverImpl.getGroupsWhereUserIsInRoles(user, roles));
+	}
+
+	/**
+	 * Get all Members where the given user has set one of the given roles
+	 * or the given user is a member of an authorized group with such roles.
+	 *
+	 * @param sess Perun session
+	 * @param user for who Members are retrieved
+	 * @param roles for which Members are retrieved
+	 * @return List of Members
+	 */
+	public static List<Member> getMembersWhereUserIsInRoles(PerunSession sess, User user, List<String> roles) {
+		for (String role: roles) {
+			if (!roleExists(role)) {
+				throw new InternalErrorException("Role: "+ role +" does not exists.");
+			}
+		}
+
+		Set<Member> members = authzResolverImpl.getMembersWhereUserIsInRoles(user, roles);
+
+		if (roles.contains(Role.SPONSORSHIP)) {
+			members.addAll(perunBl.getMembersManagerBl().getSponsoredMembers(sess, user));
+		}
+
+		return new ArrayList<>(members);
+	}
+
+	/**
+	 * Get all SecurityTeams where the given user has set one of the given roles
+	 * or the given user is a member of an authorized group with such roles.
+	 *
+	 * @param sess Perun session
+	 * @param user for who SecurityTeams are retrieved
+	 * @param roles for which SecurityTeams are retrieved
+	 * @return List of SecurityTeams
+	 */
+	public static List<SecurityTeam> getSecurityTeamsWhereUserIsInRoles(PerunSession sess, User user, List<String> roles) {
+		for (String role: roles) {
+			if (!roleExists(role)) {
+				throw new InternalErrorException("Role: "+ role +" does not exists.");
+			}
+		}
+
+		return new ArrayList<>(authzResolverImpl.getSecurityTeamsWhereUserIsInRoles(user, roles));
+	}
+
 	private static PerunBl getPerunBl() {
 		return perunBl;
 	}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AuthzResolverImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AuthzResolverImplApi.java
@@ -2,6 +2,7 @@ package cz.metacentrum.perun.core.implApi;
 
 import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.Member;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.RichUser;
@@ -19,6 +20,7 @@ import cz.metacentrum.perun.core.impl.AuthzRoles;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * This interface represents AuthzResolver methods.
@@ -568,4 +570,67 @@ public interface AuthzResolverImplApi {
 	 * @return list of authorizedGroups
 	 */
 	List<Group> getAdminGroups(Map<String, Integer> mappingOfValues);
+
+	/**
+	 * Get all Vos where the given user has set one of the given roles
+	 * or the given user is a member of an authorized group with such roles.
+	 *
+	 * @param user for who Vos are retrieved
+	 * @param roles for which Vos are retrieved
+	 * @return Set of Vos
+	 */
+	Set<Vo> getVosWhereUserIsInRoles(User user, List<String> roles);
+
+	/**
+	 * Get all Facilities where the given user has set one of the given roles
+	 * or the given user is a member of an authorized group with such roles.
+	 *
+	 * @param user for who Facilities are retrieved
+	 * @param roles for which Facilities are retrieved
+	 * @return Set of Facilities
+	 */
+
+	Set<Facility> getFacilitiesWhereUserIsInRoles(User user, List<String> roles);
+	/**
+	 * Get all Resources where the given user has set one of the given roles
+	 * or the given user is a member of an authorized group with such roles.
+	 *
+	 * @param user for who Resources are retrieved
+	 * @param roles for which Resources are retrieved
+	 * @return Set of Resources
+	 */
+	Set<Resource> getResourcesWhereUserIsInRoles(User user, List<String> roles);
+
+	/**
+	 * Get all Groups where the given user has set one of the given roles
+	 * or the given user is a member of an authorized group with such roles.
+	 *
+	 * Method does not return subgroups of the fetched groups.
+	 *
+	 * @param user for who Groups are retrieved
+	 * @param roles for which Groups are retrieved
+	 * @return Set of Groups
+	 */
+	Set<Group> getGroupsWhereUserIsInRoles(User user, List<String> roles);
+
+	/**
+	 * Get all Members where the given user has set one of the given roles
+	 * or the given user is a member of an authorized group with such roles.
+	 *
+	 * @param user for who Members are retrieved
+	 * @param roles for which Members are retrieved
+	 * @return Set of Members
+	 */
+	Set<Member> getMembersWhereUserIsInRoles(User user, List<String> roles);
+
+	/**
+	 * Get all SecurityTeams where the given user has set one of the given roles
+	 * or the given user is a member of an authorized group with such roles.
+	 *
+	 * @param user for who SecurityTeams are retrieved
+	 * @param roles for which SecurityTeams are retrieved
+	 * @return Set of SecurityTeams
+	 */
+	Set<SecurityTeam> getSecurityTeamsWhereUserIsInRoles(User user, List<String> roles);
+
 }

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/api/AuthzResolverIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/api/AuthzResolverIntegrationTest.java
@@ -1080,6 +1080,247 @@ public class AuthzResolverIntegrationTest extends AbstractPerunIntegrationTest {
 		AuthzResolver.getRichAdmins(sess, testUser, new ArrayList<>(), Role.VOADMIN, false, true);
 	}
 
+	@Test
+	public void getVosWhereUserIsInRoles() throws Exception {
+		System.out.println(CLASS_NAME + "getVosWhereUserIsInRoles");
+
+		final Vo testVo = perun.getVosManager().createVo(sess, new Vo(0,"testvo1","testvo1"));
+		final Vo testVo2 = perun.getVosManager().createVo(sess, new Vo(1,"testvo2","testvo2"));
+		final Vo testVo3 = perun.getVosManager().createVo(sess, new Vo(2,"testvo3","testvo3"));
+		final Group testGroup = perun.getGroupsManager().createGroup(sess, testVo, new Group("testGroup", "testg"));
+		final Member testMember = createSomeMember(testVo);
+		final User testUser = perun.getUsersManagerBl().getUserByMember(sess, testMember);
+		perun.getGroupsManager().addMember(sess, testGroup, testMember);
+
+		AuthzResolver.setRole(sess, testUser, testVo, Role.VOADMIN);
+		AuthzResolver.setRole(sess, testUser, testVo2, Role.SPONSOR);
+		AuthzResolver.setRole(sess, testGroup, testVo3, Role.VOOBSERVER);
+		List<Vo> result = AuthzResolver.getVosWhereUserIsInRoles(sess, testUser, Arrays.asList(Role.VOADMIN, Role.VOOBSERVER));
+
+		assertEquals(2, result.size());
+		assertTrue(result.containsAll(Arrays.asList(testVo, testVo3)));
+	}
+
+	@Test
+	public void getVosWherePrincipalIsInRoles() throws Exception {
+		System.out.println(CLASS_NAME + "getVosWherePrincipalIsInRoles");
+
+		final Vo testVo = perun.getVosManager().createVo(sess, new Vo(0,"testvo1","testvo1"));
+		final Vo testVo2 = perun.getVosManager().createVo(sess, new Vo(1,"testvo2","testvo2"));
+		final Vo testVo3 = perun.getVosManager().createVo(sess, new Vo(2,"testvo3","testvo3"));
+		final Group testGroup = perun.getGroupsManager().createGroup(sess, testVo, new Group("testGroup", "testg"));
+		final Member testMember = createSomeMember(testVo);
+		final User testUser = perun.getUsersManagerBl().getUserByMember(sess, testMember);
+		sess.getPerunPrincipal().setUser(testUser);
+		perun.getGroupsManager().addMember(sess, testGroup, testMember);
+
+		AuthzResolver.setRole(sess, testUser, testVo, Role.VOADMIN);
+		AuthzResolver.setRole(sess, testUser, testVo2, Role.SPONSOR);
+		AuthzResolver.setRole(sess, testGroup, testVo3, Role.VOOBSERVER);
+		List<Vo> result = AuthzResolver.getVosWhereUserIsInRoles(sess, null, Arrays.asList(Role.VOADMIN, Role.VOOBSERVER));
+
+		assertEquals(2, result.size());
+		assertTrue(result.containsAll(Arrays.asList(testVo, testVo3)));
+	}
+
+	@Test
+	public void getFacilitiesWhereUserIsInRoles() throws Exception {
+		System.out.println(CLASS_NAME + "getFacilitiesWhereUserIsInRoles");
+
+		final Vo testVo = perun.getVosManager().createVo(sess, new Vo(0,"testvo1","testvo1"));
+		final Facility testFacility = perun.getFacilitiesManagerBl().createFacility(sess, new Facility(0,"testfacility1","testfacility1"));
+		final Facility testFacility2 = perun.getFacilitiesManagerBl().createFacility(sess, new Facility(1,"testfacility2","testfacility2"));
+		final Group testGroup = perun.getGroupsManager().createGroup(sess, testVo, new Group("testGroup", "testg"));
+		final Member testMember = createSomeMember(testVo);
+		final User testUser = perun.getUsersManagerBl().getUserByMember(sess, testMember);
+		perun.getGroupsManager().addMember(sess, testGroup, testMember);
+
+		AuthzResolver.setRole(sess, testUser, testFacility, Role.FACILITYADMIN);
+		AuthzResolver.setRole(sess, testGroup, testFacility2, Role.FACILITYOBSERVER);
+		List<Facility> result = AuthzResolver.getFacilitiesWhereUserIsInRoles(sess, testUser, Collections.singletonList(Role.FACILITYADMIN));
+
+		assertEquals(1, result.size());
+		assertTrue(result.contains(testFacility));
+	}
+
+	@Test
+	public void getFacilitiesWherePrincipalIsInRoles() throws Exception {
+		System.out.println(CLASS_NAME + "getFacilitiesWherePrincipalIsInRoles");
+
+		final Vo testVo = perun.getVosManager().createVo(sess, new Vo(0, "testvo1", "testvo1"));
+		final Facility testFacility = perun.getFacilitiesManagerBl().createFacility(sess, new Facility(0, "testfacility1", "testfacility1"));
+		final Facility testFacility2 = perun.getFacilitiesManagerBl().createFacility(sess, new Facility(1, "testfacility2", "testfacility2"));
+		final Group testGroup = perun.getGroupsManager().createGroup(sess, testVo, new Group("testGroup", "testg"));
+		final Member testMember = createSomeMember(testVo);
+		final User testUser = perun.getUsersManagerBl().getUserByMember(sess, testMember);
+		sess.getPerunPrincipal().setUser(testUser);
+		perun.getGroupsManager().addMember(sess, testGroup, testMember);
+
+		AuthzResolver.setRole(sess, testUser, testFacility, Role.FACILITYADMIN);
+		AuthzResolver.setRole(sess, testGroup, testFacility2, Role.FACILITYOBSERVER);
+		List<Facility> result = AuthzResolver.getFacilitiesWhereUserIsInRoles(sess, null, Collections.singletonList(Role.FACILITYADMIN));
+
+		assertEquals(1, result.size());
+		assertTrue(result.contains(testFacility));
+	}
+
+	@Test
+	public void getResourcesWhereUserIsInRoles() throws Exception {
+		System.out.println(CLASS_NAME + "getResourcesWhereUserIsInRoles");
+
+		final Vo testVo = perun.getVosManager().createVo(sess, new Vo(0,"testvo1","testvo1"));
+		final Facility testFacility = perun.getFacilitiesManagerBl().createFacility(sess, new Facility(0,"testfacility1","testfacility1"));
+		final Resource testResource = perun.getResourcesManagerBl().createResource(sess, new Resource(0, "testResource", "testResource", 0, 0), testVo, testFacility);
+		final Resource testResource2 = perun.getResourcesManagerBl().createResource(sess, new Resource(0, "testResource2", "testResource2", 0, 0), testVo, testFacility);
+		final Group testGroup = perun.getGroupsManager().createGroup(sess, testVo, new Group("testGroup", "testg"));
+		final Member testMember = createSomeMember(testVo);
+		final User testUser = perun.getUsersManagerBl().getUserByMember(sess, testMember);
+		perun.getGroupsManager().addMember(sess, testGroup, testMember);
+
+		AuthzResolver.setRole(sess, testUser, testResource, Role.RESOURCEADMIN);
+		AuthzResolver.setRole(sess, testGroup, testResource2, Role.RESOURCEOBSERVER);
+		List<Resource> result = AuthzResolver.getResourcesWhereUserIsInRoles(sess, testUser, Collections.singletonList(Role.RESOURCEADMIN));
+
+		assertEquals(1, result.size());
+		assertTrue(result.contains(testResource));
+	}
+
+	@Test
+	public void getResourcesWherePrincipalIsInRoles() throws Exception {
+		System.out.println(CLASS_NAME + "getResourcesWherePrincipalIsInRoles");
+
+		final Vo testVo = perun.getVosManager().createVo(sess, new Vo(0,"testvo1","testvo1"));
+		final Facility testFacility = perun.getFacilitiesManagerBl().createFacility(sess, new Facility(0,"testfacility1","testfacility1"));
+		final Resource testResource = perun.getResourcesManagerBl().createResource(sess, new Resource(0, "testResource", "testResource", 0, 0), testVo, testFacility);
+		final Resource testResource2 = perun.getResourcesManagerBl().createResource(sess, new Resource(0, "testResource2", "testResource2", 0, 0), testVo, testFacility);
+		final Group testGroup = perun.getGroupsManager().createGroup(sess, testVo, new Group("testGroup", "testg"));
+		final Member testMember = createSomeMember(testVo);
+		final User testUser = perun.getUsersManagerBl().getUserByMember(sess, testMember);
+		sess.getPerunPrincipal().setUser(testUser);
+		perun.getGroupsManager().addMember(sess, testGroup, testMember);
+
+		AuthzResolver.setRole(sess, testUser, testResource, Role.RESOURCEADMIN);
+		AuthzResolver.setRole(sess, testGroup, testResource2, Role.RESOURCEOBSERVER);
+		List<Resource> result = AuthzResolver.getResourcesWhereUserIsInRoles(sess, null, Collections.singletonList(Role.RESOURCEADMIN));
+
+		assertEquals(1, result.size());
+		assertTrue(result.contains(testResource));
+	}
+
+	@Test
+	public void getGroupsWhereUserIsInRoles() throws Exception {
+		System.out.println(CLASS_NAME + "getGroupsWhereUserIsInRoles");
+
+		final Vo testVo = perun.getVosManager().createVo(sess, new Vo(0,"testvo1","testvo1"));
+		final Group testGroup = perun.getGroupsManager().createGroup(sess, testVo, new Group("testGroup", "testg"));
+		final Group testGroup2 = perun.getGroupsManager().createGroup(sess, testVo, new Group("testGroup2", "testg2"));
+		final Group testGroup4 = perun.getGroupsManager().createGroup(sess, testVo, new Group("testGroup4", "testg4"));
+		final Member testMember = createSomeMember(testVo);
+		final User testUser = perun.getUsersManagerBl().getUserByMember(sess, testMember);
+		perun.getGroupsManager().addMember(sess, testGroup, testMember);
+
+		AuthzResolver.setRole(sess, testUser, testGroup2, Role.GROUPADMIN);
+		AuthzResolver.setRole(sess, testGroup, testGroup4, Role.GROUPOBSERVER);
+		List<Group> result = AuthzResolver.getGroupsWhereUserIsInRoles(sess, testUser, Collections.singletonList(Role.GROUPADMIN));
+
+		assertEquals(1, result.size());
+		assertTrue(result.contains(testGroup2));
+	}
+
+	@Test
+	public void getGroupsWherePrincipalIsInRoles() throws Exception {
+		System.out.println(CLASS_NAME + "getGroupsWherePrincipalIsInRoles");
+
+		final Vo testVo = perun.getVosManager().createVo(sess, new Vo(0,"testvo1","testvo1"));
+		final Group testGroup = perun.getGroupsManager().createGroup(sess, testVo, new Group("testGroup", "testg"));
+		final Group testGroup2 = perun.getGroupsManager().createGroup(sess, testVo, new Group("testGroup2", "testg2"));
+		final Group testGroup3 = perun.getGroupsManager().createGroup(sess, testGroup2, new Group("testGroup3", "testg3"));
+		final Group testGroup4 = perun.getGroupsManager().createGroup(sess, testVo, new Group("testGroup4", "testg4"));
+		final Member testMember = createSomeMember(testVo);
+		final User testUser = perun.getUsersManagerBl().getUserByMember(sess, testMember);
+		sess.getPerunPrincipal().setUser(testUser);
+		perun.getGroupsManager().addMember(sess, testGroup, testMember);
+
+		AuthzResolver.setRole(sess, testUser, testGroup2, Role.GROUPADMIN);
+		AuthzResolver.setRole(sess, testGroup, testGroup4, Role.GROUPOBSERVER);
+		List<Group> result = AuthzResolver.getGroupsWhereUserIsInRoles(sess, null, Collections.singletonList(Role.GROUPADMIN));
+
+		assertEquals(1, result.size());
+		assertTrue(result.contains(testGroup2));
+	}
+
+	@Test
+	public void getMembersWhereUserIsInRoles() throws Exception {
+		System.out.println(CLASS_NAME + "getMembersWhereUserIsInRoles");
+
+		final Vo testVo = perun.getVosManager().createVo(sess, new Vo(0,"testvo1","testvo1"));
+		final Member testMember = createSomeMember(testVo);
+		final Member testMember2 = createSomeMember(testVo);
+		final User testUser = perun.getUsersManagerBl().getUserByMember(sess, testMember);
+		sess.getPerunPrincipal().setUser(testUser);
+
+		AuthzResolver.setRole(sess, testUser, testVo, Role.SPONSOR);
+		perun.getMembersManagerBl().setSponsorshipForMember(sess, testMember2, testUser);
+		List<Member> result = AuthzResolver.getMembersWhereUserIsInRoles(sess, testUser, Collections.singletonList(Role.SPONSORSHIP));
+
+		assertEquals(1, result.size());
+		assertTrue(result.contains(testMember2));
+	}
+
+	@Test
+	public void getMembersWherePrincipalIsInRoles() throws Exception {
+		System.out.println(CLASS_NAME + "getMembersWherePrincipalIsInRoles");
+
+		final Vo testVo = perun.getVosManager().createVo(sess, new Vo(0,"testvo1","testvo1"));
+		final Member testMember = createSomeMember(testVo);
+		final Member testMember2 = createSomeMember(testVo);
+		final User testUser = perun.getUsersManagerBl().getUserByMember(sess, testMember);
+		sess.getPerunPrincipal().setUser(testUser);
+
+		AuthzResolver.setRole(sess, testUser, testVo, Role.SPONSOR);
+		perun.getMembersManagerBl().setSponsorshipForMember(sess, testMember2, testUser);
+		List<Member> result = AuthzResolver.getMembersWhereUserIsInRoles(sess, null, Collections.singletonList(Role.SPONSORSHIP));
+
+		assertEquals(1, result.size());
+		assertTrue(result.contains(testMember2));
+	}
+
+	@Test
+	public void getSecurityTeamsWhereUserIsInRoles() throws Exception {
+		System.out.println(CLASS_NAME + "getSecurityTeamsWhereUserIsInRoles");
+
+		final Vo testVo = perun.getVosManager().createVo(sess, new Vo(0,"testvo1","testvo1"));
+		final SecurityTeam testSecurityTeam = perun.getSecurityTeamsManagerBl().createSecurityTeam(sess, new SecurityTeam(0, "testSecurityTeam", "testSecurityTeam"));
+		final Group testGroup = perun.getGroupsManager().createGroup(sess, testVo, new Group("testGroup", "testg"));
+		final Member testMember = createSomeMember(testVo);
+		final User testUser = perun.getUsersManagerBl().getUserByMember(sess, testMember);
+		sess.getPerunPrincipal().setUser(testUser);
+		perun.getGroupsManager().addMember(sess, testGroup, testMember);
+
+		AuthzResolver.setRole(sess, testGroup, testSecurityTeam, Role.SECURITYADMIN);
+		List<SecurityTeam> result = AuthzResolver.getSecurityTeamsWhereUserIsInRoles(sess, null, Collections.singletonList(Role.SECURITYADMIN));
+
+		assertEquals(1, result.size());
+		assertTrue(result.contains(testSecurityTeam));
+	}
+
+	@Test
+	public void getSecurityTeamsWherePrincipalIsInRoles() throws Exception {
+		System.out.println(CLASS_NAME + "getSecurityTeamsWherePrincipalIsInRoles");
+
+		final Vo testVo = perun.getVosManager().createVo(sess, new Vo(0,"testvo1","testvo1"));
+		final SecurityTeam testSecurityTeam = perun.getSecurityTeamsManagerBl().createSecurityTeam(sess, new SecurityTeam(0, "testSecurityTeam", "testSecurityTeam"));
+		final Group testGroup = perun.getGroupsManager().createGroup(sess, testVo, new Group("testGroup", "testg"));
+		final Member testMember = createSomeMember(testVo);
+		final User testUser = perun.getUsersManagerBl().getUserByMember(sess, testMember);
+		perun.getGroupsManager().addMember(sess, testGroup, testMember);
+
+		AuthzResolver.setRole(sess, testGroup, testSecurityTeam, Role.SECURITYADMIN);
+		List<SecurityTeam> result = AuthzResolver.getSecurityTeamsWhereUserIsInRoles(sess, testUser, Collections.singletonList(Role.SECURITYADMIN));
+
+		assertEquals(1, result.size());
+		assertTrue(result.contains(testSecurityTeam));
+	}
 	// private methods ==============================================================
 
 	private Facility setUpFacility() throws Exception {

--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -2392,6 +2392,16 @@ components:
       in: query
       required: true
 
+    ListOfRoles:
+      name: "roles[]"
+      description: "list of role names List<String>"
+      in: query
+      required: true
+      schema:
+        type: array
+        items:
+          type: string
+
     consumerName:
       name: consumerName
       schema:
@@ -3101,6 +3111,102 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/VoidResponse'
+        default:
+          $ref: '#/components/responses/ExceptionResponse'
+
+  /json/authzResolver/getVosWhereUserIsInRoles:
+    get:
+      tags:
+        - AuthzResolver
+      operationId: getVosWhereUserIsInRoles
+      summary: Get all Vos where the given user (principal if user not sent) has set one of the given roles
+        or the given user is a member of an authorized group with such roles.
+      parameters:
+        - $ref: '#/components/parameters/optionalUserId'
+        - $ref: '#/components/parameters/ListOfRoles'
+      responses:
+        '200':
+          $ref: '#/components/responses/ListOfVosResponse'
+        default:
+          $ref: '#/components/responses/ExceptionResponse'
+
+  /json/authzResolver/getFacilitiesWhereUserIsInRoles:
+    get:
+      tags:
+        - AuthzResolver
+      operationId: getFacilitiesWhereUserIsInRoles
+      summary: Get all Facilities where the given user (principal if user not sent) has set one of the given roles
+        or the given user is a member of an authorized group with such roles.
+      parameters:
+        - $ref: '#/components/parameters/optionalUserId'
+        - $ref: '#/components/parameters/ListOfRoles'
+      responses:
+        '200':
+          $ref: '#/components/responses/ListOfFacilitiesResponse'
+        default:
+          $ref: '#/components/responses/ExceptionResponse'
+
+  /json/authzResolver/getResourcesWhereUserIsInRoles:
+    get:
+      tags:
+        - AuthzResolver
+      operationId: getResourcesWhereUserIsInRoles
+      summary: Get all Resources where the given user (principal if user not sent) has set one of the given roles
+        or the given user is a member of an authorized group with such roles.
+      parameters:
+        - $ref: '#/components/parameters/optionalUserId'
+        - $ref: '#/components/parameters/ListOfRoles'
+      responses:
+        '200':
+          $ref: '#/components/responses/ListOfResourcesResponse'
+        default:
+          $ref: '#/components/responses/ExceptionResponse'
+
+  /json/authzResolver/getGroupsWhereUserIsInRoles:
+    get:
+      tags:
+        - AuthzResolver
+      operationId: getGroupsWhereUserIsInRoles
+      summary: Get all Groups where the given user (principal if user not sent) has set one of the given roles
+        or the given user is a member of an authorized group with such roles.
+      parameters:
+        - $ref: '#/components/parameters/optionalUserId'
+        - $ref: '#/components/parameters/ListOfRoles'
+      responses:
+        '200':
+          $ref: '#/components/responses/ListOfGroupsResponse'
+        default:
+          $ref: '#/components/responses/ExceptionResponse'
+
+  /json/authzResolver/getMembersWhereUserIsInRoles:
+    get:
+      tags:
+        - AuthzResolver
+      operationId: getMembersWhereUserIsInRoles
+      summary: Get all Members where the given user (principal if user not sent) has set one of the given roles
+        or the given user is a member of an authorized group with such roles.
+      parameters:
+        - $ref: '#/components/parameters/optionalUserId'
+        - $ref: '#/components/parameters/ListOfRoles'
+      responses:
+        '200':
+          $ref: '#/components/responses/ListOfMembersResponse'
+        default:
+          $ref: '#/components/responses/ExceptionResponse'
+
+  /json/authzResolver/getSecurityTeamsWhereUserIsInRoles:
+    get:
+      tags:
+        - AuthzResolver
+      operationId: getSecurityTeamsWhereUserIsInRoles
+      summary: Get all SecurityTeams where the given user (principal if user not sent) has set one of the given roles
+        or the given user is a member of an authorized group with such roles.
+      parameters:
+        - $ref: '#/components/parameters/optionalUserId'
+        - $ref: '#/components/parameters/ListOfRoles'
+      responses:
+        '200':
+          $ref: '#/components/responses/ListOfSecurityTeamsResponse'
         default:
           $ref: '#/components/responses/ExceptionResponse'
 

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/AuthzResolverMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/AuthzResolverMethod.java
@@ -11,12 +11,15 @@ import java.util.Map;
 import cz.metacentrum.perun.core.api.PerunBean;
 import cz.metacentrum.perun.core.api.PerunPolicy;
 import cz.metacentrum.perun.core.api.PerunPrincipal;
+import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.RichUser;
 import cz.metacentrum.perun.core.api.Role;
 import cz.metacentrum.perun.core.api.RoleManagementRules;
 import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.Vo;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.PerunException;
+import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
 import cz.metacentrum.perun.core.impl.AuthzRoles;
 import cz.metacentrum.perun.rpc.ApiCaller;
 import cz.metacentrum.perun.rpc.ManagerMethod;
@@ -780,6 +783,274 @@ public enum AuthzResolverMethod implements ManagerMethod {
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
 			cz.metacentrum.perun.core.api.AuthzResolver.loadAuthorizationComponents(ac.getSession());
+			return null;
+		}
+	},
+
+	/*#
+	 * Get all Vos where the given user has set one of the given roles
+	 * or the given user is a member of an authorized group with such roles.
+	 *
+	 * @param user int <code>id</code> of object User
+	 * @param roles List<String> list of role names for which Vos are retrieved
+	 * @return List<Vo> List of Vos
+	 *
+	 * @throws PrivilegeException when the principal is not authorized.
+	 */
+	/*#
+	 * Get all Vos where the given principal has set one of the given roles
+	 * or the given principal is a member of an authorized group with such roles.
+	 *
+	 * @param roles List<String> list of role names for which Vos are retrieved
+	 * @return List<Vo> List of Vos
+	 *
+	 * @throws PrivilegeException when the principal is not authorized.
+	 */
+	getVosWhereUserIsInRoles {
+		@Override
+		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
+			List<String> roles = parms.readList("roles", String.class);
+			roles.replaceAll(String::toUpperCase);
+			for (String role: roles) {
+				if (!cz.metacentrum.perun.core.api.AuthzResolver.roleExists(role)) {
+					throw new RpcException(RpcException.Type.WRONG_PARAMETER, "Role with name " + role + " does not exist.");
+				}
+			}
+			if(parms.contains("user")) {
+				cz.metacentrum.perun.core.api.AuthzResolver.getVosWhereUserIsInRoles(
+					ac.getSession(),
+					ac.getUserById(parms.readInt("user")),
+					roles);
+			} else {
+				cz.metacentrum.perun.core.api.AuthzResolver.getVosWhereUserIsInRoles(
+					ac.getSession(),
+					null,
+					roles);
+			}
+			return null;
+		}
+	},
+
+	/*#
+	 * Get all Facilities where the given user has set one of the given roles
+	 * or the given user is a member of an authorized group with such roles.
+	 *
+	 * @param user int <code>id</code> of object User
+	 * @param roles List<String> list of role names for which Facilities are retrieved
+	 * @return List<Facility> List of Facilities
+	 *
+	 * @throws PrivilegeException when the principal is not authorized.
+	 */
+	/*#
+	 * Get all Facilities where the given principal has set one of the given roles
+	 * or the given principal is a member of an authorized group with such roles.
+	 *
+	 * @param roles List<String> list of role names for which Facilities are retrieved
+	 * @return List<Facility> List of Facilities
+	 *
+	 * @throws PrivilegeException when the principal is not authorized.
+	 */
+	getFacilitiesWhereUserIsInRoles {
+		@Override
+		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
+			List<String> roles = parms.readList("roles", String.class);
+			roles.replaceAll(String::toUpperCase);
+			for (String role: roles) {
+				if (!cz.metacentrum.perun.core.api.AuthzResolver.roleExists(role)) {
+					throw new RpcException(RpcException.Type.WRONG_PARAMETER, "Role with name " + role + " does not exist.");
+				}
+			}
+			if(parms.contains("user")) {
+				cz.metacentrum.perun.core.api.AuthzResolver.getFacilitiesWhereUserIsInRoles(
+					ac.getSession(),
+					ac.getUserById(parms.readInt("user")),
+					roles);
+			} else {
+				cz.metacentrum.perun.core.api.AuthzResolver.getFacilitiesWhereUserIsInRoles(
+					ac.getSession(),
+					null,
+					roles);
+			}
+			return null;
+		}
+	},
+
+	/*#
+	 * Get all Resources where the given user has set one of the given roles
+	 * or the given user is a member of an authorized group with such roles.
+	 *
+	 * @param user int <code>id</code> of object User
+	 * @param roles List<String> list of role names for which Resources are retrieved
+	 * @return List<Resource> List of Resources
+	 *
+	 * @throws PrivilegeException when the principal is not authorized.
+	 */
+	/*#
+	 * Get all Resources where the given principal has set one of the given roles
+	 * or the given principal is a member of an authorized group with such roles.
+	 *
+	 * @param roles List<String> list of role names for which Resources are retrieved
+	 * @return List<Resource> List of Resources
+	 *
+	 * @throws PrivilegeException when the principal is not authorized.
+	 */
+	getResourcesWhereUserIsInRoles {
+		@Override
+		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
+			List<String> roles = parms.readList("roles", String.class);
+			roles.replaceAll(String::toUpperCase);
+			for (String role: roles) {
+				if (!cz.metacentrum.perun.core.api.AuthzResolver.roleExists(role)) {
+					throw new RpcException(RpcException.Type.WRONG_PARAMETER, "Role with name " + role + " does not exist.");
+				}
+			}
+			if(parms.contains("user")) {
+				cz.metacentrum.perun.core.api.AuthzResolver.getResourcesWhereUserIsInRoles(
+					ac.getSession(),
+					ac.getUserById(parms.readInt("user")),
+					roles);
+			} else {
+				cz.metacentrum.perun.core.api.AuthzResolver.getResourcesWhereUserIsInRoles(
+					ac.getSession(),
+					null,
+					roles);
+			}
+			return null;
+		}
+	},
+
+	/*#
+	 * Get all Groups where the given user has set one of the given roles
+	 * or the given user is a member of an authorized group with such roles.
+	 *
+	 * Method does not return subgroups of the fetched groups.
+	 *
+	 * @param user int <code>id</code> of object User
+	 * @param roles List<String> list of role names for which Groups are retrieved
+	 * @return List<Group> List of Groups
+	 *
+	 * @throws PrivilegeException when the principal is not authorized.
+	 */
+	/*#
+	 * Get all Groups where the given principal has set one of the given roles
+	 * or the given principal is a member of an authorized group with such roles.
+	 *
+	 * Method does not return subgroups of the fetched groups.
+	 *
+	 * @param roles List<String> list of role names for which Groups are retrieved
+	 * @return List<Group> List of Groups
+	 *
+	 * @throws PrivilegeException when the principal is not authorized.
+	 */
+	getGroupsWhereUserIsInRoles {
+		@Override
+		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
+			List<String> roles = parms.readList("roles", String.class);
+			roles.replaceAll(String::toUpperCase);
+			for (String role: roles) {
+				if (!cz.metacentrum.perun.core.api.AuthzResolver.roleExists(role)) {
+					throw new RpcException(RpcException.Type.WRONG_PARAMETER, "Role with name " + role + " does not exist.");
+				}
+			}
+			if(parms.contains("user")) {
+				cz.metacentrum.perun.core.api.AuthzResolver.getGroupsWhereUserIsInRoles(
+					ac.getSession(),
+					ac.getUserById(parms.readInt("user")),
+					roles);
+			} else {
+				cz.metacentrum.perun.core.api.AuthzResolver.getGroupsWhereUserIsInRoles(
+					ac.getSession(),
+					null,
+					roles);
+			}
+			return null;
+		}
+	},
+
+	/*#
+	 * Get all Members where the given user has set one of the given roles
+	 * or the given user is a member of an authorized group with such roles.
+	 *
+	 * @param user int <code>id</code> of object User
+	 * @param roles List<String> list of role names for which Members are retrieved
+	 * @return List<Member> List of Members
+	 *
+	 * @throws PrivilegeException when the principal is not authorized.
+	 */
+	/*#
+	 * Get all Members where the given principal has set one of the given roles
+	 * or the given principal is a member of an authorized group with such roles.
+	 *
+	 * @param roles List<String> list of role names for which Members are retrieved
+	 * @return List<Member> List of Members
+	 *
+	 * @throws PrivilegeException when the principal is not authorized.
+	 */
+	getMembersWhereUserIsInRoles {
+		@Override
+		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
+			List<String> roles = parms.readList("roles", String.class);
+			roles.replaceAll(String::toUpperCase);
+			for (String role: roles) {
+				if (!cz.metacentrum.perun.core.api.AuthzResolver.roleExists(role)) {
+					throw new RpcException(RpcException.Type.WRONG_PARAMETER, "Role with name " + role + " does not exist.");
+				}
+			}
+			if(parms.contains("user")) {
+				cz.metacentrum.perun.core.api.AuthzResolver.getMembersWhereUserIsInRoles(
+					ac.getSession(),
+					ac.getUserById(parms.readInt("user")),
+					roles);
+			} else {
+				cz.metacentrum.perun.core.api.AuthzResolver.getMembersWhereUserIsInRoles(
+					ac.getSession(),
+					null,
+					roles);
+			}
+			return null;
+		}
+	},
+
+	/*#
+	 * Get all SecurityTeams where the given user has set one of the given roles
+	 * or the given user is a member of an authorized group with such roles.
+	 *
+	 * @param user int <code>id</code> of object User
+	 * @param roles List<String> list of role names for which SecurityTeams are retrieved
+	 * @return List<SecurityTeam> List of SecurityTeams
+	 *
+	 * @throws PrivilegeException when the principal is not authorized.
+	 */
+	/*#
+	 * Get all SecurityTeams where the given principal has set one of the given roles
+	 * or the given principal is a member of an authorized group with such roles.
+	 *
+	 * @param roles List<String> list of role names for which SecurityTeams are retrieved
+	 * @return List<SecurityTeam> List of SecurityTeams
+	 *
+	 * @throws PrivilegeException when the principal is not authorized.
+	 */
+	getSecurityTeamsWhereUserIsInRoles {
+		@Override
+		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
+			List<String> roles = parms.readList("roles", String.class);
+			roles.replaceAll(String::toUpperCase);
+			for (String role: roles) {
+				if (!cz.metacentrum.perun.core.api.AuthzResolver.roleExists(role)) {
+					throw new RpcException(RpcException.Type.WRONG_PARAMETER, "Role with name " + role + " does not exist.");
+				}
+			}
+			if(parms.contains("user")) {
+				cz.metacentrum.perun.core.api.AuthzResolver.getSecurityTeamsWhereUserIsInRoles(
+					ac.getSession(),
+					ac.getUserById(parms.readInt("user")),
+					roles);
+			} else {
+				cz.metacentrum.perun.core.api.AuthzResolver.getSecurityTeamsWhereUserIsInRoles(
+					ac.getSession(),
+					null,
+					roles);
+			}
 			return null;
 		}
 	};


### PR DESCRIPTION
- These methods were implemented for Vo, Facility, Resource, Group,
  Member and SecurityTeam.
- Method for service was not implemented because it is not used at all.
- Groups are obtained with all their subgroups.
- SPONSORSHIP is supported for members.
- Fixed typo in GROUPOBSERVER name.