### PR TITLE
DISPATCHER: Fix WAITING tasks re-scheduling

### DIFF
--- a/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/scheduling/impl/SchedulingPoolImpl.java
+++ b/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/scheduling/impl/SchedulingPoolImpl.java
@@ -148,7 +148,7 @@ public class SchedulingPoolImpl implements SchedulingPool, InitializingBean {
 	}
 
 	// --- session init ----------------------------------
-	
+
 	@Override
 	public void afterPropertiesSet() {
 		// init session
@@ -164,7 +164,7 @@ public class SchedulingPoolImpl implements SchedulingPool, InitializingBean {
 			log.error("Error establishing perun session to add task schedule: ", e1);
 		}
 	}
-	
+
 	// ----- methods -------------------------------------
 
 
@@ -434,11 +434,12 @@ public class SchedulingPoolImpl implements SchedulingPool, InitializingBean {
 				log.error("Adding Task {} and Queue {} into SchedulingPool failed, so the Task will be lost.", task, queue);
 			}
 
-			// if service was not in DONE or any kind of ERROR - reschedule now
-			// error/done tasks will be rescheduled later by periodic jobs !!
-			if (!Arrays.asList(TaskStatus.DONE, TaskStatus.ERROR, TaskStatus.GENERROR, TaskStatus.SENDERROR, TaskStatus.WARNING).contains(task.getStatus())) {
+			// if task was in any kind of processing state - reschedule now !!
+			// done/error tasks will be rescheduled later by periodic jobs of PropagationMaintainer !!
+			if (Arrays.asList(TaskStatus.WAITING, TaskStatus.PLANNED, TaskStatus.GENERATING, TaskStatus.SENDING).contains(task.getStatus())) {
 				if (task.getStatus().equals(TaskStatus.WAITING)) {
-					// if were in WAITING, reset timestamp to now
+					// reset timestamp to 'now' for WAITING Tasks, since scheduling task
+					// sets this to all tasks except the waiting
 					task.setSchedule(LocalDateTime.now());
 					tasksManagerBl.updateTask(sess, task);
 				}


### PR DESCRIPTION
- Do not re-schedule WAITING tasks when source data hasn't
  changed in rescheduleDoneTasks(), since they got more
  properly re-scheduled by endStuckTask() later
  or by TaskScheduler or on dispatcher restart.
- Use shorter and positive condition in IF when
  rescheduling all tasks on dispatcher restart.
- Improved comments to be more explanatory.
- This fixes the rare case of unlimited re-scheduling of
  WAITING tasks, when engine is not started and they can't
  be switched to PLANNED. It could fill up the whole waiting queue.
  Also it was logged as "task hasn't run for X hours", which is
  not true, since WAITING tasks have 'end time' NULL by design.