### PR TITLE
User anonymization

### DIFF
--- a/perun-base/pom.xml
+++ b/perun-base/pom.xml
@@ -112,14 +112,14 @@
 		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>testcontainers</artifactId>
-			<version>1.15.0</version>
+			<version>1.15.1</version>
 			<scope>compile</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>postgresql</artifactId>
-			<version>1.15.0</version>
+			<version>1.15.1</version>
 			<scope>compile</scope>
 		</dependency>
 

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/CoreConfig.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/CoreConfig.java
@@ -82,6 +82,8 @@ public class CoreConfig {
 	private String groupNameSecondaryRegex;
 	private String groupFullNameSecondaryRegex;
 	private List<String> attributesToSearchUsersAndMembersBy;
+	private List<String> attributesToAnonymize;
+	private List<String> attributesToKeep;
 
 	public int getGroupMaxConcurentGroupsToSynchronize() {
 		return groupMaxConcurentGroupsToSynchronize;
@@ -683,5 +685,21 @@ public class CoreConfig {
 
 	public void setAttributesToSearchUsersAndMembersBy(List<String> attributesToSearchUsersAndMembersBy) {
 		this.attributesToSearchUsersAndMembersBy = attributesToSearchUsersAndMembersBy;
+	}
+
+	public List<String> getAttributesToAnonymize() {
+		return attributesToAnonymize;
+	}
+
+	public void setAttributesToAnonymize(List<String> attributesToAnonymize) {
+		this.attributesToAnonymize = attributesToAnonymize;
+	}
+
+	public List<String> getAttributesToKeep() {
+		return attributesToKeep;
+	}
+
+	public void setAttributesToKeep(List<String> attributesToKeep) {
+		this.attributesToKeep = attributesToKeep;
 	}
 }

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/AnonymizationNotSupportedException.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/AnonymizationNotSupportedException.java
@@ -1,0 +1,22 @@
+package cz.metacentrum.perun.core.api.exceptions;
+
+/**
+ * This exception is thrown when trying to get anonymized value of the attribute,
+ * whose module doesn't specify the anonymization process in method getAnonymizedValue().
+ *
+ * @author Radoslav Čerhák <r.cerhak@gmail.com>
+ */
+public class AnonymizationNotSupportedException extends PerunException {
+
+	public AnonymizationNotSupportedException(String message) {
+		super(message);
+	}
+
+	public AnonymizationNotSupportedException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public AnonymizationNotSupportedException(Throwable cause) {
+		super(cause);
+	}
+}

--- a/perun-base/src/main/resources/perun-base.xml
+++ b/perun-base/src/main/resources/perun-base.xml
@@ -66,6 +66,8 @@
 		<property name="queryTimeout" value="${perun.queryTimeout}" />
 		<property name="defaultLoaIdP" value="${perun.defaultLoa.idp}"/>
 		<property name="attributesToSearchUsersAndMembersBy" value="#{'${perun.attributesToSearchUsersAndMembersBy}'.split('\s*,\s*')}"/>
+		<property name="attributesToAnonymize" value="#{'${perun.attributesToAnonymize}'.split('\s*,\s*')}"/>
+		<property name="attributesToKeep" value="#{'${perun.attributesToKeep}'.split('\s*,\s*')}"/>
 	</bean>
 
 
@@ -131,6 +133,8 @@
 				<prop key="perun.queryTimeout">-1</prop>
 				<prop key="perun.defaultLoa.idp">2</prop>
 				<prop key="perun.attributesToSearchUsersAndMembersBy">urn:perun:user:attribute-def:def:preferredMail, urn:perun:member:attribute-def:def:mail</prop>
+				<prop key="perun.attributesToAnonymize"></prop>
+				<prop key="perun.attributesToKeep">urn:perun:user:attribute-def:def:login-namespace:*, urn:perun:user:attribute-def:def:uid-namespace:*</prop>
 				<!--
 				   this creates a map from OIDC issuer to user extsources that are used for looking up a user identified by "sub" claim
 				-->

--- a/perun-base/src/main/resources/perun-roles.yml
+++ b/perun-base/src/main/resources/perun-roles.yml
@@ -4670,6 +4670,11 @@ perun_policies:
     include_policies:
       - default_policy
 
+  anonymizeUser_User_policy:
+    policy_roles: []
+    include_policies:
+      - default_policy
+
   updateUser_User_policy:
     policy_roles:
       - REGISTRAR:

--- a/perun-base/src/test/resources/test-schema.sql
+++ b/perun-base/src/test/resources/test-schema.sql
@@ -1,4 +1,4 @@
--- database version 3.1.74 (don't forget to update insert statement at the end of file)
+-- database version 3.1.75 (don't forget to update insert statement at the end of file)
 CREATE EXTENSION IF NOT EXISTS "unaccent";
 CREATE EXTENSION IF NOT EXISTS "pgcrypto";
 
@@ -32,6 +32,7 @@ create table users (
 						modified_by varchar default user not null,
 						service_acc boolean default false not null, --is it service account?
 						sponsored_acc boolean default false not null, --is it sponsored account?
+					    anonymized boolean default false not null, --was user anonymized?
 						created_by_uid integer,
 						modified_by_uid integer,
 						constraint usr_pk primary key (id)
@@ -1639,7 +1640,7 @@ CREATE INDEX ufauv_idx ON user_facility_attr_u_values (user_id, facility_id, att
 CREATE INDEX vauv_idx ON vo_attr_u_values (vo_id, attr_id);
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.1.74');
+insert into configurations values ('DATABASE VERSION','3.1.75');
 -- insert membership types
 insert into membership_types (id, membership_type, description) values (1, 'DIRECT', 'Member is directly added into group');
 insert into membership_types (id, membership_type, description) values (2, 'INDIRECT', 'Member is added indirectly through UNION relation');

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/UsersManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/UsersManager.java
@@ -1,5 +1,6 @@
 package cz.metacentrum.perun.core.api;
 
+import cz.metacentrum.perun.core.api.exceptions.AnonymizationNotSupportedException;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ExtSourceNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.FacilityNotExistsException;
@@ -345,6 +346,21 @@ public interface UsersManager {
 	 * @throws SpecificUserAlreadyRemovedException
 	 */
 	void deleteUser(PerunSession perunSession, User user, boolean forceDelete) throws UserNotExistsException, PrivilegeException, RelationExistsException, MemberAlreadyRemovedException, UserAlreadyRemovedException, SpecificUserAlreadyRemovedException;
+
+	/**
+	 * Anonymizes user - according to configuration, each of user's attributes is either
+	 * anonymized, kept untouched or deleted. Also deletes other user's related data, e.g.
+	 * authorships of users publications, mail change and password reset requests, bans...
+	 *
+	 * @param perunSession
+	 * @param user
+	 * @throws InternalErrorException if an internal error has occurred
+	 * @throws UserNotExistsException if the user doesn't exist
+	 * @throws PrivilegeException if the method isn't called by perun admin
+	 * @throws RelationExistsException if the user has some members assigned
+	 * @throws AnonymizationNotSupportedException if an attribute should be anonymized but its module doesn't specify the anonymization process
+	 */
+	void anonymizeUser(PerunSession perunSession, User user) throws UserNotExistsException, PrivilegeException, RelationExistsException, AnonymizationNotSupportedException;
 
 	/**
 	 *  Updates users data in DB.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
@@ -18,6 +18,7 @@ import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.UserExtSource;
 import cz.metacentrum.perun.core.api.Vo;
 import cz.metacentrum.perun.core.api.exceptions.ActionTypeNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.AnonymizationNotSupportedException;
 import cz.metacentrum.perun.core.api.exceptions.AttributeAlreadyMarkedUniqueException;
 import cz.metacentrum.perun.core.api.exceptions.AttributeDefinitionExistsException;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
@@ -3448,6 +3449,19 @@ public interface AttributesManagerBl {
 	 */
 	void forceCheckAttributeSemantics(PerunSession sess, Resource resource, Attribute attribute) throws WrongAttributeAssignmentException, WrongReferenceAttributeValueException;
 
+	/**
+	 * Gets anonymized value of the attribute.
+	 *
+	 * @param sess perun session
+	 * @param user user for which you want the anonymized attribute value
+	 * @param attribute attribute to get anonymized value from
+	 * @return attribute with anonymized value
+	 *
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws WrongAttributeAssignmentException if attribute isn't user attribute
+	 * @throws AnonymizationNotSupportedException if the module doesn't exist or it doesn't implement this method
+	 */
+	Attribute getAnonymizedValue(PerunSession sess, User user, Attribute attribute) throws WrongAttributeAssignmentException, AnonymizationNotSupportedException;
 
 	/**
 	 * Unset particular attribute for the facility. Core attributes can't be removed this way.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
@@ -20,6 +20,7 @@ import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.UserExtSource;
 import cz.metacentrum.perun.core.api.Vo;
 import cz.metacentrum.perun.core.api.exceptions.AlreadyReservedLoginException;
+import cz.metacentrum.perun.core.api.exceptions.AnonymizationNotSupportedException;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ExtSourceNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
@@ -373,6 +374,19 @@ public interface UsersManagerBl {
 	 * @throws SpecificUserAlreadyRemovedException if there are no rows affected by deleting specific user in DBn
 	 */
 	void deleteUser(PerunSession perunSession, User user, boolean forceDelete) throws RelationExistsException, MemberAlreadyRemovedException, UserAlreadyRemovedException, SpecificUserAlreadyRemovedException;
+
+	/**
+	 * Anonymizes user - according to configuration, each of user's attributes is either
+	 * anonymized, kept untouched or deleted. Also deletes other user's related data, e.g.
+	 * authorships of users publications, mail change and password reset requests, bans...
+	 *
+	 * @param perunSession
+	 * @param user
+	 * @throws InternalErrorException
+	 * @throws RelationExistsException if the user has some members assigned
+	 * @throws AnonymizationNotSupportedException if an attribute should be anonymized but its module doesn't specify the anonymization process
+	 */
+	void anonymizeUser(PerunSession perunSession, User user) throws RelationExistsException, AnonymizationNotSupportedException;
 
 	/**
 	 * Updates users data in DB.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -72,6 +72,7 @@ import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.UserExtSource;
 import cz.metacentrum.perun.core.api.Vo;
 import cz.metacentrum.perun.core.api.exceptions.ActionTypeNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.AnonymizationNotSupportedException;
 import cz.metacentrum.perun.core.api.exceptions.AttributeAlreadyMarkedUniqueException;
 import cz.metacentrum.perun.core.api.exceptions.AttributeDefinitionExistsException;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
@@ -4176,6 +4177,13 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		getAttributesManagerImpl().checkNamespace(sess, attribute, AttributesManager.NS_RESOURCE_ATTR);
 
 		getAttributesManagerImpl().checkAttributeSemantics(sess, resource, attribute);
+	}
+
+	@Override
+	public Attribute getAnonymizedValue(PerunSession sess, User user, Attribute attribute) throws WrongAttributeAssignmentException, AnonymizationNotSupportedException {
+		getAttributesManagerImpl().checkNamespace(sess, attribute, NS_USER_ATTR);
+
+		return getAttributesManagerImpl().getAnonymizedValue(sess, user, attribute);
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
@@ -23,6 +23,7 @@ import cz.metacentrum.perun.core.api.UserExtSource;
 import cz.metacentrum.perun.core.api.UsersManager;
 import cz.metacentrum.perun.core.api.Vo;
 import cz.metacentrum.perun.core.api.exceptions.AlreadyReservedLoginException;
+import cz.metacentrum.perun.core.api.exceptions.AnonymizationNotSupportedException;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ConsistencyErrorException;
 import cz.metacentrum.perun.core.api.exceptions.ExtSourceNotExistsException;
@@ -414,6 +415,20 @@ public class UsersManagerEntry implements UsersManager {
 		getUsersManagerBl().checkUserExists(sess, user);
 
 		getUsersManagerBl().deleteUser(sess, user, forceDelete);
+	}
+
+	@Override
+	public void anonymizeUser(PerunSession sess, User user) throws UserNotExistsException, PrivilegeException, RelationExistsException, AnonymizationNotSupportedException {
+		Utils.checkPerunSession(sess);
+
+		// Authorization
+		if(!AuthzResolver.authorizedInternal(sess, "anonymizeUser_User_policy", user)) {
+			throw new PrivilegeException(sess, "anonymizeUser");
+		}
+
+		getUsersManagerBl().checkUserExists(sess, user);
+
+		getUsersManagerBl().anonymizeUser(sess, user);
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
@@ -23,6 +23,7 @@ import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.UserExtSource;
 import cz.metacentrum.perun.core.api.Vo;
 import cz.metacentrum.perun.core.api.exceptions.ActionTypeNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.AnonymizationNotSupportedException;
 import cz.metacentrum.perun.core.api.exceptions.AttributeDefinitionExistsException;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ConsistencyErrorException;
@@ -3436,6 +3437,16 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 		EntitylessAttributesModuleImplApi attributeModule = getEntitylessAttributeModule(sess, attribute);
 		if (attributeModule == null) return;
 		attributeModule.checkAttributeSyntax((PerunSessionImpl) sess, key, attribute);
+	}
+
+	@Override
+	public Attribute getAnonymizedValue(PerunSession sess, User user, Attribute attribute) throws AnonymizationNotSupportedException {
+		UserAttributesModuleImplApi attributeModule = getUserAttributeModule(sess, attribute);
+		if (attributeModule == null) {
+			throw new AnonymizationNotSupportedException("Cannot get anonymized attribute value. There is no module for: " + attribute.getName() + ".");
+		}
+
+		return attributeModule.getAnonymizedValue((PerunSessionImpl) sess, user, attribute);
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/UsersManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/UsersManagerImpl.java
@@ -509,6 +509,23 @@ public class UsersManagerImpl implements UsersManagerImplApi {
 	}
 
 	@Override
+	public User anonymizeUser(PerunSession sess, User user) {
+		try {
+			user.setFirstName("");
+			user.setMiddleName("");
+			user.setLastName("");
+			user.setTitleBefore("");
+			user.setTitleAfter("");
+			jdbc.update("update users set first_name=NULL, last_name=NULL, middle_name=NULL, title_before=NULL, title_after=NULL, " +
+					"anonymized=true, modified_by=?, modified_by_uid=?, modified_at=" + Compatibility.getSysdate() + " where id=?",
+				sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getUserId(), user.getId());
+			return user;
+		} catch (RuntimeException err) {
+			throw new InternalErrorException(err);
+		}
+	}
+
+	@Override
 	public void updateUserExtSourceLastAccess(PerunSession sess, UserExtSource userExtSource) {
 		try {
 			jdbc.update("update user_ext_sources set last_access=" + Compatibility.getSysdate() + " where id=?", userExtSource.getId());
@@ -1175,6 +1192,15 @@ public class UsersManagerImpl implements UsersManagerImplApi {
 			throw new InternalErrorException(e);
 		}
 
+	}
+
+	@Override
+	public void deleteUsersApplications(User user) {
+		try {
+			jdbc.update("delete from application where user_id=?", user.getId());
+		} catch (RuntimeException e) {
+			throw new InternalErrorException(e);
+		}
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
@@ -21,6 +21,7 @@ import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.UserExtSource;
 import cz.metacentrum.perun.core.api.Vo;
 import cz.metacentrum.perun.core.api.exceptions.ActionTypeNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.AnonymizationNotSupportedException;
 import cz.metacentrum.perun.core.api.exceptions.AttributeDefinitionExistsException;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.GroupResourceMismatchException;
@@ -1964,6 +1965,19 @@ public interface AttributesManagerImplApi {
 	 * @throws WrongAttributeValueException if the attribute value has wrong/illegal syntax
 	 */
 	void checkAttributeSyntax(PerunSession sess, UserExtSource ues, Attribute attribute) throws WrongAttributeValueException;
+
+	/**
+	 * Gets anonymized value of the attribute.
+	 *
+	 * @param sess perun session
+	 * @param user user
+	 * @param attribute attribute to get anonymized value from
+	 * @return attribute with anonymized value
+	 *
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws AnonymizationNotSupportedException if the module doesn't exist or it doesn't implement this method
+	 */
+	Attribute getAnonymizedValue(PerunSession sess, User user, Attribute attribute) throws AnonymizationNotSupportedException;
 
 	/**
 	 * Unset particular attribute for the facility.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/UsersManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/UsersManagerImplApi.java
@@ -258,6 +258,16 @@ public interface UsersManagerImplApi {
 	User updateNameTitles(PerunSession perunSession, User user);
 
 	/**
+	 * Anonymizes users data in DB - sets names and titles to NULL and sets anonymized flag to true.
+	 *
+	 * @param perunSession
+	 * @param user
+	 * @return user
+	 * @throws InternalErrorException
+	 */
+	User anonymizeUser(PerunSession perunSession, User user);
+
+	/**
 	 *  Updates user;s userExtSource in DB.
 	 *
 	 * @param perunSession
@@ -650,6 +660,14 @@ public interface UsersManagerImplApi {
 	 * @throws InternalErrorException
 	 */
 	void deleteUsersReservedLogins(User user);
+
+	/**
+	 * Delete all applications and submitted data for specific user.
+	 *
+	 * @param user for which delete applications and submitted data
+	 * @throws InternalErrorException
+	 */
+	void deleteUsersApplications(User user);
 
 	/**
 	 * Store request of change of user's preferred email address.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/UserAttributesModuleAbstract.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/UserAttributesModuleAbstract.java
@@ -3,6 +3,7 @@ package cz.metacentrum.perun.core.implApi.modules.attributes;
 import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.AnonymizationNotSupportedException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
@@ -35,4 +36,10 @@ public abstract class UserAttributesModuleAbstract extends AttributesModuleAbstr
 	public void changedAttributeHook(PerunSessionImpl session, User user, Attribute attribute) throws WrongReferenceAttributeValueException {
 
 	}
+
+	public Attribute getAnonymizedValue(PerunSessionImpl session, User user, Attribute attribute) throws AnonymizationNotSupportedException {
+		throw new AnonymizationNotSupportedException("Cannot get anonymized attribute value. The module for attribute "
+			+ attribute.getName() + " doesn't specify its anonymization process.");
+	}
+
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/UserAttributesModuleImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/UserAttributesModuleImplApi.java
@@ -3,6 +3,7 @@ package cz.metacentrum.perun.core.implApi.modules.attributes;
 import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.AnonymizationNotSupportedException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
@@ -66,4 +67,17 @@ public interface UserAttributesModuleImplApi extends AttributesModuleImplApi {
 	 * @param attribute the attribute
 	 */
 	void changedAttributeHook(PerunSessionImpl session, User user, Attribute attribute) throws WrongReferenceAttributeValueException;
+
+	/**
+	 * Gets anonymized value of the attribute.
+	 *
+	 * @param perunSession PerunSession
+	 * @param user User
+	 * @param attribute Attribute of the user.
+	 * @return Attribute with anonymized value
+	 * @throws InternalErrorException if an exception is raised in particular
+	 *         implementation, the exception is wrapped in InternalErrorException
+	 * @throws AnonymizationNotSupportedException if the module doesn't implement this method
+	 */
+	Attribute getAnonymizedValue(PerunSessionImpl perunSession, User user, Attribute attribute) throws AnonymizationNotSupportedException;
 }

--- a/perun-core/src/main/resources/postgresChangelog.txt
+++ b/perun-core/src/main/resources/postgresChangelog.txt
@@ -6,6 +6,10 @@
 -- Directly under version number should be version commands. They will be executed in the order they are written here.
 -- Comments are prefixed with -- and can be written only between version blocks, that means not in the lines with commands. They have to be at the start of the line.
 
+3.1.75
+ALTER TABLE users ADD COLUMN anonymized boolean default false not null;
+UPDATE configurations SET value='3.1.75' WHERE property='DATABASE VERSION';
+
 3.1.74
 UPDATE attr_names SET type='java.lang.String' WHERE type='java.lang.LargeString';
 UPDATE attr_names SET type='java.util.ArrayList' WHERE type='java.util.LargeArrayList';

--- a/perun-db/postgres.sql
+++ b/perun-db/postgres.sql
@@ -1,4 +1,4 @@
--- database version 3.1.74 (don't forget to update insert statement at the end of file)
+-- database version 3.1.75 (don't forget to update insert statement at the end of file)
 
 -- VOS - virtual organizations
 create table vos (
@@ -30,6 +30,7 @@ create table users (
 	modified_by varchar default user not null,
 	service_acc boolean default false not null, --is it service account?
 	sponsored_acc boolean default false not null, --is it sponsored account?
+	anonymized boolean default false not null, --was user anonymized?
 	created_by_uid integer,
 	modified_by_uid integer,
 	constraint usr_pk primary key (id)
@@ -1736,7 +1737,7 @@ grant all on user_ext_source_attr_u_values to perun;
 grant all on members_sponsored to perun;
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.1.74');
+insert into configurations values ('DATABASE VERSION','3.1.75');
 
 -- insert membership types
 insert into membership_types (id, membership_type, description) values (1, 'DIRECT', 'Member is directly added into group');

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/UsersManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/UsersManagerMethod.java
@@ -464,6 +464,26 @@ public enum UsersManagerMethod implements ManagerMethod {
 	},
 
 	/*#
+	 * Anonymizes user - according to configuration, each of user's attributes is either
+	 * anonymized, kept untouched or deleted. Also deletes other user's related data, e.g.
+	 * authorships of users publications, mail change and password reset requests, bans...
+	 *
+	 * @param user int User <code>id</code>
+	 * @throw UserNotExistsException When the User specified by <code>id</code> doesn't exist.
+	 * @throw RelationExistsException When the User has some members assigned.
+	 * @throw AnonymizationNotSupportedException When an attribute should be anonymized but its module doesn't specify the anonymization process.
+	 */
+	anonymizeUser {
+
+		@Override
+		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
+			parms.stateChangingCheck();
+			ac.getUsersManager().anonymizeUser(ac.getSession(), ac.getUserById(parms.readInt("user")));
+			return null;
+		}
+	},
+
+	/*#
 	 * Updates users data in DB.
 	 *
 	 * @param user User JSON object

--- a/pom.xml
+++ b/pom.xml
@@ -333,14 +333,14 @@
 			<dependency>
 				<groupId>org.testcontainers</groupId>
 				<artifactId>testcontainers</artifactId>
-				<version>1.15.0</version>
+				<version>1.15.1</version>
 				<scope>test</scope>
 			</dependency>
 
 			<dependency>
 				<groupId>org.testcontainers</groupId>
 				<artifactId>postgresql</artifactId>
-				<version>1.15.0</version>
+				<version>1.15.1</version>
 				<scope>test</scope>
 			</dependency>
 


### PR DESCRIPTION
- New method anonymizeUser() was implemented. It works as replacement for
deleteUser() when it is not possible to delete the user.
- New config property ‘attributesToAnonymize’ was added, it contains list of
attributes names, which can’t be deleted and should be anonymized instead.
- New config property ‘attributesToKeep’ was added, it contains list of
attributes names, which can’t be deleted and should be kept untouched.

Difference from deleteUser():
- User attributes configured in property ‘attributesToAnonymize’ are not
deleted but anonymized instead. The anonymized value of an attribute is
determined from the attr module's method getAnonymizedValue().
- User attributes configured in property ‘attributesToKeep’ are not
deleted but kept untouched instead.

