### PR TITLE
Deleting VO using PostgreSQL's delete-returning

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/VosManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/VosManagerBlImpl.java
@@ -205,8 +205,8 @@ public class VosManagerBlImpl implements VosManagerBl {
 		}
 
 		// Finally delete the VO
-		getVosManagerImpl().deleteVo(sess, vo);
-		getPerunBl().getAuditer().log(sess, new VoDeleted(vo));
+		Vo deletedVo = getVosManagerImpl().deleteVo(sess, vo);
+		getPerunBl().getAuditer().log(sess, new VoDeleted(deletedVo));
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/VosManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/VosManagerImplApi.java
@@ -44,9 +44,10 @@ public interface VosManagerImplApi {
 	 *
 	 * @param perunSession
 	 * @param vo
+	 * @return deleted VO
 	 * @throws InternalErrorException
 	 */
-	void deleteVo(PerunSession perunSession, Vo vo);
+	Vo deleteVo(PerunSession perunSession, Vo vo);
 
 
 	/**


### PR DESCRIPTION
- Deleting VO is now done using PostgreSQL's delete-returning. Deleted row
is returned and mapped to VO. Deleted VO is returned and used for auditing.