### PR TITLE
Upgrade to Testcontainers 1.15.1

### DIFF
--- a/perun-base/pom.xml
+++ b/perun-base/pom.xml
@@ -112,14 +112,14 @@
 		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>testcontainers</artifactId>
-			<version>1.15.0</version>
+			<version>1.15.1</version>
 			<scope>compile</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>postgresql</artifactId>
-			<version>1.15.0</version>
+			<version>1.15.1</version>
 			<scope>compile</scope>
 		</dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -333,14 +333,14 @@
 			<dependency>
 				<groupId>org.testcontainers</groupId>
 				<artifactId>testcontainers</artifactId>
-				<version>1.15.0</version>
+				<version>1.15.1</version>
 				<scope>test</scope>
 			</dependency>
 
 			<dependency>
 				<groupId>org.testcontainers</groupId>
 				<artifactId>postgresql</artifactId>
-				<version>1.15.0</version>
+				<version>1.15.1</version>
 				<scope>test</scope>
 			</dependency>
 


### PR DESCRIPTION
- Testcontainers was upgraded to 1.15.1.
- Version 1.15.0 sometimes caused container creation to fail, it should be fixed
in 1.15.1.