### PR TITLE
AutoRejection - custom reject messages

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -95,8 +95,10 @@ import cz.metacentrum.perun.core.impl.AttributesManagerImpl;
 import cz.metacentrum.perun.core.impl.Utils;
 import cz.metacentrum.perun.core.impl.modules.attributes.urn_perun_entityless_attribute_def_def_namespace_GIDRanges;
 import cz.metacentrum.perun.core.impl.modules.attributes.urn_perun_facility_attribute_def_virt_GIDRanges;
+import cz.metacentrum.perun.core.impl.modules.attributes.urn_perun_group_attribute_def_def_applicationAutoRejectMessages;
 import cz.metacentrum.perun.core.impl.modules.attributes.urn_perun_group_attribute_def_def_groupStructureResources;
 import cz.metacentrum.perun.core.impl.modules.attributes.urn_perun_member_attribute_def_def_suspensionInfo;
+import cz.metacentrum.perun.core.impl.modules.attributes.urn_perun_vo_attribute_def_def_applicationAutoRejectMessages;
 import cz.metacentrum.perun.core.implApi.AttributesManagerImplApi;
 import cz.metacentrum.perun.core.implApi.modules.attributes.AttributesModuleImplApi;
 import cz.metacentrum.perun.core.implApi.modules.attributes.SkipValueCheckDuringDependencyCheck;
@@ -7628,6 +7630,14 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		rights.add(new AttributeRights(-1, Role.GROUPADMIN, Collections.singletonList(ActionType.READ)));
 		attributes.put(attr, rights);
 
+		//urn:perun:group:attribute-def:def:applicationAutoRejectMessages
+		attr = new urn_perun_group_attribute_def_def_applicationAutoRejectMessages().getAttributeDefinition();
+		//set attribute rights (with dummy id of attribute - not known yet)
+		rights = new ArrayList<>();
+		rights.add(new AttributeRights(-1, Role.VOADMIN, Arrays.asList(ActionType.READ, ActionType.WRITE)));
+		rights.add(new AttributeRights(-1, Role.GROUPADMIN, Arrays.asList(ActionType.READ, ActionType.WRITE)));
+		attributes.put(attr, rights);
+
 		//urn:perun:facility:attribute-def:def:login-namespace
 		attr = new AttributeDefinition();
 		attr.setNamespace(AttributesManager.NS_FACILITY_ATTR_DEF);
@@ -7686,6 +7696,13 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		rights.add(new AttributeRights(-1, Role.GROUPADMIN, Collections.singletonList(ActionType.READ)));
 		rights.add(new AttributeRights(-1, Role.VOADMIN, Arrays.asList(ActionType.READ, ActionType.WRITE)));
 		rights.add(new AttributeRights(-1, Role.FACILITYADMIN, Collections.singletonList(ActionType.READ)));
+		attributes.put(attr, rights);
+
+		//urn:perun:vo:attribute-def:def:applicationAutoRejectMessages
+		attr = new urn_perun_vo_attribute_def_def_applicationAutoRejectMessages().getAttributeDefinition();
+		//set attribute rights (with dummy id of attribute - not known yet)
+		rights = new ArrayList<>();
+		rights.add(new AttributeRights(-1, Role.VOADMIN, Arrays.asList(ActionType.READ, ActionType.WRITE)));
 		attributes.put(attr, rights);
 
 		//urn:perun:user_facility:attribute-def:virt:login

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_applicationAutoRejectMessages.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_applicationAutoRejectMessages.java
@@ -1,0 +1,54 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.Vo;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import cz.metacentrum.perun.core.implApi.modules.attributes.AbstractApplicationAutoRejectMessagesModule;
+import cz.metacentrum.perun.core.implApi.modules.attributes.GroupAttributesModuleImplApi;
+
+import java.util.LinkedHashMap;
+
+/**
+ * @author vojtech sassmann <vojtech.sassmann@gmail.com>
+ */
+public class urn_perun_group_attribute_def_def_applicationAutoRejectMessages extends AbstractApplicationAutoRejectMessagesModule<Group> implements GroupAttributesModuleImplApi {
+
+	@Override
+	public void checkAttributeSyntax(PerunSessionImpl sess, Group group, Attribute attribute) throws WrongAttributeValueException {
+		super.checkAttributeSyntax(sess, group, attribute);
+	}
+
+	@Override
+	public void checkAttributeSemantics(PerunSessionImpl perunSession, Group group, Attribute attribute) throws WrongAttributeAssignmentException, WrongReferenceAttributeValueException { }
+
+	@Override
+	public Attribute fillAttribute(PerunSessionImpl perunSession, Group group, AttributeDefinition attribute) throws WrongAttributeAssignmentException {
+		return null;
+	}
+
+	@Override
+	public void changedAttributeHook(PerunSessionImpl session, Group group, Attribute attribute) throws WrongReferenceAttributeValueException {}
+
+	@Override
+	public AttributeDefinition getAttributeDefinition() {
+		AttributeDefinition attr = new AttributeDefinition();
+		attr.setNamespace(AttributesManager.NS_GROUP_ATTR_DEF);
+		attr.setFriendlyName("applicationAutoRejectMessages");
+		attr.setDisplayName("Messages for automatic application rejection");
+		attr.setType(LinkedHashMap.class.getName());
+		attr.setDescription(
+		        "These messages are used when some of the submitted applications is automatically rejected. " +
+		        "Use `ignoredByAdmin` to define a message that is used when some application is rejected when it is " +
+		        "ignored by admins. For language specific version, use `ignoredByAdmin-{lang}` e.g. `ignoredByAdmin-en`. " +
+		        "Use `emailVerification` to define a message that is used when some application is rejected because " +
+		        "user didn't verify his email in time. For language specific version, use `emailVerification-{lang}`, " +
+		        "e.g. `emailVerification-cs`.");
+		return attr;
+	}
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_vo_attribute_def_def_applicationAutoRejectMessages.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_vo_attribute_def_def_applicationAutoRejectMessages.java
@@ -1,0 +1,52 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Vo;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import cz.metacentrum.perun.core.implApi.modules.attributes.AbstractApplicationAutoRejectMessagesModule;
+import cz.metacentrum.perun.core.implApi.modules.attributes.VoAttributesModuleImplApi;
+
+import java.util.LinkedHashMap;
+
+/**
+ * @author vojtech sassmann <vojtech.sassmann@gmail.com>
+ */
+public class urn_perun_vo_attribute_def_def_applicationAutoRejectMessages extends AbstractApplicationAutoRejectMessagesModule<Vo> implements VoAttributesModuleImplApi {
+
+	@Override
+	public void checkAttributeSyntax(PerunSessionImpl sess, Vo vo, Attribute attribute) throws WrongAttributeValueException {
+		super.checkAttributeSyntax(sess, vo, attribute);
+	}
+
+	@Override
+	public Attribute fillAttribute(PerunSessionImpl perunSession, Vo vo, AttributeDefinition attribute) {
+		return null;
+	}
+
+	@Override
+	public void checkAttributeSemantics(PerunSessionImpl perunSession, Vo vo, Attribute attribute) throws WrongReferenceAttributeValueException {}
+
+	@Override
+	public void changedAttributeHook(PerunSessionImpl session, Vo vo, Attribute attribute) {}
+
+	@Override
+	public AttributeDefinition getAttributeDefinition() {
+		AttributeDefinition attr = new AttributeDefinition();
+		attr.setNamespace(AttributesManager.NS_VO_ATTR_DEF);
+		attr.setFriendlyName("applicationAutoRejectMessages");
+		attr.setDisplayName("Messages for automatic application rejection");
+		attr.setType(LinkedHashMap.class.getName());
+		attr.setDescription(
+				"These messages are used when some of the submitted applications is automatically rejected. " +
+				"Use `ignoredByAdmin` to define a message that is used when some application is rejected when it is " +
+				"ignored by admins. For language specific version, use `ignoredByAdmin-{lang}` e.g. `ignoredByAdmin-en`. " +
+				"Use `emailVerification` to define a message that is used when some application is rejected because " +
+				"user didn't verify his email in time. For language specific version, use `emailVerification-{lang}`, " +
+				"e.g. `emailVerification-cs`.\n");
+		return attr;
+	}
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/AbstractApplicationAutoRejectMessagesModule.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/AbstractApplicationAutoRejectMessagesModule.java
@@ -1,0 +1,39 @@
+package cz.metacentrum.perun.core.implApi.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.PerunBean;
+import cz.metacentrum.perun.core.api.Vo;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+
+import java.util.LinkedHashMap;
+import java.util.regex.Pattern;
+
+/**
+ * @author vojtech sassmann <vojtech.sassmann@gmail.com>
+ */
+public abstract class AbstractApplicationAutoRejectMessagesModule<T extends PerunBean> extends AttributesModuleAbstract implements AttributesModuleImplApi {
+
+	private static final Pattern IGNORED_BY_ADMIN_PATTERN = Pattern.compile("^ignoredByAdmin(-(\\w+))?$");
+	private static final Pattern MAIL_VERIFICATION_PATTERN = Pattern.compile("^emailVerification(-(\\w+))?$");
+
+	public void checkAttributeSyntax(PerunSessionImpl perunSession, T entity, Attribute attribute) throws WrongAttributeValueException {
+		LinkedHashMap<String, String> values = attribute.valueAsMap();
+		for (String key : values.keySet()) {
+			if (isInvalidKey(key)) {
+				throw new WrongAttributeValueException(attribute, "Key '" + key + "' has an invalid format.");
+			}
+		}
+	}
+
+	/**
+	 * Returns true, if the given key has a valid format.
+	 *
+	 * @param key key representing rejection message type and language
+	 * @return Returns true, if the given key has a valid format, false otherwise.
+	 */
+	private boolean isInvalidKey(String key) {
+		return !IGNORED_BY_ADMIN_PATTERN.matcher(key).matches() &&
+				!MAIL_VERIFICATION_PATTERN.matcher(key).matches();
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_applicationAutoRejectMessagesTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_applicationAutoRejectMessagesTest.java
@@ -1,0 +1,76 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.Mockito.mock;
+
+public class urn_perun_group_attribute_def_def_applicationAutoRejectMessagesTest {
+
+	private static urn_perun_group_attribute_def_def_applicationAutoRejectMessages classInstance;
+	private static PerunSessionImpl session;
+	private static Attribute attributeToCheck;
+	private static Group group;
+
+	@Before
+	public void setUp() {
+		classInstance = new urn_perun_group_attribute_def_def_applicationAutoRejectMessages();
+		session = mock(PerunSessionImpl.class);
+		attributeToCheck = new Attribute();
+		group = new Group();
+	}
+
+	@Test
+	public void testValidAdminIgnoredKey() throws Exception {
+		HashMap<String, String> value = new LinkedHashMap<>();
+		value.put("ignoredByAdmin-cs", "message");
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSyntax(session, group, attributeToCheck);
+	}
+
+	@Test
+	public void testValidAdminIgnoredKeyDefault() throws Exception {
+		HashMap<String, String> value = new LinkedHashMap<>();
+		value.put("ignoredByAdmin", "message");
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSyntax(session, group, attributeToCheck);
+	}
+
+	@Test
+	public void testValidMailVerificationKey() throws Exception {
+		HashMap<String, String> value = new LinkedHashMap<>();
+		value.put("emailVerification-en", "message");
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSyntax(session, group, attributeToCheck);
+	}
+
+	@Test
+	public void testValidMailVerificationKeyDefault() throws Exception {
+		HashMap<String, String> value = new LinkedHashMap<>();
+		value.put("emailVerification", "message");
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSyntax(session, group, attributeToCheck);
+	}
+
+	@Test
+	public void testInvalidKey() {
+		HashMap<String, String> value = new LinkedHashMap<>();
+		value.put("emailVerification-", "message");
+		attributeToCheck.setValue(value);
+
+		assertThatExceptionOfType(WrongAttributeValueException.class)
+				.isThrownBy(() -> classInstance.checkAttributeSyntax(session, group, attributeToCheck));
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_vo_attribute_def_def_applicationAutoRejectMessagesTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_vo_attribute_def_def_applicationAutoRejectMessagesTest.java
@@ -1,0 +1,76 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Vo;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.Mockito.mock;
+
+public class urn_perun_vo_attribute_def_def_applicationAutoRejectMessagesTest {
+
+	private static urn_perun_vo_attribute_def_def_applicationAutoRejectMessages classInstance;
+	private static PerunSessionImpl session;
+	private static Attribute attributeToCheck;
+	private static Vo vo;
+
+	@Before
+	public void setUp() {
+		classInstance = new urn_perun_vo_attribute_def_def_applicationAutoRejectMessages();
+		session = mock(PerunSessionImpl.class);
+		attributeToCheck = new Attribute();
+		vo = new Vo();
+	}
+
+	@Test
+	public void testValidAdminIgnoredKey() throws Exception {
+		HashMap<String, String> value = new LinkedHashMap<>();
+		value.put("ignoredByAdmin-cs", "message");
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSyntax(session, vo, attributeToCheck);
+	}
+
+	@Test
+	public void testValidAdminIgnoredKeyDefault() throws Exception {
+		HashMap<String, String> value = new LinkedHashMap<>();
+		value.put("ignoredByAdmin", "message");
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSyntax(session, vo, attributeToCheck);
+	}
+
+	@Test
+	public void testValidMailVerificationKey() throws Exception {
+		HashMap<String, String> value = new LinkedHashMap<>();
+		value.put("emailVerification-en", "message");
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSyntax(session, vo, attributeToCheck);
+	}
+
+	@Test
+	public void testValidMailVerificationKeyDefault() throws Exception {
+		HashMap<String, String> value = new LinkedHashMap<>();
+		value.put("emailVerification", "message");
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSyntax(session, vo, attributeToCheck);
+	}
+
+	@Test
+	public void testInvalidKey() {
+		HashMap<String, String> value = new LinkedHashMap<>();
+		value.put("emailVerification-", "message");
+		attributeToCheck.setValue(value);
+
+		assertThatExceptionOfType(WrongAttributeValueException.class)
+				.isThrownBy(() -> classInstance.checkAttributeSyntax(session, vo, attributeToCheck));
+	}
+}


### PR DESCRIPTION
* It is now possible to specify the custom reject messages in the
applicationAutoRejectMessages group/vo attributes.
* These attributes have Map values.
* Value with key 'ignoredByAdmin' specifies the default message used
for rejection if the application has been ignored by admins. To set
language specific values, set `ignoredByAdmin-{language}` values,
e.g. `ignoredByAdmin-en`.
* Value with key `emailVerification` specifies the default message used
when an application is rejected because the user didn't verify his email
in time. To use language specific version, use
`emailVerification-{lang}` keys, e.g. `emailVerification-en`.