### PR TITLE
moved to Java source level 15

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '8', '15' ]
+        java: [ '15' ]
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK ${{ matrix.java }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       - name: "Set up JDK"
         uses: actions/setup-java@v1
         with:
-          java-version: 8
+          java-version: 15
       - name: "Cache"
         uses: actions/cache@v1
         with:

--- a/perun-web-gui/pom.xml
+++ b/perun-web-gui/pom.xml
@@ -17,6 +17,8 @@
 	<description>JS web application based on GWT framework which provides GUI for Perun.</description>
 
 	<properties>
+		<!-- used GWT version supports only java version up to 11 -->
+		<java.version>11</java.version>
 		<!-- Convenience property to set the GWT version -->
 		<gwtVersion>2.9.0</gwtVersion>
 		<webappDirectory>${project.build.directory}/${project.name}</webappDirectory>
@@ -81,7 +83,7 @@
 				<!-- Plugin configuration. There are many available options, see
 				  gwt-maven-plugin documentation at codehaus.org -->
 				<configuration>
-					<sourceLevel>auto</sourceLevel>
+					<sourceLevel>1.11</sourceLevel>
 					<extraJvmArgs>-Xmx1024m</extraJvmArgs>
 					<modules>
 						<module>cz.metacentrum.perun.webgui.perun-web</module>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 	<properties>
 		<!-- property used by spring-boot-starter-parent project to define maven.compiler.source and maven.compiler.target
 		     properties that in turn are used by maven-compiler-plugin to specify java source and target version -->
-		<java.version>8</java.version>
+		<java.version>15</java.version>
 
 		<!-- USE UTF-8 in whole project -->
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
- changes Java source and target level to 15 in the main pom.xml
- drops GitHub CI testing with JDK 8, it is no longer needed
- changes compilation of release assets to use JDK 15