### PR TITLE
Core - fix getRichUsersFromListOfUsers methods

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
@@ -319,7 +319,13 @@ public class UsersManagerEntry implements UsersManager {
 			}
 		}
 
-		return getPerunBl().getUsersManagerBl().filterOnlyAllowedAttributes(sess, getUsersManagerBl().getRichUsersFromListOfUsers(sess, users));
+		List<Integer> userIds = users.stream()
+				.map(User::getId)
+				.collect(Collectors.toList());
+
+		List<User> usersFromDB = getPerunBl().getUsersManagerBl().getUsersByIds(sess, userIds);
+
+		return getPerunBl().getUsersManagerBl().filterOnlyAllowedAttributes(sess, getUsersManagerBl().getRichUsersFromListOfUsers(sess, usersFromDB));
 	}
 
 	@Override
@@ -339,7 +345,13 @@ public class UsersManagerEntry implements UsersManager {
 			}
 		}
 
-		return getPerunBl().getUsersManagerBl().filterOnlyAllowedAttributes(sess, getUsersManagerBl().getRichUsersWithAttributesFromListOfUsers(sess, users));
+		List<Integer> userIds = users.stream()
+				.map(User::getId)
+				.collect(Collectors.toList());
+
+		List<User> usersFromDB = getPerunBl().getUsersManagerBl().getUsersByIds(sess, userIds);
+
+		return getPerunBl().getUsersManagerBl().filterOnlyAllowedAttributes(sess, getUsersManagerBl().getRichUsersWithAttributesFromListOfUsers(sess, usersFromDB));
 	}
 
 	@Override


### PR DESCRIPTION
* There were 2 methods that used to take a list of users as an input and
just fetched for these users their attributes. However, our
deserializers are forbiden to work with UUIDs (for some reason) and thus
when the rich users were missing their UUIDs.
* These methods were rewritten so they just used the ids from the given
list of users and fetch them from DB. This way, we can ensure that the
returned data are up to date and valid.