### PR TITLE
Deleting unused destinations

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ServicesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ServicesManagerBl.java
@@ -866,4 +866,14 @@ public interface ServicesManagerBl {
 	 */
 	int getDestinationsCount(PerunSession perunSession);
 
+	/**
+	 * Deletes destination.
+	 *
+	 * @param sess
+	 * @param destination destination to be deleted
+	 * @throws InternalErrorException
+	 * @throws DestinationAlreadyRemovedException if there are 0 rows affected by deleting from DB
+	 * @throws RelationExistsException if the destination is used by some services and facilities
+	 */
+	void deleteDestination(PerunSession sess, Destination destination) throws DestinationAlreadyRemovedException, RelationExistsException;
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/ServicesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/ServicesManagerImplApi.java
@@ -16,6 +16,7 @@ import cz.metacentrum.perun.core.api.exceptions.DestinationAlreadyRemovedExcepti
 import cz.metacentrum.perun.core.api.exceptions.DestinationNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.InvalidDestinationException;
+import cz.metacentrum.perun.core.api.exceptions.RelationExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ServiceAlreadyAssignedException;
 import cz.metacentrum.perun.core.api.exceptions.ServiceAlreadyBannedException;
 import cz.metacentrum.perun.core.api.exceptions.ServiceAlreadyRemovedException;
@@ -612,4 +613,14 @@ public interface ServicesManagerImplApi {
 	 */
 	int getDestinationsCount(PerunSession perunSession);
 
+	/**
+	 * Deletes destination.
+	 *
+	 * @param sess
+	 * @param destination destination to be deleted
+	 * @throws InternalErrorException
+	 * @throws DestinationAlreadyRemovedException if there are 0 rows affected by deleting from DB
+	 * @throws RelationExistsException if the destination has some existing relations in DB
+	 */
+	void deleteDestination(PerunSession sess, Destination destination) throws DestinationAlreadyRemovedException, RelationExistsException;
 }


### PR DESCRIPTION
- Destinations were never deleted from DB, not even when they didn't have
any services assigned.
- Now, a destination is deleted when the last assigned service is removed
from the destination. Service denials and task results of the destination
are deleted as well.