### PR TITLE
added parameter "force" do method ServicesManager::deleteService() 

### DIFF
--- a/perun-base/src/main/resources/perun-roles.yml
+++ b/perun-base/src/main/resources/perun-roles.yml
@@ -4058,7 +4058,7 @@ perun_policies:
     include_policies:
       - default_policy
 
-  deleteService_Service_policy:
+  deleteService_Service_boolean_policy:
     policy_roles: []
     include_policies:
       - default_policy

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/ServicesManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/ServicesManager.java
@@ -264,6 +264,20 @@ public interface ServicesManager {
 	 */
 	void deleteService(PerunSession perunSession, Service service) throws ServiceNotExistsException, PrivilegeException, RelationExistsException, ServiceAlreadyRemovedException;
 
+	/**
+	 * Deletes the service.
+	 *
+	 * @param perunSession
+	 * @param service
+	 * @param forceFlag
+	 * @throws InternalErrorException
+	 * @throws ServiceNotExistsException
+	 * @throws PrivilegeException
+	 * @throws RelationExistsException
+	 * @throws ServiceAlreadyRemovedException if there are 0 rows affected by deleting from DB
+	 */
+	void deleteService(PerunSession perunSession, Service service, boolean forceFlag) throws ServiceNotExistsException, PrivilegeException, RelationExistsException, ServiceAlreadyRemovedException;
+
 	/** Updates the service.
 	 *
 	 * @param perunSession

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/ServicesManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/ServicesManager.java
@@ -256,19 +256,6 @@ public interface ServicesManager {
 	 *
 	 * @param perunSession
 	 * @param service
-	 * @throws InternalErrorException
-	 * @throws ServiceNotExistsException
-	 * @throws PrivilegeException
-	 * @throws RelationExistsException
-	 * @throws ServiceAlreadyRemovedException if there are 0 rows affected by deleting from DB
-	 */
-	void deleteService(PerunSession perunSession, Service service) throws ServiceNotExistsException, PrivilegeException, RelationExistsException, ServiceAlreadyRemovedException;
-
-	/**
-	 * Deletes the service.
-	 *
-	 * @param perunSession
-	 * @param service
 	 * @param forceFlag
 	 * @throws InternalErrorException
 	 * @throws ServiceNotExistsException

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/ServicesManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/ServicesManager.java
@@ -256,7 +256,7 @@ public interface ServicesManager {
 	 *
 	 * @param perunSession
 	 * @param service
-	 * @param forceFlag
+	 * @param forceFlag if true, removes all dependant objects from database instead of raising exception
 	 * @throws InternalErrorException
 	 * @throws ServiceNotExistsException
 	 * @throws PrivilegeException

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ServicesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ServicesManagerBl.java
@@ -259,7 +259,7 @@ public interface ServicesManagerBl {
 	 * @throws InternalErrorException
 	 * @throws ServiceAlreadyRemovedException if there are 0 rows affected by deleting from DB
 	 */
-	void deleteService(PerunSession sess, Service service, boolean forceFlag) throws RelationExistsException, ServiceAlreadyRemovedException;
+	void deleteService(PerunSession perunSession, Service service, boolean forceFlag) throws RelationExistsException, ServiceAlreadyRemovedException;
 
 	/** Updates the service.
 	 *

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ServicesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ServicesManagerBl.java
@@ -254,17 +254,7 @@ public interface ServicesManagerBl {
 	 *
 	 * @param perunSession
 	 * @param service
-	 * @throws RelationExistsException
-	 * @throws InternalErrorException
-	 * @throws ServiceAlreadyRemovedException if there are 0 rows affected by deleting from DB
-	 */
-	void deleteService(PerunSession perunSession, Service service) throws RelationExistsException, ServiceAlreadyRemovedException;
-
-	/** Deletes the service.
-	 *
-	 * @param perunSession
-	 * @param service
-	 * @param forceFlag
+	 * @param forceFlag if set to true, removes the service with all dependendant objects from db instead of raising exception
 	 * @throws RelationExistsException
 	 * @throws InternalErrorException
 	 * @throws ServiceAlreadyRemovedException if there are 0 rows affected by deleting from DB

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ServicesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ServicesManagerBl.java
@@ -260,6 +260,17 @@ public interface ServicesManagerBl {
 	 */
 	void deleteService(PerunSession perunSession, Service service) throws RelationExistsException, ServiceAlreadyRemovedException;
 
+	/** Deletes the service.
+	 *
+	 * @param perunSession
+	 * @param service
+	 * @param forceFlag
+	 * @throws RelationExistsException
+	 * @throws InternalErrorException
+	 * @throws ServiceAlreadyRemovedException if there are 0 rows affected by deleting from DB
+	 */
+	void deleteService(PerunSession sess, Service service, boolean forceFlag) throws RelationExistsException, ServiceAlreadyRemovedException;
+
 	/** Updates the service.
 	 *
 	 * @param perunSession
@@ -863,4 +874,5 @@ public interface ServicesManagerBl {
 	 * @throws InternalErrorException
 	 */
 	int getDestinationsCount(PerunSession perunSession);
+
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/TasksManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/TasksManagerBl.java
@@ -150,6 +150,8 @@ public interface TasksManagerBl {
 	 */
 	List<Task> listAllTasksForFacility(int facilityId);
 
+	List<Task> listAllTasksForService(int serviceId);
+
 	List<Task> listAllTasksInState(Task.TaskStatus state);
 
 	void updateTask(Task task);
@@ -161,6 +163,8 @@ public interface TasksManagerBl {
 	Task getTaskById(int id);
 
 	void removeTask(Service service, Facility facility);
+
+	void removeAllTasksForService(Service service);
 
 	List<Task> listAllTasksNotInState(Task.TaskStatus state);
 
@@ -229,7 +233,5 @@ public interface TasksManagerBl {
 	 * @throws InternalErrorException
 	 */
 	List<TaskResult> getTaskResultsForDestinations(List<String> destinationsNames);
-
-
 
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/TasksManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/TasksManagerBl.java
@@ -150,6 +150,12 @@ public interface TasksManagerBl {
 	 */
 	List<Task> listAllTasksForFacility(int facilityId);
 
+	/**
+	 * Returns all tasks associated with given service
+	 * 
+	 * @param serviceId
+	 * @return tasks for service
+	 */
 	List<Task> listAllTasksForService(int serviceId);
 
 	List<Task> listAllTasksInState(Task.TaskStatus state);
@@ -164,6 +170,11 @@ public interface TasksManagerBl {
 
 	void removeTask(Service service, Facility facility);
 
+	/**
+	 * Removes all tasks associated with given service including the associated task results
+	 * 
+	 * @param service
+	 */
 	void removeAllTasksForService(Service service);
 
 	List<Task> listAllTasksNotInState(Task.TaskStatus state);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ServicesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ServicesManagerBlImpl.java
@@ -273,9 +273,9 @@ public class ServicesManagerBlImpl implements ServicesManagerBl {
 	 *   - authz
 	 */
 	@Override
-	public void deleteService(PerunSession sess, Service service, boolean forceFlag) throws RelationExistsException, ServiceAlreadyRemovedException {
+	public void deleteService(PerunSession perunSession, Service service, boolean forceFlag) throws RelationExistsException, ServiceAlreadyRemovedException {
 
-		List<Resource> assignedResources = this.getAssignedResources(sess, service);
+		List<Resource> assignedResources = this.getAssignedResources(perunSession, service);
 		
 		if(forceFlag) {
 
@@ -286,11 +286,11 @@ public class ServicesManagerBlImpl implements ServicesManagerBl {
 			ResourcesManagerBl resourcesManager = getPerunBl().getResourcesManagerBl(); 
 			for(Resource resource: assignedResources) {
 				try {
-					resourcesManager.removeService(sess, resource, service);
+					resourcesManager.removeService(perunSession, resource, service);
 					// Remove from facility_service_destinations
 					Facility facility = getPerunBl().getFacilitiesManagerBl()
-							.getFacilityById(sess, resource.getFacilityId());
-					removeAllDestinations(sess, service, facility);
+							.getFacilityById(perunSession, resource.getFacilityId());
+					removeAllDestinations(perunSession, service, facility);
 				} catch (ServiceNotAssignedException | FacilityNotExistsException e) {
 					// should not happen
 					throw new InternalErrorException("Error removing service", e);
@@ -298,7 +298,7 @@ public class ServicesManagerBlImpl implements ServicesManagerBl {
 			}
 
 			// Remove from service packages
-			getServicesManagerImpl().removeServiceFromAllServicesPackages(sess, service);
+			getServicesManagerImpl().removeServiceFromAllServicesPackages(perunSession, service);
 
 			// Remove all related tasks
 			getPerunBl().getTasksManagerBl().removeAllTasksForService(service);
@@ -309,9 +309,9 @@ public class ServicesManagerBlImpl implements ServicesManagerBl {
 			}
 		}
 		
-		getServicesManagerImpl().removeAllRequiredAttributes(sess, service);
-		getServicesManagerImpl().deleteService(sess, service);
-		getPerunBl().getAuditer().log(sess, new ServiceDeleted(service));
+		getServicesManagerImpl().removeAllRequiredAttributes(perunSession, service);
+		getServicesManagerImpl().deleteService(perunSession, service);
+		getPerunBl().getAuditer().log(perunSession, new ServiceDeleted(service));
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/TasksManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/TasksManagerBlImpl.java
@@ -164,6 +164,11 @@ public class TasksManagerBlImpl implements TasksManagerBl {
 	}
 
 	@Override
+	public List<Task> listAllTasksForService(int serviceId) {
+		return getTasksManagerImpl().listAllTasksForService(serviceId);
+	}
+
+	@Override
 	public List<Task> listAllTasksInState(PerunSession perunSession, Task.TaskStatus state) {
 		return getTasksManagerImpl().listAllTasksInState(state);
 	}
@@ -428,4 +433,13 @@ public class TasksManagerBlImpl implements TasksManagerBl {
 	public void setPerunBl(PerunBlImpl perunBl) {
 		this.perun = perunBl;
 	}
+
+	@Override
+	public void removeAllTasksForService(Service service) {
+		for(Task task : listAllTasksForService(service.getId())) {
+			getTasksManagerImpl().deleteTaskResults(task.getId());
+			removeTask(task.getId());
+		}
+	}
+
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ServicesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ServicesManagerEntry.java
@@ -285,25 +285,11 @@ public class ServicesManagerEntry implements ServicesManager {
 	}
 
 	@Override
-	public void deleteService(PerunSession sess, Service service) throws ServiceNotExistsException, PrivilegeException, RelationExistsException, ServiceAlreadyRemovedException {
-		Utils.checkPerunSession(sess);
-
-		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "deleteService_Service_policy", service)) {
-			throw new PrivilegeException(sess, "deleteService");
-		}
-
-		getServicesManagerBl().checkServiceExists(sess, service);
-
-		getServicesManagerBl().deleteService(sess, service);
-	}
-
-	@Override
 	public void deleteService(PerunSession sess, Service service, boolean forceFlag) throws ServiceNotExistsException, PrivilegeException, RelationExistsException, ServiceAlreadyRemovedException {
 		Utils.checkPerunSession(sess);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "deleteService_Service_policy", service)) {
+		if (!AuthzResolver.authorizedInternal(sess, "deleteService_Service_boolean_policy", service)) {
 			throw new PrivilegeException(sess, "deleteService");
 		}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ServicesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ServicesManagerEntry.java
@@ -299,6 +299,20 @@ public class ServicesManagerEntry implements ServicesManager {
 	}
 
 	@Override
+	public void deleteService(PerunSession sess, Service service, boolean forceFlag) throws ServiceNotExistsException, PrivilegeException, RelationExistsException, ServiceAlreadyRemovedException {
+		Utils.checkPerunSession(sess);
+
+		// Authorization
+		if (!AuthzResolver.authorizedInternal(sess, "deleteService_Service_policy", service)) {
+			throw new PrivilegeException(sess, "deleteService");
+		}
+
+		getServicesManagerBl().checkServiceExists(sess, service);
+
+		getServicesManagerBl().deleteService(sess, service, forceFlag);
+	}
+
+	@Override
 	public void updateService(PerunSession sess, Service service) throws ServiceNotExistsException, PrivilegeException {
 		Utils.checkPerunSession(sess);
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ServicesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ServicesManagerImpl.java
@@ -339,6 +339,16 @@ public class ServicesManagerImpl implements ServicesManagerImplApi {
 		}
 	}
 
+	@SuppressWarnings("ConstantConditions")
+	@Override
+	public void unblockService(int serviceId) {
+		try {
+			jdbc.update("delete from service_denials where service_id = ?", serviceId);
+		} catch (RuntimeException ex) {
+			throw new InternalErrorException(ex);
+		}
+	}
+
 	private int queryForInt(String sql, Object... args) {
 		try {
 			@SuppressWarnings("ConstantConditions")
@@ -536,6 +546,15 @@ public class ServicesManagerImpl implements ServicesManagerImplApi {
 		try {
 			int numAffected = jdbc.update("delete from service_service_packages where package_id=? and service_id=?", servicesPackage.getId(), service.getId());
 			if(numAffected == 0) throw new ServiceAlreadyRemovedFromServicePackageException("Service: " + service + " , ServicePackage: " + servicesPackage);
+		} catch (RuntimeException e) {
+			throw new InternalErrorException(e);
+		}
+	}
+
+	@Override
+	public void removeServiceFromAllServicesPackages(PerunSession sess, Service service) {
+		try {
+			jdbc.update("delete from service_service_packages where service_id=?", service.getId());
 		} catch (RuntimeException e) {
 			throw new InternalErrorException(e);
 		}
@@ -878,4 +897,5 @@ public class ServicesManagerImpl implements ServicesManagerImplApi {
 			throw new InternalErrorException(ex);
 		}
 	}
+
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ServicesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ServicesManagerImpl.java
@@ -339,7 +339,6 @@ public class ServicesManagerImpl implements ServicesManagerImplApi {
 		}
 	}
 
-	@SuppressWarnings("ConstantConditions")
 	@Override
 	public void unblockService(int serviceId) {
 		try {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/TasksManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/TasksManagerImpl.java
@@ -501,16 +501,12 @@ public class TasksManagerImpl implements TasksManagerImplApi {
 
 	@Override
 	public List<Task> listAllTasksForService(int serviceId) {
-		try {
-			// jdbc template cannot be null
-			return getMyJdbcTemplate().query(
+		// jdbc template cannot be null
+		return getMyJdbcTemplate().query(
 				"select " + taskMappingSelectQuery + ", " + FacilitiesManagerImpl.facilityMappingSelectQuery +
-					", " + ServicesManagerImpl.serviceMappingSelectQuery + " from tasks left join services on tasks.service_id = services.id " +
-					"left join facilities on facilities.id = tasks.facility_id where services.id = ?",
+				", " + ServicesManagerImpl.serviceMappingSelectQuery + " from tasks left join services on tasks.service_id = services.id " +
+				"left join facilities on facilities.id = tasks.facility_id where services.id = ?",
 				TASK_ROWMAPPER, serviceId);
-		} catch (EmptyResultDataAccessException ex) {
-			return null;
-		}
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/TasksManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/TasksManagerImpl.java
@@ -500,6 +500,20 @@ public class TasksManagerImpl implements TasksManagerImplApi {
 	}
 
 	@Override
+	public List<Task> listAllTasksForService(int serviceId) {
+		try {
+			// jdbc template cannot be null
+			return getMyJdbcTemplate().query(
+				"select " + taskMappingSelectQuery + ", " + FacilitiesManagerImpl.facilityMappingSelectQuery +
+					", " + ServicesManagerImpl.serviceMappingSelectQuery + " from tasks left join services on tasks.service_id = services.id " +
+					"left join facilities on facilities.id = tasks.facility_id where services.id = ?",
+				TASK_ROWMAPPER, serviceId);
+		} catch (EmptyResultDataAccessException ex) {
+			return null;
+		}
+	}
+
+	@Override
 	public Task getTaskById(int id) {
 		try {
 			// jdbc template cannot be null

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/ServicesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/ServicesManagerImplApi.java
@@ -87,6 +87,13 @@ public interface ServicesManagerImplApi {
 	void unblockAllServicesOnDestination(int destination);
 
 	/**
+	 * Unblock Service everywhere. If was not blocked, nothing happens.
+	 *
+	 * @param serviceId ID of Service to unblock.
+	 */
+	void unblockService(int serviceId);
+
+	/**
 	 * Get Services blocked on Facility.
 	 *
 	 * @param facilityId ID of Facility to get blocked Services for.
@@ -301,6 +308,18 @@ public interface ServicesManagerImplApi {
 	 */
 	void removeServiceFromServicesPackage(PerunSession perunSession, ServicesPackage servicesPackage, Service service) throws ServiceAlreadyRemovedFromServicePackageException;
 
+	/**
+	 * Remove Service from all Services Packages
+	 *
+	 * @param perunSession
+	 * @param service service that will be removed from the services package
+	 *
+	 * @throws InternalErrorException
+	 * @throws ServiceNotExistsException
+	 * @throws ServiceAlreadyRemovedFromServicePackageException there are 0 rows affected by removing service from service package in DB
+	 */
+	void removeServiceFromAllServicesPackages(PerunSession sess, Service service);
+	
 	/**
 	 * List services stored in the packages
 	 *
@@ -591,4 +610,5 @@ public interface ServicesManagerImplApi {
 	 * @throws InternalErrorException
 	 */
 	int getDestinationsCount(PerunSession perunSession);
+
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/TasksManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/TasksManagerImplApi.java
@@ -26,6 +26,8 @@ public interface TasksManagerImplApi {
 	 */
 	List<Task> listAllTasksForFacility(int facilityId);
 
+	List<Task> listAllTasksForService(int serviceId);
+
 	List<Task> listAllTasksInState(Task.TaskStatus state);
 
 	List<Task> listAllTasksNotInState(TaskStatus state);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/TasksManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/TasksManagerImplApi.java
@@ -26,6 +26,12 @@ public interface TasksManagerImplApi {
 	 */
 	List<Task> listAllTasksForFacility(int facilityId);
 
+	/**
+	 * Returns all tasks associated with given service
+	 * 
+	 * @param serviceId
+	 * @return tasks for service
+	 */
 	List<Task> listAllTasksForService(int serviceId);
 
 	List<Task> listAllTasksInState(Task.TaskStatus state);

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/bl/ServicesManagerBlImplTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/bl/ServicesManagerBlImplTest.java
@@ -163,9 +163,6 @@ public class ServicesManagerBlImplTest {
 		jdbcTemplate.update("insert into facilities(id, name) values (?,?)", testFacilityId2, "Cluster_" + testFacilityId2);
 		facility2.setId(testFacilityId2);
 
-		// service denials
-		((PerunBl)perun).getServicesManagerBl().blockServiceOnDestination(perunSession, testService1, testDestinationId1);
-		
 		// vo
 		vo = new Vo(0, "ServicesManagerTestVo", "RMTestVo");
 		vo = ((PerunBl)perun).getVosManagerBl().createVo(perunSession, vo);
@@ -211,6 +208,9 @@ public class ServicesManagerBlImplTest {
 	@Test
 	public void testDeleteService() throws Exception {
 		System.out.println("ServicesManagerBlImplTest.testDeleteService");
+		
+		// service denials (set up here, otherwise it breaks other test)
+		((PerunBl)perun).getServicesManagerBl().blockServiceOnDestination(perunSession, testService1, testDestinationId1);
 		
 		((PerunBl) perun).getServicesManagerBl().deleteService(perunSession, testService1, true);
 	}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/bl/TasksManagerBlImplTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/bl/TasksManagerBlImplTest.java
@@ -1,0 +1,153 @@
+package cz.metacentrum.perun.core.bl;
+
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.sql.DataSource;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcPerunTemplate;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.ContextHierarchy;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.transaction.annotation.Transactional;
+
+import cz.metacentrum.perun.core.api.Destination;
+import cz.metacentrum.perun.core.api.ExtSourcesManager;
+import cz.metacentrum.perun.core.api.Facility;
+import cz.metacentrum.perun.core.api.Perun;
+import cz.metacentrum.perun.core.api.PerunClient;
+import cz.metacentrum.perun.core.api.PerunPrincipal;
+import cz.metacentrum.perun.core.api.PerunSession;
+import cz.metacentrum.perun.core.api.Service;
+import cz.metacentrum.perun.core.api.ServicesManager;
+import cz.metacentrum.perun.core.impl.Utils;
+import cz.metacentrum.perun.taskslib.model.Task;
+import cz.metacentrum.perun.taskslib.model.Task.TaskStatus;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextHierarchy({
+@ContextConfiguration(locations = { "classpath:perun-base.xml", "classpath:perun-core.xml" })
+})
+@Transactional(transactionManager = "springTransactionManager")
+public class TasksManagerBlImplTest {
+
+	@Autowired
+	private ServicesManager servicesManager;
+	@Autowired
+	private DataSource dataSource;
+	@Autowired
+	private Perun perun;
+	private JdbcPerunTemplate jdbcTemplate;
+	private PerunSession perunSession;
+	private Service testService1;
+	private int testDestinationId1, testDestinationId2;
+	private int testFacilityId1, testFacilityId2;
+	private Facility facility1, facility2;
+	private Destination destination;
+	private Task task1, task2;
+
+	@Before
+	public void setUp() throws Exception
+	{
+		perunSession = perun.getPerunSession(
+				new PerunPrincipal("perunTests", ExtSourcesManager.EXTSOURCE_NAME_INTERNAL, ExtSourcesManager.EXTSOURCE_INTERNAL),
+				new PerunClient());
+
+		jdbcTemplate = new JdbcPerunTemplate(dataSource);
+
+		facility1 = new Facility();
+		facility2 = new Facility();
+
+
+		// Test Service #1
+		testService1 = new Service();
+		testService1.setName("Test_service_1_" + Long.toHexString(System.currentTimeMillis()));
+		testService1.setDelay(1);
+		testService1.setRecurrence(1);
+		testService1.setEnabled(true);
+		testService1.setScript("/hellish/test/script");
+
+		testService1.setId(servicesManager.createService(perunSession, testService1).getId());
+
+		// 
+		// Testing Destination #1
+		testDestinationId1 = Utils.getNewId(jdbcTemplate, "destinations_id_seq");
+		jdbcTemplate.update("insert into destinations(id, destination, type) values (?,?,'host')", testDestinationId1, "test.destination." + testDestinationId1);
+
+		// Testing Destination #2
+		testDestinationId2 = Utils.getNewId(jdbcTemplate, "destinations_id_seq");
+		jdbcTemplate.update("insert into destinations(id, destination, type) values (?,?,'host')", testDestinationId2, "test.destination." + testDestinationId2);
+
+		// Testing Facility #1
+		testFacilityId1 = Utils.getNewId(jdbcTemplate, "facilities_id_seq");
+		jdbcTemplate.update("insert into facilities(id, name) values (?,?)", testFacilityId1, "Cluster_" + testFacilityId1);
+		facility1.setId(testFacilityId1);
+
+		// Testing Facility #2
+		testFacilityId2 = Utils.getNewId(jdbcTemplate, "facilities_id_seq");
+		jdbcTemplate.update("insert into facilities(id, name) values (?,?)", testFacilityId2, "Cluster_" + testFacilityId2);
+		facility2.setId(testFacilityId2);
+
+		// facility_service_destinations
+		destination = ((PerunBl)perun).getServicesManagerBl().getDestinationById(perunSession, testDestinationId1);
+		((PerunBl)perun).getServicesManagerBl().addDestination(perunSession, testService1, facility1, destination);
+		// facility_service_destinations
+		destination = ((PerunBl)perun).getServicesManagerBl().getDestinationById(perunSession, testDestinationId2);
+		((PerunBl)perun).getServicesManagerBl().addDestination(perunSession, testService1, facility2, destination);
+
+		// tasks
+		task1 = new Task();
+		task1.setFacility(facility1);
+		task1.setService(testService1);
+		task1.setSchedule(0L);
+		task1.setStatus(TaskStatus.DONE);
+		List<Destination> destinationsList = new ArrayList<>();
+		destinationsList.add(destination);
+		task1.setDestinations(destinationsList);
+		((PerunBl)perun).getTasksManagerBl().insertTask(task1);
+		
+		// tasks
+		task2 = new Task();
+		task2.setFacility(facility2);
+		task2.setService(testService1);
+		task2.setSchedule(0L);
+		task2.setStatus(TaskStatus.DONE);
+		destinationsList = new ArrayList<>();
+		destinationsList.add(destination);
+		task2.setDestinations(destinationsList);
+		((PerunBl)perun).getTasksManagerBl().insertTask(task2);
+
+	}
+	
+	@Test
+	public void testListAllTasksForService()
+	{
+		System.out.println("TasksManagerBlImplTest.testListAllTasksForService");
+		
+		List<Task> tasks = ((PerunBl)perun).getTasksManagerBl().listAllTasksForService(testService1.getId());
+		
+		assertNotNull(tasks);
+		assertEquals(tasks.size(), 2);
+	}
+	
+	@Test
+	public void testRemoveAllTasksForService()
+	{
+		System.out.println("TasksManagerBlImplTest.testRemoveAllTasksForService");
+		
+		((PerunBl)perun).getTasksManagerBl().removeAllTasksForService(testService1);
+		List<Task> tasks = ((PerunBl)perun).getTasksManagerBl().listAllTasksForService(testService1.getId());
+		
+		assertNotNull(tasks);
+		assertEquals(tasks.size(), 0);
+		
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ServicesManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ServicesManagerEntryIntegrationTest.java
@@ -118,7 +118,7 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 
 		service = setUpService();
 		assertNotNull("unable to create service before deletion",service);
-		perun.getServicesManager().deleteService(sess, service);
+		perun.getServicesManager().deleteService(sess, service, false);
 		perun.getServicesManager().getServiceById(sess, service.getId());
 		// shouldn't find deleted service
 
@@ -128,7 +128,7 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 	public void deleteServiceWhenServiceNotExists() throws Exception {
 		System.out.println(CLASS_NAME + "deleteServiceWhenServiceNotExists");
 
-		perun.getServicesManager().deleteService(sess, new Service());
+		perun.getServicesManager().deleteService(sess, new Service(), false);
 		// shouldn't find service
 
 	}
@@ -145,7 +145,7 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 
 		perun.getResourcesManager().assignService(sess, resource, service);
 
-		perun.getServicesManager().deleteService(sess, service);
+		perun.getServicesManager().deleteService(sess, service, false);
 		// shouldn't deleted service assigned to resource
 
 	}

--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -14000,6 +14000,7 @@ paths:
       summary: Deletes a service.
       parameters:
         - $ref: '#/components/parameters/serviceId'
+        - { name: force, description: "boolean flag to force removal with all related objects", schema: { type: boolean }, in: query, required: false }
       responses:
         '200':
           $ref: '#/components/responses/VoidResponse'

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/ServicesManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/ServicesManagerMethod.java
@@ -364,6 +364,12 @@ public enum ServicesManagerMethod implements ManagerMethod {
 	 *
 	 * @param service int Service <code>id</code>
 	 */
+	/*#
+	 * Deletes a service.
+	 *
+	 * @param service int Service <code>id</code>
+	 * @param force boolean if true, service will be removed with all dependant objects from the db instead of raising exception 
+	 */
 	deleteService {
 
 		@Override

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/ServicesManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/ServicesManagerMethod.java
@@ -371,7 +371,8 @@ public enum ServicesManagerMethod implements ManagerMethod {
 			parms.stateChangingCheck();
 
 			ac.getServicesManager().deleteService(ac.getSession(),
-					ac.getServiceById(parms.readInt("service")));
+					ac.getServiceById(parms.readInt("service")),
+					parms.readBoolean("force"));
 			return null;
 		}
 	},

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/ServicesManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/ServicesManagerMethod.java
@@ -372,7 +372,7 @@ public enum ServicesManagerMethod implements ManagerMethod {
 
 			ac.getServicesManager().deleteService(ac.getSession(),
 					ac.getServiceById(parms.readInt("service")),
-					parms.readBoolean("force"));
+					parms.contains("force") ? parms.readBoolean("force") : false);
 			return null;
 		}
 	},


### PR DESCRIPTION
Adds boolean flag to force removal of service together with all related objects (implementation of issue#6585):
  - add flag to openapi deleteService() method definition
  - add parameter to rpc deleteService() method
  - overload deleteService() method to accept new parameter at entry and bl levels in ServicesManager
  - implemented removal of related objects at bl level
  - add bl level methods for removal of tasks and task results related to given service to TaskManager
  - add impl level methods for removal of service denials for given service
  - add impl level methods for removal of service from service packages
  - added test