### PR TITLE
Register Attribute Modules only for attributes with definitions

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
@@ -1920,6 +1920,7 @@ public interface AttributesManagerBl {
 
 	/**
 	 * Creates an attribute, the attribute is stored into the appropriate DB table according to the namespace
+	 * Also tries to initialize its attribute module and register the module for listening Auditer messages.
 	 *
 	 * @param sess perun session
 	 * @param attributeDefinition attribute to create

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -2398,7 +2398,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		AttributeDefinition attributeToReturn = createAttribute(sess, attribute, true);
 
 		// try to initialize and register module
-		AttributesModuleImplApi module = getAttributesManagerImpl().getUninitiatedAttributesModule(sess, attributeToReturn);
+		AttributesModuleImplApi module = getAttributesManagerImpl().getUninitializedAttributesModule(sess, attributeToReturn);
 		if (module != null) {
 			getAttributesManagerImpl().initAttributeModule(module);
 			getAttributesManagerImpl().registerAttributeModule(module);
@@ -2565,6 +2565,13 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 			} else {
 				log.warn("Inverse strong dependencies inconsistency. Inverse strong dependencies should contain information about {}. ", attributeDef);
 			}
+		}
+
+		// try to remove and unregister attribute module
+		AttributesModuleImplApi module = (AttributesModuleImplApi) getAttributesManagerImpl().getAttributesModule(sess, attribute);
+		if (module != null) {
+			getAttributesManagerImpl().removeAttributeModule(module);
+			getAttributesManagerImpl().unregisterAttributeModule(module);
 		}
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
@@ -4520,7 +4520,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 	}
 
 	@Override
-	public AttributesModuleImplApi getUninitiatedAttributesModule(PerunSession sess, AttributeDefinition attributeDefinition) {
+	public AttributesModuleImplApi getUninitializedAttributesModule(PerunSession sess, AttributeDefinition attributeDefinition) {
 
 		// core attributes doesn't have modules
 		if (isCoreAttribute(sess, attributeDefinition)) return null;
@@ -4543,14 +4543,11 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 		}
 
 		for (AttributeDefinition attributeDefinition : allAttributesDef) {
-			AttributesModuleImplApi module = getUninitiatedAttributesModule(sess, attributeDefinition);
+			AttributesModuleImplApi module = getUninitializedAttributesModule(sess, attributeDefinition);
 
 			if (module != null) {
-				attributesModulesMap.put(module.getClass().getName(), module);
-				log.debug("Module {} loaded.", module.getClass().getSimpleName());
-				uninitializedAttributesModulesMap.remove(module.getClass().getName());
+				initAttributeModule(module);
 				registerAttributeModule(module);
-				log.debug("Module {} was registered for audit message listening.", module.getClass().getName());
 			}
 		}
 	}
@@ -4558,12 +4555,27 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 	@Override
 	public void initAttributeModule(AttributesModuleImplApi module) {
 		attributesModulesMap.putIfAbsent(module.getClass().getName(), module);
+		log.debug("Module {} loaded.", module.getClass().getSimpleName());
 		uninitializedAttributesModulesMap.remove(module.getClass().getName());
+	}
+
+	@Override
+	public void removeAttributeModule(AttributesModuleImplApi module) {
+		uninitializedAttributesModulesMap.putIfAbsent(module.getClass().getName(), module);
+		log.debug("Module {} removed.", module.getClass().getSimpleName());
+		attributesModulesMap.remove(module.getClass().getName());
 	}
 
 	@Override
 	public void registerAttributeModule(AttributesModuleImplApi module) {
 		Auditer.registerAttributeModule(module);
+		log.debug("Module {} was registered for audit message listening.", module.getClass().getName());
+	}
+
+	@Override
+	public void unregisterAttributeModule(AttributesModuleImplApi module) {
+		Auditer.unregisterAttributeModule(module);
+		log.debug("Module {} was removed from audit message listening.", module.getClass().getName());
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Auditer.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Auditer.java
@@ -87,6 +87,14 @@ public class Auditer {
 
 	}
 
+	public static void unregisterAttributeModule(AttributesModuleImplApi attributesModuleImplApi) {
+		log.trace("Auditer: Try to unregister module {}", (attributesModuleImplApi == null) ? null : attributesModuleImplApi.getClass().getName());
+		if(attributesModuleImplApi != null && registeredAttributesModules.contains(attributesModuleImplApi)) {
+			registeredAttributesModules.remove(attributesModuleImplApi);
+			log.debug("Auditer: Module {} was removed from audit message listening.", attributesModuleImplApi.getClass().getName());
+		}
+	}
+
 	public Auditer() {
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Auditer.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Auditer.java
@@ -79,19 +79,22 @@ public class Auditer {
 	private static final Set<AttributesModuleImplApi> registeredAttributesModules = new HashSet<>();
 
 	public static void registerAttributeModule(AttributesModuleImplApi attributesModuleImplApi) {
-		log.trace("Auditer: Try to register module {}", (attributesModuleImplApi == null) ? null : attributesModuleImplApi.getClass().getName());
-		if(attributesModuleImplApi != null && !registeredAttributesModules.contains(attributesModuleImplApi)) {
-			registeredAttributesModules.add(attributesModuleImplApi);
-			log.debug("Auditer: Module {} was registered for audit message listening.", attributesModuleImplApi.getClass().getName());
+		synchronized (LOCK_DB_TABLE_AUDITER_LOG) {
+			log.trace("Auditer: Try to register module {}", (attributesModuleImplApi == null) ? null : attributesModuleImplApi.getClass().getName());
+			if(attributesModuleImplApi != null && !registeredAttributesModules.contains(attributesModuleImplApi)) {
+				registeredAttributesModules.add(attributesModuleImplApi);
+				log.debug("Auditer: Module {} was registered for audit message listening.", attributesModuleImplApi.getClass().getName());
+			}
 		}
-
 	}
 
 	public static void unregisterAttributeModule(AttributesModuleImplApi attributesModuleImplApi) {
-		log.trace("Auditer: Try to unregister module {}", (attributesModuleImplApi == null) ? null : attributesModuleImplApi.getClass().getName());
-		if(attributesModuleImplApi != null && registeredAttributesModules.contains(attributesModuleImplApi)) {
-			registeredAttributesModules.remove(attributesModuleImplApi);
-			log.debug("Auditer: Module {} was removed from audit message listening.", attributesModuleImplApi.getClass().getName());
+		synchronized (LOCK_DB_TABLE_AUDITER_LOG) {
+			log.trace("Auditer: Try to unregister module {}", (attributesModuleImplApi == null) ? null : attributesModuleImplApi.getClass().getName());
+			if (attributesModuleImplApi != null && registeredAttributesModules.contains(attributesModuleImplApi)) {
+				registeredAttributesModules.remove(attributesModuleImplApi);
+				log.debug("Auditer: Module {} was removed from audit message listening.", attributesModuleImplApi.getClass().getName());
+			}
 		}
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
@@ -24,7 +24,6 @@ import cz.metacentrum.perun.core.api.exceptions.ActionTypeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.AnonymizationNotSupportedException;
 import cz.metacentrum.perun.core.api.exceptions.AttributeDefinitionExistsException;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
-import cz.metacentrum.perun.core.api.exceptions.GroupResourceMismatchException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.ModuleNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
@@ -2564,6 +2563,14 @@ public interface AttributesManagerImplApi {
 	Object getAttributesModule(PerunSession sess, AttributeDefinition attribute);
 
 	/**
+	 * Get uninitiated attributeModule for the attribute
+	 *
+	 * @param attribute get the attribute module for this attribute
+	 * @see cz.metacentrum.perun.core.impl.AttributesManagerImpl#getUninitiatedAttributesModule(PerunSession, AttributeDefinition)
+	 */
+	AttributesModuleImplApi getUninitiatedAttributesModule(PerunSession sess, AttributeDefinition attribute);
+
+	/**
 	 * Updates AttributeDefinition.
 	 *
 	 * @param perunSession
@@ -2612,20 +2619,28 @@ public interface AttributesManagerImplApi {
 	UserVirtualAttributesModuleImplApi getUserVirtualAttributeModule(PerunSession sess, AttributeDefinition attribute);
 
 	/**
-	 * Init attribute modules map in Impl layer.
+	 * Init attribute modules map in Impl layer. And register them in Auditer for message listening.
 	 *
 	 * @see AttributesManagerBlImpl#initialize()
 	 * @param modules List of attribute module class instances
 	 */
-	void initAttributeModules(ServiceLoader<AttributesModuleImplApi> modules);
+	void initAndRegisterAttributeModules(PerunSession session, ServiceLoader<AttributesModuleImplApi> modules, Set<AttributeDefinition> allAttributesDef);
 
 	/**
-	 * Register attribute modules in Auditer for message listening.
+	 * Add attribute module to attribute module map in Impl layer (if it is not there yet).
 	 *
-	 * @see AttributesManagerBlImpl#initialize()
-	 * @param modules List of attribute module class instances
+	 * @see AttributesManagerBlImpl#createAttribute(PerunSession, AttributeDefinition)
+	 * @param module module to add
 	 */
-	void registerAttributeModules(ServiceLoader<AttributesModuleImplApi> modules);
+	void initAttributeModule(AttributesModuleImplApi module);
+
+	/**
+	 * Register attribute module in Auditer for message listening (if it is not there yet).
+	 *
+	 * @see AttributesManagerBlImpl#createAttribute(PerunSession, AttributeDefinition)
+	 * @param module module to register
+	 */
+	void registerAttributeModule(AttributesModuleImplApi module);
 
 	/**
 	 * Finds ids of PerunBeans that have the attribute's value for the attribute.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
@@ -2566,9 +2566,9 @@ public interface AttributesManagerImplApi {
 	 * Get uninitiated attributeModule for the attribute
 	 *
 	 * @param attribute get the attribute module for this attribute
-	 * @see cz.metacentrum.perun.core.impl.AttributesManagerImpl#getUninitiatedAttributesModule(PerunSession, AttributeDefinition)
+	 * @see cz.metacentrum.perun.core.impl.AttributesManagerImpl#getUninitializedAttributesModule(PerunSession, AttributeDefinition)
 	 */
-	AttributesModuleImplApi getUninitiatedAttributesModule(PerunSession sess, AttributeDefinition attribute);
+	AttributesModuleImplApi getUninitializedAttributesModule(PerunSession sess, AttributeDefinition attribute);
 
 	/**
 	 * Updates AttributeDefinition.
@@ -2635,12 +2635,28 @@ public interface AttributesManagerImplApi {
 	void initAttributeModule(AttributesModuleImplApi module);
 
 	/**
+	 * Remove attribute module from attribute module map in Impl layer.
+	 *
+	 * @see AttributesManagerBlImpl#deleteAttribute(PerunSession, AttributeDefinition)
+	 * @param module module to remove
+	 */
+	void removeAttributeModule(AttributesModuleImplApi module);
+
+	/**
 	 * Register attribute module in Auditer for message listening (if it is not there yet).
 	 *
 	 * @see AttributesManagerBlImpl#createAttribute(PerunSession, AttributeDefinition)
 	 * @param module module to register
 	 */
 	void registerAttributeModule(AttributesModuleImplApi module);
+
+	/**
+	 * Unregister attribute module in Auditer from message listening (if it is not there yet).
+	 *
+	 * @see AttributesManagerBlImpl#deleteAttribute(PerunSession, AttributeDefinition)
+	 * @param module module to unregister
+	 */
+	void unregisterAttributeModule(AttributesModuleImplApi module);
 
 	/**
 	 * Finds ids of PerunBeans that have the attribute's value for the attribute.

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/AttributesManagerImplIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/AttributesManagerImplIntegrationTest.java
@@ -25,6 +25,8 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 public class AttributesManagerImplIntegrationTest extends AbstractPerunIntegrationTest {
 
@@ -122,6 +124,34 @@ public class AttributesManagerImplIntegrationTest extends AbstractPerunIntegrati
 		List<Attribute> attributes =
 			attributesManager.getRequiredAttributes(sess, Collections.singletonList(service1), resource, group);
 		assertThat(attributes).hasSize(1);
+	}
+
+	@Test
+	public void getUninitiatedAttributesModule() throws Exception {
+		System.out.println(CLASS_NAME + "getUninitiatedAttributesModule");
+
+		AttributeDefinition attr = new AttributeDefinition();
+		attr.setNamespace(AttributesManager.NS_USER_ATTR_DEF);
+		attr.setFriendlyName("IPAddresses");
+		attr.setType(ArrayList.class.getName());
+
+		assertNotNull(attributesManager.getUninitiatedAttributesModule(sess, attr));
+
+		perun.getAttributesManagerBl().createAttribute(sess, attr);
+
+		assertNull(attributesManager.getUninitiatedAttributesModule(sess, attr));
+	}
+
+	@Test
+	public void getUninitiatedAttributesModuleForAttributeWithoutModule() {
+		System.out.println(CLASS_NAME + "getUninitiatedAttributesModuleForAttributeWithoutModule");
+
+		AttributeDefinition attr = new AttributeDefinition();
+		attr.setNamespace(AttributesManager.NS_USER_ATTR_DEF);
+		attr.setFriendlyName("SomeNonexistentAttribute");
+		attr.setType(ArrayList.class.getName());
+
+		assertNull(attributesManager.getUninitiatedAttributesModule(sess, attr));
 	}
 
 

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/AttributesManagerImplIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/AttributesManagerImplIntegrationTest.java
@@ -127,31 +127,47 @@ public class AttributesManagerImplIntegrationTest extends AbstractPerunIntegrati
 	}
 
 	@Test
-	public void getUninitiatedAttributesModule() throws Exception {
-		System.out.println(CLASS_NAME + "getUninitiatedAttributesModule");
+	public void getUninitializedAttributesModule() throws Exception {
+		System.out.println(CLASS_NAME + "getUninitializedAttributesModule");
 
 		AttributeDefinition attr = new AttributeDefinition();
 		attr.setNamespace(AttributesManager.NS_USER_ATTR_DEF);
 		attr.setFriendlyName("IPAddresses");
 		attr.setType(ArrayList.class.getName());
 
-		assertNotNull(attributesManager.getUninitiatedAttributesModule(sess, attr));
+		assertNotNull(attributesManager.getUninitializedAttributesModule(sess, attr));
 
 		perun.getAttributesManagerBl().createAttribute(sess, attr);
 
-		assertNull(attributesManager.getUninitiatedAttributesModule(sess, attr));
+		assertNull(attributesManager.getUninitializedAttributesModule(sess, attr));
 	}
 
 	@Test
-	public void getUninitiatedAttributesModuleForAttributeWithoutModule() {
-		System.out.println(CLASS_NAME + "getUninitiatedAttributesModuleForAttributeWithoutModule");
+	public void getUninitializedAttributesModuleForAttributeWithoutModule() {
+		System.out.println(CLASS_NAME + "getUninitializedAttributesModuleForAttributeWithoutModule");
 
 		AttributeDefinition attr = new AttributeDefinition();
 		attr.setNamespace(AttributesManager.NS_USER_ATTR_DEF);
 		attr.setFriendlyName("SomeNonexistentAttribute");
 		attr.setType(ArrayList.class.getName());
 
-		assertNull(attributesManager.getUninitiatedAttributesModule(sess, attr));
+		assertNull(attributesManager.getUninitializedAttributesModule(sess, attr));
+	}
+
+	@Test
+	public void getUninitializedAttributesModuleFromDeletedAttribute() throws Exception {
+		System.out.println(CLASS_NAME + "getUninitializedAttributesModuleFromDeletedAttribute");
+
+		AttributeDefinition attr = new AttributeDefinition();
+		attr.setNamespace(AttributesManager.NS_USER_ATTR_DEF);
+		attr.setFriendlyName("IPAddresses");
+		attr.setType(ArrayList.class.getName());
+
+		perun.getAttributesManagerBl().createAttribute(sess, attr);
+		assertNull(attributesManager.getUninitializedAttributesModule(sess, attr));
+
+		perun.getAttributesManagerBl().deleteAttribute(sess, attr);
+		assertNotNull(attributesManager.getUninitializedAttributesModule(sess, attr));
 	}
 
 


### PR DESCRIPTION
- not all attributes are register during initialize method, but only such attributes which are already defined
- when new attribute is being created, the method also checks whether its module needs to be initialized (and registered for auditer listening) and does so
- also added tests