### PR TITLE
create audit log message when removing service from resource

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ResourcesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ResourcesManagerBlImpl.java
@@ -239,7 +239,7 @@ public class ResourcesManagerBlImpl implements ResourcesManagerBl {
 		List<Service> services = getAssignedServices(sess, resource);
 		for (Service service: services) {
 			try {
-				getResourcesManagerImpl().removeService(sess, resource, service);
+				this.removeService(sess, resource, service);
 			} catch (ServiceNotAssignedException e) {
 				throw new ConsistencyErrorException(e);
 			}


### PR DESCRIPTION
In ResourceManagerBlImpl::deleteResource(), call removeService() from Bl instead of Impl so that appropriate audit message is logged.