### PR TITLE
CORE: Removed unused config for perunLdapInitializer

### DIFF
--- a/perun-base/src/main/resources/perun-base.xml
+++ b/perun-base/src/main/resources/perun-base.xml
@@ -87,8 +87,7 @@
 				<prop key="perun.notification.principals">perunNotifications</prop>
 				<prop key="perun.rpc.principal">perunRpc</prop>
 				<prop key="perun.dont.lookup.users">perunTests, perunController, perunEngine, perunDispatcher,
-					perunRegistrar, perunSynchronizer, perunCabinet, perunNotifications, perunRpc, perunLdapc,
-					perunLdapInitializer
+					perunRegistrar, perunSynchronizer, perunCabinet, perunNotifications, perunRpc, perunLdapc
 				</prop>
 				<prop key="perun.db.type">postgresql</prop>
 				<prop key="perun.group.synchronization.interval">1</prop>


### PR DESCRIPTION
- Principal "perunLdapInitializer" is no longer used
  by any component, hence we don't have to have it in
  default config.