### PR TITLE
Validation window for account activation

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/CoreConfig.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/CoreConfig.java
@@ -39,6 +39,7 @@ public class CoreConfig {
 	private int groupMaxConcurrentGroupsStructuresToSynchronize;
 	private int mailchangeValidationWindow;
 	private int pwdresetValidationWindow;
+	private int accountActivationValidationWindow;
 	private int queryTimeout;
 	private List<String> admins;
 	private List<String> enginePrincipals;
@@ -164,6 +165,14 @@ public class CoreConfig {
 
 	public void setPwdresetValidationWindow(int pwdresetValidationWindow) {
 		this.pwdresetValidationWindow = pwdresetValidationWindow;
+	}
+
+	public int getAccountActivationValidationWindow() {
+		return accountActivationValidationWindow;
+	}
+
+	public void setAccountActivationValidationWindow(int accountActivationValidationWindow) {
+		this.accountActivationValidationWindow = accountActivationValidationWindow;
 	}
 
 	public List<String> getAdmins() {

--- a/perun-base/src/main/resources/perun-base.xml
+++ b/perun-base/src/main/resources/perun-base.xml
@@ -37,6 +37,7 @@
 		<property name="pwdresetInitVector" value="${perun.pwdreset.initVector}"/>
 		<property name="pwdresetSecretKey" value="${perun.pwdreset.secretKey}"/>
 		<property name="pwdresetValidationWindow" value="${perun.pwdreset.validationWindow}"/>
+		<property name="accountActivationValidationWindow" value="${perun.accountActivation.validationWindow}"/>
 		<property name="readOnlyPerun" value="${perun.readOnlyPerun}"/>
 		<property name="recaptchaPrivateKey" value="${perun.recaptcha.privatekey}"/>
 		<property name="registrarPrincipals" value="#{'${perun.registrar.principals}'.split('\s*,\s*')}"/>
@@ -114,6 +115,7 @@
 				<prop key="perun.pwdreset.secretKey">jda3ufK92DKs2335af</prop>
 				<prop key="perun.pwdreset.initVector">2Akd14k3o9s1d2G5</prop>
 				<prop key="perun.pwdreset.validationWindow">6</prop>
+				<prop key="perun.accountActivation.validationWindow">72</prop>
 				<prop key="perun.native.language">cs,Česky,Czech</prop>
 				<prop key="perun.loginNamespace.generated"/>
 				<prop key="perun.sms.program"/>

--- a/perun-base/src/test/resources/test-schema.sql
+++ b/perun-base/src/test/resources/test-schema.sql
@@ -2,7 +2,7 @@ set database sql syntax PGS true;
 -- fix unique index on authz, since PGS compatibility doesn't allow coalesce call in index and treats nulls in columns as different values.
 SET DATABASE SQL UNIQUE NULLS FALSE;
 
--- database version 3.1.72 (don't forget to update insert statement at the end of file)
+-- database version 3.1.73 (don't forget to update insert statement at the end of file)
 
 -- VOS - virtual organizations
 create table vos (
@@ -1264,6 +1264,7 @@ create table pwdreset (
 	namespace longvarchar not null,
 	mail longvarchar,
 	user_id integer not null,
+	validity_to timestamp not null,
 	created_at timestamp default current_date not null,
 	created_by longvarchar default user not null,
 	created_by_uid integer,
@@ -1641,7 +1642,7 @@ CREATE INDEX ufauv_idx ON user_facility_attr_u_values (user_id, facility_id, att
 CREATE INDEX vauv_idx ON vo_attr_u_values (vo_id, attr_id) ;
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.1.72');
+insert into configurations values ('DATABASE VERSION','3.1.73');
 insert into membership_types (id, membership_type, description) values (1, 'DIRECT', 'Member is directly added into group');
 insert into membership_types (id, membership_type, description) values (2, 'INDIRECT', 'Member is added indirectly through UNION relation');
 insert into action_types (id, action_type, description) values (nextval('action_types_seq'), 'read', 'Can read value.');

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
@@ -103,6 +103,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
@@ -2213,9 +2214,11 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 			throw new InternalErrorException(ex);
 		}
 
-		int id = getMembersManagerImpl().storePasswordResetRequest(sess, user, namespace, mailAddress);
-		Utils.sendPasswordResetEmail(user, mailAddress, namespace, url, id, message, subject);
+		int validationWindow = BeansUtils.getCoreConfig().getPwdresetValidationWindow();
+		LocalDateTime validityTo = LocalDateTime.now().plusHours(validationWindow);
 
+		int id = getMembersManagerImpl().storePasswordResetRequest(sess, user, namespace, mailAddress, validityTo);
+		Utils.sendPasswordResetEmail(user, mailAddress, namespace, url, id, message, subject, validityTo);
 	}
 
 	@Override
@@ -2267,9 +2270,12 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 			throw new InternalErrorException(ex);
 		}
 
+		int validationWindow = BeansUtils.getCoreConfig().getAccountActivationValidationWindow();
+		LocalDateTime validityTo = LocalDateTime.now().plusHours(validationWindow);
+
 		//IMPORTANT: we are using the same requests for password reset and account activation
-		int id = getMembersManagerImpl().storePasswordResetRequest(sess, user, namespace, mailAddress);
-		Utils.sendAccountActivationEmail(user, mailAddress, namespace, url, id, message, subject);
+		int id = getMembersManagerImpl().storePasswordResetRequest(sess, user, namespace, mailAddress, validityTo);
+		Utils.sendAccountActivationEmail(user, mailAddress, namespace, url, id, message, subject, validityTo);
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/MembersManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/MembersManagerImpl.java
@@ -41,6 +41,7 @@ import java.sql.Date;
 import java.sql.ResultSet;
 import java.sql.Timestamp;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -371,14 +372,14 @@ public class MembersManagerImpl implements MembersManagerImplApi {
 	}
 
 	@Override
-	public int storePasswordResetRequest(PerunSession sess, User user, String namespace, String mail) {
+	public int storePasswordResetRequest(PerunSession sess, User user, String namespace, String mail, LocalDateTime validityTo) {
 
 		int newId = Utils.getNewId(jdbc, "pwdreset_id_seq");
 
 		try {
-			jdbc.update("insert into pwdreset (id, namespace, user_id, mail, created_by, created_by_uid, created_at) "
-							+ "values (?,?,?,?,?,?," + Compatibility.getSysdate() + ")",
-					newId, namespace, user.getId(), mail, sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getUserId());
+			jdbc.update("insert into pwdreset (id, namespace, user_id, mail, validity_to, created_by, created_by_uid, created_at) "
+							+ "values (?,?,?,?,?,?,?," + Compatibility.getSysdate() + ")",
+					newId, namespace, user.getId(), mail, validityTo, sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getUserId());
 		} catch (RuntimeException e) {
 			throw new InternalErrorException(e);
 		}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/UsersManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/UsersManagerImpl.java
@@ -1280,14 +1280,12 @@ public class UsersManagerImpl implements UsersManagerImplApi {
 				throw new ConsistencyErrorException("Password reset request " + requestId + " exists more than once.");
 			}
 
-			int validWindow = BeansUtils.getCoreConfig().getPwdresetValidationWindow();
-
 			Pair<String,String> result;
 			if (Compatibility.isPostgreSql()) {
-				result = jdbc.queryForObject("select namespace, mail from pwdreset where user_id=? and id=? and (created_at > (now() - interval '" + validWindow + " hours'))",
+				result = jdbc.queryForObject("select namespace, mail from pwdreset where user_id=? and id=? and validity_to >= now()",
 					(resultSet, i) -> new Pair<>(resultSet.getString("namespace"), resultSet.getString("mail")), user.getId(), requestId);
 			} else {
-				result =  jdbc.queryForObject("select namespace, mail from pwdreset where user_id=? and id=? and (created_at > (SYSTIMESTAMP - INTERVAL '"+validWindow+"' HOUR))",
+				result =  jdbc.queryForObject("select namespace, mail from pwdreset where user_id=? and id=? and validity_to >= SYSTIMESTAMP",
 					(resultSet, i) -> new Pair<>(resultSet.getString("namespace"), resultSet.getString("mail")), user.getId(), requestId);
 			}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Utils.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Utils.java
@@ -1059,17 +1059,18 @@ public class Utils {
 	 * @param id ID of account activation request
 	 * @param messageTemplate message of the email (use default if null)
 	 * @param subject subject of the email (use default if null)
+	 * @param validityTo time till link is valid
 	 */
-	public static void sendAccountActivationEmail(User user, String email, String namespace, String url, int id, String messageTemplate, String subject) {
+	public static void sendAccountActivationEmail(User user, String email, String namespace, String url, int id, String messageTemplate, String subject, LocalDateTime validityTo) {
 		String instanceName = BeansUtils.getCoreConfig().getInstanceName();
 
 		String validationLink = prepareValidationLinkForPasswordResetAndAccountActivation(url, "/non/pwd-reset/", id, user, namespace, true);
-		String validityTo = prepareValidityTo();
+		String validityToString = prepareValidityTo(validityTo);
 
 		String defaultSubject = "[" + instanceName + "] Account activation in namespace: " + namespace;
 		String defaultBody = "Dear " + user.getDisplayName() + ",\n\nWe've received request to activate your account in namespace \"" + namespace + "\"." +
 			"\n\nPlease visit the link below, where you can activate your account:\n\n" + validationLink + "\n\n" +
-			"Link is valid till " + validityTo + "\n\n" +
+			"Link is valid till " + validityToString + "\n\n" +
 			"Message is automatically generated." +
 			"\n----------------------------------------------------------------" +
 			"\nPerun - Identity & Access Management System";
@@ -1082,7 +1083,7 @@ public class Utils {
 		Map<String, String> bodyParametersToReplace = new HashMap<>();
 		bodyParametersToReplace.put("{displayName}", user.getDisplayName());
 		bodyParametersToReplace.put("{namespace}", namespace);
-		bodyParametersToReplace.put("{validity}", validityTo);
+		bodyParametersToReplace.put("{validity}", validityToString);
 		// allow enforcing per-language links
 		if (messageTemplate != null && messageTemplate.contains("{link-")) {
 			Pattern pattern = Pattern.compile("\\{link-[^}]+}");
@@ -1120,18 +1121,19 @@ public class Utils {
 	 * @param id ID of pwd reset request
 	 * @param messageTemplate message of the email
 	 * @param subject subject of the email
+	 * @param validityTo time till link is valid
 	 * @throws InternalErrorException
 	 */
-	public static void sendPasswordResetEmail(User user, String email, String namespace, String url, int id, String messageTemplate, String subject) {
+	public static void sendPasswordResetEmail(User user, String email, String namespace, String url, int id, String messageTemplate, String subject, LocalDateTime validityTo) {
 		String instanceName = BeansUtils.getCoreConfig().getInstanceName();
 
 		String validationLink = prepareValidationLinkForPasswordResetAndAccountActivation(url, "/non/pwd-reset/", id, user, namespace, false);
-		String validityTo = prepareValidityTo();
+		String validityToString = prepareValidityTo(validityTo);
 
 		String defaultSubject = "[" + instanceName + "] Password reset in namespace: " + namespace;
 		String defaultBody = "Dear " + user.getDisplayName() + ",\n\nWe've received request to reset your password in namespace \"" + namespace + "\"." +
 			"\n\nPlease visit the link below, where you can set new password:\n\n" + validationLink + "\n\n" +
-			"Link is valid till " + validityTo + "\n\n" +
+			"Link is valid till " + validityToString + "\n\n" +
 			"Message is automatically generated." +
 			"\n----------------------------------------------------------------" +
 			"\nPerun - Identity & Access Management System";
@@ -1144,7 +1146,7 @@ public class Utils {
 		Map<String, String> bodyParametersToReplace = new HashMap<>();
 		bodyParametersToReplace.put("{displayName}", user.getDisplayName());
 		bodyParametersToReplace.put("{namespace}", namespace);
-		bodyParametersToReplace.put("{validity}", validityTo);
+		bodyParametersToReplace.put("{validity}", validityToString);
 		// allow enforcing per-language links
 		if (messageTemplate != null && messageTemplate.contains("{link-")) {
 			Pattern pattern = Pattern.compile("\\{link-[^}]+}");
@@ -1338,14 +1340,12 @@ public class Utils {
 	/**
 	 * Prepare validity time of validation link.
 	 *
+	 * @param validityTo
 	 * @return validity as formatted string
 	 */
-	private static String prepareValidityTo() {
-		//TODO: at this moment validity window is used the same for password reset as for account activation
-		String validity = Integer.toString(BeansUtils.getCoreConfig().getPwdresetValidationWindow());
+	private static String prepareValidityTo(LocalDateTime validityTo) {
 		DateTimeFormatter dtf = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
-		LocalDateTime localDateTime = LocalDateTime.now().plusHours(Integer.parseInt(validity));
-		return dtf.format(localDateTime);
+		return dtf.format(validityTo);
 	}
 
 	/**

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/MembersManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/MembersManagerImplApi.java
@@ -18,6 +18,7 @@ import cz.metacentrum.perun.core.api.exceptions.MemberNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.SponsorshipDoesNotExistException;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 /**
@@ -211,10 +212,11 @@ public interface MembersManagerImplApi {
 	 * @param user User to reset password for
 	 * @param namespace namespace to reset password in
 	 * @param mail mail address used to send request to
+	 * @param validityTo time till request is valid
 	 * @return ID of request to be used for validation
 	 * @throws InternalErrorException
 	 */
-	int storePasswordResetRequest(PerunSession sess, User user, String namespace, String mail);
+	int storePasswordResetRequest(PerunSession sess, User user, String namespace, String mail, LocalDateTime validityTo);
 
 	/**
 	 * Creates a new member in given Vo with flag "sponsored", and linked to its sponsoring user.

--- a/perun-core/src/main/resources/hsqldbChangelog.txt
+++ b/perun-core/src/main/resources/hsqldbChangelog.txt
@@ -3,6 +3,9 @@
 
 -- this update is not supported on hsql since its used only as in-memory db
 
+3.1.73
+update configurations set value='3.1.73' where property='DATABASE VERSION';
+
 3.1.72
 update configurations set value='3.1.72' where property='DATABASE VERSION';
 

--- a/perun-core/src/main/resources/postgresChangelog.txt
+++ b/perun-core/src/main/resources/postgresChangelog.txt
@@ -6,6 +6,12 @@
 -- Directly under version number should be version commands. They will be executed in the order they are written here.
 -- Comments are prefixed with -- and can be written only between version blocks, that means not in the lines with commands. They have to be at the start of the line.
 
+3.1.73
+ALTER TABLE pwdreset ADD COLUMN validity_to timestamp;
+UPDATE pwdreset SET validity_to = created_at + interval '1 days';
+ALTER TABLE pwdreset ALTER COLUMN validity_to SET not null;
+UPDATE configurations SET value='3.1.73' WHERE property='DATABASE VERSION';
+
 3.1.72
 alter table attr_names drop constraint attnam_attnam_fk;
 drop index idx_fk_attnam_attnam;

--- a/perun-db/postgres.sql
+++ b/perun-db/postgres.sql
@@ -1,4 +1,4 @@
--- database version 3.1.72 (don't forget to update insert statement at the end of file)
+-- database version 3.1.73 (don't forget to update insert statement at the end of file)
 
 -- VOS - virtual organizations
 create table vos (
@@ -1259,6 +1259,7 @@ create table pwdreset (
 	namespace text not null,
 	mail text,
 	user_id integer not null,
+	validity_to timestamp not null,
 	created_at timestamp default statement_timestamp() not null,
 	created_by varchar default user not null,
 	created_by_uid integer,
@@ -1735,7 +1736,7 @@ grant all on user_ext_source_attr_u_values to perun;
 grant all on members_sponsored to perun;
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.1.72');
+insert into configurations values ('DATABASE VERSION','3.1.73');
 
 -- insert membership types
 insert into membership_types (id, membership_type, description) values (1, 'DIRECT', 'Member is directly added into group');


### PR DESCRIPTION
- Links for password reset and account activation use the same logic, but account
validation should have different validation window.
- New config property was created to specify account activation validation window
with default value 3 days.
- New column validity_to was added to table pwdreset to specify till when
password reset or account activation is valid.