### PR TITLE
allow to call getPerunStatus on read-only instances

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/PerunBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/PerunBlImpl.java
@@ -146,15 +146,18 @@ public class PerunBlImpl implements PerunBl {
 						ExtSource es = extSourcesManagerBl.getExtSourceByName(internalSession, principal.getExtSourceName());
 						ues = usersManagerBl.getUserExtSourceByExtLogin(internalSession, es, principal.getActor());
 					}
-					if (ues != null && ues.getLoa() != principal.getExtSourceLoa()) {
-						ues.setLoa(principal.getExtSourceLoa());
-						usersManagerBl.updateUserExtSource(internalSession, ues);
-					}
-					// Update last access for userExtSource
-					usersManagerBl.updateUserExtSourceLastAccess(internalSession, ues);
+					if(!BeansUtils.isPerunReadOnly()) {
+						if (ues != null && ues.getLoa() != principal.getExtSourceLoa()) {
+							ues.setLoa(principal.getExtSourceLoa());
+							usersManagerBl.updateUserExtSource(internalSession, ues);
+						}
 
-					// update selected attributes for given extsourcetype
-					setUserExtSourceAttributes(perunSession, ues, principal.getAdditionalInformations());
+						// Update last access for userExtSource
+						usersManagerBl.updateUserExtSourceLastAccess(internalSession, ues);
+
+						// update selected attributes for given extsourcetype
+						setUserExtSourceAttributes(perunSession, ues, principal.getAdditionalInformations());
+					}
 
 				}
 			} catch (ExtSourceNotExistsException | UserExtSourceNotExistsException | UserNotExistsException | UserExtSourceExistsException e) {


### PR DESCRIPTION
Updates lastAccess only if the database is writable (it is not read-only).

This change is need to be able to call methods like getPerunStatus or getPerunStatistics on instances with read-only database.