### PR TITLE
New method moveMembership

### DIFF
--- a/perun-base/src/main/resources/perun-roles.yml
+++ b/perun-base/src/main/resources/perun-roles.yml
@@ -2773,6 +2773,12 @@ perun_policies:
     include_policies:
       - default_policy
 
+  moveMembership_Vo_User_User_policy:
+    policy_roles:
+      - VOADMIN: Vo
+    include_policies:
+      - default_policy
+
   #OwnersManagerEntry
   createOwner_Owner_policy:
     policy_roles: []

--- a/perun-cli/Perun/MembersAgent.pm
+++ b/perun-cli/Perun/MembersAgent.pm
@@ -133,4 +133,9 @@ sub getSponsoredMembers
  return Perun::Common::callManagerMethod('getSponsoredMembers', '[]RichMember', @_);
 }
 
+sub moveMembership
+{
+	return Perun::Common::callManagerMethod('moveMembership', '', @_);
+}
+
 1;

--- a/perun-cli/moveMembership
+++ b/perun-cli/moveMembership
@@ -1,0 +1,43 @@
+#!/usr/bin/perl -w
+
+use strict;
+use warnings;
+use Getopt::Long qw(:config no_ignore_case);
+use Perun::Agent;
+use Perun::Common qw(printMessage);
+
+sub help {
+	return qq{
+	Moves membership in VO from the source user to the target user.
+	Both user's ids and VO id are required fields.
+	------------------------------------
+	Available options:
+	--sourcetUserId   | -s source user id
+	--targetUserId    | -t target user id
+	--voId            | -v VO id
+	--batch           | -b batch
+	--help            | -h prints this help
+	};
+}
+
+my ($sourceUserId, $targetUserId, $voId, $batch);
+GetOptions ("help|h"     => sub {
+		print help();
+		exit 0;
+	},
+	"sourceUserId|s=i"       => \$sourceUserId,
+	"targetUserId|t=i"       => \$targetUserId,
+	"voId|v=i"               => \$voId,
+	"batch|b"                => \$batch) || die help();
+
+# Check options
+unless (defined($sourceUserId)) { die "ERROR: sourceUserId is required \n";}
+unless (defined($targetUserId)) { die "ERROR: targetUserId is required \n";}
+unless (defined($voId)) { die "ERROR: voId is required \n";}
+
+my $agent = Perun::Agent->new();
+my $membersAgent = $agent->getMembersAgent;
+
+$membersAgent->moveMembership( sourceUser => $sourceUserId, targetUser => $targetUserId, vo => $voId );
+
+printMessage("Membership in VO: $voId was moved from source user Id: $sourceUserId to target user Id: $targetUserId", $batch);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/MembersManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/MembersManager.java
@@ -1420,4 +1420,22 @@ public interface MembersManager {
 	 * @throws UserNotExistsException if there is no such user
 	 */
 	void updateSponsorshipValidity(PerunSession sess, Member sponsoredMember, User sponsor, LocalDate newValidity) throws PrivilegeException, SponsorshipDoesNotExistException, MemberNotExistsException, UserNotExistsException;
+
+	/**
+	 * Moves membership in VO from source user to target user - moves the source user's
+	 * memberships in non-synchronized groups, member related attributes, bans and
+	 * sponsorships in the VO. Removes the source user's member object.
+	 *
+	 * @param sess session
+	 * @param vo the VO in which the membership should be moved
+	 * @param sourceUser the user to move membership from
+	 * @param targetUser the user to move membership to
+	 * @throws UserNotExistsException if there is no such user
+	 * @throws VoNotExistsException if there is no such VO
+	 * @throws PrivilegeException insufficient permissions
+	 * @throws MemberNotExistsException when sourceUser is not member of the VO
+	 * @throws AlreadyMemberException when targetUser is already member of the VO
+	 * @throws ExtendMembershipException when targetUser doesn't have required LOA for the VO
+	 */
+	void moveMembership(PerunSession sess, Vo vo, User sourceUser, User targetUser) throws UserNotExistsException, VoNotExistsException, PrivilegeException, ExtendMembershipException, MemberNotExistsException, AlreadyMemberException;
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/MembersManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/MembersManagerBl.java
@@ -1767,4 +1767,19 @@ public interface MembersManagerBl {
 	 * @return list of sponsorships which have validityTo set in the given range
 	 */
 	List<Sponsorship> getSponsorshipsExpiringInRange(PerunSession sess, LocalDate from, LocalDate to);
+
+	/**
+	 * Moves membership in VO from source user to target user - moves the source user's
+	 * memberships in non-synchronized groups, member related attributes, bans and
+	 * sponsorships in the VO. Removes the source user's member object.
+	 *
+	 * @param sess session
+	 * @param vo the VO in which the membership should be moved
+	 * @param sourceUser the user to move membership from
+	 * @param targetUser the user to move membership to
+	 * @throws MemberNotExistsException when sourceUser is not member of the VO
+	 * @throws AlreadyMemberException when targetUser is already member of the VO
+	 * @throws ExtendMembershipException when the targetUser doesn't have required LOA for the VO
+	 */
+	void moveMembership(PerunSession sess, Vo vo, User sourceUser, User targetUser) throws MemberNotExistsException, AlreadyMemberException, ExtendMembershipException;
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/MembersManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/MembersManagerEntry.java
@@ -1578,6 +1578,22 @@ public class MembersManagerEntry implements MembersManager {
 		membersManagerBl.updateSponsorshipValidity(sess, sponsoredMember, sponsor, newValidity);
 	}
 
+	@Override
+	public void moveMembership(PerunSession sess, Vo vo, User sourceUser, User targetUser) throws UserNotExistsException, VoNotExistsException, PrivilegeException, ExtendMembershipException, MemberNotExistsException, AlreadyMemberException {
+		Utils.checkPerunSession(sess);
+
+		getPerunBl().getUsersManagerBl().checkUserExists(sess, sourceUser);
+		getPerunBl().getUsersManagerBl().checkUserExists(sess, targetUser);
+		getPerunBl().getVosManagerBl().checkVoExists(sess, vo);
+
+		//Authorization
+		if (!AuthzResolver.authorizedInternal(sess, "moveMembership_Vo_User_User_policy", vo)) {
+			throw new PrivilegeException("moveMembership");
+		}
+
+		getMembersManagerBl().moveMembership(sess, vo, sourceUser, targetUser);
+	}
+
 	/**
 	 * Converts member to member with sponsors and sets all his sponsors.
 	 *

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/MembersManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/MembersManagerImpl.java
@@ -674,4 +674,14 @@ public class MembersManagerImpl implements MembersManagerImplApi {
 						"validity_to >= ? AND validity_to < ?",
 				MEMBER_SPONSORSHIP_MAPPER, true, from, to);
 	}
+
+	@Override
+	public void moveMembersApplications(PerunSession sess, Member sourceMember, Member targetMember) {
+		try {
+			jdbc.update("update application set user_id=?, modified_at=" + Compatibility.getSysdate() + ", modified_by_uid=? where user_id=? and vo_id=?",
+				targetMember.getUserId(), sess.getPerunPrincipal().getUserId(), sourceMember.getVoId(), sourceMember.getVoId());
+		} catch (RuntimeException e) {
+			throw new InternalErrorException(e);
+		}
+	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/MembersManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/MembersManagerImplApi.java
@@ -409,4 +409,13 @@ public interface MembersManagerImplApi {
 	 * @return list of sponsorships which have validityTo set in the given range
 	 */
 	List<Sponsorship> getSponsorshipsExpiringInRange(PerunSession sess, LocalDate from, LocalDate to);
+
+	/**
+	 * Move all applications from one member to another member.
+	 *
+	 * @param sess
+	 * @param sourceMember for which move applications from
+	 * @param targetMember for which move applications to
+	 */
+	void moveMembersApplications(PerunSession sess, Member sourceMember, Member targetMember);
 }

--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -8829,6 +8829,23 @@ paths:
         default:
           $ref: '#/components/responses/ExceptionResponse'
 
+  /urlinjsonout/membersManager/moveMembership:
+    post:
+      tags:
+        - MembersManager
+      operationId: moveMembership
+      summary: Moves membership in VO from source user to target user - moves the source user's memberships in non-synchronized groups,
+        member related attributes, bans and sponsorships in the VO. Removes the source user's member object.
+      parameters:
+        - $ref: '#/components/parameters/voId'
+        - { name: sourceUser, schema: { type: integer }, in: query, description: "id of source user", required: true }
+        - { name: targetUser, schema: { type: integer }, in: query, description: "id of target user", required: true }
+      responses:
+        '200':
+          $ref: '#/components/responses/VoidResponse'
+        default:
+          $ref: '#/components/responses/ExceptionResponse'
+
 
   #################################################
   #                                               #

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/MembersManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/MembersManagerMethod.java
@@ -1685,6 +1685,32 @@ public enum MembersManagerMethod implements ManagerMethod {
 			return null;
 
 		}
-	}
+	},
 
+	/*#
+	 * Moves membership in VO from source user to target user - moves the source user's
+	 * memberships in non-synchronized groups, member related attributes, bans and
+	 * sponsorships in the VO. Removes the source user's member object.
+	 *
+	 * @param vo int VO <code>id</code>
+	 * @param sourceUser int User <code>id</code> to move membership from
+	 * @param targetUser int User <code>id</code> to move membership to
+	 * @throw UserNotExistsException if there is no such user
+	 * @throw VoNotExistsException if there is no such VO
+	 * @throw PrivilegeException insufficient permissions
+	 * @throw MemberNotExistsException when sourceUser is not member of the VO
+	 * @throw AlreadyMemberException when targetUser is already member of the VO
+	 * @throw ExtendMembershipException when targetUser doesn't have required LOA for the VO
+	 */
+	moveMembership {
+		@Override
+		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
+			parms.stateChangingCheck();
+
+			ac.getMembersManager().moveMembership(ac.getSession(), ac.getVoById(parms.readInt("vo")),
+				ac.getUserById(parms.readInt("sourceUser")), ac.getUserById(parms.readInt("targetUser")));
+
+			return null;
+		}
+	}
 }


### PR DESCRIPTION
- New method moveMembership was added, it moves membership in VO from source user
to target user.
- Source member is deleted and his attributes, sponsorships and bans are moved
to new target member. Target member is added only to non-synchronized groups of
source member.
- Method was added to CLI as well.