### PR TITLE
Core - generate password for sponsored user

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/MembersManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/MembersManager.java
@@ -1152,7 +1152,8 @@ public interface MembersManager {
 	 * @param vo virtual organization  for the member
 	 * @param namespace namespace for selecting password module
 	 * @param name a map containing the full name or its parts (mandatory: firstName, lastName; optionally: titleBefore, titleAfter)
-	 * @param password  password
+	 * @param password password, if the password is empty, and the `sendActivationLink` is set to true, this method will
+	 *                 generate a random password for the created user
 	 * @param email (optional) preferred email that will be set to the created user. If no email
 	 *              is provided, "no-reply@muni.cz" is used.
 	 * @param sponsor sponsoring user or null for the caller

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/MembersManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/MembersManagerBl.java
@@ -1445,7 +1445,8 @@ public interface MembersManagerBl {
 	 * @param vo virtual organization
 	 * @param namespace used for selecting external system in which guest user account will be created
 	 * @param name a map containing the full name or its parts (mandatory: firstName, lastName; optionally: titleBefore, titleAfter)
-	 * @param password password
+	 * @param password password, if the password is empty, and the `sendActivationLink` is set to true, this method will
+	 *                 generate a random password for the created user
 	 * @param email (optional) preferred email that will be set to the created user. If no email
 	 *              is provided, "no-reply@muni.cz" is used.
 	 * @param sponsor sponsoring user
@@ -1474,7 +1475,8 @@ public interface MembersManagerBl {
 	 * @param vo virtual organization
 	 * @param namespace used for selecting external system in which guest user account will be created
 	 * @param name a map containing the full name or its parts (mandatory: firstName, lastName; optionally: titleBefore, titleAfter)
-	 * @param password password
+	 * @param password password, if the password is empty, and the `sendActivationLink` is set to true, this method will
+	 *                 generate a random password for the created user
 	 * @param email (optional) preferred email that will be set to the created user. If no email
 	 *              is provided, "no-reply@muni.cz" is used.
 	 * @param sponsor sponsoring user

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
@@ -2386,6 +2386,11 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 			}
 		}
 
+		if (password.isBlank() && sendActivationLink) {
+			var module = getPerunBl().getUsersManagerBl().getPasswordManagerModule(session, namespace);
+			password = module.generateRandomPassword(session, null);
+		}
+
 		Member sponsoredMember = setSponsoredMember(session, vo, sponsoredUser, namespace, password, sponsor, validityTo, validation);
 
 		//try to send activation link

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/MembersManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/MembersManagerMethod.java
@@ -131,7 +131,8 @@ public enum MembersManagerMethod implements ManagerMethod {
 	 * @param lastName last name - mandatory
 	 * @param titleBefore titles before the name - optionally
 	 * @param titleAfter titles after the name - optionally
-	 * @param password String password
+	 * @param password String password, if the password is empty, and the `sendActivationLink` is set to true, this method will
+	 *                 generate a random password for the created user
 	 * @param vo int VO ID
 	 * @param namespace String namespace selecting remote system for storing the password
 	 * @param sponsor int sponsor's ID


### PR DESCRIPTION
* If the password provided for the created sponsored user is blank, and
the sendActivationLink is set to true, we will now generate a random
password for the specified namespace.
* The problem was when users didn't want to specify the password for the
created user and wanted to let him choose it. However, some exteral
systems still requires a password, when creating an account. Therefore,
we have to generate some password in such cases.