### PR TITLE
Replaced string "UTF-8" with constant where applicable

### DIFF
--- a/perun-cabinet/src/main/java/cz/metacentrum/perun/cabinet/strategy/impl/EuropePMCStrategy.java
+++ b/perun-cabinet/src/main/java/cz/metacentrum/perun/cabinet/strategy/impl/EuropePMCStrategy.java
@@ -36,6 +36,7 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -53,7 +54,7 @@ public class EuropePMCStrategy extends AbstractPublicationSystemStrategy {
 	@Override
 	public List<Publication> parseHttpResponse(HttpResponse response) throws CabinetException {
 		try {
-			return parseResponse(EntityUtils.toString(response.getEntity(), "utf-8"));
+			return parseResponse(EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8));
 		} catch (IOException e) {
 			throw new CabinetException(ErrorCodes.IO_EXCEPTION, e);
 		}
@@ -74,7 +75,7 @@ public class EuropePMCStrategy extends AbstractPublicationSystemStrategy {
 		// prepare valid uri
 		URI uri = null;
 		try {
-			uri = new URI(ps.getUrl() + URLEncodedUtils.format(formparams, "UTF-8"));
+			uri = new URI(ps.getUrl() + URLEncodedUtils.format(formparams, StandardCharsets.UTF_8));
 			// log response into /var/log/perun/perun-cabinet.log
 			//log.debug("URI: {}", uri);
 

--- a/perun-cabinet/src/main/java/cz/metacentrum/perun/cabinet/strategy/impl/MUStrategy.java
+++ b/perun-cabinet/src/main/java/cz/metacentrum/perun/cabinet/strategy/impl/MUStrategy.java
@@ -39,6 +39,7 @@ import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
 import java.io.IOException;
 import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -94,7 +95,7 @@ public class MUStrategy extends AbstractPublicationSystemStrategy {
 		MultipartEntityBuilder entityBuilder = MultipartEntityBuilder.create();
 		try {
 			entityBuilder.addPart("typ", new StringBody("xml", ContentType.create("text/plain", Consts.UTF_8)));
-			entityBuilder.addPart("kodovani", new StringBody("utf-8", ContentType.create("text/plain", Consts.UTF_8)));
+			entityBuilder.addPart("kodovani", new StringBody(StandardCharsets.UTF_8.toString(), ContentType.create("text/plain", Consts.UTF_8)));
 			entityBuilder.addPart("keyfile", new ByteArrayBody(buildRequestKeyfile(Integer.parseInt(uco), yearSince, yearTill).getBytes(), "template.xml"));
 		} catch (Exception e) {
 			throw new RuntimeException(e);
@@ -103,7 +104,7 @@ public class MUStrategy extends AbstractPublicationSystemStrategy {
 		//prepare post request
 		HttpPost post = new HttpPost(ps.getUrl());
 		UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(ps.getUsername(), ps.getPassword());
-		post.addHeader(BasicScheme.authenticate(credentials, "utf-8", false));//cred, enc, proxy
+		post.addHeader(BasicScheme.authenticate(credentials, StandardCharsets.UTF_8.toString(), false));//cred, enc, proxy
 		post.setEntity(entityBuilder.build());
 		return post;
 

--- a/perun-cabinet/src/main/java/cz/metacentrum/perun/cabinet/strategy/impl/OBD30Strategy.java
+++ b/perun-cabinet/src/main/java/cz/metacentrum/perun/cabinet/strategy/impl/OBD30Strategy.java
@@ -35,6 +35,7 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -57,7 +58,7 @@ public class OBD30Strategy extends AbstractPublicationSystemStrategy {
 	@Override
 	public List<Publication> parseHttpResponse(HttpResponse response) throws CabinetException {
 		try {
-			return parseResponse(EntityUtils.toString(response.getEntity(), "utf-8"));
+			return parseResponse(EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8));
 		} catch (IOException e) {
 			throw new CabinetException(ErrorCodes.IO_EXCEPTION, e);
 		}
@@ -82,7 +83,7 @@ public class OBD30Strategy extends AbstractPublicationSystemStrategy {
 		// prepare valid uri
 		URI uri = null;
 		try {
-			uri = new URI(ps.getUrl() + URLEncodedUtils.format(formparams, "UTF-8"));
+			uri = new URI(ps.getUrl() + URLEncodedUtils.format(formparams, StandardCharsets.UTF_8));
 			// log response into /var/log/perun/perun-cabinet.log
 			//log.debug("URI: {}", uri);
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/RTMessagesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/RTMessagesManagerBlImpl.java
@@ -36,6 +36,7 @@ import org.springframework.mail.SimpleMailMessage;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -275,7 +276,7 @@ public class RTMessagesManagerBlImpl implements RTMessagesManagerBl {
 		MultipartEntityBuilder entityBuilder = MultipartEntityBuilder.create();
 		try {
 			entityBuilder.addPart("Content-Type", new StringBody("application/x-www-form-urlencoded", ContentType.create("text/plain", Consts.UTF_8)));
-			entityBuilder.addPart("charset", new StringBody("utf-8", ContentType.create("text/plain", Consts.UTF_8)));
+			entityBuilder.addPart("charset", new StringBody(StandardCharsets.UTF_8.toString(), ContentType.create("text/plain", Consts.UTF_8)));
 			entityBuilder.addPart("Connection", new StringBody("Close", ContentType.create("text/plain", Consts.UTF_8)));
 			StringBody content = new StringBody("id: " + id + '\n' +
 					"Queue: " + queue + '\n' +

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourcePerun.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourcePerun.java
@@ -306,11 +306,11 @@ public class ExtSourcePerun extends ExtSource implements ExtSourceApi {
 
 		HttpGet get = new HttpGet(commandUrl);
 		get.setHeader("Content-Type", "application/json");
-		get.setHeader("charset", "utf-8");
+		get.setHeader("charset", StandardCharsets.UTF_8.toString());
 		get.setHeader("Connection", "Close");
 		UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(username, password);
 
-		get.addHeader(BasicScheme.authenticate(credentials, "utf-8", false));
+		get.addHeader(BasicScheme.authenticate(credentials, StandardCharsets.UTF_8.toString(), false));
 		//post.setParams(params);
 
 		InputStream rpcServerAnswer = null;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourcePerun.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourcePerun.java
@@ -30,11 +30,11 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
 import java.net.ProtocolException;
 import java.net.URLEncoder;
 import java.net.UnknownHostException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -227,13 +227,8 @@ public class ExtSourcePerun extends ExtSource implements ExtSourceApi {
 	private List<RichUser> findRichUsers(String substring) {
 
 		String query;
-		try {
-			// encode query params
-			query = "searchString=" + URLEncoder.encode(substring, "UTF-8");
-		} catch (UnsupportedEncodingException ex) {
-			// sent query params not encoded
-			query = "searchString=" + substring;
-		}
+		// encode query params
+		query = "searchString=" + URLEncoder.encode(substring, StandardCharsets.UTF_8);
 
 		List<RichUser> richUsers;
 		try {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Utils.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Utils.java
@@ -56,7 +56,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.UnsupportedEncodingException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.MalformedURLException;
@@ -1378,18 +1377,16 @@ public class Utils {
 			link.append(urlObject.getHost());
 			link.append(linkLocation);
 			link.append("?i=");
-			link.append(URLEncoder.encode(i, "UTF-8"));
+			link.append(URLEncoder.encode(i, StandardCharsets.UTF_8));
 			link.append("&m=");
-			link.append(URLEncoder.encode(m, "UTF-8"));
+			link.append(URLEncoder.encode(m, StandardCharsets.UTF_8));
 			link.append("&login-namespace=");
-			link.append(URLEncoder.encode(namespace, "UTF-8"));
+			link.append(URLEncoder.encode(namespace, StandardCharsets.UTF_8));
 			if(activation) {
 				link.append("&activation=true");
 			}
 		} catch (MalformedURLException ex) {
 			throw new InternalErrorException("Not valid URL of running Perun instance.", ex);
-		} catch (UnsupportedEncodingException ex) {
-			throw new InternalErrorException("Unable to encode URL for password reset.", ex);
 		}
 
 		return link.toString();
@@ -1424,14 +1421,12 @@ public class Utils {
 			link.append(urlObject.getHost());
 			link.append(linkLocation);
 			link.append("?i=");
-			link.append(URLEncoder.encode(i, "UTF-8"));
+			link.append(URLEncoder.encode(i, StandardCharsets.UTF_8));
 			link.append("&m=");
-			link.append(URLEncoder.encode(m, "UTF-8"));
+			link.append(URLEncoder.encode(m, StandardCharsets.UTF_8));
 			link.append("&u=" + user.getId());
 		} catch (MalformedURLException ex) {
 			throw new InternalErrorException("Not valid URL of running Perun instance.", ex);
-		} catch (UnsupportedEncodingException ex) {
-			throw new InternalErrorException("Unable to encode URL for password reset.", ex);
 		}
 
 		return link.toString();

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/MuPasswordManagerModule.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/MuPasswordManagerModule.java
@@ -44,6 +44,7 @@ import java.io.PrintWriter;
 import java.io.StringReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 import java.util.HashMap;
@@ -290,9 +291,9 @@ public class MuPasswordManagerModule implements PasswordManagerModule {
 
 			String response = null;
 			try {
-				response = convertStreamToString(con.getErrorStream(), "UTF-8");
+				response = convertStreamToString(con.getErrorStream(), StandardCharsets.UTF_8);
 			} catch (IOException ex) {
-				log.error("Unable to convert InputStream to String: {}", ex);
+				log.error("Unable to convert InputStream to String.", ex);
 			}
 
 			log.trace("[IS Request {}] Response: {}", requestId, response);
@@ -485,7 +486,7 @@ public class MuPasswordManagerModule implements PasswordManagerModule {
 
 		String response;
 		try {
-			response = convertStreamToString(inputStream, "UTF-8");
+			response = convertStreamToString(inputStream, StandardCharsets.UTF_8);
 		} catch (IOException ex) {
 			throw new IllegalArgumentException("Unable to convert InputStream to String.", ex);
 		}
@@ -558,7 +559,7 @@ public class MuPasswordManagerModule implements PasswordManagerModule {
 	 * @return Content of inputStream as a String
 	 * @throws IOException
 	 */
-	static String convertStreamToString(InputStream inputStream, String encoding) throws IOException {
+	static String convertStreamToString(InputStream inputStream, Charset encoding) throws IOException {
 
 		ByteArrayOutputStream result = new ByteArrayOutputStream();
 		byte[] buffer = new byte[1024];

--- a/perun-notification/src/main/java/cz/metacentrum/perun/notif/entities/PerunNotifPoolMessage.java
+++ b/perun-notification/src/main/java/cz/metacentrum/perun/notif/entities/PerunNotifPoolMessage.java
@@ -1,12 +1,12 @@
 package cz.metacentrum.perun.notif.entities;
 
 import cz.metacentrum.perun.notif.dto.PoolMessage;
-import org.springframework.dao.DataAccessException;
 import org.springframework.jdbc.core.ResultSetExtractor;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.Instant;
@@ -224,7 +224,7 @@ public class PerunNotifPoolMessage {
 		for (String pair : pairs) {
 			String key = pair.substring(0, pair.indexOf("="));
 			String value = pair.substring(pair.indexOf("=") + 1);
-			String decodedValue = URLDecoder.decode(value, "utf-8");
+			String decodedValue = URLDecoder.decode(value, StandardCharsets.UTF_8);
 
 			result.put(key, decodedValue);
 		}
@@ -238,7 +238,7 @@ public class PerunNotifPoolMessage {
 		Collections.sort(sortedList);
 		for (String key : sortedList) {
 			if (map.get(key) != null) {
-				String encodedKey = URLEncoder.encode(map.get(key), "utf-8");
+				String encodedKey = URLEncoder.encode(map.get(key), StandardCharsets.UTF_8);
 				serializedKeyAttributes.append(key).append("=").append(encodedKey).append(PerunNotifPoolMessage.DELIMITER);
 			}
 		}

--- a/perun-notification/src/main/java/cz/metacentrum/perun/notif/mail/MessagePreparator.java
+++ b/perun-notification/src/main/java/cz/metacentrum/perun/notif/mail/MessagePreparator.java
@@ -16,6 +16,7 @@ import javax.mail.internet.MimeBodyPart;
 import javax.mail.internet.MimeMessage;
 import javax.mail.internet.MimeMultipart;
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -131,7 +132,7 @@ public class MessagePreparator implements MimeMessagePreparator {
 	private BodyPart createTextMessage() throws Exception {
 		BodyPart textPart = new MimeBodyPart();
 
-		textPart.setDataHandler(createDataHandler(content.getBytes("utf-8"), "text/plain;charset=utf-8"));
+		textPart.setDataHandler(createDataHandler(content.getBytes(StandardCharsets.UTF_8), "text/plain;charset=utf-8"));
 
 		logger.debug("TEXT MESSAGE CREATED ; content: " + content);
 
@@ -148,7 +149,7 @@ public class MessagePreparator implements MimeMessagePreparator {
 		Multipart htmlContent = new MimeMultipart("related");
 		BodyPart htmlPage = new MimeBodyPart();
 
-		htmlPage.setDataHandler(createDataHandler(content.getBytes("utf-8"), "text/html;charset=utf-8"));
+		htmlPage.setDataHandler(createDataHandler(content.getBytes(StandardCharsets.UTF_8), "text/html;charset=utf-8"));
 
 		htmlContent.addBodyPart(htmlPage);
 		BodyPart htmlPart = new MimeBodyPart();

--- a/perun-notification/src/main/java/cz/metacentrum/perun/notif/managers/PerunNotifEmailManagerImpl.java
+++ b/perun-notification/src/main/java/cz/metacentrum/perun/notif/managers/PerunNotifEmailManagerImpl.java
@@ -16,8 +16,7 @@ import javax.annotation.PostConstruct;
 import javax.mail.*;
 import javax.mail.internet.MimeMessage;
 import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 
 @org.springframework.stereotype.Service("perunNotifEmailManager")
@@ -148,8 +147,7 @@ public class PerunNotifEmailManagerImpl implements PerunNotifEmailManager {
 						MimeMessage message = (MimeMessage) key;
 						ByteArrayOutputStream out = new ByteArrayOutputStream();
 						message.writeTo(out);
-						byte[] charData = out.toByteArray();
-						String str = new String(charData, Charset.forName("UTF-8"));
+						String str = out.toString(StandardCharsets.UTF_8);
 						failedEmailLogger.error(str);
 					} catch (Exception e) {
 						logger.error("Failed to write log about not sent email.", ex);

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/MailManagerImpl.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/MailManagerImpl.java
@@ -1616,17 +1616,13 @@ public class MailManagerImpl implements MailManager {
 	}
 
 	/**
-	 * Return URL encoded String in utf-8. If not possible, return original string.
+	 * Return URL encoded String in UTF-8. If not possible, return original string.
 	 *
 	 * @param s String to encode
 	 * @return URL Encoded string
 	 */
 	private static String getUrlEncodedString(String s) {
-		try {
-			return URLEncoder.encode(s, "UTF-8");
-		} catch (UnsupportedEncodingException ex) {
-			return s;
-		}
+		return URLEncoder.encode(s, StandardCharsets.UTF_8);
 	}
 
 	private void copyApplicationMails(PerunSession sess, ApplicationForm formFrom, ApplicationForm formTo) throws PerunException {
@@ -1732,11 +1728,7 @@ public class MailManagerImpl implements MailManager {
 									newValue += namespace + "/registrar/";
 									newValue += "?vo="+ getUrlEncodedString(app.getVo().getShortName());
 									newValue += ((app.getGroup() != null) ? "&group="+ getUrlEncodedString(app.getGroup().getName()) : EMPTY_STRING);
-									try {
-										newValue += "&i=" + URLEncoder.encode(i, "UTF-8") + "&m=" + URLEncoder.encode(m, "UTF-8");
-									} catch (UnsupportedEncodingException ex) {
-										newValue += "&i=" + i + "&m=" + m;
-									}
+									newValue += "&i=" + URLEncoder.encode(i, StandardCharsets.UTF_8) + "&m=" + URLEncoder.encode(m, StandardCharsets.UTF_8);
 								}
 							}
 							// substitute {validationLink-authz} with actual value or empty string
@@ -1767,12 +1759,8 @@ public class MailManagerImpl implements MailManager {
 								if (!url2.toString().isEmpty()) url2.append("?");
 							}
 
-							try {
-								if (!url2.toString().isEmpty())
-									url2.append("i=").append(URLEncoder.encode(i, "UTF-8")).append("&m=").append(URLEncoder.encode(m, "UTF-8"));
-							} catch (UnsupportedEncodingException ex) {
-								if (!url2.toString().isEmpty()) url2.append("i=").append(i).append("&m=").append(m);
-							}
+							if (!url2.toString().isEmpty())
+								url2.append("i=").append(URLEncoder.encode(i, StandardCharsets.UTF_8)).append("&m=").append(URLEncoder.encode(m, StandardCharsets.UTF_8));
 
 							// replace validation link
 							mailText = mailText.replace(FIELD_VALIDATION_LINK, url2.toString());

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/ELIXIRCILogonDNGenerator.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/ELIXIRCILogonDNGenerator.java
@@ -122,7 +122,7 @@ public class ELIXIRCILogonDNGenerator extends DefaultRegistrarModule {
 			size = RDN_MAX_SIZE;
 		}
 
-		Charset defaultCharset = Charset.forName("UTF-8");
+		Charset defaultCharset = StandardCharsets.UTF_8;
 
 		// only truncate if the RDN exceeds the maximum allowed size
 		if ( rdn.getBytes(defaultCharset).length > size ) {

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/Api.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/Api.java
@@ -44,6 +44,7 @@ import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.io.UnsupportedEncodingException;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.security.cert.CertificateParsingException;
 import java.security.cert.X509Certificate;
 import java.sql.Timestamp;
@@ -339,11 +340,7 @@ public class Api extends HttpServlet {
 			if(attrValue!=null) {
 				//fix shibboleth encoding
 				if (ExtSourcesManager.EXTSOURCE_IDP.equals(extSourceType)) {
-					try {
-						attrValue = new String(attrValue.getBytes("iso-8859-1"), "utf-8");
-					} catch (UnsupportedEncodingException e) {
-						log.error("utf-8 is not known");
-					}
+					attrValue = new String(attrValue.getBytes(StandardCharsets.ISO_8859_1), StandardCharsets.UTF_8);
 				}
 				log.debug("storing {}={} to additionalInformations", attr.getFriendlyName(), attrValue);
 				additionalInformations.put(attr.getFriendlyName(), attrValue);


### PR DESCRIPTION
- Use StandardCharsets.UTF_8 constant instead of string.
  This removes necessity to catch UnsupportedEncodingException.
- Same for other charsets if necessary.
- Simplified reading of ByteArrayOutputStrem when printing
  mails which failed to be sent.
- Charset in HTTP headers is too case-insensitive,
  replaced with StandardCharsets.