### PR TITLE
Fixed audit message ResourceDeleted

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/audit/events/ResourceManagerEvents/ResourceDeleted.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/audit/events/ResourceManagerEvents/ResourceDeleted.java
@@ -3,26 +3,21 @@ package cz.metacentrum.perun.audit.events.ResourceManagerEvents;
 import cz.metacentrum.perun.audit.events.AuditEvent;
 import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.Resource;
-import cz.metacentrum.perun.core.api.Service;
-
-import java.util.List;
 
 public class ResourceDeleted extends AuditEvent {
 
 	private Resource resource;
 	private Facility facility;
-	private List<Service> services;
 	private String message;
 
 	@SuppressWarnings("unused") // used by jackson mapper
 	public ResourceDeleted() {
 	}
 
-	public ResourceDeleted(Resource resource, Facility facility, List<Service> services) {
+	public ResourceDeleted(Resource resource, Facility facility) {
 		this.resource = resource;
 		this.facility = facility;
-		this.services = services;
-		this.message = formatMessage("%s deleted.#%s. Afected services:%s.", resource, facility, services);
+		this.message = formatMessage("%s deleted.#%s.", resource, facility);
 	}
 
 	@Override
@@ -36,10 +31,6 @@ public class ResourceDeleted extends AuditEvent {
 
 	public Facility getFacility() {
 		return facility;
-	}
-
-	public List<Service> getServices() {
-		return services;
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ResourcesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ResourcesManagerBlImpl.java
@@ -286,7 +286,7 @@ public class ResourcesManagerBlImpl implements ResourcesManagerBl {
 		// Get the resource VO
 		Vo vo = this.getVo(sess, resource);
 		getResourcesManagerImpl().deleteResource(sess, vo, resource);
-		getPerunBl().getAuditer().log(sess, new ResourceDeleted(resource, facility, services));
+		getPerunBl().getAuditer().log(sess, new ResourceDeleted(resource, facility));
 	}
 
 	@Override


### PR DESCRIPTION
* This audit message used to have a part with list of affected services, but audit-parser cannot work with list of entities, so message was in incorrect format.
* I removed services from ResourceDeleted and now in audit message are only mentioned resource and facility.