### PR TITLE
Core - extension of hashed data

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/GenDataNode.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/GenDataNode.java
@@ -19,7 +19,7 @@ public class GenDataNode {
 	private final Map<Integer, GenDataNode> children;
 	private final Map<Integer, Integer> members;
 
-	private GenDataNode(Map<Integer, GenDataNode> children, Map<Integer, Integer> members) {
+	protected GenDataNode(Map<Integer, GenDataNode> children, Map<Integer, Integer> members) {
 		this.children = children;
 		this.members = members;
 	}

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/GenResourceDataNode.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/GenResourceDataNode.java
@@ -1,0 +1,77 @@
+package cz.metacentrum.perun.core.api;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * This class represents a node in the hierarchy of hashed data for provisioning.
+ * This node is meant for a resource and additionally, contains vo id.
+ *
+ * @author Vojtech Sassmann <vojtech.sassmann@gmail.com>
+ */
+public class GenResourceDataNode extends GenDataNode {
+
+	private final Integer voId;
+
+	private GenResourceDataNode(Map<Integer, GenDataNode> children, Map<Integer, Integer> members, Integer vo) {
+		super(children, members);
+		this.voId = vo;
+	}
+
+	@JsonProperty("v")
+	public Integer getVoId() {
+		return voId;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (!(o instanceof GenResourceDataNode)) return false;
+		if (!super.equals(o)) return false;
+
+		GenResourceDataNode that = (GenResourceDataNode) o;
+
+		return getVoId() != null ? getVoId().equals(that.getVoId()) : that.getVoId() == null;
+	}
+
+	@Override
+	public int hashCode() {
+		int result = super.hashCode();
+		result = 31 * result + (getVoId() != null ? getVoId().hashCode() : 0);
+		return result;
+	}
+
+	public static class Builder {
+
+		private Map<Integer, GenDataNode> children = new HashMap<>();
+		private Map<Integer, Integer> members = new HashMap<>();
+		private Integer voId;
+
+		public Builder hashes() {
+			return this;
+		}
+
+		public Builder children(Map<Integer, GenDataNode> children) {
+			this.children = children;
+			return this;
+		}
+
+		public Builder members(Map<Integer, Integer> members) {
+			this.members = members;
+			return this;
+		}
+
+		public Builder voId(Integer voId) {
+			this.voId = voId;
+			return this;
+		}
+
+		public GenResourceDataNode build() {
+			return new GenResourceDataNode(children, members, voId);
+		}
+	}
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/ServicesManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/ServicesManager.java
@@ -388,7 +388,8 @@ public interface ServicesManager {
 	 *     }
 	 *     children: [
 	 *       "2": {    ** resource id **
-	 *         children: []
+	 *         children: [],
+	 *         voId: 99,
 	 *         members: {    ** all members on the resource with id 2 **
 	 *           "4" : 5    ** member id : user id **
 	 *         }
@@ -426,6 +427,7 @@ public interface ServicesManager {
 	 *     }
 	 *     children: [
 	 *       "2": {    ** resource id **
+	 *         voId: 99,
 	 *         children: [
 	 *           "89": {    ** group id **
 	 *              "children": {},

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ServicesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ServicesManagerBl.java
@@ -347,7 +347,8 @@ public interface ServicesManagerBl {
 	 *     }
 	 *     children: [
 	 *       "2": {    ** resource id **
-	 *         children: []
+	 *         children: [],
+	 *         voId: 99,
 	 *         members: {    ** all members on the resource with id 2 **
 	 *           "4" : 5    ** member id : user id **
 	 *         }
@@ -382,6 +383,7 @@ public interface ServicesManagerBl {
 	 *     }
 	 *     children: [
 	 *       "2": {    ** resource id **
+	 *         voId: 99,
 	 *         children: [
 	 *           "89": {    ** group id **
 	 *              "children": {},

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/provisioning/GenDataProviderImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/provisioning/GenDataProviderImpl.java
@@ -22,8 +22,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 
-import static java.util.Collections.emptyList;
-import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 
@@ -154,6 +152,8 @@ public class GenDataProviderImpl implements GenDataProvider {
 	public List<String> getFacilityAttributesHashes() {
 		String hash = hasher.hashFacility(facility);
 
+		var hashes = new ArrayList<String>();
+
 		if (!attributesByHash.containsKey(hash)) {
 			if (facilityAttrs == null) {
 				throw new IllegalStateException("Facility attributes need to be loaded first.");
@@ -161,7 +161,11 @@ public class GenDataProviderImpl implements GenDataProvider {
 			attributesByHash.put(hash, facilityAttrs);
 		}
 
-		return attributesByHash.get(hash).isEmpty() ? emptyList() : singletonList(hash);
+		if (!attributesByHash.get(hash).isEmpty()) {
+			hashes.add(hash);
+		}
+
+		return hashes;
 	}
 
 	@Override
@@ -320,13 +324,17 @@ public class GenDataProviderImpl implements GenDataProvider {
 	 * @return List with the hash or empty list if the map doesn't contain any attributes for the given entity
 	 */
 	private <T> List<String> getAndStoreHash(String hash, T entity, Map<T, List<Attribute>> map) {
+		var hashes = new ArrayList<String>();
 		if (!attributesByHash.containsKey(hash)) {
 			if (!map.containsKey(entity)) {
-				return emptyList();
+				return hashes;
 			}
 			attributesByHash.put(hash, map.get(entity));
 		}
-		return attributesByHash.get(hash).isEmpty() ? emptyList() : singletonList(hash);
+		if (!attributesByHash.get(hash).isEmpty()) {
+			hashes.add(hash);
+		}
+		return hashes;
 	}
 
 	private void loadMemberSpecificAttributes(List<Member> members) {

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ServicesManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ServicesManagerEntryIntegrationTest.java
@@ -9,6 +9,7 @@ import cz.metacentrum.perun.core.api.Destination;
 import cz.metacentrum.perun.core.api.ExtSource;
 import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.GenDataNode;
+import cz.metacentrum.perun.core.api.GenResourceDataNode;
 import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.HashedGenData;
 import cz.metacentrum.perun.core.api.Host;
@@ -64,6 +65,7 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 	private final static String A_R_C_NAME = "urn:perun:resource:attribute-def:core:name";
 	private final static String A_G_C_NAME = "urn:perun:group:attribute-def:core:name";
 	private final static String A_M_C_ID = "urn:perun:member:attribute-def:core:id";
+	private final static String A_V_C_ID = "urn:perun:vo:attribute-def:core:id";
 
 	// these are in DB only after setUp"Type"() method and must be set up in right order.
 	private Service service;
@@ -1850,6 +1852,9 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 		Attribute reqMemAttr;
 		reqMemAttr = perun.getAttributesManager().getAttribute(sess, member, A_M_C_ID);
 		perun.getServicesManager().addRequiredAttribute(sess, service, reqMemAttr);
+		Attribute reqVoAttr;
+		reqVoAttr = perun.getAttributesManager().getAttribute(sess, vo, A_V_C_ID);
+		perun.getServicesManager().addRequiredAttribute(sess, service, reqVoAttr);
 
 		// finally assign service
 		perun.getResourcesManager().assignService(sess, resource, service);
@@ -1874,14 +1879,13 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 		String facilityAttrsHash = "f-" + facility.getId();
 		String memberAttrsHash = "m-" + member.getId();
 		String groupAttrsHash = "g-" + group.getId();
+		String voAttrsHash = "v-" + vo.getId();
 		String resource1AttrsHash = "r-" + resource.getId();
 		String resource2AttrsHash = "r-" + resource2.getId();
-		String resource3AttrsHash = "r-" + resource3.getId();
 
 		// Verify that the list of all attributes contains correct attributes
-		assertThat(attributes).containsKeys(facilityAttrsHash, memberAttrsHash, resource1AttrsHash, groupAttrsHash,
-				resource2AttrsHash);
-		assertThat(attributes).doesNotContainKey(resource3AttrsHash);
+		assertThat(attributes).containsOnlyKeys(facilityAttrsHash, memberAttrsHash, resource1AttrsHash, groupAttrsHash,
+				resource2AttrsHash, voAttrsHash);
 
 		Map<String, Object> facilityAttributes = attributes.get(facilityAttrsHash);
 		assertThat(facilityAttributes).hasSize(1);
@@ -1899,6 +1903,10 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 		assertThat(resource1Attributes).hasSize(1);
 		assertThat(resource1Attributes.get(A_R_C_NAME)).isEqualTo(resource.getName());
 
+		Map<String, Object> voAttributes = attributes.get(voAttrsHash);
+		assertThat(voAttributes).hasSize(1);
+		assertThat(voAttributes.get(A_V_C_ID)).isEqualTo(vo.getId());
+
 		Map<String, Object> resource2Attributes = attributes.get(resource2AttrsHash);
 		assertThat(resource2Attributes).hasSize(1);
 		assertThat(resource2Attributes.get(A_R_C_NAME)).isEqualTo(resource2.getName());
@@ -1911,11 +1919,13 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 		GenDataNode res1Node = facilityNode.getChildren().get(resource.getId());
 		assertThat(res1Node.getMembers()).hasSize(1);
 		assertThat(res1Node.getChildren()).hasSize(1);
+		assertThat(((GenResourceDataNode)res1Node).getVoId()).isEqualTo(vo.getId());
 		assertThat(res1Node.getMembers()).containsKey(member.getId());
 
 		GenDataNode res2Node = facilityNode.getChildren().get(resource2.getId());
 		assertThat(res2Node.getMembers()).hasSize(1);
 		assertThat(res2Node.getChildren()).hasSize(1);
+		assertThat(((GenResourceDataNode)res2Node).getVoId()).isEqualTo(vo.getId());
 		assertThat(res2Node.getMembers()).containsKey(member.getId());
 
 		GenDataNode res1GroupNode = res1Node.getChildren().get(group.getId());
@@ -1955,6 +1965,9 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 		Attribute reqMemAttr;
 		reqMemAttr = perun.getAttributesManager().getAttribute(sess, member, A_M_C_ID);
 		perun.getServicesManager().addRequiredAttribute(sess, service, reqMemAttr);
+		Attribute reqVoAttr;
+		reqVoAttr = perun.getAttributesManager().getAttribute(sess, vo, A_V_C_ID);
+		perun.getServicesManager().addRequiredAttribute(sess, service, reqVoAttr);
 
 		// finally assign service
 		perun.getResourcesManager().assignService(sess, resource, service);
@@ -1979,14 +1992,14 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 		String facilityAttrsHash = "f-" + facility.getId();
 		String memberAttrsHash = "m-" + member.getId();
 		String groupAttrsHash = "g-" + group.getId();
+		String voAttrsHash = "v-" + vo.getId();
 		String resource1AttrsHash = "r-" + resource.getId();
 		String resource2AttrsHash = "r-" + resource2.getId();
 		String resource3AttrsHash = "r-" + resource3.getId();
 
 		// Verify that the list of all attributes contains correct attributes
-		assertThat(attributes).containsKeys(facilityAttrsHash, memberAttrsHash, resource1AttrsHash,
-				resource2AttrsHash);
-		assertThat(attributes).doesNotContainKeys(resource3AttrsHash, groupAttrsHash);
+		assertThat(attributes).containsOnlyKeys(facilityAttrsHash, memberAttrsHash, resource1AttrsHash,
+				resource2AttrsHash, voAttrsHash);
 
 		Map<String, Object> facilityAttributes = attributes.get(facilityAttrsHash);
 		assertThat(facilityAttributes).hasSize(1);
@@ -1995,6 +2008,10 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 		Map<String, Object> memberAttributes = attributes.get(memberAttrsHash);
 		assertThat(memberAttributes).hasSize(1);
 		assertThat(memberAttributes.get(A_M_C_ID)).isEqualTo(member.getId());
+
+		Map<String, Object> voAttributes = attributes.get(voAttrsHash);
+		assertThat(voAttributes).hasSize(1);
+		assertThat(voAttributes.get(A_V_C_ID)).isEqualTo(vo.getId());
 
 		Map<String, Object> resource1Attributes = attributes.get(resource1AttrsHash);
 		assertThat(resource1Attributes).hasSize(1);
@@ -2011,10 +2028,12 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 
 		GenDataNode res1Node = facilityNode.getChildren().get(resource.getId());
 		assertThat(res1Node.getMembers().keySet()).hasSize(1);
+		assertThat(((GenResourceDataNode)res1Node).getVoId()).isEqualTo(vo.getId());
 		assertThat(res1Node.getChildren()).isEmpty();
 		assertThat(res1Node.getMembers()).containsKey(member.getId());
 
 		GenDataNode res2Node = facilityNode.getChildren().get(resource2.getId());
+		assertThat(((GenResourceDataNode)res2Node).getVoId()).isEqualTo(vo.getId());
 		assertThat(res2Node.getMembers()).hasSize(1);
 		assertThat(res2Node.getChildren()).isEmpty();
 		assertThat(res2Node.getMembers()).containsKey(member.getId());

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/ServicesManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/ServicesManagerMethod.java
@@ -453,6 +453,7 @@ public enum ServicesManagerMethod implements ManagerMethod {
 	/*#
 	 * Generates the list of attributes per each member associated with the resource.
 	 *
+	 * @deprecated use getHashedDataWithGroups
 	 * @param service int Service <code>id</code>
 	 * @param facility int Facility <code>id</code>. You will get attributes for this facility, resources associated with it and members assigned to the resources.
 	 * @param filterExpiredMembers if true the method does not take members expired in groups into account
@@ -479,11 +480,11 @@ public enum ServicesManagerMethod implements ManagerMethod {
 	 |        +-------Attrs
 	 +...
 	 </pre>
-	 *
 	 */
 	/*#
 	 * Generates the list of attributes per each member associated with the resource.
 	 *
+	 * @deprecated use getHashedDataWithGroups
 	 * @param service int Service <code>id</code>
 	 * @param facility int Facility <code>id</code>. You will get attributes for this facility, resources associated with it and members assigned to the resources.
 	 * @return List<ServiceAttributes> Attributes in special structure. Facility is in the root, facility children are resources. And resource children are members.
@@ -509,7 +510,6 @@ public enum ServicesManagerMethod implements ManagerMethod {
 	 |        +-------Attrs
 	 +...
 	 </pre>
-	 *
 	 */
 	getHierarchicalData {
 
@@ -542,7 +542,8 @@ public enum ServicesManagerMethod implements ManagerMethod {
 	 *     }
 	 *     children: [
 	 *       "2": {    ** resource id **
-	 *         children: []
+	 *         children: [],
+	 *         voId: 99,
 	 *         members: {    ** all members on the resource with id 2 **
 	 *           "4" : 5    ** member id : user id **
 	 *         }
@@ -575,7 +576,8 @@ public enum ServicesManagerMethod implements ManagerMethod {
 	 *     }
 	 *     children: [
 	 *       "2": {    ** resource id **
-	 *         children: []
+	 *         children: [],
+	 *         voId: 99,
 	 *         members: {    ** all members on the resource with id 2 **
 	 *           "4" : 5    ** member id : user id **
 	 *         }
@@ -626,6 +628,7 @@ public enum ServicesManagerMethod implements ManagerMethod {
 	 *     }
 	 *     children: [
 	 *       "2": {    ** resource id **
+	 *         voId: 99,
 	 *         children: [
 	 *           "89": {    ** group id **
 	 *              "children": {},
@@ -670,6 +673,7 @@ public enum ServicesManagerMethod implements ManagerMethod {
 	 *     }
 	 *     children: [
 	 *       "2": {    ** resource id **
+	 *         voId: 99,
 	 *         children: [
 	 *           "89": {    ** group id **
 	 *              "children": {},
@@ -718,6 +722,7 @@ public enum ServicesManagerMethod implements ManagerMethod {
 	/*#
 	 * Generates the list of attributes per each user and per each resource. Never return member or member-resource attribute.
 	 *
+	 * @deprecated use getHashedHierarchicalData
 	 * @param service int Service <code>id</code>. You will get attributes required by this service
 	 * @param facility int Facility <code>id</code>. You will get attributes for this facility, resources associated with it and members assigned to the resources
 	 * @param filterExpiredMembers if true the method does not take members expired in groups into account
@@ -748,6 +753,7 @@ public enum ServicesManagerMethod implements ManagerMethod {
 	/*#
 	 * Generates the list of attributes per each user and per each resource. Never return member or member-resource attribute.
 	 *
+	 * @deprecated use getHashedDataWithGroups
 	 * @param service int Service <code>id</code>. You will get attributes required by this service
 	 * @param facility int Facility <code>id</code>. You will get attributes for this facility, resources associated with it and members assigned to the resources
 	 * @return ServiceAttributes Attributes in special structure. The facility is in the root. Facility first children is abstract node which contains no attributes and it's children are all resources. Facility second child is abstract node with no attribute and it's children are all users.
@@ -771,8 +777,6 @@ public enum ServicesManagerMethod implements ManagerMethod {
 	 |        +-------Attrs (do NOT return member, member-resource attributes)
 	 +...
 	 </pre>
-
-	 *
 	 */
 	getFlatData {
 
@@ -795,6 +799,7 @@ public enum ServicesManagerMethod implements ManagerMethod {
 	/*#
 	 * Generates the list of attributes per each member associated with the resources and groups.
 	 *
+	 * @deprecated use getHashedDataWithGroups
 	 * @param service int Service <code>id</code>. You will get attributes reuqired by this service
 	 * @param facility int Facility <code>id</code>. You will get attributes for this facility, resources associated with it and members assigned to the resources
 	 * @param filterExpiredMembers if true the method does not take members expired in groups into account
@@ -866,11 +871,11 @@ public enum ServicesManagerMethod implements ManagerMethod {
 	 .
 	 .
 	 </pre>
-	 *
 	 */
 	/*#
 	 * Generates the list of attributes per each member associated with the resources and groups.
 	 *
+	 * @deprecated use getHashedDataWithGroups
 	 * @param service int Service <code>id</code>. You will get attributes reuqired by this service
 	 * @param facility int Facility <code>id</code>. You will get attributes for this facility, resources associated with it and members assigned to the resources
 	 * @return ServiceAttributes Attributes in special structure. Facility is in the root, facility children are resources.
@@ -933,7 +938,6 @@ public enum ServicesManagerMethod implements ManagerMethod {
 	 .
 	 .
 	 </pre>
-	 *
 	 */
 	getDataWithGroups {
 
@@ -956,6 +960,7 @@ public enum ServicesManagerMethod implements ManagerMethod {
 	/*#
 	 * Generates the list of attributes per each member associated with the resources and groups in vos.
 	 *
+	 * @deprecated use getHashedDataWithGroups
 	 * @param service attributes required by this service you will get
 	 * @param facility you will get attributes for this facility, vos associated with this facility by resources, resources associated with it and members assigned to the resources
 	 * @param filterExpiredMembers if true the method does not take members expired in groups into account
@@ -1034,6 +1039,7 @@ public enum ServicesManagerMethod implements ManagerMethod {
 	/*#
 	 * Generates the list of attributes per each member associated with the resources and groups in vos.
 	 *
+	 * @deprecated use getHashedDataWithGroups
 	 * @param service attributes required by this service you will get
 	 * @param facility you will get attributes for this facility, vos associated with this facility by resources, resources associated with it and members assigned to the resources
 	 * @return attributes in special structure.


### PR DESCRIPTION
* Some services couldn't be rewritten to use the new hashedData method
because they were using getDataWithVos or getFlatData. We have figured
out that we don't actually need to create new "hashed" version of these
methods. Insteady, we can reuse the already existing methods with some
minor modifications.
* The methods getHashedHierarchicalData and getHashedDataWithGroups now
also contains vo id in resource nodes and can return vo attributes.
* In the data provider class, there were some missuses of the emptyList
and singletonList methods that caused trouble, because they are
immutable.
* The old getData methods were annotated as deprecated in the API.