### PR TITLE
Core - general sponsorship

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/NamespaceRules.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/NamespaceRules.java
@@ -6,11 +6,13 @@ import java.util.Set;
 public class NamespaceRules {
 
 	private String namespaceName;
+	private String defaultEmail;
 	private Set<String> requiredAttributes;
 	private Set<String> optionalAttributes;
 
-	public NamespaceRules(String namespaceName, Set<String> requiredAttributes, Set<String> optionalAttributes) {
+	public NamespaceRules(String namespaceName, String defaultEmail, Set<String> requiredAttributes, Set<String> optionalAttributes) {
 		this.namespaceName = namespaceName;
+		this.defaultEmail = defaultEmail;
 		this.requiredAttributes = requiredAttributes;
 		this.optionalAttributes = optionalAttributes;
 	}
@@ -59,5 +61,13 @@ public class NamespaceRules {
 			", requiredAttributes=" + requiredAttributes +
 			", optionalAttributes=" + optionalAttributes +
 			'}';
+	}
+
+	public String getDefaultEmail() {
+		return defaultEmail;
+	}
+
+	public void setDefaultEmail(String defaultEmail) {
+		this.defaultEmail = defaultEmail;
 	}
 }

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/SponsoredUserData.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/SponsoredUserData.java
@@ -1,0 +1,102 @@
+package cz.metacentrum.perun.core.api;
+
+/**
+ * @author Vojtech Sassmann <vojtech.sassmann@gmail.com>
+ */
+public class SponsoredUserData {
+
+	private String guestName;
+	private String firstName;
+	private String lastName;
+	private String titleBefore;
+	private String titleAfter;
+	private String namespace;
+	private String email;
+	private String password;
+	private String login;
+
+	public SponsoredUserData() {}
+	public SponsoredUserData(String guestName, String firstName, String lastName, String titleBefore, String titleAfter, String namespace, String email, String password, String login) {
+		this.guestName = guestName;
+		this.firstName = firstName;
+		this.lastName = lastName;
+		this.titleBefore = titleBefore;
+		this.titleAfter = titleAfter;
+		this.namespace = namespace;
+		this.email = email;
+		this.password = password;
+		this.login = login;
+	}
+
+	public String getFirstName() {
+		return firstName;
+	}
+
+	public void setFirstName(String firstName) {
+		this.firstName = firstName;
+	}
+
+	public String getLastName() {
+		return lastName;
+	}
+
+	public void setLastName(String lastName) {
+		this.lastName = lastName;
+	}
+
+	public String getTitleBefore() {
+		return titleBefore;
+	}
+
+	public void setTitleBefore(String titleBefore) {
+		this.titleBefore = titleBefore;
+	}
+
+	public String getTitleAfter() {
+		return titleAfter;
+	}
+
+	public void setTitleAfter(String titleAfter) {
+		this.titleAfter = titleAfter;
+	}
+
+	public String getLogin() {
+		return login;
+	}
+
+	public void setLogin(String login) {
+		this.login = login;
+	}
+
+	public String getPassword() {
+		return password;
+	}
+
+	public void setPassword(String password) {
+		this.password = password;
+	}
+
+	public String getEmail() {
+		return email;
+	}
+
+	public void setEmail(String email) {
+		this.email = email;
+	}
+
+	public String getNamespace() {
+		return namespace;
+	}
+
+	public void setNamespace(String namespace) {
+		this.namespace = namespace;
+	}
+
+	public String getGuestName() {
+		return guestName;
+	}
+
+	public void setGuestName(String guestName) {
+		this.guestName = guestName;
+	}
+}

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/InvalidSponsoredUserDataException.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/InvalidSponsoredUserDataException.java
@@ -1,0 +1,29 @@
+package cz.metacentrum.perun.core.api.exceptions;
+
+/**
+ * @author Vojtech Sassmann <vojtech.sassmann@gmail.com>
+ */
+public class InvalidSponsoredUserDataException extends PerunException {
+
+	static final long serialVersionUID = 0;
+
+	public InvalidSponsoredUserDataException() {
+	}
+
+	public InvalidSponsoredUserDataException(String message) {
+		super(message);
+	}
+
+	public InvalidSponsoredUserDataException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public InvalidSponsoredUserDataException(Throwable cause) {
+		super(cause);
+	}
+
+	@Override
+	public String getFriendlyMessageTemplate() {
+		return "Invalid data provided for the creation of a sponsored user.";
+	}
+}

--- a/perun-base/src/test/resources/sponsored-accounts-config.yml
+++ b/perun-base/src/test/resources/sponsored-accounts-config.yml
@@ -1,7 +1,50 @@
 ---
+# Namespace rules which are used to determine, which information is needed
+# for each namespace during sponsorship of a new user. These information are generally
+# used to create an external account.
+#
+#
+# default_email - this field determines, which email will be set as a preferred attribute, for the generated sponsored
+#                 user. If this value is not specified, it fallbacks to 'no-reply@perun-aai.org'
+# required_attributes - fields from the SponsoredUserData class, which are required for the given namespace during the
+#                       creation of a sponsorship. Allowed values are fields of the SponsoredUserData class. This
+#                       should be mainly used in GUI to determine, which items should be visible in the dialog. But, it
+#                       is also used in the backend to validate the RPC input data. The value of these fields has to
+#                       be provided and only these fields should be used in the namespace's implementation. The only
+#                       exception is the 'password' which doesn't have to be provided, if the user will receive an
+#                       activation link.
+# optional_attributes - fields from the SponsoredUserData class, which are optional for the given namespace during the
+#                       creation of a sponsorship. Allowed values are fields of the SponsoredUserData class. This is
+#                       used only in GUI! It doesn't affect anything on the backend, since the optional attributes are
+#                       limited by the actual fields of the SponsoredUserData class. These values can be omitted and it
+#                       should be still possible to create a sponsored user.
+#
+# Currently allowed fields are:
+#  * guestName
+#  * firstName
+#  * lastName
+#  * titleBefore
+#  * titleAfter
+#  * email
+#  * password
+#  * login
+#
+# If some namespace would require an additional information, some steps are needed to be done:
+#  1.A new field has to be added to the SponsoredUserData class
+#  2 GUI has to edit the dialog accordingly
+#  3.This configuration has to be updated for the namespaces which need this new field
+#  4.Update the list of the currently allowed fields above.
+#
 namespaces:
 
-  dummy_namespace:
+  dummy:
+    default_email: "no-reply@dummy.com"
+    required_attributes: []
+    optional_attributes:
+      - password
+
+  dummy_with_login:
+    default_email: "no-reply@dummy.com"
     required_attributes:
       - login
     optional_attributes:

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/MembersManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/MembersManager.java
@@ -10,6 +10,7 @@ import cz.metacentrum.perun.core.api.exceptions.GroupNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.GroupResourceMismatchException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.InvalidLoginException;
+import cz.metacentrum.perun.core.api.exceptions.InvalidSponsoredUserDataException;
 import cz.metacentrum.perun.core.api.exceptions.LoginNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.MemberAlreadyRemovedException;
 import cz.metacentrum.perun.core.api.exceptions.MemberNotExistsException;
@@ -1151,12 +1152,9 @@ public interface MembersManager {
 	 * Creates a new sponsored Member and its User.
 	 * @param session actor
 	 * @param vo virtual organization  for the member
-	 * @param namespace namespace for selecting password module
-	 * @param name a map containing the full name or its parts (mandatory: firstName, lastName; optionally: titleBefore, titleAfter)
-	 * @param password password, if the password is empty, and the `sendActivationLink` is set to true, this method will
-	 *                 generate a random password for the created user
-	 * @param email (optional) preferred email that will be set to the created user. If no email
-	 *              is provided, "no-reply@muni.cz" is used.
+	 * @param data about the user that should be created, required fields depend on the
+	 *        provided namespace. However, it has to contain either `guestName`, or `firstName` and `lastName`.
+	 *        Also, if you want to create an external account, specify the `namespace` field.
 	 * @param sponsor sponsoring user or null for the caller
 	 * @param validityTo last day when the sponsorship is active (null means the sponsorship will last forever)
 	 * @param sendActivationLink if true link for manual activation of account will be send to the email
@@ -1175,7 +1173,7 @@ public interface MembersManager {
 	 * @throws UserNotInRoleException
 	 * @throws AlreadySponsorException
 	 */
-	RichMember createSponsoredMember(PerunSession session, Vo vo, String namespace, Map<String, String> name, String password, String email, User sponsor, LocalDate validityTo, boolean sendActivationLink, String url) throws PrivilegeException, AlreadyMemberException, LoginNotExistsException, PasswordCreationFailedException, ExtendMembershipException, WrongAttributeValueException, ExtSourceNotExistsException, WrongReferenceAttributeValueException, UserNotInRoleException, PasswordStrengthException, InvalidLoginException, AlreadySponsorException;
+	RichMember createSponsoredMember(PerunSession session, SponsoredUserData data, Vo vo, User sponsor, LocalDate validityTo, boolean sendActivationLink, String url) throws PrivilegeException, AlreadyMemberException, LoginNotExistsException, PasswordCreationFailedException, ExtendMembershipException, WrongAttributeValueException, ExtSourceNotExistsException, WrongReferenceAttributeValueException, UserNotInRoleException, PasswordStrengthException, InvalidLoginException, AlreadySponsorException, InvalidSponsoredUserDataException, NamespaceRulesNotExistsException;
 
 	/**
 	 * Creates a sponsored membership for the given user.
@@ -1185,6 +1183,7 @@ public interface MembersManager {
 	 * @param userToBeSponsored user, that will be sponsored by sponsor
 	 * @param namespace namespace for selecting password module
 	 * @param password password
+	 * @param login login
 	 * @param sponsor sponsoring user or null for the caller
 	 * @param validityTo last day when the sponsorship is active (null means the sponsorship will last forever)
 	 *
@@ -1203,7 +1202,7 @@ public interface MembersManager {
 	 * @throws InvalidLoginException
 	 * @throws AlreadySponsorException
 	 */
-	RichMember setSponsoredMember(PerunSession session, Vo vo, User userToBeSponsored, String namespace, String password, User sponsor, LocalDate validityTo) throws PrivilegeException, AlreadyMemberException, LoginNotExistsException, PasswordCreationFailedException, ExtendMembershipException, WrongAttributeValueException, ExtSourceNotExistsException, WrongReferenceAttributeValueException, UserNotInRoleException, PasswordStrengthException, InvalidLoginException, AlreadySponsorException;
+	RichMember setSponsoredMember(PerunSession session, Vo vo, User userToBeSponsored, String namespace, String password, String login, User sponsor, LocalDate validityTo) throws PrivilegeException, AlreadyMemberException, LoginNotExistsException, PasswordCreationFailedException, ExtendMembershipException, WrongAttributeValueException, ExtSourceNotExistsException, WrongReferenceAttributeValueException, UserNotInRoleException, PasswordStrengthException, InvalidLoginException, AlreadySponsorException, InvalidSponsoredUserDataException, NamespaceRulesNotExistsException;
 
 	/**
 	 * Creates new sponsored members using input from CSV file.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/SponsoredAccountsConfigContainer.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/SponsoredAccountsConfigContainer.java
@@ -28,7 +28,7 @@ public class SponsoredAccountsConfigContainer {
 	 */
 	public NamespaceRules getNamespaceRules(String namespace) throws NamespaceRulesNotExistsException {
 		if (namespacesRules.get(namespace) == null) {
-			throw new NamespaceRulesNotExistsException("Namespace with name "+ namespace + "does not exist in the SponsoredAccountsConfigContainer.");
+			throw new NamespaceRulesNotExistsException("Namespace with name '"+ namespace + "' does not exist in the SponsoredAccountsConfigContainer.");
 		}
 
 		return namespacesRules.get(namespace);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/SponsoredAccountsConfigLoader.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/SponsoredAccountsConfigLoader.java
@@ -56,12 +56,13 @@ public class SponsoredAccountsConfigLoader {
 		while (namespacesNames.hasNext()) {
 			String namespaceName = namespacesNames.next();
 			JsonNode namespaceNode = namespacesNodes.get(namespaceName);
+			JsonNode defaultEmail = namespaceNode.get("default_email");
 			JsonNode requiredAttributesNode = namespaceNode.get("required_attributes");
 			JsonNode optionalAttributesNode = namespaceNode.get("optional_attributes");
 			Set<String> requiredAttributes = objectMapper.convertValue(requiredAttributesNode, new TypeReference<>() {});
 			Set<String> optionalAttributes = objectMapper.convertValue(optionalAttributesNode, new TypeReference<>() {});
 
-			rules.add(new NamespaceRules(namespaceName,requiredAttributes, optionalAttributes));
+			rules.add(new NamespaceRules(namespaceName, defaultEmail.asText(), requiredAttributes, optionalAttributes));
 		}
 
 		return rules;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/DummyPasswordManagerModule.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/DummyPasswordManagerModule.java
@@ -3,11 +3,13 @@ package cz.metacentrum.perun.core.impl.modules.pwdmgr;
 import cz.metacentrum.perun.core.api.ExtSource;
 import cz.metacentrum.perun.core.api.ExtSourcesManager;
 import cz.metacentrum.perun.core.api.PerunSession;
+import cz.metacentrum.perun.core.api.SponsoredUserData;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.UserExtSource;
 import cz.metacentrum.perun.core.api.exceptions.ExtSourceExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ExtSourceNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InvalidLoginException;
+import cz.metacentrum.perun.core.api.exceptions.PasswordStrengthException;
 import cz.metacentrum.perun.core.api.exceptions.UserExtSourceExistsException;
 import cz.metacentrum.perun.core.bl.PerunBl;
 import cz.metacentrum.perun.core.implApi.modules.pwdmgr.PasswordManagerModule;
@@ -28,6 +30,20 @@ public class DummyPasswordManagerModule implements PasswordManagerModule {
 	private final static Logger log = LoggerFactory.getLogger(DummyPasswordManagerModule.class);
 
 	private static final Random RANDOM = new Random();
+
+	@Override
+	public String handleSponsorship(PerunSession sess, SponsoredUserData userData) throws PasswordStrengthException {
+		Map<String, String> parameters = new HashMap<>();
+		parameters.put(PasswordManagerModule.TITLE_BEFORE_KEY, userData.getTitleBefore());
+		parameters.put(PasswordManagerModule.FIRST_NAME_KEY, userData.getFirstName());
+		parameters.put(PasswordManagerModule.LAST_NAME_KEY, userData.getLastName());
+		parameters.put(PasswordManagerModule.TITLE_AFTER_KEY, userData.getTitleAfter());
+		if (userData.getPassword() != null) {
+			parameters.put(PasswordManagerModule.PASSWORD_KEY, userData.getPassword());
+		}
+		return generateAccount(sess, parameters).get(PasswordManagerModule.LOGIN_PREFIX + "dummy");
+	}
+
 	@Override
 	public Map<String, String> generateAccount(PerunSession sess, Map<String, String> parameters) {
 		log.debug("generateAccount(parameters={})",parameters);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/EinfraPasswordManagerModule.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/EinfraPasswordManagerModule.java
@@ -4,12 +4,14 @@ import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.ExtSource;
 import cz.metacentrum.perun.core.api.PerunSession;
+import cz.metacentrum.perun.core.api.SponsoredUserData;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.UserExtSource;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ExtSourceNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.InvalidLoginException;
+import cz.metacentrum.perun.core.api.exceptions.InvalidSponsoredUserDataException;
 import cz.metacentrum.perun.core.api.exceptions.PasswordStrengthException;
 import cz.metacentrum.perun.core.api.exceptions.UserExtSourceExistsException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
@@ -65,6 +67,13 @@ public class EinfraPasswordManagerModule extends GenericPasswordManagerModule {
 			altPasswordManagerProgram += ".einfra";
 		}
 
+	}
+
+	@Override
+	public String handleSponsorship(PerunSession sess, SponsoredUserData userData) throws InvalidLoginException, PasswordStrengthException {
+		reservePassword(sess, userData.getLogin(), userData.getPassword());
+
+		return userData.getLogin();
 	}
 
 	@Override
@@ -225,7 +234,7 @@ public class EinfraPasswordManagerModule extends GenericPasswordManagerModule {
 		}
 
 		// if login is at least 3 chars, test if its not contained in password
-		if (login.length() > 2) {
+		if (login != null && login.length() > 2) {
 			String backwardsLogin = StringUtils.reverse(login);
 			if (password.toLowerCase().contains(login.toLowerCase()) ||
 					password.toLowerCase().contains(backwardsLogin.toLowerCase())) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/MuPasswordManagerModule.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/MuPasswordManagerModule.java
@@ -4,6 +4,7 @@ import cz.metacentrum.perun.core.api.BeansUtils;
 import cz.metacentrum.perun.core.api.ExtSource;
 import cz.metacentrum.perun.core.api.ExtSourcesManager;
 import cz.metacentrum.perun.core.api.PerunSession;
+import cz.metacentrum.perun.core.api.SponsoredUserData;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.UserExtSource;
 import cz.metacentrum.perun.core.api.exceptions.ExtSourceNotExistsException;
@@ -71,6 +72,20 @@ public class MuPasswordManagerModule implements PasswordManagerModule {
 	protected final Pattern muPasswordContainsLower = Pattern.compile(".*[a-z].*");
 	protected final Pattern muPasswordContainsUpper = Pattern.compile(".*[A-Z].*");
 	protected final Pattern muPasswordContainsSpec = Pattern.compile(".*[\\x20-\\x2F\\x3A-\\x40\\x5B-\\x60\\x7B-\\x7E].*");
+
+	@Override
+	public String handleSponsorship(PerunSession sess, SponsoredUserData userData) throws PasswordStrengthException {
+		Map<String, String> parameters = new HashMap<>();
+		parameters.put(PasswordManagerModule.TITLE_BEFORE_KEY, userData.getTitleBefore());
+		parameters.put(PasswordManagerModule.FIRST_NAME_KEY, userData.getFirstName());
+		parameters.put(PasswordManagerModule.LAST_NAME_KEY, userData.getLastName());
+		parameters.put(PasswordManagerModule.TITLE_AFTER_KEY, userData.getTitleAfter());
+		if (userData.getPassword() != null) {
+			parameters.put(PasswordManagerModule.PASSWORD_KEY, userData.getPassword());
+		}
+
+		return generateAccount(sess, parameters).get(PasswordManagerModule.LOGIN_PREFIX + "mu");
+	}
 
 	@Override
 	public Map<String, String> generateAccount(PerunSession session, Map<String, String> parameters) throws PasswordStrengthException {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/pwdmgr/PasswordManagerModule.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/pwdmgr/PasswordManagerModule.java
@@ -2,13 +2,11 @@ package cz.metacentrum.perun.core.implApi.modules.pwdmgr;
 
 import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.PerunSession;
+import cz.metacentrum.perun.core.api.SponsoredUserData;
 import cz.metacentrum.perun.core.api.User;
-import cz.metacentrum.perun.core.api.exceptions.ExtSourceNotExistsException;
-import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.InvalidLoginException;
+import cz.metacentrum.perun.core.api.exceptions.InvalidSponsoredUserDataException;
 import cz.metacentrum.perun.core.api.exceptions.PasswordStrengthException;
-import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
-import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 
 import java.util.Map;
 
@@ -34,6 +32,21 @@ public interface PasswordManagerModule {
 	String ALT_PASSWORD_PREFIX = AttributesManager.NS_USER_ATTR_DEF + ":altPasswords:";
 
 	Map<String,String> generateAccount(PerunSession sess, Map<String, String> parameters) throws PasswordStrengthException;
+
+	/**
+	 * Handles member's sponsorship in given namespace. Returns login, which should be used in the given namespace.
+	 * This method is usually used to create an account in external systems.
+	 *
+	 * @param sess session
+	 * @param userData information, about the user for which the sponsorship should be handled
+	 * @return login, or null, if no login was provided nor generated
+	 * @throws PasswordStrengthException if the password strength is too weak for given namespace
+	 * @throws InvalidLoginException if the provided login is invalid for the given namespace
+	 */
+	default String handleSponsorship(PerunSession sess, SponsoredUserData userData) throws InvalidLoginException, PasswordStrengthException {
+		// do nothing
+		return userData.getLogin();
+	}
 
 	void reservePassword(PerunSession sess, String userLogin, String password) throws InvalidLoginException, PasswordStrengthException;
 

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/MembersManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/MembersManagerEntryIntegrationTest.java
@@ -17,6 +17,7 @@ import cz.metacentrum.perun.core.api.MemberWithSponsors;
 import cz.metacentrum.perun.core.api.MembersManager;
 import cz.metacentrum.perun.core.api.NamespaceRules;
 import cz.metacentrum.perun.core.api.PerunBean;
+import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.RichMember;
 import cz.metacentrum.perun.core.api.Role;
@@ -44,6 +45,7 @@ import cz.metacentrum.perun.core.api.exceptions.UserNotInRoleException;
 import cz.metacentrum.perun.core.api.exceptions.VoNotExistsException;
 import cz.metacentrum.perun.core.blImpl.AuthzResolverBlImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.AbstractMembershipExpirationRulesModule;
+import cz.metacentrum.perun.core.api.SponsoredUserData;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -58,7 +60,6 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import static cz.metacentrum.perun.core.impl.modules.attributes.urn_perun_vo_attribute_def_def_membershipExpirationRules.VO_EXPIRATION_RULES_ATTR;
 import static cz.metacentrum.perun.core.impl.modules.attributes.urn_perun_vo_attribute_def_def_membershipExpirationRules.expireSponsoredMembers;
@@ -146,7 +147,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 		AuthzResolverBlImpl.setRole(sess, sponsorUser, createdVo, Role.SPONSOR);
 		Map<String, String> nameOfUser1 = new HashMap<>();
 		nameOfUser1.put("guestName", "Abraka 123");
-		perun.getMembersManagerBl().createSponsoredMember(sess, createdVo, "dummy", nameOfUser1, "secret", null, sponsorUser, false, null, Validation.SYNC);
+		createSponsoredMember(sess, createdVo, "dummy", nameOfUser1, "secret", null, sponsorUser);
 	}
 
 	@Test
@@ -165,7 +166,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 
 		Map<String, String> nameOfUser1 = new HashMap<>();
 		nameOfUser1.put("guestName", "Ing. Petr Draxler");
-		Member sponsoredMember1 = perun.getMembersManagerBl().createSponsoredMember(sess, createdVo, "dummy", nameOfUser1, "secret", null, sponsorUser, false, null, Validation.SYNC);
+		Member sponsoredMember1 = createSponsoredMember(sess, createdVo, "dummy", nameOfUser1, "secret", null, sponsorUser);
 
 		//should contain one sponsored member
 		List<Member> sponsoredMembers = perun.getMembersManagerBl().getSponsoredMembers(sess, createdVo);
@@ -175,7 +176,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 
 		Map<String, String> nameOfUser2 = new HashMap<>();
 		nameOfUser2.put("guestName", "Miloš Zeman");
-		Member sponsoredMember2 = perun.getMembersManagerBl().createSponsoredMember(sess, createdVo, "dummy", nameOfUser2, "password", null, sponsorUser, false, null, Validation.SYNC);
+		Member sponsoredMember2 = createSponsoredMember(sess, createdVo, "dummy", nameOfUser2, "password", null, sponsorUser);
 
 		sponsoredMembers = perun.getMembersManagerBl().getSponsoredMembers(sess, createdVo);
 
@@ -198,7 +199,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 
 		Map<String, String> userName = new HashMap<>();
 		userName.put("guestName", "Ing. Jan Novák");
-		Member sponsoredMember = perun.getMembersManagerBl().createSponsoredMember(sess, createdVo, "dummy", userName, "secret", null, sponsorUser, false, null, Validation.SYNC);
+		Member sponsoredMember = createSponsoredMember(sess, createdVo, "dummy", userName, "secret", null, sponsorUser);
 
 		ArrayList<String> attrNames = new ArrayList<>();
 		attrNames.add("urn:perun:user:attribute-def:def:preferredMail");
@@ -223,7 +224,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 
 		Map<String, String> userName = new HashMap<>();
 		userName.put("guestName", "Ing. Jan Novák");
-		Member sponsoredMember = perun.getMembersManagerBl().createSponsoredMember(sess, createdVo, "dummy", userName, "secret", null, sponsorUser, false, null, Validation.SYNC);
+		Member sponsoredMember = createSponsoredMember(sess, createdVo, "dummy", userName, "secret", null, sponsorUser);
 
 		ArrayList<String> attrNames = new ArrayList<>();
 		attrNames.add("urn:perun:user:attribute-def:def:preferredMail");
@@ -1479,7 +1480,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 		assertTrue("user must have SPONSOR role", perun.getVosManagerBl().isUserInRoleForVo(sess, sponsorUser, Role.SPONSOR, createdVo, true));
 		Map<String, String> nameOfUser1 = new HashMap<>();
 		nameOfUser1.put("guestName", "Ing. Jiří Novák, CSc.");
-		Member sponsoredMember = perun.getMembersManagerBl().createSponsoredMember(sess, createdVo, "dummy", nameOfUser1, "secret", null, sponsorUser, false, null, Validation.SYNC);
+		Member sponsoredMember = createSponsoredMember(sess, createdVo, "dummy", nameOfUser1, "secret", null, sponsorUser);
 		assertNotNull("sponsored member must not be null",sponsoredMember);
 		assertTrue("sponsored memer must have flag 'sponsored' set",sponsoredMember.isSponsored());
 		assertTrue("sponsored member should have status VALID",sponsoredMember.getStatus()==Status.VALID);
@@ -1503,7 +1504,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 		Map<String, String> nameOfUser1 = new HashMap<>();
 		nameOfUser1.put("guestName", "Ing. Jiří Novák, CSc.");
 		String email = "test@email.cz";
-		Member sponsoredMember = perun.getMembersManagerBl().createSponsoredMember(sess, createdVo, "dummy", nameOfUser1, "secret", email, sponsorUser, false, null, Validation.SYNC);
+		Member sponsoredMember = createSponsoredMember(sess, createdVo, "dummy", nameOfUser1, "secret", email, sponsorUser);
 
 		User createdUser = perun.getUsersManagerBl().getUserByMember(sess, sponsoredMember);
 		Attribute emailAttribute = perun.getAttributesManager().getAttribute(sess, createdUser, A_U_PREFERRED_MAIL);
@@ -1522,12 +1523,12 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 		//create guest
 		Map<String, String> nameOfUser1 = new HashMap<>();
 		nameOfUser1.put("guestName", "Ing. Jiří Novák, CSc.");
-		Member sponsoredMember = perun.getMembersManagerBl().createSponsoredMember(sess, createdVo, "dummy", nameOfUser1, "secret", null, sponsorUser, false, null, Validation.SYNC);
+		Member sponsoredMember = createSponsoredMember(sess, createdVo, "dummy", nameOfUser1, "secret", null, sponsorUser);
 
 		User createdUser = perun.getUsersManagerBl().getUserByMember(sess, sponsoredMember);
 		Attribute emailAttribute = perun.getAttributesManager().getAttribute(sess, createdUser, A_U_PREFERRED_MAIL);
 
-		assertThat(emailAttribute.valueAsString()).isEqualTo("no-reply@muni.cz");
+		assertThat(emailAttribute.valueAsString()).isEqualTo("no-reply@dummy.com");
 	}
 
 	@Test
@@ -1547,7 +1548,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 		nameOfUser1.put("lastName", "Morgan");
 		nameOfUser1.put("titleBefore", "prof. RNDr.");
 		nameOfUser1.put("titleAfter", "Ph.D.");
-		Member sponsoredMember = perun.getMembersManagerBl().createSponsoredMember(sess, createdVo, "dummy", nameOfUser1, "TB", null, sponsorUser, false, null, Validation.SYNC);
+		Member sponsoredMember = createSponsoredMember(sess, createdVo, "dummy", nameOfUser1, "TB", null, sponsorUser);
 		assertNotNull("sponsored member must not be null",sponsoredMember);
 		assertTrue("sponsored member must have flag 'sponsored' set",sponsoredMember.isSponsored());
 		assertTrue("sponsored member should have status VALID",sponsoredMember.getStatus()==Status.VALID);
@@ -1573,7 +1574,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 		Map<String, String> nameOfUser1 = new HashMap<>();
 		nameOfUser1.put("firstName", "Arthur");
 		nameOfUser1.put("lastName", "Morgan");
-		Member sponsoredMember = perun.getMembersManagerBl().createSponsoredMember(sess, createdVo, "dummy", nameOfUser1, "TB", null, sponsorUser, false, null, Validation.SYNC);
+		Member sponsoredMember = createSponsoredMember(sess, createdVo, "dummy", nameOfUser1, "TB", null, sponsorUser);
 		assertNotNull("sponsored member must not be null",sponsoredMember);
 		assertTrue("sponsored member must have flag 'sponsored' set",sponsoredMember.isSponsored());
 		assertTrue("sponsored member should have status VALID",sponsoredMember.getStatus()==Status.VALID);
@@ -1601,7 +1602,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 		nameOfUser1.put("firstName", "Morgan");
 		nameOfUser1.put("titleBefore", "prof. RNDr.");
 		nameOfUser1.put("titleAfter", "Ph.D.");
-		Member sponsoredMember = perun.getMembersManagerBl().createSponsoredMember(sess, createdVo, "dummy", nameOfUser1, "TB", null, sponsorUser, false, null, Validation.SYNC);
+		Member sponsoredMember = createSponsoredMember(sess, createdVo, "dummy", nameOfUser1, "TB", null, sponsorUser);
 	}
 
 	@Test
@@ -1805,7 +1806,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 		//create sponsored member
 		Map<String, String> nameOfUser1 = new HashMap<>();
 		nameOfUser1.put("guestName", "Ing. Jiří Novák, CSc.");
-		Member sponsoredMember = perun.getMembersManagerBl().createSponsoredMember(sess, createdVo, "dummy", nameOfUser1, "secret", null, sponsorUser, false, null, Validation.SYNC);
+		Member sponsoredMember = createSponsoredMember(sess, createdVo, "dummy", nameOfUser1, "secret", null, sponsorUser);
 		assertNotNull("sponsored member must not be null", sponsoredMember);
 		assertTrue("sponsored memer must have flag 'sponsored' set", sponsoredMember.isSponsored());
 		assertTrue("sponsored member should have status VALID", sponsoredMember.getStatus() == Status.VALID);
@@ -2149,7 +2150,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 		AuthzResolverBlImpl.setRole(sess, sponsorUser, createdVo, Role.SPONSOR);
 		Map<String, String> nameOfUser1 = new HashMap<>();
 		nameOfUser1.put("guestName", "Ing. Petr Novák, CSc.");
-		Member sponsoredMember = perun.getMembersManagerBl().createSponsoredMember(sess, createdVo, "dummy", nameOfUser1, "secret", null, sponsorUser, false, null, Validation.SYNC);
+		Member sponsoredMember = createSponsoredMember(sess, createdVo, "dummy", nameOfUser1, "secret", null, sponsorUser);
 		User user = perun.getUsersManagerBl().getUserByMember(sess, sponsoredMember);
 		System.out.println(user);
 		List<Member> members = perun.getMembersManagerBl().findMembers(sess, createdVo, user.getFirstName(), true);
@@ -2177,7 +2178,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 		//create sponsored member
 		Map<String, String> nameOfUser1 = new HashMap<>();
 		nameOfUser1.put("guestName", "Ing. Jiří Novák, CSc.");
-		Member sponsoredMember = perun.getMembersManagerBl().createSponsoredMember(sess, createdVo, "dummy", nameOfUser1, "secret", null, sponsorUser, false, null, Validation.SYNC);
+		Member sponsoredMember = createSponsoredMember(sess, createdVo, "dummy", nameOfUser1, "secret", null, sponsorUser);
 		//Remove sponsor
 		perun.getMembersManagerBl().removeSponsor(sess, sponsoredMember, sponsorUser);
 		//refresh from DB
@@ -2198,11 +2199,11 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 		// create two sponsored members
 		Map<String, String> name = new HashMap<>();
 		name.put("guestName", "Bruce Wayne");
-		Member member = perun.getMembersManagerBl().createSponsoredMember(sess, createdVo, "dummy", name, "secret", null, sponsorUser, false, null, Validation.SYNC);
+		Member member = createSponsoredMember(sess, createdVo, "dummy", name, "secret", null, sponsorUser);
 		RichMember richMember = perun.getMembersManager().getRichMemberById(sess, member.getId());
 		Map<String, String> name2 = new HashMap<>();
 		name2.put("guestName", "Clark Kent");
-		Member member2 = perun.getMembersManagerBl().createSponsoredMember(sess, createdVo, "dummy", name2, "secret", null, sponsorUser, false, null, Validation.SYNC);
+		Member member2 = createSponsoredMember(sess, createdVo, "dummy", name2, "secret", null, sponsorUser);
 		RichMember richMember2 = perun.getMembersManager().getRichMemberById(sess, member2.getId());
 
 		List<RichMember> allSponsoredMembers = perun.getMembersManager().getAllSponsoredMembers(sess, createdVo);
@@ -2437,9 +2438,9 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 	public void getNamespaceRules() throws Exception {
 		System.out.println(CLASS_NAME + "getNamespaceRule");
 
-		NamespaceRules rules = perun.getMembersManagerBl().getNamespaceRules("dummy_namespace");
+		NamespaceRules rules = perun.getMembersManagerBl().getNamespaceRules("dummy_with_login");
 
-		assertEquals(rules.getNamespaceName(), "dummy_namespace");
+		assertEquals(rules.getNamespaceName(), "dummy_with_login");
 		assertThat(rules.getRequiredAttributes()).containsExactly("login");
 		assertThat(rules.getOptionalAttributes()).containsExactly("password");
 	}
@@ -2457,8 +2458,9 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 
 		List<NamespaceRules> allRules = membersManagerEntry.getAllNamespacesRules();
 
-		assertEquals(allRules.size(), 1);
-		assertEquals(allRules.get(0).getNamespaceName(), "dummy_namespace");
+		assertEquals(allRules.size(), 2);
+		assertEquals(allRules.get(0).getNamespaceName(), "dummy");
+		assertEquals(allRules.get(1).getNamespaceName(), "dummy_with_login");
 	}
 
 	private Attribute setUpAttribute(String type, String friendlyName, String namespace, Object value) throws Exception {
@@ -2670,5 +2672,21 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 	private void checkUserAttribute(User user, String attrName, Object expectedValue) throws Exception {
 		Attribute user1MailAttr = perun.getAttributesManagerBl().getAttribute(sess, user, attrName);
 		assertThat(user1MailAttr.getValue()).isEqualTo(expectedValue);
+	}
+
+	private Member createSponsoredMember(PerunSession sess, Vo vo, String namespace,
+	                                     Map<String, String> names, String password, String email,
+	                                     User sponsor) throws Exception {
+		SponsoredUserData input = new SponsoredUserData();
+		input.setNamespace(namespace);
+		input.setFirstName(names.get("firstName"));
+		input.setLastName(names.get("lastName"));
+		input.setGuestName(names.get("guestName"));
+		input.setTitleBefore(names.get("titleBefore"));
+		input.setTitleAfter(names.get("titleAfter"));
+		input.setPassword(password);
+		input.setEmail(email);
+
+		return perun.getMembersManagerBl().createSponsoredMember(sess, input, vo, sponsor, null, false, null, Validation.SYNC);
 	}
 }

--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -465,6 +465,7 @@ components:
     NamespaceRules:
       type: object
       properties:
+        defaultEmail: { type: string }
         namespaceName: { type: string }
         requiredAttributes:
           type: array
@@ -1014,6 +1015,19 @@ components:
       type: object
       additionalProperties:
         $ref: '#/components/schemas/Attribute'
+
+    SponsoredUserData:
+      type: object
+      properties:
+        guestName: { type: string }
+        firstName: { type: string }
+        lastName: { type: string }
+        titleBefore: { type: string }
+        titleAfter: { type: string }
+        namespace: { type: string }
+        email: { type: string }
+        password: { type: string }
+        login: { type: string }
 
   #################################################
   #                                               #
@@ -8322,24 +8336,15 @@ paths:
               description: "input for createSponsoredMember"
               type: object
               required:
-                - firstName
-                - lastName
-                - password
+                - userData
                 - vo
                 - sponsor
-                - namespace
               properties:
-                firstName: { type: string }
-                lastName: { type: string }
-                titleBefore: { type: string }
-                titleAfter: { type: string }
-                password: { type: string }
-                email: { type: string }
                 vo: { type: integer }
-                sponsor: { type: integer }
-                namespace: { type: string }
                 validityTo: { type: string }
+                sponsor: { type: integer }
                 sendActivationLink: { type: boolean }
+                userData: { $ref: '#/components/schemas/SponsoredUserData' }
 
   /json/membersManager/setSponsoredMember:
     post:


### PR DESCRIPTION
* There are changes in the API! These changes require changes to be made
in the gui, so this will work. These changes are introduced in https://github.com/CESNET/perun-web-apps/pull/623
* Until now, it was impossible to sponsor users (or create sponsored
users) in any other namespace than MU. From now, it is possible to
sponsor users for other namespaces, and even without a namespace.
* It is possible to configure namespaces, that can be used to sponsor
members. This should be done in a
/etc/perun/sponsored-accounts-config.yml file.
* The code has been restructured, so it is can be used for such
purposes.