### PR TITLE
New method getAllSponsoredMembersAndTheirSponsors

### DIFF
--- a/perun-base/src/main/resources/perun-roles.yml
+++ b/perun-base/src/main/resources/perun-roles.yml
@@ -2708,6 +2708,15 @@ perun_policies:
     include_policies:
       - default_policy
 
+  getAllSponsoredMembersAndTheirSponsors_Vo_policy:
+    policy_roles:
+      - VOADMIN: Vo
+      - VOOBSERVER: Vo
+      - PERUNOBSERVER:
+      - SPONSOR: Vo
+    include_policies:
+      - default_policy
+
   extendExpirationForSponsoredMember_Member_User_policy:
     policy_roles:
       - REGISTRAR:

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/MembersManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/MembersManager.java
@@ -1364,6 +1364,18 @@ public interface MembersManager {
 	List<MemberWithSponsors> getSponsoredMembersAndTheirSponsors(PerunSession sess, Vo vo, List<String> attrNames) throws VoNotExistsException, PrivilegeException, AttributeNotExistsException;
 
 	/**
+	 * Gets list of VO's all sponsored members with sponsors.
+	 *
+	 * @param sess session
+	 * @param vo virtual organization from which are the sponsored members chosen
+	 * @param attrNames list of attrNames for selected attributes
+	 * @throws VoNotExistsException if given VO does not exist
+	 * @throws PrivilegeException if not VOADMIN, VOOBSERVER, PERUNOBSERVER or SPONSOR
+	 * @return list of members with sponsors
+	 */
+	List<MemberWithSponsors> getAllSponsoredMembersAndTheirSponsors(PerunSession sess, Vo vo, List<String> attrNames) throws VoNotExistsException, PrivilegeException, AttributeNotExistsException;
+
+	/**
 	 * Extends expiration date. Sponsored members cannot apply for membership extension, this method allows a sponsor to extend it.
 	 * @param session actor
 	 * @param sponsored existing member that is sponsored

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/MembersManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/MembersManagerEntry.java
@@ -1456,12 +1456,27 @@ public class MembersManagerEntry implements MembersManager {
 	public List<MemberWithSponsors> getSponsoredMembersAndTheirSponsors(PerunSession sess, Vo vo, List<String> attrNames) throws VoNotExistsException, PrivilegeException, AttributeNotExistsException {
 		Utils.checkPerunSession(sess);
 		Utils.notNull(vo, "vo");
+		
+		//Authorization
+		if(!AuthzResolver.authorizedInternal(sess, "getSponsoredMembersAndTheirSponsors_Vo_policy", vo)) {
+			throw new PrivilegeException(sess, "getSponsoredMembersAndTheirSponsors");
+		}
+
+		return getAllSponsoredMembersAndTheirSponsors(sess, vo, attrNames).stream()
+			.filter(memberWithSponsors -> AuthzResolver.authorizedInternal(sess, "filter-getSponsoredMembersAndTheirSponsors_Vo_policy", memberWithSponsors.getMember(), vo))
+			.collect(Collectors.toList());
+	}
+
+	@Override
+	public List<MemberWithSponsors> getAllSponsoredMembersAndTheirSponsors(PerunSession sess, Vo vo, List<String> attrNames) throws VoNotExistsException, PrivilegeException, AttributeNotExistsException {
+		Utils.checkPerunSession(sess);
+		Utils.notNull(vo, "vo");
 
 		perunBl.getVosManagerBl().checkVoExists(sess, vo);
 
 		//Authorization
-		if(!AuthzResolver.authorizedInternal(sess, "getSponsoredMembersAndTheirSponsors_Vo_policy", vo)) {
-			throw new PrivilegeException(sess, "getSponsoredMembersAndTheirSponsors");
+		if(!AuthzResolver.authorizedInternal(sess, "getAllSponsoredMembersAndTheirSponsors_Vo_policy", vo)) {
+			throw new PrivilegeException(sess, "getAllSponsoredMembersAndTheirSponsors");
 		}
 
 		List<AttributeDefinition> attrsDef = new ArrayList<>();
@@ -1475,7 +1490,6 @@ public class MembersManagerEntry implements MembersManager {
 		richMembers = membersManagerBl.filterOnlyAllowedAttributes(sess, richMembers, null, true);
 
 		return richMembers.stream()
-			.filter(member -> AuthzResolver.authorizedInternal(sess, "filter-getSponsoredMembersAndTheirSponsors_Vo_policy", member, vo))
 			.map(member -> convertMemberToMemberWithSponsors(sess, member))
 			.collect(Collectors.toList());
 	}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/MembersManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/MembersManagerEntryIntegrationTest.java
@@ -204,6 +204,31 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 	}
 
 	@Test
+	public void getAllSponsoredMembersAndTheirSponsors() throws Exception {
+		System.out.println(CLASS_NAME + "getAllSponsoredMembersAndTheirSponsors");
+
+		Member sponsorMember = setUpSponsor(createdVo);
+		User sponsorUser = perun.getUsersManagerBl().getUserByMember(sess, sponsorMember);
+		Group sponsors = new Group("sponsors","users able to sponsor");
+		sponsors = perun.getGroupsManagerBl().createGroup(sess, createdVo, sponsors);
+		AuthzResolverBlImpl.setRole(sess, sponsors, createdVo, Role.SPONSOR);
+		perun.getGroupsManagerBl().addMember(sess, sponsors, sponsorMember);
+
+		Map<String, String> userName = new HashMap<>();
+		userName.put("guestName", "Ing. Jan Novák");
+		Member sponsoredMember = perun.getMembersManagerBl().createSponsoredMember(sess, createdVo, "dummy", userName, "secret", null, sponsorUser, false, null, false);
+
+		ArrayList<String> attrNames = new ArrayList<>();
+		attrNames.add("urn:perun:user:attribute-def:def:preferredMail");
+
+		List<MemberWithSponsors> memberWithSponsors = perun.getMembersManager().getAllSponsoredMembersAndTheirSponsors(sess, createdVo, attrNames);
+
+		assertEquals(memberWithSponsors.get(0).getMember(), sponsoredMember);
+		assertEquals(memberWithSponsors.get(0).getSponsors().get(0).getUser(), sponsorUser);
+		assertEquals(1, memberWithSponsors.get(0).getSponsors().size());
+	}
+
+	@Test
 	public void createMember() throws Exception {
 		System.out.println(CLASS_NAME + "createMemberSync");
 

--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -8221,6 +8221,20 @@ paths:
         default:
           $ref: '#/components/responses/ExceptionResponse'
 
+  /json/membersManager/getAllSponsoredMembersAndTheirSponsors:
+    get:
+      tags:
+        - MembersManager
+      operationId: getAllSponsoredMembersAndTheirSponsors
+      summary: Gets list of VO's all sponsored members with sponsors.
+      parameters:
+        - $ref: '#/components/parameters/voId'
+        - $ref: '#/components/parameters/attrNames'
+      responses:
+        '200':
+          $ref: '#/components/responses/ListOfMemberWithSponsorsResponse'
+        default:
+          $ref: '#/components/responses/ExceptionResponse'
 
   /json/membersManager/createSponsoredMember/withFullName:
     post:

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/MembersManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/MembersManagerMethod.java
@@ -542,6 +542,23 @@ public enum MembersManagerMethod implements ManagerMethod {
 	},
 
 	/*#
+	 * Gets list of VO's all sponsored members with sponsors.
+	 *
+	 * @param vo int id of virtual organization from which are the sponsored members chosen
+	 * @param attrNames List<String> list of attribute names
+	 * @throw VoNotExistsException if given VO does not exist
+	 * @return List<MemberWithSponsors> list of members with sponsors
+	 */
+	getAllSponsoredMembersAndTheirSponsors {
+		@Override
+		public List<MemberWithSponsors> call(ApiCaller ac, Deserializer params) throws PerunException {
+			Vo vo = ac.getVoById(params.readInt("vo"));
+			List<String> attrNames = params.contains("attrNames") ? params.readList("attrNames",String.class) : Collections.emptyList();
+			return ac.getMembersManager().getAllSponsoredMembersAndTheirSponsors(ac.getSession(), vo, attrNames);
+		}
+	},
+
+	/*#
 	 * Gets users sponsoring a given user in a VO.
 	 *
 	 * @deprecated - use usersManager/getSponsorsForMember


### PR DESCRIPTION
- New method getAllSponsoredMembersAndTheirSponsors was added. It is similar to
getSponsoredMembersAndTheirSponsors but doesn’t filter members that are not
sponsored by principal.