### PR TITLE
Core - deserialize messages with localDate

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/audit/events/MembersManagerEvents/SponsorshipEstablished.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/audit/events/MembersManagerEvents/SponsorshipEstablished.java
@@ -11,7 +11,7 @@ public class SponsorshipEstablished extends AuditEvent {
 	private Member sponsoredMember;
 	private User sponsor;
 	private String message;
-	private String validity;
+	private LocalDate validity;
 
 	@SuppressWarnings("unused") // used by jackson mapper
 	public SponsorshipEstablished() {
@@ -20,9 +20,9 @@ public class SponsorshipEstablished extends AuditEvent {
 	public SponsorshipEstablished(Member sponsoredMember, User sponsor, LocalDate validityTo) {
 		this.sponsoredMember = sponsoredMember;
 		this.sponsor = sponsor;
-		this.validity = (validityTo == null) ? "FOREVER" : validityTo.toString();
+		this.validity = validityTo;
 		this.message = formatMessage("Sponsorship of %s by %s established with validity to %s.",
-				sponsoredMember, sponsor, validity);
+				sponsoredMember, sponsor, (validityTo == null) ? "FOREVER" : validityTo.toString());
 	}
 
 	@Override
@@ -38,7 +38,7 @@ public class SponsorshipEstablished extends AuditEvent {
 		return sponsor;
 	}
 
-	public String getValidity() {
+	public LocalDate getValidity() {
 		return validity;
 	}
 

--- a/perun-base/src/main/java/cz/metacentrum/perun/audit/events/MembersManagerEvents/SponsorshipValidityUpdated.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/audit/events/MembersManagerEvents/SponsorshipValidityUpdated.java
@@ -14,7 +14,7 @@ public class SponsorshipValidityUpdated extends AuditEvent {
 	private Member sponsoredMember;
 	private User sponsor;
 	private String message;
-	private String validity;
+	private LocalDate validity;
 
 	@SuppressWarnings("unused") // used by jackson mapper
 	public SponsorshipValidityUpdated() {
@@ -23,9 +23,9 @@ public class SponsorshipValidityUpdated extends AuditEvent {
 	public SponsorshipValidityUpdated(Member sponsoredMember, User sponsor, LocalDate validityTo) {
 		this.sponsoredMember = sponsoredMember;
 		this.sponsor = sponsor;
-		this.validity = (validityTo == null) ? "FOREVER" : validityTo.toString();
+		this.validity = validityTo;
 		this.message = formatMessage("Validity of sponsorship of %s by %s changed to %s.",
-				sponsoredMember, sponsor, validity);
+				sponsoredMember, sponsor, (validityTo == null) ? "FOREVER" : validityTo.toString());
 	}
 
 	@Override
@@ -41,7 +41,7 @@ public class SponsorshipValidityUpdated extends AuditEvent {
 		return sponsor;
 	}
 
-	public String getValidity() {
+	public LocalDate getValidity() {
 		return validity;
 	}
 

--- a/perun-core/pom.xml
+++ b/perun-core/pom.xml
@@ -176,6 +176,11 @@
 			<artifactId>jackson-dataformat-yaml</artifactId>
 		</dependency>
 
+		<dependency>
+			<groupId>com.fasterxml.jackson.datatype</groupId>
+			<artifactId>jackson-datatype-jsr310</artifactId>
+		</dependency>
+
 		<!-- PostgreSQL driver -->
 		<dependency>
 			<groupId>org.postgresql</groupId>

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AuditMessagesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AuditMessagesManagerImpl.java
@@ -3,6 +3,7 @@ package cz.metacentrum.perun.core.impl;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import cz.metacentrum.perun.audit.events.AuditEvent;
 import cz.metacentrum.perun.cabinet.model.Author;
 import cz.metacentrum.perun.cabinet.model.Category;
@@ -56,7 +57,8 @@ import java.util.Map;
 public class AuditMessagesManagerImpl implements AuditMessagesManagerImplApi {
 
 	private final static Logger log = LoggerFactory.getLogger(AuditMessagesManagerImpl.class);
-	private final static ObjectMapper mapper = new ObjectMapper();
+	private final static ObjectMapper mapper = new ObjectMapper().registerModule(new JavaTimeModule());
+
 	private static final Map<Class<?>,Class<?>> mixinMap = new HashMap<>();
 	private final static String auditMessageMappingSelectQuery = "id, msg, actor, created_at, created_by_uid";
 

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/AuditMessagesManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/AuditMessagesManagerEntryIntegrationTest.java
@@ -1,17 +1,27 @@
 package cz.metacentrum.perun.core.entry;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import cz.metacentrum.perun.audit.events.AuditEvent;
+import cz.metacentrum.perun.audit.events.ExpirationNotifScheduler.SponsorshipExpired;
 import cz.metacentrum.perun.audit.events.FacilityManagerEvents.FacilityCreated;
+import cz.metacentrum.perun.audit.events.MembersManagerEvents.SponsorshipEstablished;
 import cz.metacentrum.perun.audit.events.StringMessageEvent;
 import cz.metacentrum.perun.core.AbstractPerunIntegrationTest;
 import cz.metacentrum.perun.core.api.AuditMessage;
 import cz.metacentrum.perun.core.api.AuditMessagesManager;
+import cz.metacentrum.perun.core.api.EnrichedSponsorship;
 import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.exceptions.WrongRangeOfCountException;
+import cz.metacentrum.perun.core.impl.AuditMessagesManagerImpl;
 import org.junit.Before;
 import org.junit.Test;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.test.util.ReflectionTestUtils;
 
+import java.time.LocalDate;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -75,6 +85,36 @@ public class AuditMessagesManagerEntryIntegrationTest extends AbstractPerunInteg
 	public void testLessThanZeroCountOfMessages() throws Exception {
 		System.out.println(CLASS_NAME + "testLessThanZeroCountOfMessages");
 		perun.getAuditMessagesManager().getMessages(sess, -1);
+	}
+
+	@Test
+	public void testLocalDate() throws Exception {
+		System.out.println(CLASS_NAME + "testLocalDate");
+
+		AuditMessagesManagerImpl auditMessagesManagerImpl = (AuditMessagesManagerImpl)ReflectionTestUtils
+				.getField(perun.getAuditMessagesManagerBl(), "auditMessagesManagerImpl");
+		assertThat(auditMessagesManagerImpl).isNotNull();
+
+		ObjectMapper mapper = (ObjectMapper)ReflectionTestUtils.getField(auditMessagesManagerImpl, "mapper");
+		assertThat(mapper).isNotNull();
+
+		AuditEvent event = new SponsorshipEstablished(null, null, LocalDate.MIN);
+
+		testAuditEventMapper(mapper, event);
+
+		EnrichedSponsorship enrichedSponsorship = new EnrichedSponsorship();
+		enrichedSponsorship.setValidityTo(LocalDate.MAX);
+		AuditEvent event2 = new SponsorshipExpired();
+
+		testAuditEventMapper(mapper, event2);
+	}
+
+	private void testAuditEventMapper(ObjectMapper mapper, AuditEvent event) throws Exception {
+		String value = mapper.writeValueAsString(event);
+
+		AuditEvent deserializedEvent = mapper.readValue(value, AuditEvent.class);
+
+		assertThat(deserializedEvent).isEqualTo(event);
 	}
 
 }


### PR DESCRIPTION
* Added dependency for jackson-datatype-jsr310 which can be used to
extend the ObjectMapper used in auditeMessagesManager. This way, the
mapper can work with LocalDates.
* Events, where we have recently replace the LocalDate with String type,
were again reworked to use LocalDate for the validity.
* Added module JavaTimeModule to the ObjectMapper in the
auditMessagesManagerImpl so it can deserialize messages with
LocalDate properties.
* Added a simple test to verify the new functionality.