### PR TITLE
Added dependency on javax.xml.bind

### DIFF
--- a/perun-base/pom.xml
+++ b/perun-base/pom.xml
@@ -102,6 +102,11 @@
 			<version>${json.version}</version>
 		</dependency>
 
+		<dependency>
+			<groupId>javax.xml.bind</groupId>
+			<artifactId>jaxb-api</artifactId>
+		</dependency>
+
 	</dependencies>
 
 </project>


### PR DESCRIPTION
- Since its no longer part of Java itself, we must
  declare explicit dependency on it.
  Without it, printing HTML to PDF doesn't work
  (aka random password reset doesn't work).