### PR TITLE
added sourceLevel=auto to gwt-maven-plugin

### DIFF
--- a/perun-web-gui/pom.xml
+++ b/perun-web-gui/pom.xml
@@ -81,6 +81,7 @@
 				<!-- Plugin configuration. There are many available options, see
 				  gwt-maven-plugin documentation at codehaus.org -->
 				<configuration>
+					<sourceLevel>auto</sourceLevel>
 					<extraJvmArgs>-Xmx1024m</extraJvmArgs>
 					<modules>
 						<module>cz.metacentrum.perun.webgui.perun-web</module>


### PR DESCRIPTION
The configuration option sourceLevel=auto enables function of GWT regardless of the setting of the java.version property.