### PR TITLE
Edited finding firstName and lastName in displayName

### DIFF
--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
@@ -3506,9 +3506,9 @@ public class RegistrarManagerImpl implements RegistrarManager {
 
 	private void parseTitlesAndMiddleName(Candidate candidate, String displayName, String firstName, String lastName) {
 		Pattern pattern = getNamesPattern(firstName, lastName);
-		if (!tryToParseTitlesAndMiddleNameFromPattern(candidate, displayName, pattern)) {
+		if (!tryToParseTitlesAndMiddleNameFromPattern(candidate, displayName, pattern, firstName)) {
 			Pattern reversePattern = getNamesPattern(lastName, firstName);
-			tryToParseTitlesAndMiddleNameFromPattern(candidate, displayName, reversePattern);
+			tryToParseTitlesAndMiddleNameFromPattern(candidate, displayName, reversePattern, lastName);
 		}
 	}
 
@@ -3523,7 +3523,7 @@ public class RegistrarManagerImpl implements RegistrarManager {
 	 * @param pattern pattern with 3 matching groups
 	 * @return true, if the matcher matched
 	 */
-	private boolean tryToParseTitlesAndMiddleNameFromPattern(Candidate candidate, String displayName, Pattern pattern) {
+	private boolean tryToParseTitlesAndMiddleNameFromPattern(Candidate candidate, String displayName, Pattern pattern, String firstName) {
 		Matcher matcher = pattern.matcher(displayName);
 		if (!matcher.matches()) {
 			return false;
@@ -3533,8 +3533,14 @@ public class RegistrarManagerImpl implements RegistrarManager {
 					"titles after, but get " + matcher.groupCount() + " groups." );
 		}
 
-		parseTitlesBefore(candidate, matcher.group(1).trim());
-		parseMiddleName(candidate, matcher.group(2).trim());
+		// if the middle name equals to the first name placed in displayName (it can be firstName or lastName too)
+		if (matcher.group(1).contains(firstName)) {
+			candidate.setTitleBefore(matcher.group(1).split(firstName)[0].trim());
+			candidate.setMiddleName(firstName);
+		} else {
+			parseTitlesBefore(candidate, matcher.group(1).trim());
+			parseMiddleName(candidate, matcher.group(2).trim());
+		}
 		parseTitlesAfter(candidate, matcher.group(3).trim());
 
 		return true;

--- a/perun-registrar-lib/src/test/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImplUnitTest.java
+++ b/perun-registrar-lib/src/test/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImplUnitTest.java
@@ -189,4 +189,53 @@ public class RegistrarManagerImplUnitTest {
 		assertThat(candidate.getFirstName()).isEqualTo("Vojtech");
 	}
 
+	@Test
+	public void testParseNamesIfTheMiddleNameEqualsFirstName() {
+		Candidate candidate = new Candidate();
+		Map<String, String> attributes = new HashMap<>();
+		attributes.put(URN_USER_DISPLAY_NAME, "Bc. Jakub Jakub Hejda Dis.");
+		Map<String, String> fedData = new HashMap<>();
+		fedData.put("givenName", "Jakub");
+		fedData.put("sn", "Hejda");
+
+		Candidate candidate2 = new Candidate();
+		Map<String, String> attributes2 = new HashMap<>();
+		attributes2.put(URN_USER_DISPLAY_NAME, "Sir doc. John Paolo John Paolo Van Horn Phd.");
+		Map<String, String> fedData2 = new HashMap<>();
+		fedData2.put("givenName", "John Paolo");
+		fedData2.put("sn", "Van Horn");
+
+		registrarManager.parseNamesFromDisplayNameAndFedInfo(candidate, attributes, fedData);
+		registrarManager.parseNamesFromDisplayNameAndFedInfo(candidate2, attributes2, fedData2);
+
+		assertThat(candidate.getTitleBefore()).isEqualTo("Bc.");
+		assertThat(candidate.getFirstName()).isEqualTo("Jakub");
+		assertThat(candidate.getMiddleName()).isEqualTo("Jakub");
+		assertThat(candidate.getLastName()).isEqualTo("Hejda");
+		assertThat(candidate.getTitleAfter()).isEqualTo("Dis.");
+
+		assertThat(candidate2.getTitleBefore()).isEqualTo("Sir doc.");
+		assertThat(candidate2.getFirstName()).isEqualTo("John Paolo");
+		assertThat(candidate2.getMiddleName()).isEqualTo("John Paolo");
+		assertThat(candidate2.getLastName()).isEqualTo("Van Horn");
+		assertThat(candidate2.getTitleAfter()).isEqualTo("Phd.");
+	}
+
+	@Test
+	public void testParseNamesIfTheMiddleNameEqualsFirstNameReversePattern() {
+		Candidate candidate = new Candidate();
+		Map<String, String> attributes = new HashMap<>();
+		attributes.put(URN_USER_DISPLAY_NAME, "Bc. Hejda Hejda Jakub Dis.");
+		Map<String, String> fedData = new HashMap<>();
+		fedData.put("givenName", "Jakub");
+		fedData.put("sn", "Hejda");
+
+		registrarManager.parseNamesFromDisplayNameAndFedInfo(candidate, attributes, fedData);
+
+		assertThat(candidate.getTitleBefore()).isEqualTo("Bc.");
+		assertThat(candidate.getFirstName()).isEqualTo("Jakub");
+		assertThat(candidate.getMiddleName()).isEqualTo("Hejda");
+		assertThat(candidate.getLastName()).isEqualTo("Hejda");
+		assertThat(candidate.getTitleAfter()).isEqualTo("Dis.");
+	}
 }


### PR DESCRIPTION
* If the name placed at the first position in displayName (it can be firstName or lastName) is the same as middle name, then the parsing was incorrect.
* This use case has been fixed and all tests run successfully.