### PR TITLE
Fixewd method getMembersWhereUserIsInRoles

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AuthzResolverImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AuthzResolverImpl.java
@@ -988,8 +988,8 @@ public class AuthzResolverImpl implements AuthzResolverImplApi {
 		try {
 			return new HashSet<>(namedParameterJdbcTemplate.query("select " + memberMappingSelectQuery + " from authz join members on authz.member_id=members.id " +
 					" left outer join groups_members on groups_members.group_id=authz.authorized_group_id " +
-					" left outer join members on members.id=groups_members.member_id " +
-					" where (authz.user_id=:uid or members.user_id=:uid) and authz.role_id in " +
+					" left outer join members m on m.id=groups_members.member_id " +
+					" where (authz.user_id=:uid or m.user_id=:uid) and authz.role_id in " +
 					"(select id from roles where name in (:roles))",
 				parameters, MEMBER_MAPPER));
 		} catch (RuntimeException ex) {


### PR DESCRIPTION
-Method getMembersWhereUserIsInRoles in AuthzResolverImpl had wrong SQL
 command. It was joining table members twice which is not allowed in
 PostgreSQL. Thi was not discovered earlier, because HSQL database does
 not have problem with it. However when it would be used in production
 it would failed I assume.
- Therefore for the second join was used alias for members table which
  is also used in where clause.
- As we do not have use case for this method yet (we do not store any
  roles applied to members in authz table), I have tested it manualy on
  fictional use case.