### PR TITLE
We don't want to send complementary object if it should be null

### DIFF
--- a/perun-cli/makeUserPerunAdmin
+++ b/perun-cli/makeUserPerunAdmin
@@ -31,6 +31,6 @@ my $role = "PERUNADMIN";
 my $agent = Perun::Agent->new();
 my $authzResolverAgent = $agent->getAuthzResolverAgent;
 
-$authzResolverAgent->setRole( user => $userId, complementaryObject => undef, role => $role );
+$authzResolverAgent->setRole( user => $userId, role => $role );
 
 printMessage("User Id: $userId became PERUNADMIN", $batch);

--- a/perun-cli/revokeUserPerunAdmin
+++ b/perun-cli/revokeUserPerunAdmin
@@ -31,6 +31,6 @@ my $role = "PERUNADMIN";
 my $agent = Perun::Agent->new();
 my $authzResolverAgent = $agent->getAuthzResolverAgent;
 
-$authzResolverAgent->unsetRole( user => $userId, complementaryObject => undef, role => $role );
+$authzResolverAgent->unsetRole( user => $userId, role => $role );
 
 printMessage("User Id: $userId is not PERUNADMIN from now", $batch);

--- a/perun-cli/setRole
+++ b/perun-cli/setRole
@@ -60,7 +60,7 @@ if ($role eq "PERUNADMIN") {
 		die "ERROR: no other object needed when setting role $role\n";
 	}
 	if (defined($userId)) {
-		$authzResolverAgent->setRole( user => $userId, complementaryObject => undef, role => $role );
+		$authzResolverAgent->setRole( user => $userId, role => $role );
 		printMessage("PERUNADMIN role is successfully set for user $userId", $batch);
 	} else {
 		die "ERROR: PERUNADMIN role cannot be set for group \n";
@@ -70,10 +70,10 @@ if ($role eq "PERUNADMIN") {
 		die "ERROR: no other object needed when setting role $role\n";
 	}
 	if (defined($userId)) {
-		$authzResolverAgent->setRole( user => $userId, complementaryObject => undef, role => $role );
+		$authzResolverAgent->setRole( user => $userId, role => $role );
 		printMessage("PERUNOBSERVER role is successfully set for user $userId", $batch);
 	} else {
-		$authzResolverAgent->setRole( authorizedGroup => $authorizedGroupId, complementaryObject => undef, role => $role );
+		$authzResolverAgent->setRole( authorizedGroup => $authorizedGroupId, role => $role );
 		printMessage("PERUNOBSERVER role is successfully set for authorizedGroup $authorizedGroupId", $batch);
 	}
 } elsif ($role eq "CABINETADMIN") {
@@ -81,7 +81,7 @@ if ($role eq "PERUNADMIN") {
 		die "ERROR: no other object needed when setting role $role\n";
 	}
 	if (defined($userId)) {
-		$authzResolverAgent->setRole( user => $userId, complementaryObject => undef, role => $role );
+		$authzResolverAgent->setRole( user => $userId, role => $role );
 		printMessage("CABINETADMIN role is successfully set for user $userId", $batch);
 	} else {
 		die "ERROR: CABINETADMIN role cannot be set for group \n";

--- a/perun-cli/unsetRole
+++ b/perun-cli/unsetRole
@@ -60,7 +60,7 @@ if ($role eq "PERUNADMIN") {
 		die "ERROR: no other object needed when setting role $role\n";
 	}
 	if (defined($userId)) {
-		$authzResolverAgent->unsetRole( user => $userId, complementaryObject => undef, role => $role );
+		$authzResolverAgent->unsetRole( user => $userId, role => $role );
 		printMessage("PERUNADMIN role was removed from user $userId", $batch);
 	} else {
 		die "ERROR: PERUNADMIN role cannot be unset from group \n";
@@ -70,10 +70,10 @@ if ($role eq "PERUNADMIN") {
 		die "ERROR: no other object needed when setting role $role\n";
 	}
 	if (defined($userId)) {
-		$authzResolverAgent->unsetRole( user => $userId, complementaryObject => undef, role => $role );
+		$authzResolverAgent->unsetRole( user => $userId, role => $role );
 		printMessage("PERUNOBSERVER role was removed from user $userId", $batch);
 	} else {
-		$authzResolverAgent->unsetRole( authorizedGroup => $authorizedGroupId, complementaryObject => undef, role => $role );
+		$authzResolverAgent->unsetRole( authorizedGroup => $authorizedGroupId, role => $role );
 		printMessage("PERUNOBSERVER role was removed from authorizedGroup $authorizedGroupId", $batch);
 	}
 	#if there is other role, only one complementary object is needed
@@ -82,7 +82,7 @@ if ($role eq "PERUNADMIN") {
 		die "ERROR: no other object needed when setting role $role\n";
 	}
 	if (defined($userId)) {
-		$authzResolverAgent->unsetRole( user => $userId, complementaryObject => undef, role => $role );
+		$authzResolverAgent->unsetRole( user => $userId, role => $role );
 		printMessage("CABINETADMIN role was removed from user $userId", $batch);
 	} else {
 		die "ERROR: CABINETADMIN role cannot be unset from group \n";


### PR DESCRIPTION
 - for roles like PerunAdmin, PerunObserver a CabinetAdmin the
 complementary object should be null, for this reason we don't want to
 send it at all (sending undef is not the same as null in the backend)