### PR TITLE
Core - find optimization

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/MembersManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/MembersManagerImpl.java
@@ -631,7 +631,7 @@ public class MembersManagerImpl implements MembersManagerImplApi {
 		Set<Member> members = new HashSet<>(namedParameterJdbcTemplate.query("select distinct " + memberMappingSelectQuery +
 				" from members " +
 				" left join users on members.user_id=users.id " +
-				" left join user_ext_sources ues on ues.user_id=users.id " +
+				" left join user_ext_sources ues on ues.user_id=users.id lower(ues.login_ext)=lower(:searchString) " +
 				attributesToSearchByQueries.get("memberAttributesQuery").getLeft() +
 				attributesToSearchByQueries.get("userAttributesQuery").getLeft() +
 				attributesToSearchByQueries.get("uesAttributesQuery").getLeft() +

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/UsersManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/UsersManagerImpl.java
@@ -876,7 +876,7 @@ public class UsersManagerImpl implements UsersManagerImplApi {
 		Set<User> users = new HashSet<>(namedParameterJdbcTemplate.query("select distinct " + userMappingSelectQuery +
 			" from users " +
 			" left join members on users.id=members.user_id " +
-			" left join user_ext_sources ues on ues.user_id=users.id " +
+			" left join user_ext_sources ues on ues.user_id=users.id and lower(ues.login_ext)=lower(:searchString) " +
 			attributesToSearchByQueries.get("memberAttributesQuery").getLeft() +
 			attributesToSearchByQueries.get("userAttributesQuery").getLeft() +
 			attributesToSearchByQueries.get("uesAttributesQuery").getLeft() +


### PR DESCRIPTION
* Implemented optimization of find methods in members manager and users
manager. The key is that there is a search in ues login and it is done
after a table join. However, the search string can limit the records
from ues table before the join. From my testing, this has improved the
execution time of the original SQL from 1.5s to 0.5s.