### PR TITLE
RPC - parseLocalDate fix null

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/rpc/deserializer/Deserializer.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/rpc/deserializer/Deserializer.java
@@ -62,7 +62,8 @@ public abstract class Deserializer {
 	 * @return parsed local date
 	 */
 	public LocalDate readLocalDate(String name) {
-		return LocalDate.parse(readString(name));
+		String date = readString(name);
+		return date == null ? null : LocalDate.parse(date);
 	}
 
 	public int[] readArrayOfInts(String name) {

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/MembersManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/MembersManagerMethod.java
@@ -275,7 +275,7 @@ public enum MembersManagerMethod implements ManagerMethod {
 				sendActivationLink = params.readBoolean("sendActivationLinks");
 			}
 			LocalDate validityTo = null;
-			if (params.contains("validityTo") && params.readString("validityTo") != null) {
+			if (params.contains("validityTo")) {
 				validityTo = params.readLocalDate("validityTo");
 			}
 			User sponsor = null;
@@ -455,7 +455,7 @@ public enum MembersManagerMethod implements ManagerMethod {
 			Member sponsoredMember = ac.getMemberById(params.readInt("member"));
 			User sponsor = ac.getUserById(params.readInt("sponsor"));
 			LocalDate newValidity = null;
-			if (params.contains("validityTo") && params.readString("validityTo") != null) {
+			if (params.contains("validityTo")) {
 				newValidity = params.readLocalDate("validityTo");
 			}
 


### PR DESCRIPTION
* The method parseLocalDate was not working properly with null values.
In case of a null, it throw an Exception, but we want it to return the
null.
* Removed checks which are no longer needed.