### PR TITLE
Fixed async validation when creating sponsored member

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/Validation.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/Validation.java
@@ -1,0 +1,12 @@
+package cz.metacentrum.perun.core.api;
+
+/**
+ * Switch to choose between sync or async or none member validation in all member creation-like methods.
+ *
+ * @author Pavel Zlámal <zlamal@cesnet.cz>
+ */
+public enum Validation {
+	NONE,
+	SYNC,
+	ASYNC
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/MembersManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/MembersManager.java
@@ -322,7 +322,7 @@ public interface MembersManager {
 	/**
 	 * Create new member from user by login and ExtSource.
 	 *
-	 * <strong>This method runs asynchronously</strong>
+	 * <strong>This method validates member asynchronously</strong>
 	 *
 	 * @param sess
 	 * @param vo
@@ -346,7 +346,7 @@ public interface MembersManager {
 	 *
 	 * Also add this member to groups in list.
 	 *
-	 * <strong>This method runs asynchronously</strong>
+	 * <strong>This method validates member asynchronously</strong>
 	 *
 	 * @param sess
 	 * @param vo

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/MembersManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/MembersManagerBl.java
@@ -16,6 +16,7 @@ import cz.metacentrum.perun.core.api.Sponsorship;
 import cz.metacentrum.perun.core.api.Status;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.UserExtSource;
+import cz.metacentrum.perun.core.api.Validation;
 import cz.metacentrum.perun.core.api.Vo;
 import cz.metacentrum.perun.core.api.exceptions.AlreadyMemberException;
 import cz.metacentrum.perun.core.api.exceptions.AlreadySponsorException;
@@ -1450,7 +1451,7 @@ public interface MembersManagerBl {
 	 * @param sponsor sponsoring user
 	 * @param sendActivationLink if true link for manual activation of account will be send to the email
 	 *                           be careful when using with empty (no-reply) email
-	 * @param asyncValidation
+	 * @param validation Type of validation, when using Validation.ASYNC do not call this method in a cycle!
 	 * @param url base URL of Perun Instance
 	 * @return created member
 	 * @throws InternalErrorException
@@ -1464,7 +1465,7 @@ public interface MembersManagerBl {
 	 * @throws UserNotInRoleException if the member is not in required role
 	 * @throws AlreadySponsorException
 	 */
-	Member createSponsoredMember(PerunSession session, Vo vo, String namespace, Map<String, String> name, String password, String email, User sponsor, boolean sendActivationLink, String url, boolean asyncValidation) throws AlreadyMemberException, LoginNotExistsException, PasswordCreationFailedException, ExtendMembershipException, WrongAttributeValueException, ExtSourceNotExistsException, WrongReferenceAttributeValueException, UserNotInRoleException, PasswordStrengthException, InvalidLoginException, AlreadySponsorException;
+	Member createSponsoredMember(PerunSession session, Vo vo, String namespace, Map<String, String> name, String password, String email, User sponsor, boolean sendActivationLink, String url, Validation validation) throws AlreadyMemberException, LoginNotExistsException, PasswordCreationFailedException, ExtendMembershipException, WrongAttributeValueException, ExtSourceNotExistsException, WrongReferenceAttributeValueException, UserNotInRoleException, PasswordStrengthException, InvalidLoginException, AlreadySponsorException;
 
 	/**
 	 * Creates a new sponsored member.
@@ -1481,7 +1482,7 @@ public interface MembersManagerBl {
 	 * @param sendActivationLink if true link for manual activation of account will be send to the email
 	 *                           be careful when using with empty (no-reply) email
 	 * @param url base URL of Perun Instance
-	 * @param asyncValidation
+	 * @param validation Type of members validation, when using Validation.ASYNC do not call this method in a cycle!
 	 * @return created member
 	 * @throws InternalErrorException
 	 * @throws AlreadyMemberException
@@ -1494,7 +1495,7 @@ public interface MembersManagerBl {
 	 * @throws UserNotInRoleException if the member is not in required role
 	 * @throws AlreadySponsorException
 	 */
-	Member createSponsoredMember(PerunSession session, Vo vo, String namespace, Map<String, String> name, String password, String email, User sponsor, LocalDate validityTo, boolean sendActivationLink, String url, boolean asyncValidation) throws AlreadyMemberException, LoginNotExistsException, PasswordCreationFailedException, ExtendMembershipException, WrongAttributeValueException, ExtSourceNotExistsException, WrongReferenceAttributeValueException, UserNotInRoleException, PasswordStrengthException, InvalidLoginException, AlreadySponsorException;
+	Member createSponsoredMember(PerunSession session, Vo vo, String namespace, Map<String, String> name, String password, String email, User sponsor, LocalDate validityTo, boolean sendActivationLink, String url, Validation validation) throws AlreadyMemberException, LoginNotExistsException, PasswordCreationFailedException, ExtendMembershipException, WrongAttributeValueException, ExtSourceNotExistsException, WrongReferenceAttributeValueException, UserNotInRoleException, PasswordStrengthException, InvalidLoginException, AlreadySponsorException;
 
 	/**
 	 * Creates a sponsored membership for the given user.
@@ -1505,7 +1506,7 @@ public interface MembersManagerBl {
 	 * @param namespace used for selecting external system in which guest user account will be created
 	 * @param password password
 	 * @param sponsor sponsoring user
-	 * @param asyncValidation
+	 * @param validation Type of members validation, when using Validation.ASYNC do not call this method in a cycle!
 	 * @return sponsored member
 	 * @throws AlreadyMemberException
 	 * @throws ExtendMembershipException
@@ -1519,7 +1520,7 @@ public interface MembersManagerBl {
 	 * @throws ExtSourceNotExistsException
 	 * @throws AlreadySponsorException
 	 */
-	Member setSponsoredMember(PerunSession session, Vo vo, User userToBeSponsored, String namespace, String password, User sponsor, LocalDate validityTo, boolean asyncValidation) throws AlreadyMemberException, ExtendMembershipException, UserNotInRoleException, PasswordStrengthException, WrongAttributeValueException, WrongReferenceAttributeValueException, LoginNotExistsException, PasswordCreationFailedException, InvalidLoginException, ExtSourceNotExistsException, AlreadySponsorException;
+	Member setSponsoredMember(PerunSession session, Vo vo, User userToBeSponsored, String namespace, String password, User sponsor, LocalDate validityTo, Validation validation) throws AlreadyMemberException, ExtendMembershipException, UserNotInRoleException, PasswordStrengthException, WrongAttributeValueException, WrongReferenceAttributeValueException, LoginNotExistsException, PasswordCreationFailedException, InvalidLoginException, ExtSourceNotExistsException, AlreadySponsorException;
 
 	/**
 	 * Creates a sponsored membership for the given user.
@@ -1530,7 +1531,7 @@ public interface MembersManagerBl {
 	 * @param namespace used for selecting external system in which guest user account will be created
 	 * @param password password
 	 * @param sponsor sponsoring user
-	 * @param asyncValidation
+	 * @param validation Type of members validation, when using Validation.ASYNC do not call this method in a cycle!
 	 * @return sponsored member
 	 * @throws AlreadyMemberException
 	 * @throws ExtendMembershipException
@@ -1544,7 +1545,7 @@ public interface MembersManagerBl {
 	 * @throws ExtSourceNotExistsException
 	 * @throws AlreadySponsorException
 	 */
-	Member setSponsoredMember(PerunSession session, Vo vo, User userToBeSponsored, String namespace, String password, User sponsor, boolean asyncValidation) throws AlreadyMemberException, ExtendMembershipException, UserNotInRoleException, PasswordStrengthException, WrongAttributeValueException, WrongReferenceAttributeValueException, LoginNotExistsException, PasswordCreationFailedException, InvalidLoginException, ExtSourceNotExistsException, AlreadySponsorException;
+	Member setSponsoredMember(PerunSession session, Vo vo, User userToBeSponsored, String namespace, String password, User sponsor, Validation validation) throws AlreadyMemberException, ExtendMembershipException, UserNotInRoleException, PasswordStrengthException, WrongAttributeValueException, WrongReferenceAttributeValueException, LoginNotExistsException, PasswordCreationFailedException, InvalidLoginException, ExtSourceNotExistsException, AlreadySponsorException;
 
 	/**
 	 * Creates new sponsored members.
@@ -1570,13 +1571,13 @@ public interface MembersManagerBl {
 	 * @param sendActivationLink if true link for manual activation of every created sponsored member account will be send
 	 *                           to email which was set for him, be careful when using no-reply emails
 	 * @param url base URL of Perun Instance
-	 * @param asyncValidation switch for easier testing
-	 * @return map of names to map of status, login and password
+	 * @param validation Type of members validation, when ASYNC do not call this method in a cycle!
+	 * @return map of names to map of status, login, password, user and member
 	 */
 	Map<String, Map<String, String>> createSponsoredMembersFromCSV(PerunSession sess, Vo vo, String namespace,
 	                                                               List<String> data, String header, User sponsor,
 	                                                               LocalDate validityTo, boolean sendActivationLink,
-																   String url, boolean asyncValidation);
+																   String url, Validation validation);
 
 	/**
 	 * Creates new sponsored members.
@@ -1601,10 +1602,10 @@ public interface MembersManagerBl {
 	 * @param sendActivationLink if true link for manual activation of every created sponsored member account will be send
 	 *                           to the email, be careful when using with empty (no-reply) email
 	 * @param url base URL of Perun Instance
-	 * @param asyncValidation switch for easier testing
-	 * @return map of names to map of status, login and password
+	 * @param validation Type of members validation, when ASYNC do not call this method in a cycle!
+	 * @return map of names to map of status, login, password
 	 */
-	Map<String, Map<String, String>> createSponsoredMembers(PerunSession session, Vo vo, String namespace, List<String> names, String email, User sponsor, LocalDate validityTo, boolean sendActivationLink, String url, boolean asyncValidation);
+	Map<String, Map<String, String>> createSponsoredMembers(PerunSession session, Vo vo, String namespace, List<String> names, String email, User sponsor, LocalDate validityTo, boolean sendActivationLink, String url, Validation validation);
 
 	/**
 	 * Links sponsored member and sponsoring user.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
@@ -135,6 +135,12 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 
 	private static final String NO_REPLY_EMAIL = "no-reply@muni.cz";
 
+	private static final String OK = "OK";
+	private static final String LOGIN = "login";
+	private static final String PASSWORD = "password";
+	private static final String STATUS = "status";
+	private static final String MEMBER = "member";
+
 	public static final List<String> SPONSORED_MEMBER_REQUIRED_FIELDS = Arrays.asList(
 			"firstname",
 			"lastname",
@@ -2475,14 +2481,14 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 
 			// convert result to expected "type" for outer API
 			Map<String, String> newResult = new HashMap<>();
-			if ("OK".equals(originalResult.get("status"))) {
-				newResult.put("status", (String)originalResult.get("status"));
-				newResult.put("login", (String)originalResult.get("login"));
-				newResult.put("password", (String)originalResult.get("password"));
-				createdMembers.add((Member)originalResult.get("member"));
+			if (OK.equals(originalResult.get(STATUS))) {
+				newResult.put(STATUS, (String)originalResult.get(STATUS));
+				newResult.put(LOGIN, (String)originalResult.get(LOGIN));
+				newResult.put(PASSWORD, (String)originalResult.get(PASSWORD));
+				createdMembers.add((Member)originalResult.get(MEMBER));
 			} else {
 				// error when creating
-				newResult.put("status", (String)originalResult.get("status"));
+				newResult.put(STATUS, (String)originalResult.get(STATUS));
 			}
 			totalResult.put(data.get(processedCounter++), newResult);
 		}
@@ -2526,9 +2532,9 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 				// get login to return
 				String login = perunBl.getAttributesManagerBl().getAttribute(sess, user, PasswordManagerModule.LOGIN_PREFIX + namespace).valueAsString();
 				Map<String, String> statusWithLogin = new HashMap<>();
-				statusWithLogin.put("status", "OK");
-				statusWithLogin.put("login", login);
-				statusWithLogin.put("password", password);
+				statusWithLogin.put(STATUS, OK);
+				statusWithLogin.put(LOGIN, login);
+				statusWithLogin.put(PASSWORD, password);
 
 				result.put(name, statusWithLogin);
 
@@ -2536,7 +2542,7 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 
 			} catch (Exception e) {
 				Map<String, String> status = new HashMap<>();
-				status.put("status", e.getMessage());
+				status.put(STATUS, e.getMessage());
 				result.put(name, status);
 			}
 		}
@@ -2905,17 +2911,17 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 			// get login to return
 			String login = perunBl.getAttributesManagerBl().getAttribute(sess, user,
 					PasswordManagerModule.LOGIN_PREFIX + namespace).valueAsString();
-			status.put("login", login);
-			status.put("password", password);
+			status.put(LOGIN, login);
+			status.put(PASSWORD, password);
 
 			setAdditionalValues(sess, additionalValues, data, user, member);
 
 			// we must pass member back for the purpose of validation
-			status.put("member", member);
+			status.put(MEMBER, member);
 
-			status.put("status", "OK");
+			status.put(STATUS, OK);
 		} catch (Exception e) {
-			status.put("status", e.getMessage());
+			status.put(STATUS, e.getMessage());
 		}
 		return status;
 	}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
@@ -44,6 +44,7 @@ import cz.metacentrum.perun.core.api.Sponsorship;
 import cz.metacentrum.perun.core.api.Status;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.UserExtSource;
+import cz.metacentrum.perun.core.api.Validation;
 import cz.metacentrum.perun.core.api.Vo;
 import cz.metacentrum.perun.core.api.VosManager;
 import cz.metacentrum.perun.core.api.exceptions.AlreadyAdminException;
@@ -117,6 +118,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -2340,13 +2342,13 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 
 
 	@Override
-	public Member createSponsoredMember(PerunSession session, Vo vo, String namespace, Map<String, String> name, String password, String email, User sponsor, boolean sendActivationLink, String url, boolean asyncValidation) throws AlreadyMemberException, LoginNotExistsException, PasswordCreationFailedException, ExtendMembershipException, WrongAttributeValueException, ExtSourceNotExistsException, WrongReferenceAttributeValueException, UserNotInRoleException, InvalidLoginException, AlreadySponsorException {
-		return createSponsoredMember(session, vo, namespace, name, password, email, sponsor, null, sendActivationLink, url, asyncValidation);
+	public Member createSponsoredMember(PerunSession session, Vo vo, String namespace, Map<String, String> name, String password, String email, User sponsor, boolean sendActivationLink, String url, Validation validation) throws AlreadyMemberException, LoginNotExistsException, PasswordCreationFailedException, ExtendMembershipException, WrongAttributeValueException, ExtSourceNotExistsException, WrongReferenceAttributeValueException, UserNotInRoleException, InvalidLoginException, AlreadySponsorException {
+		return createSponsoredMember(session, vo, namespace, name, password, email, sponsor, null, sendActivationLink, url, validation);
 	}
 
 	@Override
 	public Member createSponsoredMember(PerunSession session, Vo vo, String namespace, Map<String, String> name,
-		String password, String email, User sponsor, LocalDate validityTo, boolean sendActivationLink, String url, boolean asyncValidation) throws AlreadyMemberException, LoginNotExistsException, PasswordCreationFailedException, ExtendMembershipException, WrongAttributeValueException, ExtSourceNotExistsException, WrongReferenceAttributeValueException, UserNotInRoleException, InvalidLoginException, AlreadySponsorException {
+	                                    String password, String email, User sponsor, LocalDate validityTo, boolean sendActivationLink, String url, Validation validation) throws AlreadyMemberException, LoginNotExistsException, PasswordCreationFailedException, ExtendMembershipException, WrongAttributeValueException, ExtSourceNotExistsException, WrongReferenceAttributeValueException, UserNotInRoleException, InvalidLoginException, AlreadySponsorException {
 
 		if (email == null) {
 			email = NO_REPLY_EMAIL;
@@ -2376,7 +2378,7 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 			}
 		}
 
-		Member sponsoredMember = setSponsoredMember(session, vo, sponsoredUser, namespace, password, sponsor, validityTo, asyncValidation);
+		Member sponsoredMember = setSponsoredMember(session, vo, sponsoredUser, namespace, password, sponsor, validityTo, validation);
 
 		//try to send activation link
 		if (sendActivationLink) {
@@ -2393,13 +2395,13 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 	}
 
 	@Override
-	public Member setSponsoredMember(PerunSession session, Vo vo, User userToBeSponsored, String namespace, String password, User sponsor, boolean asyncValidation) throws AlreadyMemberException, ExtendMembershipException, UserNotInRoleException, WrongAttributeValueException, WrongReferenceAttributeValueException, LoginNotExistsException, PasswordCreationFailedException, InvalidLoginException, ExtSourceNotExistsException, AlreadySponsorException {
-		return setSponsoredMember(session, vo, userToBeSponsored, namespace, password, sponsor, null, asyncValidation);
+	public Member setSponsoredMember(PerunSession session, Vo vo, User userToBeSponsored, String namespace, String password, User sponsor, Validation validation) throws AlreadyMemberException, ExtendMembershipException, UserNotInRoleException, WrongAttributeValueException, WrongReferenceAttributeValueException, LoginNotExistsException, PasswordCreationFailedException, InvalidLoginException, ExtSourceNotExistsException, AlreadySponsorException {
+		return setSponsoredMember(session, vo, userToBeSponsored, namespace, password, sponsor, null, validation);
 	}
 
 	@Override
 	public Member setSponsoredMember(PerunSession session, Vo vo, User userToBeSponsored, String namespace,
-	                                 String password, User sponsor, LocalDate validityTo, boolean asyncValidation) throws AlreadyMemberException, ExtendMembershipException, UserNotInRoleException, WrongAttributeValueException, WrongReferenceAttributeValueException, LoginNotExistsException, PasswordCreationFailedException, InvalidLoginException, ExtSourceNotExistsException, AlreadySponsorException {
+	                                 String password, User sponsor, LocalDate validityTo, Validation validation) throws AlreadyMemberException, ExtendMembershipException, UserNotInRoleException, WrongAttributeValueException, WrongReferenceAttributeValueException, LoginNotExistsException, PasswordCreationFailedException, InvalidLoginException, ExtSourceNotExistsException, AlreadySponsorException {
 		//check that sponsoring user has role SPONSOR for the VO
 		if (!getPerunBl().getVosManagerBl().isUserInRoleForVo(session, sponsor, Role.SPONSOR, vo, true)) {
 			try {
@@ -2427,12 +2429,13 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 		extendMembership(session, sponsoredMember);
 		insertToMemberGroup(session, sponsoredMember, vo);
 
-		if (asyncValidation) {
+		if (Validation.ASYNC.equals(validation)) {
 			validateMemberAsync(session, sponsoredMember);
-		} else {
+		} else if (Validation.SYNC.equals(validation)) {
 			//for unit tests
 			validateMember(session, sponsoredMember);
 		}
+
 		getPerunBl().getUsersManagerBl().validatePassword(session, userToBeSponsored, namespace);
 
 		return sponsoredMember;
@@ -2440,9 +2443,10 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 
 	@Override
 	public Map<String, Map<String, String>> createSponsoredMembersFromCSV(PerunSession sess, Vo vo, String namespace,
-			List<String> data, String header, User sponsor, LocalDate validityTo, boolean sendActivationLink, String url, boolean asyncValidation) {
+			List<String> data, String header, User sponsor, LocalDate validityTo, boolean sendActivationLink, String url, Validation validation) {
 
 		Map<String, Map<String, String>> totalResult = new HashMap<>();
+		Set<Member> createdMembers = new HashSet<>();
 
 		List<String> dataWithHeader = new ArrayList<>();
 		dataWithHeader.add(header);
@@ -2464,18 +2468,41 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 		int processedCounter = 0;
 		while(dataIterator.hasNext()) {
 			Map<String, String> singleRow = dataIterator.next();
-			Map<String, String> singleResult = createSingleSponsoredMemberFromCSV(sess, vo, namespace, singleRow,
-					sponsor, validityTo, sendActivationLink, url, asyncValidation);
-			totalResult.put(data.get(processedCounter++), singleResult);
+			// async validation must be performed at the end, not directly during member creation
+			Validation localValidation = (Objects.equals(Validation.ASYNC, validation)) ? Validation.NONE : validation;
+			Map<String, Object> originalResult = createSingleSponsoredMemberFromCSV(sess, vo, namespace, singleRow,
+					sponsor, validityTo, sendActivationLink, url, localValidation);
+
+			// convert result to expected "type" for outer API
+			Map<String, String> newResult = new HashMap<>();
+			if ("OK".equals(originalResult.get("status"))) {
+				newResult.put("status", (String)originalResult.get("status"));
+				newResult.put("login", (String)originalResult.get("login"));
+				newResult.put("password", (String)originalResult.get("password"));
+				createdMembers.add((Member)originalResult.get("member"));
+			} else {
+				// error when creating
+				newResult.put("status", (String)originalResult.get("status"));
+			}
+			totalResult.put(data.get(processedCounter++), newResult);
+		}
+
+		// perform async validation if necessary
+		if (Objects.equals(Validation.ASYNC, validation)) {
+			for (Member member : createdMembers) {
+				getPerunBl().getMembersManagerBl().validateMemberAsync(sess, member);
+			}
 		}
 
 		return totalResult;
 	}
 
 	@Override
-	public Map<String, Map<String, String>> createSponsoredMembers(PerunSession sess, Vo vo, String namespace, List<String> names, String email, User sponsor, LocalDate validityTo, boolean sendActivationLink, String url, boolean asyncValidation) {
+	public Map<String, Map<String, String>> createSponsoredMembers(PerunSession sess, Vo vo, String namespace, List<String> names, String email, User sponsor, LocalDate validityTo, boolean sendActivationLink, String url, Validation validation) {
 		Map<String, Map<String, String>> result = new HashMap<>();
 		PasswordManagerModule module = getPerunBl().getUsersManagerBl().getPasswordManagerModule(sess, namespace);
+
+		Set<Member> createdMembers = new HashSet<>();
 
 		for (String name : names) {
 			Map<String, String> mapName = new HashMap<>();
@@ -2492,19 +2519,32 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 			// create sponsored member
 			User user;
 			try {
-				user = perunBl.getUsersManagerBl().getUserByMember(sess,
-						createSponsoredMember(sess, vo, namespace, mapName, password, email, sponsor, validityTo, sendActivationLink, url, asyncValidation));
+				// async validation must be performed at the end, not directly during member creation
+				Validation localValidation = (Objects.equals(Validation.ASYNC, validation)) ? Validation.NONE : validation;
+				Member member = createSponsoredMember(sess, vo, namespace, mapName, password, email, sponsor, validityTo, sendActivationLink, url, localValidation);
+				user = perunBl.getUsersManagerBl().getUserByMember(sess, member);
 				// get login to return
 				String login = perunBl.getAttributesManagerBl().getAttribute(sess, user, PasswordManagerModule.LOGIN_PREFIX + namespace).valueAsString();
 				Map<String, String> statusWithLogin = new HashMap<>();
 				statusWithLogin.put("status", "OK");
 				statusWithLogin.put("login", login);
 				statusWithLogin.put("password", password);
+
 				result.put(name, statusWithLogin);
+
+				createdMembers.add(member);
+
 			} catch (Exception e) {
 				Map<String, String> status = new HashMap<>();
 				status.put("status", e.getMessage());
 				result.put(name, status);
+			}
+		}
+
+		// perform async validation if necessary
+		if (Objects.equals(Validation.ASYNC, validation)) {
+			for (Member member : createdMembers) {
+				getPerunBl().getMembersManagerBl().validateMemberAsync(sess, member);
 			}
 		}
 
@@ -2823,13 +2863,13 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 	 * @param sponsor user, who will be set as a sponsor to the newly created user
 	 * @param validityTo validity of the sponsorship. If null, the sponsorship will not be automatically canceled.
 	 * @param url base URL of Perun Instance
-	 * @param asyncValidation switch for easier testing
+	 * @param validation Which type of validation to perform. If you are using ASYNC, do not call this method in a cycle!
 	 * @return result of the procedure
 	 */
-	private Map<String, String> createSingleSponsoredMemberFromCSV(PerunSession sess, Vo vo, String namespace,
+	private Map<String, Object> createSingleSponsoredMemberFromCSV(PerunSession sess, Vo vo, String namespace,
 	                                                               Map<String, String> data, User sponsor,
 	                                                               LocalDate validityTo, boolean sendActivationLink,
-																   String url, boolean asyncValidation) {
+																   String url, Validation validation) {
 		for (String requiredField : SPONSORED_MEMBER_REQUIRED_FIELDS) {
 			if (!data.containsKey(requiredField)) {
 				log.error("Invalid data passed, missing required value: {}", requiredField);
@@ -2857,10 +2897,10 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 		String password = module.generateRandomPassword(sess, null);
 
 		// create sponsored member
-		Map<String, String> status = new HashMap<>();
+		Map<String, Object> status = new HashMap<>();
 		try {
 			Member member = createSponsoredMember(sess, vo, namespace, mapName, password, email, sponsor, validityTo,
-					sendActivationLink, url, asyncValidation);
+					sendActivationLink, url, validation);
 			User user = perunBl.getUsersManagerBl().getUserByMember(sess, member);
 			// get login to return
 			String login = perunBl.getAttributesManagerBl().getAttribute(sess, user,
@@ -2869,6 +2909,9 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 			status.put("password", password);
 
 			setAdditionalValues(sess, additionalValues, data, user, member);
+
+			// we must pass member back for the purpose of validation
+			status.put("member", member);
 
 			status.put("status", "OK");
 		} catch (Exception e) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/MembersManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/MembersManagerEntry.java
@@ -18,6 +18,7 @@ import cz.metacentrum.perun.core.api.SpecificUserType;
 import cz.metacentrum.perun.core.api.Status;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.UserExtSource;
+import cz.metacentrum.perun.core.api.Validation;
 import cz.metacentrum.perun.core.api.Vo;
 import cz.metacentrum.perun.core.api.exceptions.AlreadyMemberException;
 import cz.metacentrum.perun.core.api.exceptions.AlreadySponsorException;
@@ -1248,7 +1249,7 @@ public class MembersManagerEntry implements MembersManager {
 			}
 		}
 		//create the sponsored member
-		return membersManagerBl.getRichMemberWithAttributes(session, membersManagerBl.createSponsoredMember(session, vo, namespace, name, password, email, sponsor, validityTo, sendActivationLink, url, true));
+		return membersManagerBl.getRichMemberWithAttributes(session, membersManagerBl.createSponsoredMember(session, vo, namespace, name, password, email, sponsor, validityTo, sendActivationLink, url, Validation.ASYNC));
 	}
 
 	@Override
@@ -1276,7 +1277,7 @@ public class MembersManagerEntry implements MembersManager {
 			}
 		}
 		//create the sponsored member
-		return membersManagerBl.getRichMember(session, membersManagerBl.setSponsoredMember(session, vo, userToBeSponsored, namespace, password, sponsor, validityTo, true));
+		return membersManagerBl.getRichMember(session, membersManagerBl.setSponsoredMember(session, vo, userToBeSponsored, namespace, password, sponsor, validityTo, Validation.ASYNC));
 	}
 
 	@Override
@@ -1300,7 +1301,7 @@ public class MembersManagerEntry implements MembersManager {
 		}
 
 		return membersManagerBl
-				.createSponsoredMembersFromCSV(sess, vo, namespace, data, header, sponsor, validityTo, sendActivationLink, url, true);
+				.createSponsoredMembersFromCSV(sess, vo, namespace, data, header, sponsor, validityTo, sendActivationLink, url, Validation.ASYNC);
 	}
 
 	@Override
@@ -1321,7 +1322,7 @@ public class MembersManagerEntry implements MembersManager {
 		}
 
 		// create sponsored members
-		return membersManagerBl.createSponsoredMembers(session, vo, namespace, names, email, sponsor, validityTo, sendActivationLink, url, true);
+		return membersManagerBl.createSponsoredMembers(session, vo, namespace, names, email, sponsor, validityTo, sendActivationLink, url, Validation.ASYNC);
 	}
 
 	@Override
@@ -1471,7 +1472,7 @@ public class MembersManagerEntry implements MembersManager {
 	public List<MemberWithSponsors> getSponsoredMembersAndTheirSponsors(PerunSession sess, Vo vo, List<String> attrNames) throws VoNotExistsException, PrivilegeException, AttributeNotExistsException {
 		Utils.checkPerunSession(sess);
 		Utils.notNull(vo, "vo");
-		
+
 		//Authorization
 		if(!AuthzResolver.authorizedInternal(sess, "getSponsoredMembersAndTheirSponsors_Vo_policy", vo)) {
 			throw new PrivilegeException(sess, "getSponsoredMembersAndTheirSponsors");

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/MembersManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/MembersManagerEntryIntegrationTest.java
@@ -24,6 +24,7 @@ import cz.metacentrum.perun.core.api.Status;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.UserExtSource;
 import cz.metacentrum.perun.core.api.UsersManager;
+import cz.metacentrum.perun.core.api.Validation;
 import cz.metacentrum.perun.core.api.Vo;
 import cz.metacentrum.perun.core.api.VosManager;
 import cz.metacentrum.perun.core.api.exceptions.AlreadyMemberException;
@@ -139,7 +140,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 		AuthzResolverBlImpl.setRole(sess, sponsorUser, createdVo, Role.SPONSOR);
 		Map<String, String> nameOfUser1 = new HashMap<>();
 		nameOfUser1.put("guestName", "Abraka 123");
-		perun.getMembersManagerBl().createSponsoredMember(sess, createdVo, "dummy", nameOfUser1, "secret", null, sponsorUser, false, null, false);
+		perun.getMembersManagerBl().createSponsoredMember(sess, createdVo, "dummy", nameOfUser1, "secret", null, sponsorUser, false, null, Validation.SYNC);
 	}
 
 	@Test
@@ -158,7 +159,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 
 		Map<String, String> nameOfUser1 = new HashMap<>();
 		nameOfUser1.put("guestName", "Ing. Petr Draxler");
-		Member sponsoredMember1 = perun.getMembersManagerBl().createSponsoredMember(sess, createdVo, "dummy", nameOfUser1, "secret", null, sponsorUser, false, null, false);
+		Member sponsoredMember1 = perun.getMembersManagerBl().createSponsoredMember(sess, createdVo, "dummy", nameOfUser1, "secret", null, sponsorUser, false, null, Validation.SYNC);
 
 		//should contain one sponsored member
 		List<Member> sponsoredMembers = perun.getMembersManagerBl().getSponsoredMembers(sess, createdVo);
@@ -168,7 +169,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 
 		Map<String, String> nameOfUser2 = new HashMap<>();
 		nameOfUser2.put("guestName", "Miloš Zeman");
-		Member sponsoredMember2 = perun.getMembersManagerBl().createSponsoredMember(sess, createdVo, "dummy", nameOfUser2, "password", null, sponsorUser, false, null, false);
+		Member sponsoredMember2 = perun.getMembersManagerBl().createSponsoredMember(sess, createdVo, "dummy", nameOfUser2, "password", null, sponsorUser, false, null, Validation.SYNC);
 
 		sponsoredMembers = perun.getMembersManagerBl().getSponsoredMembers(sess, createdVo);
 
@@ -191,7 +192,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 
 		Map<String, String> userName = new HashMap<>();
 		userName.put("guestName", "Ing. Jan Novák");
-		Member sponsoredMember = perun.getMembersManagerBl().createSponsoredMember(sess, createdVo, "dummy", userName, "secret", null, sponsorUser, false, null, false);
+		Member sponsoredMember = perun.getMembersManagerBl().createSponsoredMember(sess, createdVo, "dummy", userName, "secret", null, sponsorUser, false, null, Validation.SYNC);
 
 		ArrayList<String> attrNames = new ArrayList<>();
 		attrNames.add("urn:perun:user:attribute-def:def:preferredMail");
@@ -216,7 +217,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 
 		Map<String, String> userName = new HashMap<>();
 		userName.put("guestName", "Ing. Jan Novák");
-		Member sponsoredMember = perun.getMembersManagerBl().createSponsoredMember(sess, createdVo, "dummy", userName, "secret", null, sponsorUser, false, null, false);
+		Member sponsoredMember = perun.getMembersManagerBl().createSponsoredMember(sess, createdVo, "dummy", userName, "secret", null, sponsorUser, false, null, Validation.SYNC);
 
 		ArrayList<String> attrNames = new ArrayList<>();
 		attrNames.add("urn:perun:user:attribute-def:def:preferredMail");
@@ -1472,7 +1473,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 		assertTrue("user must have SPONSOR role", perun.getVosManagerBl().isUserInRoleForVo(sess, sponsorUser, Role.SPONSOR, createdVo, true));
 		Map<String, String> nameOfUser1 = new HashMap<>();
 		nameOfUser1.put("guestName", "Ing. Jiří Novák, CSc.");
-		Member sponsoredMember = perun.getMembersManagerBl().createSponsoredMember(sess, createdVo, "dummy", nameOfUser1, "secret", null, sponsorUser, false, null, false);
+		Member sponsoredMember = perun.getMembersManagerBl().createSponsoredMember(sess, createdVo, "dummy", nameOfUser1, "secret", null, sponsorUser, false, null, Validation.SYNC);
 		assertNotNull("sponsored member must not be null",sponsoredMember);
 		assertTrue("sponsored memer must have flag 'sponsored' set",sponsoredMember.isSponsored());
 		assertTrue("sponsored member should have status VALID",sponsoredMember.getStatus()==Status.VALID);
@@ -1496,7 +1497,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 		Map<String, String> nameOfUser1 = new HashMap<>();
 		nameOfUser1.put("guestName", "Ing. Jiří Novák, CSc.");
 		String email = "test@email.cz";
-		Member sponsoredMember = perun.getMembersManagerBl().createSponsoredMember(sess, createdVo, "dummy", nameOfUser1, "secret", email, sponsorUser, false, null, false);
+		Member sponsoredMember = perun.getMembersManagerBl().createSponsoredMember(sess, createdVo, "dummy", nameOfUser1, "secret", email, sponsorUser, false, null, Validation.SYNC);
 
 		User createdUser = perun.getUsersManagerBl().getUserByMember(sess, sponsoredMember);
 		Attribute emailAttribute = perun.getAttributesManager().getAttribute(sess, createdUser, A_U_PREFERRED_MAIL);
@@ -1515,7 +1516,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 		//create guest
 		Map<String, String> nameOfUser1 = new HashMap<>();
 		nameOfUser1.put("guestName", "Ing. Jiří Novák, CSc.");
-		Member sponsoredMember = perun.getMembersManagerBl().createSponsoredMember(sess, createdVo, "dummy", nameOfUser1, "secret", null, sponsorUser, false, null, false);
+		Member sponsoredMember = perun.getMembersManagerBl().createSponsoredMember(sess, createdVo, "dummy", nameOfUser1, "secret", null, sponsorUser, false, null, Validation.SYNC);
 
 		User createdUser = perun.getUsersManagerBl().getUserByMember(sess, sponsoredMember);
 		Attribute emailAttribute = perun.getAttributesManager().getAttribute(sess, createdUser, A_U_PREFERRED_MAIL);
@@ -1540,7 +1541,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 		nameOfUser1.put("lastName", "Morgan");
 		nameOfUser1.put("titleBefore", "prof. RNDr.");
 		nameOfUser1.put("titleAfter", "Ph.D.");
-		Member sponsoredMember = perun.getMembersManagerBl().createSponsoredMember(sess, createdVo, "dummy", nameOfUser1, "TB", null, sponsorUser, false, null, false);
+		Member sponsoredMember = perun.getMembersManagerBl().createSponsoredMember(sess, createdVo, "dummy", nameOfUser1, "TB", null, sponsorUser, false, null, Validation.SYNC);
 		assertNotNull("sponsored member must not be null",sponsoredMember);
 		assertTrue("sponsored member must have flag 'sponsored' set",sponsoredMember.isSponsored());
 		assertTrue("sponsored member should have status VALID",sponsoredMember.getStatus()==Status.VALID);
@@ -1566,7 +1567,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 		Map<String, String> nameOfUser1 = new HashMap<>();
 		nameOfUser1.put("firstName", "Arthur");
 		nameOfUser1.put("lastName", "Morgan");
-		Member sponsoredMember = perun.getMembersManagerBl().createSponsoredMember(sess, createdVo, "dummy", nameOfUser1, "TB", null, sponsorUser, false, null, false);
+		Member sponsoredMember = perun.getMembersManagerBl().createSponsoredMember(sess, createdVo, "dummy", nameOfUser1, "TB", null, sponsorUser, false, null, Validation.SYNC);
 		assertNotNull("sponsored member must not be null",sponsoredMember);
 		assertTrue("sponsored member must have flag 'sponsored' set",sponsoredMember.isSponsored());
 		assertTrue("sponsored member should have status VALID",sponsoredMember.getStatus()==Status.VALID);
@@ -1594,7 +1595,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 		nameOfUser1.put("firstName", "Morgan");
 		nameOfUser1.put("titleBefore", "prof. RNDr.");
 		nameOfUser1.put("titleAfter", "Ph.D.");
-		Member sponsoredMember = perun.getMembersManagerBl().createSponsoredMember(sess, createdVo, "dummy", nameOfUser1, "TB", null, sponsorUser, false, null, false);
+		Member sponsoredMember = perun.getMembersManagerBl().createSponsoredMember(sess, createdVo, "dummy", nameOfUser1, "TB", null, sponsorUser, false, null, Validation.SYNC);
 	}
 
 	@Test
@@ -1607,7 +1608,8 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 		Member sponsorMember = setUpSponsor(createdVo);
 		User sponsor = perun.getUsersManagerBl().getUserByMember(sess, sponsorMember);
 		AuthzResolverBlImpl.setRole(sess, sponsor, createdVo, Role.SPONSOR);
-		Member sponsoredMember = perun.getMembersManagerBl().setSponsoredMember(sess, createdVo, sponsoredUser, "dummy", "password", sponsor, true);
+		// FIXME - we shouldn't call async validation from test
+		Member sponsoredMember = perun.getMembersManagerBl().setSponsoredMember(sess, createdVo, sponsoredUser, "dummy", "password", sponsor, Validation.ASYNC);
 
 		Member memberFromDb = perun.getMembersManagerBl().getMemberByUser(sess, createdVo, sponsoredUser);
 		assertTrue(memberFromDb.isSponsored());
@@ -1628,7 +1630,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 				"Obi-wan;Kenobi;obi@ics.muni.cz;\"He has the high ground\""
 		);
 		Map<String, Map<String, String>> allResults = perun.getMembersManagerBl().createSponsoredMembersFromCSV(
-				sess, createdVo, "dummy", data, header, sponsorUser, null, false, null, false);
+				sess, createdVo, "dummy", data, header, sponsorUser, null, false, null, Validation.SYNC);
 		assertThat(allResults).hasSize(2);
 
 		Map<String, String> user1Data = allResults.get("Darth;Vader;vader@ics.muni.cz;\"Best dad ever\"");
@@ -1665,7 +1667,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 		);
 		assertThatExceptionOfType(InternalErrorException.class)
 				.isThrownBy(() -> perun.getMembersManagerBl().createSponsoredMembersFromCSV(sess, createdVo, "dummy",
-						data, header, sponsorUser, null, false, null, false))
+						data, header, sponsorUser, null, false, null, Validation.SYNC))
 				.withMessageContaining("Not allowed additional value passed, value: ");
 	}
 
@@ -1681,7 +1683,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 		perun.getGroupsManagerBl().addMember(sess,sponsors,sponsorMember);
 		assertTrue("user must have SPONSOR role", perun.getVosManagerBl().isUserInRoleForVo(sess, sponsorUser, Role.SPONSOR, createdVo, true));
 		//create guests
-		Map<String, Map<String, String>> loginAndPassword = perun.getMembersManagerBl().createSponsoredMembers(sess, createdVo, "dummy", Arrays.asList("Ing. Jiří Novák, CSc.", "Jan Novák"), null, sponsorUser, null, false, null, false);
+		Map<String, Map<String, String>> loginAndPassword = perun.getMembersManagerBl().createSponsoredMembers(sess, createdVo, "dummy", Arrays.asList("Ing. Jiří Novák, CSc.", "Jan Novák"), null, sponsorUser, null, false, null, Validation.SYNC);
 		assertEquals("there should be two members", 2, loginAndPassword.size());
 		for (String name : loginAndPassword.keySet()) {
 			assertEquals("status should be OK", "OK", loginAndPassword.get(name).get("status"));
@@ -1703,7 +1705,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 
 		//create guests
 		Map<String, Map<String, String>> loginAndPassword = perun.getMembersManagerBl().createSponsoredMembers(sess,
-				createdVo, "dummy", Collections.singletonList(firstName + ";" + lastName), null, sponsorUser, null, false, null, false);
+				createdVo, "dummy", Collections.singletonList(firstName + ";" + lastName), null, sponsorUser, null, false, null, Validation.SYNC);
 
 		assertThat(loginAndPassword).hasSize(1);
 
@@ -1728,7 +1730,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 		perun.getGroupsManagerBl().addMember(sess,sponsors,sponsorMember);
 		assertTrue("user must have SPONSOR role", perun.getVosManagerBl().isUserInRoleForVo(sess, sponsorUser, Role.SPONSOR, createdVo, true));
 		//create guests
-		Map<String, Map<String, String>> loginAndPassword = perun.getMembersManagerBl().createSponsoredMembers(sess, createdVo, "dummy", Arrays.asList("Ing. Jiří Novák, CSc.", "Novák", "Jan Novák"), null, sponsorUser, null, false, null, false);
+		Map<String, Map<String, String>> loginAndPassword = perun.getMembersManagerBl().createSponsoredMembers(sess, createdVo, "dummy", Arrays.asList("Ing. Jiří Novák, CSc.", "Novák", "Jan Novák"), null, sponsorUser, null, false, null, Validation.SYNC);
 		assertEquals("there should be two members", 3, loginAndPassword.size());
 
 		assertEquals("status should be OK", "OK", loginAndPassword.get("Ing. Jiří Novák, CSc.").get("status"));
@@ -1797,7 +1799,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 		//create sponsored member
 		Map<String, String> nameOfUser1 = new HashMap<>();
 		nameOfUser1.put("guestName", "Ing. Jiří Novák, CSc.");
-		Member sponsoredMember = perun.getMembersManagerBl().createSponsoredMember(sess, createdVo, "dummy", nameOfUser1, "secret", null, sponsorUser, false, null, false);
+		Member sponsoredMember = perun.getMembersManagerBl().createSponsoredMember(sess, createdVo, "dummy", nameOfUser1, "secret", null, sponsorUser, false, null, Validation.SYNC);
 		assertNotNull("sponsored member must not be null", sponsoredMember);
 		assertTrue("sponsored memer must have flag 'sponsored' set", sponsoredMember.isSponsored());
 		assertTrue("sponsored member should have status VALID", sponsoredMember.getStatus() == Status.VALID);
@@ -2141,7 +2143,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 		AuthzResolverBlImpl.setRole(sess, sponsorUser, createdVo, Role.SPONSOR);
 		Map<String, String> nameOfUser1 = new HashMap<>();
 		nameOfUser1.put("guestName", "Ing. Petr Novák, CSc.");
-		Member sponsoredMember = perun.getMembersManagerBl().createSponsoredMember(sess, createdVo, "dummy", nameOfUser1, "secret", null, sponsorUser, false, null, false);
+		Member sponsoredMember = perun.getMembersManagerBl().createSponsoredMember(sess, createdVo, "dummy", nameOfUser1, "secret", null, sponsorUser, false, null, Validation.SYNC);
 		User user = perun.getUsersManagerBl().getUserByMember(sess, sponsoredMember);
 		System.out.println(user);
 		List<Member> members = perun.getMembersManagerBl().findMembers(sess, createdVo, user.getFirstName(), true);
@@ -2169,7 +2171,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 		//create sponsored member
 		Map<String, String> nameOfUser1 = new HashMap<>();
 		nameOfUser1.put("guestName", "Ing. Jiří Novák, CSc.");
-		Member sponsoredMember = perun.getMembersManagerBl().createSponsoredMember(sess, createdVo, "dummy", nameOfUser1, "secret", null, sponsorUser, false, null, false);
+		Member sponsoredMember = perun.getMembersManagerBl().createSponsoredMember(sess, createdVo, "dummy", nameOfUser1, "secret", null, sponsorUser, false, null, Validation.SYNC);
 		//Remove sponsor
 		perun.getMembersManagerBl().removeSponsor(sess, sponsoredMember, sponsorUser);
 		//refresh from DB
@@ -2190,11 +2192,11 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 		// create two sponsored members
 		Map<String, String> name = new HashMap<>();
 		name.put("guestName", "Bruce Wayne");
-		Member member = perun.getMembersManagerBl().createSponsoredMember(sess, createdVo, "dummy", name, "secret", null, sponsorUser, false, null, false);
+		Member member = perun.getMembersManagerBl().createSponsoredMember(sess, createdVo, "dummy", name, "secret", null, sponsorUser, false, null, Validation.SYNC);
 		RichMember richMember = perun.getMembersManager().getRichMemberById(sess, member.getId());
 		Map<String, String> name2 = new HashMap<>();
 		name2.put("guestName", "Clark Kent");
-		Member member2 = perun.getMembersManagerBl().createSponsoredMember(sess, createdVo, "dummy", name2, "secret", null, sponsorUser, false, null, false);
+		Member member2 = perun.getMembersManagerBl().createSponsoredMember(sess, createdVo, "dummy", name2, "secret", null, sponsorUser, false, null, Validation.SYNC);
 		RichMember richMember2 = perun.getMembersManager().getRichMemberById(sess, member2.getId());
 
 		List<RichMember> allSponsoredMembers = perun.getMembersManager().getAllSponsoredMembers(sess, createdVo);


### PR DESCRIPTION
- Async validation should be always the last step in any
  member creation method.
  Since methods createSponsoredMembers() and
  createSponsoredMembersFromCSV() iterate over
  the creation of single sponsored member, we must provide
  the means to skip validation until all iteration is done.
- For this purpose new Validation enum was introduced.
  It can be used to either perform SYNC or ASYNC validation
  or to skip validation using the NONE value.
- Methods to create/set sponsored member(s) which were using
  boolean param "asyncValidation" are now using "validation"
  enum.
- Return value of Map<String, Map<String, String>> was changed
  to Map<String, Map<String, Object>> for inner CSV method,
  since we need to get also the Member object in order
  to call validation afterwards.
  Outer API (RPC/OpenAPI) is not modified.
- Fixed tests.