### PR TITLE
Unifying methods for password validation

### DIFF
--- a/perun-base/src/main/resources/perun-roles.yml
+++ b/perun-base/src/main/resources/perun-roles.yml
@@ -4738,22 +4738,16 @@ perun_policies:
     include_policies:
       - default_policy
 
-  validatePasswordAndSetExtSources_User_String_String_policy:
+  validatePassword_User_String_policy:
     policy_roles:
       - REGISTRAR:
       - SELF: User
     include_policies:
       - default_policy
 
-  service_user-validatePasswordAndSetExtSources_User_String_String_policy:
+  service_user-validatePassword_User_String_policy:
     policy_roles:
       - VOADMIN:
-    include_policies:
-      - default_policy
-
-  validatePassword_User_String_policy:
-    policy_roles:
-      - SELF: User
     include_policies:
       - default_policy
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/UsersManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/UsersManager.java
@@ -875,7 +875,8 @@ public interface UsersManager {
 			throws PasswordCreationFailedException, PrivilegeException, UserNotExistsException, LoginNotExistsException, PasswordOperationTimeoutException, PasswordStrengthFailedException, InvalidLoginException, PasswordStrengthException;
 
 	/**
-	 * Validates the password in external system. User must not exists.
+	 * Validates the password in external system and sets user extSources and extSource related attributes.
+	 * User must not exists.
 	 *
 	 * @param sess
 	 * @param userLogin string representation of the userLogin
@@ -888,27 +889,8 @@ public interface UsersManager {
 			throws PasswordCreationFailedException, PrivilegeException, InvalidLoginException;
 
 	/**
-	 * Validates the password in external system and set user extSources and extSource related attributes. User must exists.
-	 *
-	 * @param sess
-	 * @param user
-	 * @param userLogin
-	 * @param loginNamespace
-	 *
-	 * @throws InternalErrorException
-	 * @throws PrivilegeException
-	 * @throws PasswordCreationFailedException
-	 * @throws LoginNotExistsException
-	 * @throws ExtSourceNotExistsException
-	 * @throws WrongAttributeValueException
-	 * @throws WrongReferenceAttributeValueException
-	 * @throws InvalidLoginException
-	 */
-	void validatePasswordAndSetExtSources(PerunSession sess, User user, String userLogin, String loginNamespace) throws PrivilegeException, PasswordCreationFailedException, LoginNotExistsException, ExtSourceNotExistsException, InvalidLoginException, WrongReferenceAttributeValueException, WrongAttributeValueException;
-
-
-	/**
-	 * Validates the password in external system. User must exists.
+	 * Validates the password in external system and sets user extSources and extSource related attributes.
+	 * User must exists.
 	 *
 	 * @param sess
 	 * @param user

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ModulesUtilsBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ModulesUtilsBl.java
@@ -6,6 +6,7 @@ import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.Pair;
 import cz.metacentrum.perun.core.api.PerunBean;
+import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
@@ -523,4 +524,14 @@ public interface ModulesUtilsBl {
 	 * @throws WrongAttributeValueException if value of attribute in parameter does not contain valid ranges without overlaps
 	 */
 	Map<Integer, Integer> checkAndConvertIDRanges(Attribute idRangesAttribute) throws WrongAttributeValueException;
+
+	/**
+	 * Gets user by login in specified namespace.
+	 *
+	 * @param sess
+	 * @param login user's login
+	 * @param namespace login-namespace
+	 * @return found user or null if no user was found
+	 */
+	User getUserByLoginInNamespace(PerunSession sess, String login, String namespace);
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
@@ -993,7 +993,8 @@ public interface UsersManagerBl {
 			throws PasswordCreationFailedException, LoginNotExistsException, PasswordOperationTimeoutException, PasswordStrengthFailedException, InvalidLoginException, PasswordStrengthException;
 
 	/**
-	 * Validates the password in external system. User must not exists.
+	 * Validates the password in external system and sets user extSources and extSource related attributes.
+	 * User must not exists.
 	 *
 	 * @param sess
 	 * @param userLogin      string representation of the userLogin
@@ -1006,7 +1007,8 @@ public interface UsersManagerBl {
 			throws PasswordCreationFailedException, InvalidLoginException;
 
 	/**
-	 * Validates the password in external system. User must exists.
+	 * Validates the password in external system and sets user extSources and extSource related attributes.
+	 * User must exists.
 	 *
 	 * @param sess
 	 * @param user
@@ -1018,23 +1020,6 @@ public interface UsersManagerBl {
 	 */
 	void validatePassword(PerunSession sess, User user, String loginNamespace)
 			throws PasswordCreationFailedException, LoginNotExistsException, InvalidLoginException;
-
-	/**
-	 * Validates the password in external system and set user extSources and extSource related attributes. User must exists.
-	 *
-	 * @param sess
-	 * @param user
-	 * @param userLogin
-	 * @param loginNamespace
-	 * @throws InternalErrorException
-	 * @throws PasswordCreationFailedException
-	 * @throws ExtSourceNotExistsException
-	 * @throws WrongAttributeValueException
-	 * @throws WrongReferenceAttributeValueException
-	 * @throws LoginNotExistsException When user doesn't have login in specified namespace
-	 * @throws InvalidLoginException When When login of user has invalid syntax (is not allowed)
-	 */
-	void validatePasswordAndSetExtSources(PerunSession sess, User user, String userLogin, String loginNamespace) throws PasswordCreationFailedException, LoginNotExistsException, ExtSourceNotExistsException, WrongAttributeValueException, WrongReferenceAttributeValueException, InvalidLoginException;
 
 	/**
 	 * Deletes password in external system. User must not exists.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
@@ -2406,7 +2406,7 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 		String attributeValue = getAttributeValueAsString (session, userToBeSponsored, loginAttributeName);
 
 		//create the user account in external system if does not exist yet
-		String login = createUserAccountInExternalSystem (session, userToBeSponsored, namespace, attributeValue, loginAttributeName, password);
+		createUserAccountInExternalSystem(session, userToBeSponsored, namespace, attributeValue, loginAttributeName, password);
 
 		//create the member in Perun
 		Member sponsoredMember = getMembersManagerImpl().createSponsoredMember(session, vo, userToBeSponsored, sponsor, validityTo);
@@ -2422,7 +2422,7 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 			//for unit tests
 			validateMember(session, sponsoredMember);
 		}
-		getPerunBl().getUsersManagerBl().validatePasswordAndSetExtSources(session, userToBeSponsored, login, namespace);
+		getPerunBl().getUsersManagerBl().validatePassword(session, userToBeSponsored, namespace);
 
 		return sponsoredMember;
 	}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ModulesUtilsBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ModulesUtilsBlImpl.java
@@ -12,6 +12,7 @@ import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.Member;
 import cz.metacentrum.perun.core.api.Pair;
 import cz.metacentrum.perun.core.api.PerunBean;
+import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.UserExtSource;
@@ -1181,6 +1182,20 @@ public class ModulesUtilsBlImpl implements ModulesUtilsBl {
 		}
 
 		return convertedRanges;
+	}
+
+	@Override
+	public User getUserByLoginInNamespace(PerunSession sess, String login, String namespace) {
+		String attrName = AttributesManager.NS_USER_ATTR_DEF + ":" + AttributesManager.LOGIN_NAMESPACE + ":" + namespace;
+		List<User> usersByLoginInNamespace = getPerunBl().getUsersManagerBl().getUsersByAttributeValue(sess, attrName, login);
+
+		if (usersByLoginInNamespace.isEmpty()) {
+			return null;
+		} else if (usersByLoginInNamespace.size() == 1) {
+			return usersByLoginInNamespace.get(0);
+		} else {
+			throw new ConsistencyErrorException("There is more than 1 login '" + login + "' in namespace " + namespace + ".");
+		}
 	}
 
 	/**

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
@@ -1246,7 +1246,7 @@ public class UsersManagerBlImpl implements UsersManagerBl {
 		// Validate the password
 		PasswordManagerModule module = getPasswordManagerModule(sess, loginNamespace);
 		try {
-			module.validatePassword(sess, userLogin);
+			module.validatePassword(sess, userLogin, null);
 		} catch (PasswordCreationFailedRuntimeException e) {
 			throw new PasswordCreationFailedException(e);
 		}
@@ -1268,7 +1268,7 @@ public class UsersManagerBlImpl implements UsersManagerBl {
 			// Validate the password
 			PasswordManagerModule module = getPasswordManagerModule(sess, loginNamespace);
 			try {
-				module.validatePassword(sess, attr.valueAsString());
+				module.validatePassword(sess, attr.valueAsString(), user);
 			} catch (PasswordCreationFailedRuntimeException e) {
 				throw new PasswordCreationFailedException(e);
 			}
@@ -1277,271 +1277,6 @@ public class UsersManagerBlImpl implements UsersManagerBl {
 		} catch (WrongAttributeAssignmentException e) {
 			throw new InternalErrorException(e);
 		}
-	}
-
-	@Override
-	public void validatePasswordAndSetExtSources(PerunSession sess, User user, String userLogin, String loginNamespace) throws PasswordCreationFailedException, LoginNotExistsException, ExtSourceNotExistsException, WrongAttributeValueException, WrongReferenceAttributeValueException, InvalidLoginException {
-		/*
-		 * FIXME This method is very badly writen - it should be rewrited or refactored
-		 */
-
-		try {
-			switch (loginNamespace) {
-				case "einfra": {
-					List<String> kerberosLogins = new ArrayList<>();
-
-					// Set META and EINFRA userExtSources
-					ExtSource extSource = getPerunBl().getExtSourcesManagerBl().getExtSourceByName(sess, "META");
-					UserExtSource ues = new UserExtSource(extSource, userLogin + "@META");
-					ues.setLoa(0);
-
-					try {
-						getPerunBl().getUsersManagerBl().addUserExtSource(sess, user, ues);
-					} catch (UserExtSourceExistsException ex) {
-						//this is OK
-					}
-
-					extSource = getPerunBl().getExtSourcesManagerBl().getExtSourceByName(sess, "EINFRA");
-					ues = new UserExtSource(extSource, userLogin + "@EINFRA");
-					ues.setLoa(0);
-
-					try {
-						getPerunBl().getUsersManagerBl().addUserExtSource(sess, user, ues);
-					} catch (UserExtSourceExistsException ex) {
-						//this is OK
-					}
-
-					extSource = getPerunBl().getExtSourcesManagerBl().getExtSourceByName(sess, "https://login.ics.muni.cz/idp/shibboleth");
-					ues = new UserExtSource(extSource, userLogin + "@meta.cesnet.cz");
-					ues.setLoa(0);
-
-					try {
-						getPerunBl().getUsersManagerBl().addUserExtSource(sess, user, ues);
-					} catch (UserExtSourceExistsException ex) {
-						//this is OK
-					}
-
-					// Store also Kerberos logins
-					Attribute kerberosLoginsAttr = getPerunBl().getAttributesManagerBl().getAttribute(sess, user, AttributesManager.NS_USER_ATTR_DEF + ":" + "kerberosLogins");
-					if (kerberosLoginsAttr != null && kerberosLoginsAttr.getValue() != null) {
-						kerberosLogins.addAll((List<String>) kerberosLoginsAttr.getValue());
-					}
-
-					boolean someChange = false;
-					if (!kerberosLogins.contains(userLogin + "@EINFRA")) {
-						kerberosLogins.add(userLogin + "@EINFRA");
-						someChange = true;
-					}
-					if (!kerberosLogins.contains(userLogin + "@META")) {
-						kerberosLogins.add(userLogin + "@META");
-						someChange = true;
-					}
-
-					if (someChange && kerberosLoginsAttr != null) {
-						kerberosLoginsAttr.setValue(kerberosLogins);
-						getPerunBl().getAttributesManagerBl().setAttribute(sess, user, kerberosLoginsAttr);
-					}
-
-					break;
-				}
-				case "egi-ui": {
-
-					List<String> kerberosLogins = new ArrayList<>();
-
-					ExtSource extSource = getPerunBl().getExtSourcesManagerBl().getExtSourceByName(sess, "EGI");
-					UserExtSource ues = new UserExtSource(extSource, userLogin + "@EGI");
-					ues.setLoa(0);
-
-					try {
-						getPerunBl().getUsersManagerBl().addUserExtSource(sess, user, ues);
-					} catch (UserExtSourceExistsException ex) {
-						//this is OK
-					}
-
-					// Store also Kerberos logins
-					Attribute kerberosLoginsAttr = getPerunBl().getAttributesManagerBl().getAttribute(sess, user, AttributesManager.NS_USER_ATTR_DEF + ":" + "kerberosLogins");
-					if (kerberosLoginsAttr != null && kerberosLoginsAttr.getValue() != null) {
-						kerberosLogins.addAll((List<String>) kerberosLoginsAttr.getValue());
-					}
-
-					if (!kerberosLogins.contains(userLogin + "@EGI") && kerberosLoginsAttr != null) {
-						kerberosLogins.add(userLogin + "@EGI");
-						kerberosLoginsAttr.setValue(kerberosLogins);
-						getPerunBl().getAttributesManagerBl().setAttribute(sess, user, kerberosLoginsAttr);
-					}
-
-					break;
-				}
-				case "sitola": {
-
-					List<String> kerberosLogins = new ArrayList<>();
-
-					ExtSource extSource = getPerunBl().getExtSourcesManagerBl().getExtSourceByName(sess, "SITOLA.FI.MUNI.CZ");
-					UserExtSource ues = new UserExtSource(extSource, userLogin + "@SITOLA.FI.MUNI.CZ");
-					ues.setLoa(0);
-
-					try {
-						getPerunBl().getUsersManagerBl().addUserExtSource(sess, user, ues);
-					} catch (UserExtSourceExistsException ex) {
-						//this is OK
-					}
-
-					// Store also Kerberos logins
-					Attribute kerberosLoginsAttr = getPerunBl().getAttributesManagerBl().getAttribute(sess, user, AttributesManager.NS_USER_ATTR_DEF + ":" + "kerberosLogins");
-					if (kerberosLoginsAttr != null && kerberosLoginsAttr.getValue() != null) {
-						kerberosLogins.addAll((List<String>) kerberosLoginsAttr.getValue());
-					}
-
-					if (!kerberosLogins.contains(userLogin + "@SITOLA.FI.MUNI.CZ") && kerberosLoginsAttr != null) {
-						kerberosLogins.add(userLogin + "@SITOLA.FI.MUNI.CZ");
-						kerberosLoginsAttr.setValue(kerberosLogins);
-						getPerunBl().getAttributesManagerBl().setAttribute(sess, user, kerberosLoginsAttr);
-					}
-
-					break;
-				}
-				case "ics-muni-cz": {
-
-					List<String> kerberosLogins = new ArrayList<>();
-
-					ExtSource extSource = getPerunBl().getExtSourcesManagerBl().getExtSourceByName(sess, "ICS.MUNI.CZ");
-					UserExtSource ues = new UserExtSource(extSource, userLogin + "@ICS.MUNI.CZ");
-					ues.setLoa(0);
-
-					try {
-						getPerunBl().getUsersManagerBl().addUserExtSource(sess, user, ues);
-					} catch (UserExtSourceExistsException ex) {
-						//this is OK
-					}
-
-					// Store also Kerberos logins
-					Attribute kerberosLoginsAttr = getPerunBl().getAttributesManagerBl().getAttribute(sess, user, AttributesManager.NS_USER_ATTR_DEF + ":" + "kerberosLogins");
-					if (kerberosLoginsAttr != null && kerberosLoginsAttr.getValue() != null) {
-						kerberosLogins.addAll((List<String>) kerberosLoginsAttr.getValue());
-					}
-
-					if (!kerberosLogins.contains(userLogin + "@ICS.MUNI.CZ") && kerberosLoginsAttr != null) {
-						kerberosLogins.add(userLogin + "@ICS.MUNI.CZ");
-						kerberosLoginsAttr.setValue(kerberosLogins);
-						getPerunBl().getAttributesManagerBl().setAttribute(sess, user, kerberosLoginsAttr);
-					}
-
-					break;
-				}
-				case "mu": {
-
-					ExtSource extSource = getPerunBl().getExtSourcesManagerBl().getExtSourceByName(sess, "https://idp2.ics.muni.cz/idp/shibboleth");
-					UserExtSource ues = new UserExtSource(extSource, userLogin + "@muni.cz");
-					ues.setLoa(2);
-
-					try {
-						getPerunBl().getUsersManagerBl().addUserExtSource(sess, user, ues);
-					} catch (UserExtSourceExistsException ex) {
-						//this is OK
-					}
-
-					break;
-				}
-				case "vsup": {
-
-					// Add UES in their ActiveDirectory to access Perun by it
-					ExtSource extSource = getPerunBl().getExtSourcesManagerBl().getExtSourceByName(sess, "AD");
-					UserExtSource ues = new UserExtSource(extSource, userLogin);
-					ues.setLoa(0);
-
-					try {
-						getPerunBl().getUsersManagerBl().addUserExtSource(sess, user, ues);
-					} catch (UserExtSourceExistsException ex) {
-						//this is OK
-					}
-					break;
-				}
-				case "elixir": {
-
-					ExtSource extSource = getPerunBl().getExtSourcesManagerBl().getExtSourceByName(sess, "ELIXIR-EUROPE.ORG");
-					UserExtSource ues = new UserExtSource(extSource, userLogin + "@ELIXIR-EUROPE.ORG");
-					ues.setLoa(0);
-
-					try {
-						getPerunBl().getUsersManagerBl().addUserExtSource(sess, user, ues);
-					} catch (UserExtSourceExistsException ex) {
-						//this is OK
-					}
-
-					List<String> kerberosLogins = new ArrayList<>();
-
-					// Store also Kerberos logins
-					Attribute kerberosLoginsAttr = getPerunBl().getAttributesManagerBl().getAttribute(sess, user, AttributesManager.NS_USER_ATTR_DEF + ":" + "kerberosLogins");
-					if (kerberosLoginsAttr != null && kerberosLoginsAttr.getValue() != null) {
-						kerberosLogins.addAll((List<String>) kerberosLoginsAttr.getValue());
-					}
-
-					if (!kerberosLogins.contains(userLogin + "@ELIXIR-EUROPE.ORG") && kerberosLoginsAttr != null) {
-						kerberosLogins.add(userLogin + "@ELIXIR-EUROPE.ORG");
-						kerberosLoginsAttr.setValue(kerberosLogins);
-						getPerunBl().getAttributesManagerBl().setAttribute(sess, user, kerberosLoginsAttr);
-					}
-
-					break;
-				}
-				case "einfra-services": {
-
-					ExtSource extSource = getPerunBl().getExtSourcesManagerBl().getExtSourceByName(sess, "EINFRA-SERVICES");
-					UserExtSource ues = new UserExtSource(extSource, userLogin + "@EINFRA-SERVICES");
-					ues.setLoa(0);
-
-					try {
-						getPerunBl().getUsersManagerBl().addUserExtSource(sess, user, ues);
-					} catch (UserExtSourceExistsException ex) {
-						//this is OK
-					}
-
-					List<String> kerberosLogins = new ArrayList<>();
-
-					// Store also Kerberos logins
-					Attribute kerberosLoginsAttr = getPerunBl().getAttributesManagerBl().getAttribute(sess, user, AttributesManager.NS_USER_ATTR_DEF + ":" + "kerberosLogins");
-					if (kerberosLoginsAttr != null && kerberosLoginsAttr.getValue() != null) {
-						kerberosLogins.addAll((List<String>) kerberosLoginsAttr.getValue());
-					}
-
-					if (!kerberosLogins.contains(userLogin + "@EINFRA-SERVICES") && kerberosLoginsAttr != null) {
-						kerberosLogins.add(userLogin + "@EINFRA-SERVICES");
-						kerberosLoginsAttr.setValue(kerberosLogins);
-						getPerunBl().getAttributesManagerBl().setAttribute(sess, user, kerberosLoginsAttr);
-					}
-
-					break;
-				}
-				case "dummy": {
-					//dummy namespace for testing, it has accompanying DummyPasswordModule that just generates random numbers
-					ExtSource extSource;
-					try {
-						extSource = getPerunBl().getExtSourcesManagerBl().getExtSourceByName(sess, "https://dummy");
-					} catch (ExtSourceNotExistsException e) {
-						extSource = new ExtSource("https://dummy", ExtSourcesManager.EXTSOURCE_IDP);
-						try {
-							extSource = getPerunBl().getExtSourcesManagerBl().createExtSource(sess, extSource, null);
-						} catch (ExtSourceExistsException e1) {
-							log.warn("impossible or race condition", e1);
-						}
-					}
-					UserExtSource ues = new UserExtSource(extSource, userLogin + "@dummy");
-					ues.setLoa(2);
-					try {
-						getPerunBl().getUsersManagerBl().addUserExtSource(sess, user, ues);
-					} catch (UserExtSourceExistsException ex) {
-						//this is OK
-					}
-
-					break;
-				}
-			}
-		} catch (WrongAttributeAssignmentException | AttributeNotExistsException ex) {
-			throw new InternalErrorException(ex);
-		}
-
-		validatePassword(sess, user, loginNamespace);
-
 	}
 
 	@Override
@@ -1616,11 +1351,9 @@ public class UsersManagerBlImpl implements UsersManagerBl {
 
 		//validate and set user ext sources
 		try {
-			this.validatePasswordAndSetExtSources(sess, user, (String) userLogin.getValue(), loginNamespace);
+			this.validatePassword(sess, user, loginNamespace);
 		} catch(PasswordCreationFailedException ex) {
 			throw new PasswordChangeFailedException(ex);
-		} catch(ExtSourceNotExistsException | AttributeValueException ex) {
-			throw new InternalErrorException(ex);
 		}
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
@@ -997,31 +997,13 @@ public class UsersManagerEntry implements UsersManager {
 	}
 
 	@Override
-	public void validatePasswordAndSetExtSources(PerunSession sess, User user, String userLogin, String loginNamespace) throws PrivilegeException, PasswordCreationFailedException, LoginNotExistsException, ExtSourceNotExistsException, InvalidLoginException, WrongReferenceAttributeValueException, WrongAttributeValueException {
-		Utils.checkPerunSession(sess);
-
-		// Authorization
-		if(!AuthzResolver.authorizedInternal(sess, "validatePasswordAndSetExtSources_User_String_String_policy", user)
-			&& (!(AuthzResolver.authorizedInternal(sess, "service_user-validatePasswordAndSetExtSources_User_String_String_policy", user)) && user.isServiceUser())) {
-			throw new PrivilegeException(sess, "validatePasswordAndSetExtSources");
-		}
-
-		// Check if the login is already occupied == reserved, if not throw an exception.
-		// We cannot set password for the users who have not reserved login in perun DB and in registrar DB as well.
-		if (!getPerunBl().getUsersManagerBl().isLoginAvailable(sess, loginNamespace, userLogin)) {
-			getUsersManagerBl().validatePasswordAndSetExtSources(sess, user, userLogin, loginNamespace);
-		} else {
-			throw new PasswordCreationFailedException("Login " + userLogin + " in namespace " + loginNamespace + " is not reserved.");
-		}
-	}
-
-	@Override
 	public void validatePassword(PerunSession sess, User user, String loginNamespace) throws
 			PrivilegeException, PasswordCreationFailedException, UserNotExistsException, LoginNotExistsException, InvalidLoginException {
 		Utils.checkPerunSession(sess);
 
 		// Authorization
-		if(!AuthzResolver.authorizedInternal(sess, "validatePassword_User_String_policy", user)) {
+		if(!AuthzResolver.authorizedInternal(sess, "validatePassword_User_String_policy", user)
+			&& (!(AuthzResolver.authorizedInternal(sess, "service_user-validatePassword_User_String_policy", user)) && user.isServiceUser())) {
 			throw new PrivilegeException(sess, "validatePassword");
 		}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/EgiuiPasswordManagerModule.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/EgiuiPasswordManagerModule.java
@@ -1,0 +1,78 @@
+package cz.metacentrum.perun.core.impl.modules.pwdmgr;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.ExtSource;
+import cz.metacentrum.perun.core.api.PerunSession;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.UserExtSource;
+import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.ExtSourceNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.InvalidLoginException;
+import cz.metacentrum.perun.core.api.exceptions.UserExtSourceExistsException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Password manager for EGI-UI login-namespace.
+ */
+public class EgiuiPasswordManagerModule extends GenericPasswordManagerModule {
+
+	private final static Logger log = LoggerFactory.getLogger(EinfraPasswordManagerModule.class);
+
+	public EgiuiPasswordManagerModule() {
+		// set proper namespace
+		this.actualLoginNamespace = "egi-ui";
+	}
+
+	@Override
+	public void validatePassword(PerunSession sess, String userLogin, User user) throws InvalidLoginException {
+		if (user == null) {
+			user = ((PerunBl) sess.getPerun()).getModulesUtilsBl().getUserByLoginInNamespace(sess, userLogin, actualLoginNamespace);
+		}
+
+		if (user == null) {
+			log.warn("No user was found by login '{}' in {} namespace.", userLogin, actualLoginNamespace);
+		} else {
+			// set extSources and extSource related attributes
+			try {
+				List<String> kerberosLogins = new ArrayList<>();
+
+				ExtSource extSource = ((PerunBl) sess.getPerun()).getExtSourcesManagerBl().getExtSourceByName(sess, "EGI");
+				UserExtSource ues = new UserExtSource(extSource, userLogin + "@EGI");
+				ues.setLoa(0);
+
+				try {
+					((PerunBl) sess.getPerun()).getUsersManagerBl().addUserExtSource(sess, user, ues);
+				} catch (UserExtSourceExistsException ex) {
+					//this is OK
+				}
+
+				// Store also Kerberos logins
+				Attribute kerberosLoginsAttr = ((PerunBl) sess.getPerun()).getAttributesManagerBl().getAttribute(sess, user, AttributesManager.NS_USER_ATTR_DEF + ":" + "kerberosLogins");
+				if (kerberosLoginsAttr != null && kerberosLoginsAttr.getValue() != null) {
+					kerberosLogins.addAll((List<String>) kerberosLoginsAttr.getValue());
+				}
+
+				if (!kerberosLogins.contains(userLogin + "@EGI") && kerberosLoginsAttr != null) {
+					kerberosLogins.add(userLogin + "@EGI");
+					kerberosLoginsAttr.setValue(kerberosLogins);
+					((PerunBl) sess.getPerun()).getAttributesManagerBl().setAttribute(sess, user, kerberosLoginsAttr);
+				}
+			} catch (WrongAttributeAssignmentException | AttributeNotExistsException | ExtSourceNotExistsException | WrongAttributeValueException | WrongReferenceAttributeValueException ex) {
+				throw new InternalErrorException(ex);
+			}
+		}
+
+		// validate password
+		super.validatePassword(sess, userLogin, user);
+	}
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/EinfraservicesPasswordManagerModule.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/EinfraservicesPasswordManagerModule.java
@@ -1,0 +1,78 @@
+package cz.metacentrum.perun.core.impl.modules.pwdmgr;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.ExtSource;
+import cz.metacentrum.perun.core.api.PerunSession;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.UserExtSource;
+import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.ExtSourceNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.InvalidLoginException;
+import cz.metacentrum.perun.core.api.exceptions.UserExtSourceExistsException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Password manager for EINFRA-SERVICES login-namespace.
+ */
+public class EinfraservicesPasswordManagerModule extends GenericPasswordManagerModule {
+
+	private final static Logger log = LoggerFactory.getLogger(EinfraPasswordManagerModule.class);
+
+	public EinfraservicesPasswordManagerModule() {
+		// set proper namespace
+		this.actualLoginNamespace = "einfra-services";
+	}
+
+	@Override
+	public void validatePassword(PerunSession sess, String userLogin, User user) throws InvalidLoginException {
+		if (user == null) {
+			user = ((PerunBl) sess.getPerun()).getModulesUtilsBl().getUserByLoginInNamespace(sess, userLogin, actualLoginNamespace);
+		}
+
+		if (user == null) {
+			log.warn("No user was found by login '{}' in {} namespace.", userLogin, actualLoginNamespace);
+		} else {
+			// set extSources and extSource related attributes
+			try {
+				ExtSource extSource = ((PerunBl) sess.getPerun()).getExtSourcesManagerBl().getExtSourceByName(sess, "EINFRA-SERVICES");
+				UserExtSource ues = new UserExtSource(extSource, userLogin + "@EINFRA-SERVICES");
+				ues.setLoa(0);
+
+				try {
+					((PerunBl) sess.getPerun()).getUsersManagerBl().addUserExtSource(sess, user, ues);
+				} catch (UserExtSourceExistsException ex) {
+					//this is OK
+				}
+
+				List<String> kerberosLogins = new ArrayList<>();
+
+				// Store also Kerberos logins
+				Attribute kerberosLoginsAttr = ((PerunBl) sess.getPerun()).getAttributesManagerBl().getAttribute(sess, user, AttributesManager.NS_USER_ATTR_DEF + ":" + "kerberosLogins");
+				if (kerberosLoginsAttr != null && kerberosLoginsAttr.getValue() != null) {
+					kerberosLogins.addAll((List<String>) kerberosLoginsAttr.getValue());
+				}
+
+				if (!kerberosLogins.contains(userLogin + "@EINFRA-SERVICES") && kerberosLoginsAttr != null) {
+					kerberosLogins.add(userLogin + "@EINFRA-SERVICES");
+					kerberosLoginsAttr.setValue(kerberosLogins);
+					((PerunBl) sess.getPerun()).getAttributesManagerBl().setAttribute(sess, user, kerberosLoginsAttr);
+				}
+			} catch (WrongAttributeAssignmentException | AttributeNotExistsException | ExtSourceNotExistsException | WrongAttributeValueException | WrongReferenceAttributeValueException ex) {
+				throw new InternalErrorException(ex);
+			}
+		}
+
+		// validate password
+		super.validatePassword(sess, userLogin, user);
+	}
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/ElixirPasswordManagerModule.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/ElixirPasswordManagerModule.java
@@ -1,0 +1,78 @@
+package cz.metacentrum.perun.core.impl.modules.pwdmgr;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.ExtSource;
+import cz.metacentrum.perun.core.api.PerunSession;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.UserExtSource;
+import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.ExtSourceNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.InvalidLoginException;
+import cz.metacentrum.perun.core.api.exceptions.UserExtSourceExistsException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Password manager for ELIXIR login-namespace.
+ */
+public class ElixirPasswordManagerModule extends GenericPasswordManagerModule {
+
+	private final static Logger log = LoggerFactory.getLogger(EinfraPasswordManagerModule.class);
+
+	public ElixirPasswordManagerModule() {
+		// set proper namespace
+		this.actualLoginNamespace = "elixir";
+	}
+
+	@Override
+	public void validatePassword(PerunSession sess, String userLogin, User user) throws InvalidLoginException {
+		if (user == null) {
+			user = ((PerunBl) sess.getPerun()).getModulesUtilsBl().getUserByLoginInNamespace(sess, userLogin, actualLoginNamespace);
+		}
+
+		if (user == null) {
+			log.warn("No user was found by login '{}' in {} namespace.", userLogin, actualLoginNamespace);
+		} else {
+			// set extSources and extSource related attributes
+			try {
+				ExtSource extSource = ((PerunBl) sess.getPerun()).getExtSourcesManagerBl().getExtSourceByName(sess, "ELIXIR-EUROPE.ORG");
+				UserExtSource ues = new UserExtSource(extSource, userLogin + "@ELIXIR-EUROPE.ORG");
+				ues.setLoa(0);
+
+				try {
+					((PerunBl) sess.getPerun()).getUsersManagerBl().addUserExtSource(sess, user, ues);
+				} catch (UserExtSourceExistsException ex) {
+					//this is OK
+				}
+
+				List<String> kerberosLogins = new ArrayList<>();
+
+				// Store also Kerberos logins
+				Attribute kerberosLoginsAttr = ((PerunBl) sess.getPerun()).getAttributesManagerBl().getAttribute(sess, user, AttributesManager.NS_USER_ATTR_DEF + ":" + "kerberosLogins");
+				if (kerberosLoginsAttr != null && kerberosLoginsAttr.getValue() != null) {
+					kerberosLogins.addAll((List<String>) kerberosLoginsAttr.getValue());
+				}
+
+				if (!kerberosLogins.contains(userLogin + "@ELIXIR-EUROPE.ORG") && kerberosLoginsAttr != null) {
+					kerberosLogins.add(userLogin + "@ELIXIR-EUROPE.ORG");
+					kerberosLoginsAttr.setValue(kerberosLogins);
+					((PerunBl) sess.getPerun()).getAttributesManagerBl().setAttribute(sess, user, kerberosLoginsAttr);
+				}
+			} catch (WrongAttributeAssignmentException | AttributeNotExistsException | ExtSourceNotExistsException | WrongAttributeValueException | WrongReferenceAttributeValueException ex) {
+				throw new InternalErrorException(ex);
+			}
+		}
+
+		// validate password
+		super.validatePassword(sess, userLogin, user);
+	}
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/GenericPasswordManagerModule.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/GenericPasswordManagerModule.java
@@ -112,7 +112,7 @@ public class GenericPasswordManagerModule implements PasswordManagerModule {
 	}
 
 	@Override
-	public void validatePassword(PerunSession sess, String userLogin) throws InvalidLoginException {
+	public void validatePassword(PerunSession sess, String userLogin, User user) throws InvalidLoginException {
 		checkLoginFormat(sess, userLogin);
 		Process process = createPwdManagerProcess(PASSWORD_VALIDATE, actualLoginNamespace, userLogin);
 		handleExit(process, actualLoginNamespace, userLogin);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/IcsmuniczPasswordManagerModule.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/IcsmuniczPasswordManagerModule.java
@@ -1,0 +1,78 @@
+package cz.metacentrum.perun.core.impl.modules.pwdmgr;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.ExtSource;
+import cz.metacentrum.perun.core.api.PerunSession;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.UserExtSource;
+import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.ExtSourceNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.InvalidLoginException;
+import cz.metacentrum.perun.core.api.exceptions.UserExtSourceExistsException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Password manager for ICS-MUNI-CZ login-namespace.
+ */
+public class IcsmuniczPasswordManagerModule extends GenericPasswordManagerModule {
+
+	private final static Logger log = LoggerFactory.getLogger(EinfraPasswordManagerModule.class);
+
+	public IcsmuniczPasswordManagerModule() {
+		// set proper namespace
+		this.actualLoginNamespace = "ics-muni-cz";
+	}
+
+	@Override
+	public void validatePassword(PerunSession sess, String userLogin, User user) throws InvalidLoginException {
+		if (user == null) {
+			user = ((PerunBl) sess.getPerun()).getModulesUtilsBl().getUserByLoginInNamespace(sess, userLogin, actualLoginNamespace);
+		}
+
+		if (user == null) {
+			log.warn("No user was found by login '{}' in {} namespace.", userLogin, actualLoginNamespace);
+		} else {
+			// set extSources and extSource related attributes
+			try {
+				List<String> kerberosLogins = new ArrayList<>();
+
+				ExtSource extSource = ((PerunBl) sess.getPerun()).getExtSourcesManagerBl().getExtSourceByName(sess, "ICS.MUNI.CZ");
+				UserExtSource ues = new UserExtSource(extSource, userLogin + "@ICS.MUNI.CZ");
+				ues.setLoa(0);
+
+				try {
+					((PerunBl) sess.getPerun()).getUsersManagerBl().addUserExtSource(sess, user, ues);
+				} catch (UserExtSourceExistsException ex) {
+					//this is OK
+				}
+
+				// Store also Kerberos logins
+				Attribute kerberosLoginsAttr = ((PerunBl) sess.getPerun()).getAttributesManagerBl().getAttribute(sess, user, AttributesManager.NS_USER_ATTR_DEF + ":" + "kerberosLogins");
+				if (kerberosLoginsAttr != null && kerberosLoginsAttr.getValue() != null) {
+					kerberosLogins.addAll((List<String>) kerberosLoginsAttr.getValue());
+				}
+
+				if (!kerberosLogins.contains(userLogin + "@ICS.MUNI.CZ") && kerberosLoginsAttr != null) {
+					kerberosLogins.add(userLogin + "@ICS.MUNI.CZ");
+					kerberosLoginsAttr.setValue(kerberosLogins);
+					((PerunBl) sess.getPerun()).getAttributesManagerBl().setAttribute(sess, user, kerberosLoginsAttr);
+				}
+			} catch (WrongAttributeAssignmentException | AttributeNotExistsException | ExtSourceNotExistsException | WrongAttributeValueException | WrongReferenceAttributeValueException ex) {
+				throw new InternalErrorException(ex);
+			}
+		}
+
+		// validate password
+		super.validatePassword(sess, userLogin, user);
+	}
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/SambaduPasswordManagerModule.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/SambaduPasswordManagerModule.java
@@ -7,6 +7,7 @@ import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.InvalidLoginException;
 import cz.metacentrum.perun.core.api.exceptions.PasswordStrengthException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.api.exceptions.rt.LoginNotExistsRuntimeException;
@@ -78,7 +79,7 @@ public class SambaduPasswordManagerModule extends EinfraPasswordManagerModule {
 	}
 
 	@Override
-	public void validatePassword(PerunSession sess, String userLogin) {
+	public void validatePassword(PerunSession sess, String userLogin, User user) throws InvalidLoginException {
 		throw new InternalErrorException("Validating password in login namespace 'samba-du' is not supported.");
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/SitolaPasswordManagerModule.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/SitolaPasswordManagerModule.java
@@ -1,0 +1,78 @@
+package cz.metacentrum.perun.core.impl.modules.pwdmgr;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.ExtSource;
+import cz.metacentrum.perun.core.api.PerunSession;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.UserExtSource;
+import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.ExtSourceNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.InvalidLoginException;
+import cz.metacentrum.perun.core.api.exceptions.UserExtSourceExistsException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Password manager for SITOLA login-namespace.
+ */
+public class SitolaPasswordManagerModule extends GenericPasswordManagerModule {
+
+	private final static Logger log = LoggerFactory.getLogger(EinfraPasswordManagerModule.class);
+
+	public SitolaPasswordManagerModule() {
+		// set proper namespace
+		this.actualLoginNamespace = "sitola";
+	}
+
+	@Override
+	public void validatePassword(PerunSession sess, String userLogin, User user) throws InvalidLoginException {
+		if (user == null) {
+			user = ((PerunBl) sess.getPerun()).getModulesUtilsBl().getUserByLoginInNamespace(sess, userLogin, actualLoginNamespace);
+		}
+
+		if (user == null) {
+			log.warn("No user was found by login '{}' in {} namespace.", userLogin, actualLoginNamespace);
+		} else {
+			// set extSources and extSource related attributes
+			try {
+				List<String> kerberosLogins = new ArrayList<>();
+
+				ExtSource extSource = ((PerunBl) sess.getPerun()).getExtSourcesManagerBl().getExtSourceByName(sess, "SITOLA.FI.MUNI.CZ");
+				UserExtSource ues = new UserExtSource(extSource, userLogin + "@SITOLA.FI.MUNI.CZ");
+				ues.setLoa(0);
+
+				try {
+					((PerunBl) sess.getPerun()).getUsersManagerBl().addUserExtSource(sess, user, ues);
+				} catch (UserExtSourceExistsException ex) {
+					//this is OK
+				}
+
+				// Store also Kerberos logins
+				Attribute kerberosLoginsAttr = ((PerunBl) sess.getPerun()).getAttributesManagerBl().getAttribute(sess, user, AttributesManager.NS_USER_ATTR_DEF + ":" + "kerberosLogins");
+				if (kerberosLoginsAttr != null && kerberosLoginsAttr.getValue() != null) {
+					kerberosLogins.addAll((List<String>) kerberosLoginsAttr.getValue());
+				}
+
+				if (!kerberosLogins.contains(userLogin + "@SITOLA.FI.MUNI.CZ") && kerberosLoginsAttr != null) {
+					kerberosLogins.add(userLogin + "@SITOLA.FI.MUNI.CZ");
+					kerberosLoginsAttr.setValue(kerberosLogins);
+					((PerunBl) sess.getPerun()).getAttributesManagerBl().setAttribute(sess, user, kerberosLoginsAttr);
+				}
+			} catch (WrongAttributeAssignmentException | AttributeNotExistsException | ExtSourceNotExistsException | WrongAttributeValueException | WrongReferenceAttributeValueException ex) {
+				throw new InternalErrorException(ex);
+			}
+		}
+
+		// validate password
+		super.validatePassword(sess, userLogin, user);
+	}
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/VsupPasswordManagerModule.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/VsupPasswordManagerModule.java
@@ -1,6 +1,21 @@
 package cz.metacentrum.perun.core.impl.modules.pwdmgr;
 
+import cz.metacentrum.perun.core.api.ExtSource;
+import cz.metacentrum.perun.core.api.PerunSession;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.UserExtSource;
+import cz.metacentrum.perun.core.api.exceptions.ExtSourceNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.InvalidLoginException;
+import cz.metacentrum.perun.core.api.exceptions.UserExtSourceExistsException;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
 public class VsupPasswordManagerModule extends GenericPasswordManagerModule {
+
+	private final static Logger log = LoggerFactory.getLogger(EinfraPasswordManagerModule.class);
 
 	public VsupPasswordManagerModule() {
 
@@ -15,4 +30,33 @@ public class VsupPasswordManagerModule extends GenericPasswordManagerModule {
 
 	}
 
+	@Override
+	public void validatePassword(PerunSession sess, String userLogin, User user) throws InvalidLoginException {
+		if (user == null) {
+			user = ((PerunBl) sess.getPerun()).getModulesUtilsBl().getUserByLoginInNamespace(sess, userLogin, actualLoginNamespace);
+		}
+
+		if (user == null) {
+			log.warn("No user was found by login '{}' in {} namespace.", userLogin, actualLoginNamespace);
+		} else {
+			// set extSources and extSource related attributes
+			try {
+				// Add UES in their ActiveDirectory to access Perun by it
+				ExtSource extSource = ((PerunBl) sess.getPerun()).getExtSourcesManagerBl().getExtSourceByName(sess, "AD");
+				UserExtSource ues = new UserExtSource(extSource, userLogin);
+				ues.setLoa(0);
+
+				try {
+					((PerunBl) sess.getPerun()).getUsersManagerBl().addUserExtSource(sess, user, ues);
+				} catch (UserExtSourceExistsException ex) {
+					//this is OK
+				}
+			} catch (ExtSourceNotExistsException ex) {
+				throw new InternalErrorException(ex);
+			}
+		}
+
+		// validate password
+		super.validatePassword(sess, userLogin, user);
+	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/pwdmgr/PasswordManagerModule.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/pwdmgr/PasswordManagerModule.java
@@ -3,9 +3,12 @@ package cz.metacentrum.perun.core.implApi.modules.pwdmgr;
 import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.ExtSourceNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.InvalidLoginException;
 import cz.metacentrum.perun.core.api.exceptions.PasswordStrengthException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 
 import java.util.Map;
 
@@ -40,7 +43,7 @@ public interface PasswordManagerModule {
 
 	void changePassword(PerunSession sess, String userLogin, String newPassword) throws InvalidLoginException, PasswordStrengthException;
 
-	void validatePassword(PerunSession sess, String userLogin) throws InvalidLoginException;
+	void validatePassword(PerunSession sess, String userLogin, User user) throws InvalidLoginException;
 
 	void deletePassword(PerunSession sess, String userLogin) throws InvalidLoginException;
 

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
@@ -1631,7 +1631,7 @@ public class RegistrarManagerImpl implements RegistrarManager {
 				for (Pair<String, String> pair : logins) {
 					// LOGIN IN NAMESPACE IS PURELY NEW => VALIDATE ENTRY IN KDC
 					// left = namespace, right = login
-					usersManager.validatePasswordAndSetExtSources(registrarSession, app.getUser(), pair.getRight(), pair.getLeft());
+					usersManager.validatePassword(registrarSession, app.getUser(), pair.getLeft());
 				}
 
 				// update titles before/after users name if part of application !! USER MUST EXISTS !!
@@ -1720,7 +1720,7 @@ public class RegistrarManagerImpl implements RegistrarManager {
 				for (Pair<String, String> pair : logins) {
 					// LOGIN IN NAMESPACE IS PURELY NEW => VALIDATE ENTRY IN KDC
 					// left = namespace, right = login
-					usersManager.validatePasswordAndSetExtSources(registrarSession, u, pair.getRight(), pair.getLeft());
+					usersManager.validatePassword(registrarSession, u, pair.getLeft());
 				}
 
 				// log
@@ -1770,7 +1770,7 @@ public class RegistrarManagerImpl implements RegistrarManager {
 			// validate purely new logins in KDC
 			for (Pair<String, String> pair : logins) {
 				// left = namespace, right = login
-				usersManager.validatePasswordAndSetExtSources(registrarSession, app.getUser(), pair.getRight(), pair.getLeft());
+				usersManager.validatePassword(registrarSession, app.getUser(), pair.getLeft());
 			}
 
 			// update titles before/after users name if part of application !! USER MUST EXISTS !!

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/UsersManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/UsersManagerMethod.java
@@ -1123,7 +1123,7 @@ public enum UsersManagerMethod implements ManagerMethod {
 	},
 	/*#
 	 * Validates password for a user in specified login-namespace. After that, user should be able to log-in
-	 * in external authz system using his credentials.
+	 * in external authz system using his credentials. It also creates UserExtSources and sets some required attributes.
 	 *
 	 * @param user int User <code>id</code>
 	 * @param namespace String Namespace
@@ -1132,7 +1132,7 @@ public enum UsersManagerMethod implements ManagerMethod {
 	 */
 	/*#
 	 * Validates password for a user in specified login-namespace. After that, user should be able to log-in
-	 * in external authz system using his credentials.
+	 * in external authz system using his credentials. It also creates UserExtSources and sets some required attributes.
 	 *
 	 * @param login String Login
 	 * @param namespace String Namespace
@@ -1158,6 +1158,7 @@ public enum UsersManagerMethod implements ManagerMethod {
 	 * Validates password for a user in specified login-namespace. After that, user should be able to log-in
 	 * in external authz system using his credentials. It also creates UserExtSource and sets some required attributes.
 	 *
+	 * @deprecated use validatePassword
 	 * @param user int User <code>id</code>
 	 * @param login String Login
 	 * @param namespace String Namespace
@@ -1169,7 +1170,7 @@ public enum UsersManagerMethod implements ManagerMethod {
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
 			parms.stateChangingCheck();
 
-			ac.getUsersManager().validatePasswordAndSetExtSources(ac.getSession(), ac.getUserById(parms.readInt("user")), parms.readString("login"), parms.readString("namespace"));
+			ac.getUsersManager().validatePassword(ac.getSession(), ac.getUserById(parms.readInt("user")), parms.readString("namespace"));
 
 			return null;
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/usersManager/CreatePassword.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/usersManager/CreatePassword.java
@@ -26,7 +26,6 @@ public class CreatePassword {
 	final String JSON_URL_RESERVE = "usersManager/reservePassword";
 	final String JSON_URL_RESERVE_RANDOM = "usersManager/reserveRandomPassword";
 	final String JSON_URL_VALIDATE = "usersManager/validatePassword";
-	final String JSON_URL_VALIDATE_AND_SET_USER_EXT_SOURCE = "usersManager/validatePasswordAndSetExtSources";
 
 	// external events
 	private JsonCallbackEvents events = new JsonCallbackEvents();
@@ -94,7 +93,7 @@ public class CreatePassword {
 			@Override
 			public void onFinished(JavaScriptObject jso) {
 				JsonPostClient jspc = new JsonPostClient(newEvents);
-				jspc.sendData(JSON_URL_VALIDATE_AND_SET_USER_EXT_SOURCE, validateCallJSON());
+				jspc.sendData(JSON_URL_VALIDATE, validateCallJSON());
 			};
 			@Override
 			public void onLoadingStart() {
@@ -166,7 +165,7 @@ public class CreatePassword {
 			@Override
 			public void onFinished(JavaScriptObject jso) {
 				JsonPostClient jspc = new JsonPostClient(newEvents);
-				jspc.sendData(JSON_URL_VALIDATE_AND_SET_USER_EXT_SOURCE, validateCallJSON());
+				jspc.sendData(JSON_URL_VALIDATE, validateCallJSON());
 			};
 			@Override
 			public void onLoadingStart() {
@@ -253,7 +252,7 @@ public class CreatePassword {
 	 * @param login used for validation only
 	 * @param namespace defined login in namespace
 	 */
-	public void validateAndSetUserExtSources(int userId, String login, String namespace) {
+	public void validatePassword(int userId, String login, String namespace) {
 
 		this.userId = userId;
 		this.namespace = namespace;
@@ -281,7 +280,7 @@ public class CreatePassword {
 		}
 
 		JsonPostClient jspc = new JsonPostClient(events);
-		jspc.sendData(JSON_URL_VALIDATE_AND_SET_USER_EXT_SOURCE, validateCallJSON());
+		jspc.sendData(JSON_URL_VALIDATE, validateCallJSON());
 
 	}
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/CreateServiceMemberInVoTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/CreateServiceMemberInVoTabItem.java
@@ -487,7 +487,7 @@ public class CreateServiceMemberInVoTabItem implements TabItem, TabItemWithUrl {
 																}
 															}));
 															// validate login returned from account generation
-															req.validateAndSetUserExtSources(member.getUserId(), login, namespaceValue);
+															req.validatePassword(member.getUserId(), login, namespaceValue);
 
 															// show assigned login
 															UiElements.generateInfo("Assigned login", "You were assigned with login <b>"+login+"</b> in namespace MU.");
@@ -573,7 +573,7 @@ public class CreateServiceMemberInVoTabItem implements TabItem, TabItemWithUrl {
 																}
 															}));
 															// validate login returned from account generation
-															req.validateAndSetUserExtSources(member.getUserId(), login, namespaceValue);
+															req.validatePassword(member.getUserId(), login, namespaceValue);
 
 															// show assigned login
 															UiElements.generateInfo("Assigned login", "You were assigned with login <b>" + login + "</b> in namespace MU.");

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/SelfPasswordTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/SelfPasswordTabItem.java
@@ -320,7 +320,7 @@ public class SelfPasswordTabItem implements TabItem, TabItemWithUrl{
 
 										// VALIDATE PASSWORD - SET EXT SOURCES
 										CreatePassword req = new CreatePassword(JsonCallbackEvents.closeTabDisableButtonEvents(createButton, tab, true));
-										req.validateAndSetUserExtSources(user.getId(), login, namespace);
+										req.validatePassword(user.getId(), login, namespace);
 
 									}
 								}));
@@ -436,7 +436,7 @@ public class SelfPasswordTabItem implements TabItem, TabItemWithUrl{
 
 										// VALIDATE PASSWORD - SET EXT SOURCES
 										CreatePassword req = new CreatePassword(JsonCallbackEvents.closeTabDisableButtonEvents(createButton, tab, true));
-										req.validateAndSetUserExtSources(user.getId(), login, namespace);
+										req.validatePassword(user.getId(), login, namespace);
 
 									}
 								}));


### PR DESCRIPTION
- There were 2 core methods for password validation - validatePassword() and
validatePasswordAndSetExtSources().
- Method validatePasswordAndSetExtSources() was removed from UsersManager, in RPC
it is now marked as deprecated and calls validatePassword().
- Creation of UserExtSources and related attributes was moved to password managers
modules.
- Deleted method was used in Registrar, so it was replaced by validatePassword().
The deprecated RPC method was only used in old GUI (and wasn't used in WUI, new
GUI and OpenAPI), where it was replaced by RPC method validatePassword.