### PR TITLE
Remove support for Large attributes

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/Attribute.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/Attribute.java
@@ -158,9 +158,9 @@ public class Attribute extends AttributeDefinition implements Serializable {
 	 */
 	@SuppressWarnings("unchecked")
 	public boolean valueContains(String value) {
-		if (this.getType().equals(String.class.getName()) || this.getType().equals(BeansUtils.largeStringClassName)) {
+		if (this.getType().equals(String.class.getName())) {
 			return value == null ? this.getValue() == null : value.equals(this.getValue());
-		} else if (this.getType().equals(ArrayList.class.getName()) || this.getType().equals(BeansUtils.largeArrayListClassName)) {
+		} else if (this.getType().equals(ArrayList.class.getName())) {
 			return this.getValue() == null ? value == null : ((ArrayList<String>) this.getValue()).contains(value);
 		} else if (this.getType().equals(LinkedHashMap.class.getName())) {
 			return this.getValue() == null ? value == null :

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/BeansUtils.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/BeansUtils.java
@@ -42,8 +42,6 @@ public class BeansUtils {
 	private final static int MAX_SIZE_OF_ITEMS_IN_SQL_IN_CLAUSE = 1000;
 	private final static String MULTIVALUE_ATTRIBUTE_SEPARATOR_REGEX = ";";
 	private final static String configurationsLocations = "/etc/perun/";
-	public final static String largeStringClassName = "java.lang.LargeString";
-	public final static String largeArrayListClassName = "java.util.LargeArrayList";
 
 	private static CoreConfig coreConfig;
 
@@ -232,9 +230,6 @@ public class BeansUtils {
 
 
 		String attributeType = attribute.getType();
-		// convert internal "large" types to generic java types
-		if (Objects.equals(attributeType, BeansUtils.largeStringClassName)) attributeType = String.class.getName();
-		if (Objects.equals(attributeType, BeansUtils.largeArrayListClassName)) attributeType = ArrayList.class.getName();
 
 		if(!Objects.equals(attributeType, attribute.getValue().getClass().getName())) {
 			throw new InternalErrorException("Attribute's type mismatch " + attribute + ". The type of attribute's value (" + attribute.getValue().getClass().getName() + ") doesn't match the type of attribute (" + attribute.getType() + ").");
@@ -396,15 +391,7 @@ public class BeansUtils {
 
 		Class<?> attributeClass;
 		try {
-			// convert internal "large" types to generic java types
-			if (Objects.equals(type, BeansUtils.largeStringClassName)) {
-				attributeClass = Class.forName(String.class.getName());
-			} else if (Objects.equals(type, BeansUtils.largeArrayListClassName)) {
-				attributeClass = Class.forName(ArrayList.class.getName());
-			} else {
-				// is already generic java type
-				attributeClass = Class.forName(type);
-			}
+			attributeClass = Class.forName(type);
 		} catch (ClassNotFoundException e) {
 			throw new InternalErrorException("Unknown attribute type", e);
 		} catch (NoClassDefFoundError e) {

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/CoreConfig.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/CoreConfig.java
@@ -503,12 +503,12 @@ public class CoreConfig {
 				case "entitlement":
 					attr.setDisplayName("eduPersonEntitlement");
 					attr.setDescription("Entitlements of user (aka group memberships).");
-					attr.setType(BeansUtils.largeStringClassName);
+					attr.setType(String.class.getName());
 					break;
 				case "assurance":
 					attr.setDisplayName("eduPersonAssurance");
 					attr.setDescription("Assurance about user as defined at: https://wiki.refeds.org/display/ASS/REFEDS+Assurance+Framework+ver+1.0");
-					attr.setType(BeansUtils.largeStringClassName);
+					attr.setType(String.class.getName());
 					break;
 				case "europeanStudentID":
 					attr.setDisplayName("European Student ID");
@@ -529,7 +529,7 @@ public class CoreConfig {
 				case "certificate":
 					attr.setDisplayName("X509 certificate");
 					attr.setDescription("PEM encoded X509 certificate");
-					attr.setType(BeansUtils.largeStringClassName);
+					attr.setType(String.class.getName());
 					break;
 				case "additionalIdentifiers":
 					attr.setDisplayName("Additional Identifiers");

--- a/perun-base/src/test/resources/test-schema.sql
+++ b/perun-base/src/test/resources/test-schema.sql
@@ -2,7 +2,7 @@ set database sql syntax PGS true;
 -- fix unique index on authz, since PGS compatibility doesn't allow coalesce call in index and treats nulls in columns as different values.
 SET DATABASE SQL UNIQUE NULLS FALSE;
 
--- database version 3.1.73 (don't forget to update insert statement at the end of file)
+-- database version 3.1.74 (don't forget to update insert statement at the end of file)
 
 -- VOS - virtual organizations
 create table vos (
@@ -1642,7 +1642,7 @@ CREATE INDEX ufauv_idx ON user_facility_attr_u_values (user_id, facility_id, att
 CREATE INDEX vauv_idx ON vo_attr_u_values (vo_id, attr_id) ;
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.1.73');
+insert into configurations values ('DATABASE VERSION','3.1.74');
 insert into membership_types (id, membership_type, description) values (1, 'DIRECT', 'Member is directly added into group');
 insert into membership_types (id, membership_type, description) values (2, 'INDIRECT', 'Member is added indirectly through UNION relation');
 insert into action_types (id, action_type, description) values (nextval('action_types_seq'), 'read', 'Can read value.');

--- a/perun-cli/Perun/beans/Attribute.pm
+++ b/perun-cli/Perun/beans/Attribute.pm
@@ -228,12 +228,8 @@ sub getType
 		$type = 'integer';
 	} elsif ($type eq 'java.lang.String') {
 		$type = 'string';
-	} elsif ($type eq 'java.lang.LargeString') {
-		$type = 'largestring';
 	} elsif ($type eq 'java.util.ArrayList') {
 		$type = 'array';
-	}  elsif ($type eq 'java.util.LargeArrayList') {
-		$type = 'largearray';
 	} elsif ($type eq 'java.util.LinkedHashMap') {
 		$type = 'hash';
 	} elsif ($type eq 'java.lang.Boolean') {
@@ -252,12 +248,8 @@ sub setType
 		$type = 'java.lang.Integer';
 	} elsif ($type eq 'string') {
 		$type = 'java.lang.String';
-	} elsif ($type eq 'largestring') {
-		$type = 'java.lang.LargeString';
 	} elsif ($type eq 'array') {
 		$type = 'java.util.ArrayList';
-	} elsif ($type eq 'largearray') {
-		$type = 'java.util.LargeArrayList';
 	} elsif ($type eq 'hash') {
 		$type = 'java.util.LinkedHashMap';
 	} elsif ($type eq 'boolean') {
@@ -304,7 +296,7 @@ sub setValueFromArray {
 	my $attribute = shift; #self
 
 	switch ($attribute->getType) {
-		case /^string$|^largestring$/ {
+		case /^string$/ {
 			if (scalar @_ > 1) { Perun::Common::printMessage(
 				"More than one value passed as attribute value. Taking first one and ignoring the rest.", $::batch); }
 			$attribute->setValue( $_[0] );
@@ -329,7 +321,7 @@ sub setValueFromArray {
 					"Value is not of boolean type, please use numbers 1/0 or strings true/false as input.", $::batch);
 			}
 		}
-		case /^array$|^largearray$/ {
+		case /^array$/ {
 			$attribute->setValue( \@_ );
 		}
 		case "hash" {

--- a/perun-cli/Perun/beans/AttributeDefinition.pm
+++ b/perun-cli/Perun/beans/AttributeDefinition.pm
@@ -190,12 +190,8 @@ sub getType
 		$type = 'integer';
 	} elsif ($type eq 'java.lang.String') {
 		$type = 'string';
-	} elsif ($type eq 'java.lang.LargeString') {
-		$type = 'largestring';
 	} elsif ($type eq 'java.util.ArrayList') {
 		$type = 'array';
-	}  elsif ($type eq 'java.util.LargeArrayList') {
-		$type = 'largearray';
 	} elsif ($type eq 'java.util.LinkedHashMap') {
 		$type = 'hash';
 	} elsif ($type eq 'java.lang.Boolean') {
@@ -214,12 +210,8 @@ sub setType
 		$type = 'java.lang.Integer';
 	} elsif ($type eq 'string') {
 		$type = 'java.lang.String';
-	} elsif ($type eq 'largestring') {
-		$type = 'java.lang.LargeString';
 	} elsif ($type eq 'array') {
 		$type = 'java.util.ArrayList';
-	} elsif ($type eq 'largearray') {
-		$type = 'java.util.LargeArrayList';
 	} elsif ($type eq 'hash') {
 		$type = 'java.util.LinkedHashMap';
 	} elsif ($type eq 'boolean') {

--- a/perun-cli/createAttribute
+++ b/perun-cli/createAttribute
@@ -14,13 +14,11 @@ sub help {
 	--attributeName       | -N attribute friendly name
 	--attributeNameSpace  | -n namespace (e.g.: urn:perun:user:attribute-def:def)
 	--attributeDisplayName| -e attribute display name
-	--attributeType       | -t attribute type (integer/string/array/hash/boolean/largestring/largearray)*
+	--attributeType       | -t attribute type (integer/string/array/hash/boolean)
 	--attributeDsc        | -d description
 	--isUnique            | -u attribute have to be unique
 	--batch               | -b batch
 	--help                | -h prints this help
-
-	*) If you expect values larger than 4000 chars, you should user large version of string/array.
 
 	};
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -2423,10 +2423,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 
 		//check if attribute.type is valid class name
 		try {
-			if (!attribute.getType().equals(BeansUtils.largeStringClassName) &&
-					!attribute.getType().equals(BeansUtils.largeArrayListClassName)) {
-				Class.forName(attribute.getType());
-			}
+			Class.forName(attribute.getType());
 		} catch (ClassNotFoundException ex) {
 			throw new InternalErrorException("Wrong attribute type", ex);
 		} catch (RuntimeException ex) {
@@ -5406,8 +5403,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 
 	@Override
 	public Object stringToAttributeValue(String value, String type) {
-		if (type.equals(ArrayList.class.getName()) || type.equals(LinkedHashMap.class.getName()) ||
-				type.equals(BeansUtils.largeArrayListClassName)) {
+		if (type.equals(ArrayList.class.getName()) || type.equals(LinkedHashMap.class.getName())) {
 			if (value != null && !value.isEmpty() && !value.endsWith(String.valueOf(AttributesManagerImpl.LIST_DELIMITER))) {
 				value = value.concat(String.valueOf(AttributesManagerImpl.LIST_DELIMITER));
 			}
@@ -5543,7 +5539,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 			return storedAttribute;
 
 		// Check type ArrayList
-		if (attribute.getType().equals(ArrayList.class.getName()) || attribute.getType().equals(BeansUtils.largeArrayListClassName)) {
+		if (attribute.getType().equals(ArrayList.class.getName())) {
 			ArrayList<String> updatedList = (ArrayList<String>) storedAttribute.getValue();
 			// If there were someting then find values which haven't been already stored
 			if (updatedList != null) {
@@ -7699,7 +7695,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		//urn_perun_entityless_attribute_def_def_randomPwdResetTemplate
 		attr = new AttributeDefinition();
 		attr.setNamespace(AttributesManager.NS_ENTITYLESS_ATTR_DEF);
-		attr.setType("java.lang.LargeString");
+		attr.setType(String.class.getName());
 		attr.setFriendlyName("randomPwdResetTemplate");
 		attr.setDisplayName("Random password reset templates");
 		attr.setDescription("Random password reset templates. Each value should be String representing an HTML page." +
@@ -7720,7 +7716,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 
 		attr = new AttributeDefinition();
 		attr.setNamespace(AttributesManager.NS_ENTITYLESS_ATTR_DEF);
-		attr.setType("java.lang.LargeString");
+		attr.setType(String.class.getName());
 		attr.setFriendlyName("preferredMailChangeMailTemplate");
 		attr.setDisplayName("PreferredMail change mail template");
 		attr.setDescription("Template of the preferred mail change notification. Keyword {link} will be replaced with the link to verify new mail address.");
@@ -7763,7 +7759,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 
 			attr = new AttributeDefinition();
 			attr.setNamespace(AttributesManager.NS_ENTITYLESS_ATTR_DEF);
-			attr.setType("java.lang.LargeString");
+			attr.setType(String.class.getName());
 			attr.setFriendlyName("nonAuthzPwdResetConfirmMailTemplate:"+namespace);
 			attr.setDisplayName("Non-Authz Pwd Reset Confirmation Mail Template");
 			attr.setDescription("Template of confirmation message in password reset notification.");
@@ -7783,7 +7779,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 
 			attr = new AttributeDefinition();
 			attr.setNamespace(AttributesManager.NS_ENTITYLESS_ATTR_DEF);
-			attr.setType("java.lang.LargeString");
+			attr.setType(String.class.getName());
 			attr.setFriendlyName("nonAuthzPwdResetMailTemplate:"+namespace);
 			attr.setDisplayName("Non-Authz Pwd Reset Mail Template");
 			attr.setDescription("Non authz password reset mail template for "+namespace+".");

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/PerunBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/PerunBlImpl.java
@@ -201,7 +201,7 @@ public class PerunBlImpl implements PerunBl {
 					}
 
 					//for Array list attributes try to parse string value into individual fields
-					if(attributeWithValue.getType().equals(ArrayList.class.getName()) || attributeWithValue.getType().equals(BeansUtils.largeArrayListClassName)) {
+					if(attributeWithValue.getType().equals(ArrayList.class.getName())) {
 						List<String> value = new ArrayList<>();
 						if (attrValue != null) {
 							value = new ArrayList<>(Arrays.asList(attrValue.split(UsersManagerBl.MULTIVALUE_ATTRIBUTE_SEPARATOR_REGEX)));

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
@@ -151,9 +151,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 			Integer.class.getName(),
 			Boolean.class.getName(),
 			ArrayList.class.getName(),
-			LinkedHashMap.class.getName(),
-			BeansUtils.largeStringClassName,
-			BeansUtils.largeArrayListClassName
+			LinkedHashMap.class.getName()
 	);
 
 	static {
@@ -367,7 +365,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 			//noinspection StatementWithEmptyBody
 			if (value == null) {
 				// No need to convert NULL value (for String it caused NULL->"null" conversion)
-			} else if ((attribute.getType().equals(String.class.getName()) || attribute.getType().equals(BeansUtils.largeStringClassName)) && !(value instanceof String)) {
+			} else if ((attribute.getType().equals(String.class.getName())) && !(value instanceof String)) {
 				//TODO check exceptions
 				value = String.valueOf(value);
 			} else //noinspection StatementWithEmptyBody
@@ -376,7 +374,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 				} else //noinspection StatementWithEmptyBody
 					if (attribute.getType().equals(Boolean.class.getName()) && !(value instanceof Boolean)) {
 						//TODO try to cast to boolean
-					} else if ((attribute.getType().equals(ArrayList.class.getName()) || attribute.getType().equals(BeansUtils.largeArrayListClassName)) && !(value instanceof ArrayList)) {
+					} else if (attribute.getType().equals(ArrayList.class.getName()) && !(value instanceof ArrayList)) {
 						if (value instanceof List) {
 							//noinspection unchecked
 							value = new ArrayList<String>((List) value);
@@ -1862,7 +1860,6 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 		String sql = "INSERT INTO " + tableName + " (attr_value," + buildParameters(columnNames, "", ", ") + ") VALUES (?" + questionMarks + ")";
 			switch (attribute.getType()) {
 				case "java.util.ArrayList":
-				case BeansUtils.largeArrayListClassName:
 					for (String value : (List<String>) attribute.getValue()) {
 						sqlArgs[0] = value;
 						tryToInsertUniqueValue(sql,sqlArgs, attribute, pb1, pb2);
@@ -4545,13 +4542,11 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 		HashSet<Pair<Integer,Integer>> ids = new HashSet<>();
 		switch(attribute.getType()) {
 			case "java.lang.String":
-			case BeansUtils.largeStringClassName:
 			case "java.lang.Integer":
 			case "java.lang.Boolean":
 				ids.addAll(jdbc.query(sql, pairRowMapper, attribute.getId(), attribute.getValue().toString()));
 				break;
 			case "java.util.ArrayList":
-			case BeansUtils.largeArrayListClassName:
 				for(String value : attribute.valueAsList()) {
 					ids.addAll(jdbc.query(sql, pairRowMapper,attribute.getId(),value));
 				}
@@ -4585,13 +4580,11 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 						Utils.notNull(value, "value");
 						switch (attrDef.getType()) {
 							case "java.lang.String":
-							case BeansUtils.largeStringClassName:
 							case "java.lang.Integer":
 							case "java.lang.Boolean":
 								jdbc.update("INSERT INTO " + tablePrefix + "_attr_u_values (" + bean + "_id,attr_id,attr_value) VALUES (?,?,?)", beanId, attrDef.getId(), value.toString());
 								break;
 							case "java.util.ArrayList":
-							case BeansUtils.largeArrayListClassName:
 								@SuppressWarnings("unchecked") ArrayList<String> list = (ArrayList<String>) value;
 								for (String s : list) {
 									jdbc.update("INSERT INTO " + tablePrefix + "_attr_u_values (" + bean + "_id,attr_id,attr_value) VALUES (?,?,?)", beanId, attrDef.getId(), s);
@@ -4625,13 +4618,11 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 						Utils.notNull(value, "value");
 						switch (attrDef.getType()) {
 							case "java.lang.String":
-							case BeansUtils.largeStringClassName:
 							case "java.lang.Integer":
 							case "java.lang.Boolean":
 								jdbc.update("INSERT INTO " + tablePrefix + "_attr_u_values (" + bean1 + "_id," + bean2 + "_id,attr_id,attr_value) VALUES (?,?,?,?)", bean1Id, bean2Id, attrDef.getId(), value.toString());
 								break;
 							case "java.util.ArrayList":
-							case BeansUtils.largeArrayListClassName:
 								@SuppressWarnings("unchecked") ArrayList<String> list = (ArrayList<String>) value;
 								for (String s : list) {
 									jdbc.update("INSERT INTO " + tablePrefix + "_attr_u_values (" + bean1 + "_id," + bean2 + "_id,attr_id,attr_value) VALUES (?,?,?,?)", bean1Id, bean2Id, attrDef.getId(), s);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/SearcherImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/SearcherImpl.java
@@ -209,7 +209,7 @@ public class SearcherImpl implements SearcherImplApi {
 					whereClauses.add("nam" + counter + ".type=:n" + counter + " ");
 					parameters.addValue("n" + counter, Integer.class.getName());
 					parameters.addValue("v" + counter, BeansUtils.attributeValueToString(key));
-				} else if (key.getType().equals(String.class.getName()) || key.getType().equals(BeansUtils.largeStringClassName)) {
+				} else if (key.getType().equals(String.class.getName())) {
 					key.setValue(value);
 					if(allowPartialMatchForString) {
 						whereClauses.add("lower(" + Compatibility.convertToAscii("val" + counter + ".attr_value") + ") LIKE CONCAT('%', CONCAT(lower(" + Compatibility.convertToAscii(":v" + counter) + "), '%')) ");
@@ -225,7 +225,7 @@ public class SearcherImpl implements SearcherImplApi {
 					whereClauses.add("nam" + counter + ".type=:n" + counter + " ");
 					parameters.addValue("n" + counter, Boolean.class.getName());
 					parameters.addValue("v" + counter, BeansUtils.attributeValueToString(key));
-				} else if (key.getType().equals(ArrayList.class.getName()) || key.getType().equals(BeansUtils.largeArrayListClassName)) {
+				} else if (key.getType().equals(ArrayList.class.getName())) {
 					List<String> list = new ArrayList<>();
 					list.add(value);
 					key.setValue(list);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/UsersManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/UsersManagerImpl.java
@@ -787,8 +787,7 @@ public class UsersManagerImpl implements UsersManagerImplApi {
 	public List<User> getUsersByAttributeValue(PerunSession sess, AttributeDefinition attributeDefinition, String attributeValue) {
 		String value = "";
 		String operator = "=";
-		if (attributeDefinition.getType().equals(String.class.getName()) ||
-				attributeDefinition.getType().equals(BeansUtils.largeStringClassName)) {
+		if (attributeDefinition.getType().equals(String.class.getName())) {
 			value = attributeValue.trim();
 			operator = "=";
 		} else if (attributeDefinition.getType().equals(Integer.class.getName())) {
@@ -797,8 +796,7 @@ public class UsersManagerImpl implements UsersManagerImplApi {
 		}  else if (attributeDefinition.getType().equals(Boolean.class.getName())) {
 			value = attributeValue.trim();
 			operator = "=";
-		} else if (attributeDefinition.getType().equals(ArrayList.class.getName()) ||
-				attributeDefinition.getType().equals(BeansUtils.largeArrayListClassName)) {
+		} else if (attributeDefinition.getType().equals(ArrayList.class.getName())) {
 			value = "%" + attributeValue.trim() + "%";
 			operator = "like";
 		} else if (attributeDefinition.getType().equals(LinkedHashMap.class.getName())) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_vo_attribute_def_def_aup.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_vo_attribute_def_def_aup.java
@@ -51,7 +51,7 @@ public class urn_perun_vo_attribute_def_def_aup extends VoAttributesModuleAbstra
 		attr.setNamespace(AttributesManager.NS_VO_ATTR_DEF);
 		attr.setFriendlyName("aup");
 		attr.setDisplayName("AUP");
-		attr.setType(BeansUtils.largeStringClassName);
+		attr.setType(String.class.getName());
 		attr.setDescription("Contains all custom AUPs used at VO level.");
 		return attr;
 	}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/FacilitiesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/FacilitiesManagerImplApi.java
@@ -335,7 +335,6 @@ public interface FacilitiesManagerImplApi {
 
 	/**
 	 * Returns all facilities which have set the attribute with the value. Searching only def and opt attributes.
-	 * Large attributes are not supported.
 	 *
 	 * @param sess
 	 * @param attribute

--- a/perun-core/src/main/resources/hsqldbChangelog.txt
+++ b/perun-core/src/main/resources/hsqldbChangelog.txt
@@ -3,6 +3,9 @@
 
 -- this update is not supported on hsql since its used only as in-memory db
 
+3.1.74
+UPDATE configurations SET value='3.1.74' WHERE property='DATABASE VERSION';
+
 3.1.73
 update configurations set value='3.1.73' where property='DATABASE VERSION';
 

--- a/perun-core/src/main/resources/postgresChangelog.txt
+++ b/perun-core/src/main/resources/postgresChangelog.txt
@@ -6,6 +6,11 @@
 -- Directly under version number should be version commands. They will be executed in the order they are written here.
 -- Comments are prefixed with -- and can be written only between version blocks, that means not in the lines with commands. They have to be at the start of the line.
 
+3.1.74
+UPDATE attr_names SET type='java.lang.String' WHERE type='java.lang.LargeString';
+UPDATE attr_names SET type='java.util.ArrayList' WHERE type='java.util.LargeArrayList';
+UPDATE configurations SET value='3.1.74' WHERE property='DATABASE VERSION';
+
 3.1.73
 ALTER TABLE pwdreset ADD COLUMN validity_to timestamp;
 UPDATE pwdreset SET validity_to = created_at + interval '1 days';

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/AttributesManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/AttributesManagerEntryIntegrationTest.java
@@ -5390,7 +5390,6 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 			if (bean.equals("entityless")) continue;
 
 			for (String type : AttributesManagerImpl.ATTRIBUTE_TYPES) {
-				//large string and large array are unsupported types for uniqueness
 
 				log.debug("conversion to unique bean {} type {}", bean, type);
 				String namespace = AttributesManagerImpl.BEANS_TO_NAMESPACES_MAP.get(bean) + ":def";
@@ -5414,7 +5413,6 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 				Attribute b = new Attribute(attributeDefinition);
 				switch (type) {
 					case "java.lang.String":
-					case BeansUtils.largeStringClassName:
 						a.setValue("string1");
 						b.setValue("string2");
 						break;
@@ -5427,7 +5425,6 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 						b.setValue(Boolean.TRUE);
 						break;
 					case "java.util.ArrayList":
-					case BeansUtils.largeArrayListClassName:
 						a.setValue(new ArrayList<>(Arrays.asList("value1","value2")));
 						b.setValue(new ArrayList<>(Arrays.asList("value3","value4")));
 						break;
@@ -5627,7 +5624,6 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 				Attribute b = new Attribute(attributeDefinition);
 				switch (type) {
 					case "java.lang.String":
-					case BeansUtils.largeStringClassName:
 						a.setValue("samestring");
 						b.setValue("samestring");
 						break;
@@ -5640,7 +5636,6 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 						b.setValue(Boolean.TRUE);
 						break;
 					case "java.util.ArrayList":
-					case BeansUtils.largeArrayListClassName:
 						a.setValue(Lists.newArrayList("value1","value2"));
 						b.setValue(Lists.newArrayList("value3","value2"));
 						break;

--- a/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/model/impl/MultipleAttributeValueExtractor.java
+++ b/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/model/impl/MultipleAttributeValueExtractor.java
@@ -19,7 +19,7 @@ public class MultipleAttributeValueExtractor<T extends PerunBean> extends Attrib
 		for (Attribute attribute : attributes) {
 			if (this.appliesToAttribute(attribute)) {
 				if (attribute == null) return null;
-				if (attribute.getType().equals(ArrayList.class.getName()) || attribute.getType().equals(BeansUtils.largeArrayListClassName)) {
+				if (attribute.getType().equals(ArrayList.class.getName())) {
 					List<String> values = attribute.valueAsList();
 					if (values == null || values.size() == 0)
 						return null;
@@ -49,7 +49,7 @@ public class MultipleAttributeValueExtractor<T extends PerunBean> extends Attrib
 						}
 					}
 				} else {
-					// use toString() for String, LargeString, Integer nad Boolean types
+					// use toString() for String, Integer nad Boolean types
 					Object value = attribute.getValue();
 					if (value == null)
 						return null;

--- a/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/model/impl/SingleAttributeValueExtractor.java
+++ b/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/model/impl/SingleAttributeValueExtractor.java
@@ -18,7 +18,7 @@ public class SingleAttributeValueExtractor<T extends PerunBean> extends Attribut
 		for (Attribute attribute : attributes) {
 			if (this.appliesToAttribute(attribute)) {
 				if (attribute == null) return null;
-				if (attribute.getType().equals(ArrayList.class.getName()) || attribute.getType().equals(BeansUtils.largeArrayListClassName)) {
+				if (attribute.getType().equals(ArrayList.class.getName())) {
 					List<String> values = attribute.valueAsList();
 					if (values == null || values.size() == 0)
 						return null;
@@ -33,7 +33,7 @@ public class SingleAttributeValueExtractor<T extends PerunBean> extends Attribut
 						result = (valueTransformer == null)
 								? values.toString() : valueTransformer.getValue(values, attribute);
 				} else {
-					// use toString() for String, LargeString, Integer nad Boolean types
+					// use toString() for String, Integer nad Boolean types
 					Object value = attribute.getValue();
 					if (value == null)
 						return null;

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
@@ -461,7 +461,7 @@ public class RegistrarManagerImpl implements RegistrarManager {
 			attrDef.setFriendlyName("voLogoURL");
 			attrDef.setNamespace("urn:perun:vo:attribute-def:def");
 			attrDef.setDescription("Full URL of the VO's logo image (including https://) or base64 encoded data like: 'data:image/png;base64,....'");
-			attrDef.setType(BeansUtils.largeStringClassName);
+			attrDef.setType(String.class.getName());
 			attrDef = attrManager.createAttribute(registrarSession, attrDef);
 			// set attribute rights
 			List<AttributeRights> rights = new ArrayList<>();
@@ -3224,7 +3224,7 @@ public class RegistrarManagerImpl implements RegistrarManager {
 					if (a.getType().equalsIgnoreCase(LinkedHashMap.class.getName())) {
 						// FIXME do not set hash map attributes - not supported in GUI and registrar
 						continue;
-					} else if (a.getType().equalsIgnoreCase(ArrayList.class.getName()) || a.getType().equalsIgnoreCase(BeansUtils.largeArrayListClassName)) {
+					} else if (a.getType().equalsIgnoreCase(ArrayList.class.getName())) {
 						// we expects that list contains strings
 						ArrayList<String> value = a.valueAsList();
 						// if value not present in list => add

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/AttributesManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/AttributesManagerMethod.java
@@ -1412,7 +1412,7 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	 * @param namespace String namespace in URN format
 	 * @param description String description
 	 * @param type String type which is one of the: "java.lang.String", "java.lang.Integer", "java.lang.Boolean", "java.util.ArrayList",
-	 *                                              "java.util.LinkedHashMap", "java.lang.LargeString" or "java.util.LargeArrayList"
+	 *                                              "java.util.LinkedHashMap"
 	 * @param displayName String displayName
 	 * @param unique Boolean unique
 	 * @return AttributeDefinition Created AttributeDefinition

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/FacilitiesManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/FacilitiesManagerMethod.java
@@ -122,7 +122,7 @@ public enum FacilitiesManagerMethod implements ManagerMethod {
 
 	/*#
 	 * Returns all facilities that have set the attribute 'attributeName' with the value 'attributeValue'.
-	 * Searching only def and opt attributes. Large attributes are not supported.
+	 * Searching only def and opt attributes.
 	 *
 	 * @param attributeName String
 	 * @param attributeValue String

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/UsersManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/UsersManagerMethod.java
@@ -811,11 +811,11 @@ public enum UsersManagerMethod implements ManagerMethod {
 
 					if(attr.getType().equals(Integer.class.getName())) {
 						attr.setValue(parms.readInt("attributeValue"));
-					} else if(attr.getType().equals(String.class.getName()) || attr.getType().equals(BeansUtils.largeStringClassName)) {
+					} else if(attr.getType().equals(String.class.getName())) {
 						attr.setValue(parms.readString("attributeValue"));
 					} else if(attr.getType().equals(Boolean.class.getName())) {
 						attr.setValue(parms.readBoolean("attributeValue"));
-					} else if(attr.getType().equals(ArrayList.class.getName()) || attr.getType().equals(BeansUtils.largeArrayListClassName)) {
+					} else if(attr.getType().equals(ArrayList.class.getName())) {
 						attr.setValue(parms.readList("attributeValue", String.class));
 					} else if(attr.getType().equals(LinkedHashMap.class.getName())) {
 						attr.setValue(parms.read("attributeValue", LinkedHashMap.class));

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/UiElements.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/UiElements.java
@@ -429,11 +429,11 @@ public class UiElements {
 
 		String text = "";
 		String name = object.getDisplayName();
-		if (object.getType().equalsIgnoreCase("java.lang.String") || object.getType().equalsIgnoreCase(Utils.largeStringClassName)) {
+		if (object.getType().equalsIgnoreCase("java.lang.String")) {
 			text = WidgetTranslation.INSTANCE.cantSaveAttributeValueDialogBoxWrongString(name);
 		} else if (object.getType().equalsIgnoreCase("java.lang.Integer")) {
 			text = WidgetTranslation.INSTANCE.cantSaveAttributeValueDialogBoxWrongInteger(name);
-		} else if (object.getType().equalsIgnoreCase("java.util.ArrayList") || object.getType().equalsIgnoreCase(Utils.largeArrayListClassName)) {
+		} else if (object.getType().equalsIgnoreCase("java.util.ArrayList")) {
 			text = WidgetTranslation.INSTANCE.cantSaveAttributeValueDialogBoxWrongList(name);
 		} else {
 			text = WidgetTranslation.INSTANCE.cantSaveAttributeValueDialogBoxGeneral(name);

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/resources/Utils.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/resources/Utils.java
@@ -33,9 +33,6 @@ public class Utils {
 	private static final RegExp firstNamePattern = RegExp.compile("^(["+pL+"'-]+)$");
 	private static final RegExp lastNamePattern = RegExp.compile("^((["+pL+"'-]+)|(["+pL+"][.]))$");
 
-	public final static String largeStringClassName = "java.lang.LargeString";
-	public final static String largeArrayListClassName = "java.util.LargeArrayList";
-
 	/**
 	 * Try to parse rawName to keys: "titleBefore" "firstName" "lastName" "titleAfter"
 	 *

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/Attribute.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/Attribute.java
@@ -228,7 +228,7 @@ public class Attribute extends JavaScriptObject {
 				return false;
 			}
 		}
-		if (this.type == "java.util.ArrayList" || this.type == "java.util.LargeArrayList") {
+		if (this.type == "java.util.ArrayList") {
 			this.value = [];
 			var count = 0;
 			var input = "";

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/attributestabs/CreateAttributeDefinitionTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/attributestabs/CreateAttributeDefinitionTabItem.java
@@ -168,8 +168,6 @@ public class CreateAttributeDefinitionTabItem implements TabItem {
 		typeListBox.addItem("Boolean", "java.lang.Boolean");
 		typeListBox.addItem("Array", "java.util.ArrayList");
 		typeListBox.addItem("LinkedHashMap", "java.util.LinkedHashMap");
-		typeListBox.addItem("LargeString", Utils.largeStringClassName);
-		typeListBox.addItem("LargeArrayList", Utils.largeArrayListClassName);
 
 		// prepare layout for this tab
 		FlexTable layout = new FlexTable();

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/entitylessattributestabs/EntitylessAttributeEditKeyTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/entitylessattributestabs/EntitylessAttributeEditKeyTabItem.java
@@ -390,14 +390,6 @@ public class EntitylessAttributeEditKeyTabItem implements TabItem, TabItemWithUr
 			case "java.lang.Boolean":
 				newAttr.put("value", JSONBoolean.getInstance(Boolean.parseBoolean("True")));
 				break;
-			case "java.lang.LargeString":
-				newAttr.put("value", new JSONString(value));
-				break;
-			case "java.util.LargeArrayList":
-				JSONArray lal = new JSONArray();
-				lal.set(0, new JSONString("value"));
-				newAttr.put("value", lal);
-				break;
 		}
 
 		// create whole JSON query
@@ -412,8 +404,7 @@ public class EntitylessAttributeEditKeyTabItem implements TabItem, TabItemWithUr
 
 	private boolean shouldHaveValueBox() {
 		return (attrDef.getType().equals("java.lang.String") ||
-				attrDef.getType().equals("java.lang.Integer") ||
-				attrDef.getType().equals("java.lang.LargeString"));
+				attrDef.getType().equals("java.lang.Integer"));
 	}
 
 	static public EntitylessAttributeEditKeyTabItem load(Map<String, String> parameters) {

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/widgets/cells/PerunAttributeValueCell.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/widgets/cells/PerunAttributeValueCell.java
@@ -244,7 +244,7 @@ public class PerunAttributeValueCell extends AbstractSafeHtmlCell<Attribute> {
 		if (attr.getType().equals("java.lang.Boolean")) {
 			return generateValueFromBoolean(attr, getUniqueCellId(attr));
 		}
-		if (attr.getType().equals("java.util.ArrayList") || attr.getType().equals(Utils.largeArrayListClassName)) {
+		if (attr.getType().equals("java.util.ArrayList") ) {
 			return generateValueFromList(attr, getUniqueCellId(attr));
 		}
 
@@ -402,7 +402,7 @@ public class PerunAttributeValueCell extends AbstractSafeHtmlCell<Attribute> {
 			return generateNumberBox(attr.getValue(), attr.isWritable());
 		} else if (attr.getType().equals("java.lang.Boolean")) {
 			return generateCheckBox(attr.getValue(), attr.isWritable());
-		} else if (attr.getType().equals("java.util.ArrayList") || attr.getType().equals(Utils.largeArrayListClassName)) {
+		} else if (attr.getType().equals("java.util.ArrayList")) {
 			return generateList(attr.getValueAsJsArray(), attr.isWritable());
 		}
 


### PR DESCRIPTION
- large attributes are no longer needed. Therefore, they were removed
  from the whole perun-core code.
- DB changelog updated. All large attribute types were converted to a
  normal type.