### PR TITLE
replaced JDK 11 with JDK 15 in CI tests

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '8', '11' ]
+        java: [ '8', '15' ]
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK ${{ matrix.java }}


### PR DESCRIPTION
16 of 22 Perun instances now run on JDK 15, so it is time to change the tests