### PR TITLE
Require stronger passwords for MU namespace

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/EinfraPasswordManagerModule.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/EinfraPasswordManagerModule.java
@@ -220,7 +220,7 @@ public class EinfraPasswordManagerModule extends GenericPasswordManagerModule {
 		}
 
 		if (password.length() < 10) {
-			log.warn("Password for {}:{} is too short. At least 10 characters is required.", actualLoginNamespace, login);
+			log.warn("Password for {}:{} is too short. At least 10 characters are required.", actualLoginNamespace, login);
 			throw new PasswordStrengthException("Password for " + actualLoginNamespace + ":" + login + " is too short. At least 10 characters is required.");
 		}
 
@@ -249,8 +249,8 @@ public class EinfraPasswordManagerModule extends GenericPasswordManagerModule {
 		if (einfraPasswordContainsSpec.matcher(password).matches()) groupsCounter++;
 
 		if (groupsCounter < 3) {
-			log.warn("Password for {}:{} is two weak. It must consist of at least 3 kinds of characters from: lower-case letter, upper-case letter, digit, spec. character.", actualLoginNamespace, login);
-			throw new PasswordStrengthException("Password for " + actualLoginNamespace + ":" + login + " is two weak. It must consist of at least 3 kinds of characters from: lower-case letter, upper-case letter, digit, spec. character.");
+			log.warn("Password for {}:{} is too weak. It has to contain at least 3 kinds of characters from: lower-case letter, upper-case letter, digit, spec. character.", actualLoginNamespace, login);
+			throw new PasswordStrengthException("Password for " + actualLoginNamespace + ":" + login + " is too weak. It has to contain at least 3 kinds of characters from: lower-case letter, upper-case letter, digit, spec. character.");
 		}
 
 	}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/MuPasswordManagerModule.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/MuPasswordManagerModule.java
@@ -188,7 +188,7 @@ public class MuPasswordManagerModule implements PasswordManagerModule {
 		}
 
 		if (password.length() < 12) {
-			log.warn("Password for {}:{} is too short. At least 12 characters is required.", "mu", login);
+			log.warn("Password for {}:{} is too short. At least 12 characters are required.", "mu", login);
 			throw new PasswordStrengthException("Password for mu:" + login + " is too short. At least 12 characters is required.");
 		}
 
@@ -200,8 +200,8 @@ public class MuPasswordManagerModule implements PasswordManagerModule {
 		if (muPasswordContainsSpec.matcher(password).matches()) groupsCounter++;
 
 		if (groupsCounter < 3) {
-			log.warn("Password for {}:{} is two weak. It must consist of at least 3 kinds of characters from: lower-case letter, upper-case letter, digit, spec. character.", "mu", login);
-			throw new PasswordStrengthException("Password for mu:" + login + " is two weak. It must consist of at least 3 kinds of characters from: lower-case letter, upper-case letter, digit, spec. character.");
+			log.warn("Password for {}:{} is too weak. It has to contain at least 3 kinds of characters from: lower-case letter, upper-case letter, digit, spec. character.", "mu", login);
+			throw new PasswordStrengthException("Password for mu:" + login + " is too weak. It has to contain at least 3 kinds of characters from: lower-case letter, upper-case letter, digit, spec. character.");
 		}
 
 	}


### PR DESCRIPTION
- Require at least 12 characters.
- Require at least 3 of 4 character groups.
- Generated passwords for guest accounts
  are now 24 characters long.