### PR TITLE
Inserting VO using PostgreSQL's insert-returning

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/VosManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/VosManagerImpl.java
@@ -158,20 +158,13 @@ public class VosManagerImpl implements VosManagerImplApi {
 		if (this.voExists(sess, vo)) throw new VoExistsException(vo.toString());
 		if (this.shortNameForVoExists(sess, vo)) throw new VoExistsException(vo.toString());
 
-		// Get VO ID
-		int voId;
 		try {
-			voId = Utils.getNewId(jdbc, "vos_id_seq");
-			jdbc.update("insert into vos(id, name, short_name, created_by,modified_by, created_by_uid, modified_by_uid) values (?,?,?,?,?,?,?)",
-					voId, vo.getName(), vo.getShortName(), sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getUserId(), sess.getPerunPrincipal().getUserId());
+			// Get VO ID
+			return jdbc.queryForObject("insert into vos(id, name, short_name, created_by,modified_by, created_by_uid, modified_by_uid) values (nextval('vos_id_seq'),?,?,?,?,?,?) returning " + voMappingSelectQuery,
+					VO_MAPPER, vo.getName(), vo.getShortName(), sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getUserId(), sess.getPerunPrincipal().getUserId());
 		} catch (RuntimeException e) {
 			throw new InternalErrorException(e);
 		}
-
-		// set assigned id
-		vo.setId(voId);
-
-		return vo;
 	}
 
 	@Override

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/AttributesManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/AttributesManagerEntryIntegrationTest.java
@@ -14852,8 +14852,9 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		Vo vo = new Vo();
 		vo.setName("AttributesMangerTestVo");
 		vo.setShortName("AMTVO");
-		assertNotNull("unable to create VO",perun.getVosManager().createVo(sess, vo));
-		return vo;
+		Vo createdVo = perun.getVosManager().createVo(sess, vo);
+		assertNotNull("unable to create VO", createdVo);
+		return createdVo;
 
 	}
 

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntryIntegrationTest.java
@@ -486,7 +486,8 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		Vo vo2 = new Vo();
 		vo2.setName("FacilitiesMangerTestVo2");
 		vo2.setShortName("FMTVO2");
-		assertNotNull("unable to create VO",perun.getVosManager().createVo(sess, vo2));
+		vo2 = perun.getVosManager().createVo(sess, vo2);
+		assertNotNull("unable to create VO", vo2);
 
 		Member member2 = setUpMember(vo2);
 		User user2 = perun.getUsersManagerBl().getUserByMember(sess, member2);
@@ -2289,9 +2290,9 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		Vo vo = new Vo();
 		vo.setName("FacilitiesMangerTestVo");
 		vo.setShortName("FMTVO");
-		assertNotNull("unable to create VO",perun.getVosManager().createVo(sess, vo));
-		//System.out.println(vo);
-		return vo;
+		Vo createdVo = perun.getVosManager().createVo(sess, vo);
+		assertNotNull("unable to create VO", createdVo);
+		return createdVo;
 
 	}
 

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ModulesUtilsEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ModulesUtilsEntryIntegrationTest.java
@@ -961,8 +961,9 @@ public class ModulesUtilsEntryIntegrationTest extends AbstractPerunIntegrationTe
 		Vo vo = new Vo();
 		vo.setName("AttributesMangerTestVo");
 		vo.setShortName("AMTVO");
-		assertNotNull("unable to create VO",perun.getVosManager().createVo(sess, vo));
-		return vo;
+		Vo createdVo = perun.getVosManager().createVo(sess, vo);
+		assertNotNull("unable to create VO", createdVo);
+		return createdVo;
 
 	}
 

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/SearcherEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/SearcherEntryIntegrationTest.java
@@ -858,6 +858,7 @@ public class SearcherEntryIntegrationTest extends AbstractPerunIntegrationTest {
 		Vo returnedVo = perun.getVosManager().createVo(sess, newVo);
 		// create test VO in database
 		assertNotNull("unable to create testing Vo",returnedVo);
+		newVo.setId(returnedVo.getId());
 		assertEquals("both VOs should be the same",newVo,returnedVo);
 		ExtSource newExtSource = new ExtSource(extSourceName, ExtSourcesManager.EXTSOURCE_INTERNAL);
 		ExtSource es = perun.getExtSourcesManager().createExtSource(sess, newExtSource, null);

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/SecurityTeamsManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/SecurityTeamsManagerEntryIntegrationTest.java
@@ -966,14 +966,14 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 		Vo vo = new Vo();
 		vo.setShortName("testVo");
 		vo.setName("Test VO");
-		perun.getVosManager().createVo(sess, vo);
+		Vo createdVo = perun.getVosManager().createVo(sess, vo);
 
 		Group authGroup = new Group();
 		authGroup.setShortName("testGroup");
 		authGroup.setName("Test Group");
-		Member m0 = perun.getMembersManager().createMember(sess, vo, u0);
-		Member m1 = perun.getMembersManager().createMember(sess, vo, u1);
-		perun.getGroupsManager().createGroup(sess, vo, authGroup);
+		Member m0 = perun.getMembersManager().createMember(sess, createdVo, u0);
+		Member m1 = perun.getMembersManager().createMember(sess, createdVo, u1);
+		perun.getGroupsManager().createGroup(sess, createdVo, authGroup);
 		perun.getGroupsManager().addMember(sess, authGroup, m0);
 		perun.getGroupsManager().addMember(sess, authGroup, m1);
 

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/UsersManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/UsersManagerEntryIntegrationTest.java
@@ -1761,6 +1761,7 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 		Vo returnedVo = perun.getVosManager().createVo(sess, newVo);
 		// create test VO in database
 		assertNotNull("unable to create testing Vo",returnedVo);
+		newVo.setId(returnedVo.getId());
 		assertEquals("both VOs should be the same",newVo,returnedVo);
 		ExtSource newExtSource = new ExtSource(extSourceName, ExtSourcesManager.EXTSOURCE_INTERNAL);
 		ExtSource es = perun.getExtSourcesManager().createExtSource(sess, newExtSource, null);

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/VosManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/VosManagerEntryIntegrationTest.java
@@ -101,7 +101,7 @@ public class VosManagerEntryIntegrationTest extends AbstractPerunIntegrationTest
 		System.out.println(CLASS_NAME + "getVoById");
 
 		final Vo createdVo = vosManagerEntry.createVo(sess, myVo);
-		final Vo returnedVo = vosManagerEntry.getVoById(sess, myVo.getId());
+		final Vo returnedVo = vosManagerEntry.getVoById(sess, createdVo.getId());
 
 		final String createVoFailMsg = "The created vo is not ok, maybe try to check createVo()?";
 

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/AuthzResolverImplIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/AuthzResolverImplIntegrationTest.java
@@ -21,7 +21,7 @@ public class AuthzResolverImplIntegrationTest extends AbstractPerunIntegrationTe
 
 	private static final String CLASS_NAME = "AttributesManagerImplIntegrationTest.";
 	private AuthzResolverImplApi authzResolverImpl;
-	private static final Vo vo = new Vo(1, "", "");
+	private static Vo createdVo;
 	private static final User user1 = new User(1, "", "", "", "", "");
 	private static final User user2 = new User(2, "", "", "", "", "");
 	private static final User user3 = new User(3, "", "", "", "", "");
@@ -34,7 +34,7 @@ public class AuthzResolverImplIntegrationTest extends AbstractPerunIntegrationTe
 			AuthzResolverBlImpl.class, "authzResolverImpl"
 		);
 
-		perun.getVosManagerBl().createVo(sess, vo);
+		createdVo = perun.getVosManagerBl().createVo(sess, new Vo(1, "", ""));
 		perun.getUsersManagerBl().createUser(sess, user1);
 		perun.getUsersManagerBl().createUser(sess, user2);
 		perun.getUsersManagerBl().createUser(sess, user3);
@@ -50,7 +50,7 @@ public class AuthzResolverImplIntegrationTest extends AbstractPerunIntegrationTe
 		authzResolverImpl.setRole(sess, mapping, Role.VOADMIN);
 		AuthzRoles userRoles = AuthzResolverBlImpl.getUserRoles(sess, user1);
 
-		assertTrue(userRoles.hasRole(Role.VOADMIN, vo));
+		assertTrue(userRoles.hasRole(Role.VOADMIN, createdVo));
 	}
 
 	@Test
@@ -88,7 +88,7 @@ public class AuthzResolverImplIntegrationTest extends AbstractPerunIntegrationTe
 		Map<String, Integer> mapping = new HashMap<>();
 
 		mapping.put("user_id", user.getId());
-		mapping.put("vo_id", vo.getId());
+		mapping.put("vo_id", createdVo.getId());
 		mapping.put("role_id", authzResolverImpl.getRoleId(Role.VOADMIN));
 
 		return mapping;

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/UtilsIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/UtilsIntegrationTest.java
@@ -448,6 +448,7 @@ public class UtilsIntegrationTest extends AbstractPerunIntegrationTest {
 		Vo returnedVo = perun.getVosManager().createVo(sess, newVo);
 		// create test VO in database
 		assertNotNull("unable to create testing Vo",returnedVo);
+		newVo.setId(returnedVo.getId());
 		assertEquals("both VOs should be the same",newVo,returnedVo);
 		ExtSource newExtSource = new ExtSource(extSourceName, ExtSourcesManager.EXTSOURCE_INTERNAL);
 		ExtSource es = perun.getExtSourcesManager().createExtSource(sess, newExtSource, null);

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_isUnixGroupIntegrationtest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_isUnixGroupIntegrationtest.java
@@ -139,6 +139,7 @@ public class urn_perun_group_resource_attribute_def_def_isUnixGroupIntegrationte
 		Vo returnedVo = perun.getVosManager().createVo(sess, newVo);
 		// create test VO in database
 		assertNotNull("unable to create testing Vo",returnedVo);
+		newVo.setId(returnedVo.getId());
 		assertEquals("both VOs should be the same",newVo,returnedVo);
 
 		ExtSource es = perun.getExtSourcesManager().getExtSourceByName(sess, extSourceName);

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_group_attribute_def_virt_isGroupAdminTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_group_attribute_def_virt_isGroupAdminTest.java
@@ -78,6 +78,7 @@ public class urn_perun_member_group_attribute_def_virt_isGroupAdminTest  extends
         Vo newVo = new Vo(0, "TestVo", "TestVo");
         Vo returnedVo = vosManager.createVo(sess, newVo);
         assertNotNull(returnedVo);
+        newVo.setId(returnedVo.getId());
         assertEquals(newVo,returnedVo);
         return returnedVo;
 


### PR DESCRIPTION
- Inserting VO is now done using PostgreSQL's insert-returning. Inserted row
is mapped to VO and returned.
- Until now, VO object passed to createVo() had its ID set in Impl layer and
this object was returned from Impl. Now, the passed VO object doesn't have
its ID set in Impl layer and new VO object is returned. Some tests were
changed because they expected the passed VO object to have its ID set.