### PR TITLE
Core - checkPasswordStrength

### DIFF
--- a/perun-base/src/main/resources/perun-roles.yml
+++ b/perun-base/src/main/resources/perun-roles.yml
@@ -5174,6 +5174,12 @@ perun_policies:
     include_policies:
       - default_policy
 
+  checkPasswordStrength_String_String:
+    policy_roles:
+      - SELF:
+    include_policies:
+      - default_policy
+
   getGroupsWhereUserIsActive_Resource_User_policy:
     policy_roles:
       - VOOBSERVER: Vo

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/UsersManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/UsersManager.java
@@ -1225,6 +1225,17 @@ public interface UsersManager {
 	String changePasswordRandom(PerunSession sess, User user, String loginNamespace) throws PrivilegeException, PasswordOperationTimeoutException, LoginNotExistsException, PasswordChangeFailedException, InvalidLoginException, PasswordStrengthException;
 
 	/**
+	 * Check password strength for the given namespace. If the password is too weak,
+	 * the PasswordStrengthException is thrown
+	 *
+	 * @param password password, that will be checked
+	 * @param namespace namespace, that will be used to check the strength of the password
+	 *
+	 * @throws PasswordStrengthException When password doesn't match expected strength by namespace configuration
+	 * @throws PrivilegeException insufficient permission
+	 */
+	void checkPasswordStrength(PerunSession sess, String password, String namespace) throws PasswordStrengthException, PrivilegeException;
+	/**
 	 * Return all groups where user is active (has VALID status in VO and Group together)
 	 * for specified user and resource
 	 *

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
@@ -36,6 +36,7 @@ import cz.metacentrum.perun.core.api.exceptions.PasswordResetLinkExpiredExceptio
 import cz.metacentrum.perun.core.api.exceptions.PasswordResetLinkNotValidException;
 import cz.metacentrum.perun.core.api.exceptions.PasswordStrengthException;
 import cz.metacentrum.perun.core.api.exceptions.PasswordStrengthFailedException;
+import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
 import cz.metacentrum.perun.core.api.exceptions.RelationExistsException;
 import cz.metacentrum.perun.core.api.exceptions.RelationNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.SpecificUserAlreadyRemovedException;
@@ -1435,6 +1436,16 @@ public interface UsersManagerBl {
 	 */
 	String changePasswordRandom(PerunSession session, User user, String loginNamespace) throws PasswordOperationTimeoutException, LoginNotExistsException, PasswordChangeFailedException, InvalidLoginException, PasswordStrengthException;
 
+	/**
+	 * Check password strength for the given namespace. If the password is too weak,
+	 * the PasswordStrengthException is thrown
+	 *
+	 * @param password password, that will be checked
+	 * @param namespace namespace, that will be used to check the strength of the password
+	 *
+	 * @throws PasswordStrengthException When password doesn't match expected strength by namespace configuration
+	 */
+	void checkPasswordStrength(PerunSession sess, String password, String namespace) throws PasswordStrengthException;
 	/**
 	 * Return all groups where user is active (has VALID status in VO and Group together)
 	 * for specified user and resource

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
@@ -1909,6 +1909,11 @@ public class UsersManagerBlImpl implements UsersManagerBl {
 				.replace("{login}", StringEscapeUtils.escapeHtml4(userLogin));
 	}
 
+	@Override
+	public void checkPasswordStrength(PerunSession sess, String password, String namespace) throws PasswordStrengthException {
+		getPasswordManagerModule(sess, namespace).checkPasswordStrength(sess, null, password);
+	}
+
 	/**
 	 * Returns template for password reset.
 	 * <p>

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
@@ -1424,6 +1424,17 @@ public class UsersManagerEntry implements UsersManager {
 	}
 
 	@Override
+	public void checkPasswordStrength(PerunSession sess, String password, String namespace) throws PasswordStrengthException, PrivilegeException {
+		Utils.checkPerunSession(sess);
+
+		if (!AuthzResolver.authorizedInternal(sess, "checkPasswordStrength_String_String")) {
+			throw new PrivilegeException("checkPasswordStrength");
+		}
+
+		usersManagerBl.checkPasswordStrength(sess, password, namespace);
+	}
+
+	@Override
 	public List<Group> getGroupsWhereUserIsActive(PerunSession sess, Resource resource, User user) throws PrivilegeException {
 		Utils.checkPerunSession(sess);
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/ISServiceCallerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/ISServiceCallerImpl.java
@@ -1,0 +1,262 @@
+package cz.metacentrum.perun.core.impl.modules.pwdmgr;
+
+import cz.metacentrum.perun.core.api.BeansUtils;
+import cz.metacentrum.perun.core.api.exceptions.IllegalArgumentException;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.implApi.modules.pwdmgr.ISResponseData;
+import cz.metacentrum.perun.core.implApi.modules.pwdmgr.ISServiceCaller;
+import org.apache.commons.codec.binary.Base64;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.Document;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
+
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLSocketFactory;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpression;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.io.StringReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * @author Vojtech Sassmann <vojtech.sassmann@gmail.com>
+ */
+public class ISServiceCallerImpl implements ISServiceCaller {
+
+	private final static Logger log = LoggerFactory.getLogger(ISServiceCallerImpl.class);
+	private final static String CRLF = "\r\n"; // Line separator required by multipart/form-data.
+
+	private static volatile ISServiceCallerImpl instance;
+
+	public static ISServiceCallerImpl getInstance() {
+		if (instance == null) {
+			instance = new ISServiceCallerImpl();
+		}
+		return instance;
+	}
+
+	@Override
+	public ISResponseData call(String requestBody, int requestId) throws IOException {
+		InputStream responseInputStream = makeCall(requestBody, requestId);
+		return parseResponse(responseInputStream, requestId);
+	}
+
+	/**
+	 * Makes secure SSL connection to IS MU and perform required password manager action
+	 *
+	 * @param dataToPass XML request body
+	 * @param requestId unique ID of a request
+	 * @return InputStream response to be parsed
+	 * @throws InternalErrorException
+	 * @throws IOException
+	 */
+	public InputStream makeCall(String dataToPass, int requestId) throws IOException {
+
+		//prepare sslFactory
+		SSLSocketFactory factory = (SSLSocketFactory) SSLSocketFactory.getDefault();
+		HttpsURLConnection.setDefaultSSLSocketFactory(factory);
+
+		// we want to log what we send
+		StringBuilder logBuilder = new StringBuilder();
+
+		String uri = BeansUtils.getPropertyFromCustomConfiguration("pwchange.mu.is", "uri");
+		String login = BeansUtils.getPropertyFromCustomConfiguration("pwchange.mu.is", "login");
+		String password = BeansUtils.getPropertyFromCustomConfiguration("pwchange.mu.is", "password");
+
+		URL myurl = new URL(uri);
+		HttpURLConnection con = (HttpURLConnection) myurl.openConnection();
+		String boundary = Long.toHexString(System.currentTimeMillis()); //random number for purpose of creating boundaries in multipart
+
+		// Prepare the basic auth, if the username and password was specified
+		if (login != null && password != null) {
+			String val = login + ":" + password;
+			Base64 encoder = new Base64();
+			String base64Encoded = new String(encoder.encode(val.getBytes()));
+			base64Encoded = base64Encoded.trim();
+			String authorizationString = "Basic " + base64Encoded;
+			con.setRequestProperty("Authorization", authorizationString);
+		}
+		con.setAllowUserInteraction(false);
+
+		//set request header if is required (set in extSource xml)
+		con.setDoOutput(true);
+		con.setRequestProperty("Content-Type", "multipart/form-data; boundary=" + boundary);
+		log.trace("[IS Request {}] Content-Type: multipart/form-data; boundary={}", requestId, boundary);
+
+		try (
+				OutputStream output = con.getOutputStream();
+				PrintWriter writer = new PrintWriter(new OutputStreamWriter(output, StandardCharsets.UTF_8), true)
+		) {
+			// Send param about return
+			writer.append("--" + boundary).append(CRLF);
+			logBuilder.append("--" + boundary).append(CRLF);
+			writer.append("Content-Disposition: form-data; name=\"out\"").append(CRLF);
+			logBuilder.append("Content-Disposition: form-data; name=\"out\"").append(CRLF);
+			writer.append(CRLF).append("xml").append(CRLF).flush();
+			logBuilder.append(CRLF).append("xml").append(CRLF);
+
+			// Send xml file.
+			writer.append("--" + boundary).append(CRLF);
+			logBuilder.append("--" + boundary).append(CRLF);
+			writer.append("Content-Disposition: form-data; name=\"xml\"; filename=\"perun-pwd-manager.xml\"").append(CRLF);
+			logBuilder.append("Content-Disposition: form-data; name=\"xml\"; filename=\"perun-pwd-manager.xml\"").append(CRLF);
+			writer.append("Content-Type: text/xml; charset=" + StandardCharsets.UTF_8).append(CRLF); // Text file itself must be saved in this charset!
+			logBuilder.append("Content-Type: text/xml; charset=" + StandardCharsets.UTF_8).append(CRLF);
+			writer.append(CRLF).flush();
+			logBuilder.append(CRLF);
+			writer.append(dataToPass);
+			logBuilder.append("\n--File content is logged separately--\n");
+			output.flush(); // Important before continuing with writer!
+			writer.append(CRLF).flush(); // CRLF is important! It indicates end of boundary.
+			logBuilder.append(CRLF);
+
+			// End of multipart/form-data.
+			writer.append("--" + boundary + "--").append(CRLF).flush();
+			logBuilder.append("--" + boundary + "--").append(CRLF);
+
+			log.trace("[IS Request {}] {}", requestId, logBuilder.toString());
+
+		}
+
+		int responseCode = con.getResponseCode();
+		if (responseCode == 200) {
+			return con.getInputStream();
+		} else {
+
+			String response = null;
+			try {
+				response = convertStreamToString(con.getErrorStream(), StandardCharsets.UTF_8);
+			} catch (IOException ex) {
+				log.error("Unable to convert InputStream to String.", ex);
+			}
+
+			log.trace("[IS Request {}] Response: {}", requestId, response);
+
+		}
+
+		throw new InternalErrorException("Wrong response code while opening connection on uri '" + uri + "'. Response code: " + responseCode + ". Request ID: " + requestId);
+	}
+
+
+	/**
+	 * Parse XML response from IS MU to XML document.
+	 *
+	 * @param inputStream Stream to be parsed to Document
+	 * @param requestID ID of request made to IS MU.
+	 * @return XML document for further processing
+	 * @throws InternalErrorException
+	 */
+	public ISResponseData parseResponse(InputStream inputStream, int requestID) {
+
+		//Create new document factory builder
+		DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+		DocumentBuilder builder;
+		try {
+			builder = factory.newDocumentBuilder();
+		} catch (ParserConfigurationException ex) {
+			throw new InternalErrorException("Error when creating newDocumentBuilder. Request ID: " + requestID, ex);
+		}
+
+		String response;
+		try {
+			response = convertStreamToString(inputStream, StandardCharsets.UTF_8);
+		} catch (IOException ex) {
+			throw new IllegalArgumentException("Unable to convert InputStream to String.", ex);
+		}
+
+		log.trace("[IS Request {}] Response: {}", requestID, response);
+		log.debug("[IS Request {}] Processing response from IS MU.", requestID);
+
+		Document doc;
+		try {
+			doc = builder.parse(new InputSource(new StringReader(response)));
+		} catch (SAXParseException ex) {
+			throw new InternalErrorException("Error when parsing uri by document builder. Request ID: " + requestID, ex);
+		} catch (SAXException ex) {
+			throw new InternalErrorException("Problem with parsing is more complex, not only invalid characters. Request ID: " + requestID, ex);
+		} catch (IOException ex) {
+			throw new InternalErrorException("Error when parsing uri by document builder. Problem with input or output. Request ID: " + requestID, ex);
+		}
+
+		//Prepare xpath expression
+		XPathFactory xPathfactory = XPathFactory.newInstance();
+		XPath xpath = xPathfactory.newXPath();
+		XPathExpression isErrorExpr;
+		XPathExpression getErrorTextExpr;
+		XPathExpression getDbErrorTextExpr;
+		try {
+			isErrorExpr = xpath.compile("//resp/stav/text()");
+			getErrorTextExpr = xpath.compile("//resp/error/text()");
+			getDbErrorTextExpr = xpath.compile("//resp/dberror/text()");
+		} catch (XPathExpressionException ex) {
+			throw new InternalErrorException("Error when compiling xpath query. Request ID: " + requestID, ex);
+		}
+
+		// OK or ERROR
+		String responseStatus;
+		try {
+			responseStatus = (String) isErrorExpr.evaluate(doc, XPathConstants.STRING);
+		} catch (XPathExpressionException ex) {
+			throw new InternalErrorException("Error when evaluate xpath query on document to resolve response status. Request ID: " + requestID, ex);
+		}
+
+		log.trace("[IS Request {}] Response of request from IS MU has status: {}", requestID, responseStatus);
+		log.debug("[IS Request {}] Response of request from IS MU has status: {}", requestID, responseStatus);
+
+		ISResponseData responseData = new ISResponseData();
+		responseData.setStatus(responseStatus);
+		responseData.setResponse(doc);
+
+		if (!IS_OK_STATUS.equals(responseStatus)) {
+			try {
+				String error = (String) getErrorTextExpr.evaluate(doc, XPathConstants.STRING);
+				if (error == null || error.isEmpty()) {
+					error = (String) getDbErrorTextExpr.evaluate(doc, XPathConstants.STRING);
+				}
+				responseData.setError(error.trim());
+			} catch (XPathExpressionException ex) {
+				throw new InternalErrorException("Error when evaluate xpath query on document to resolve error status. Request ID: " + requestID, ex);
+			}
+		}
+
+		return responseData;
+	}
+
+	/**
+	 * Based on tests from: http://stackoverflow.com/questions/309424/read-convert-an-inputstream-to-a-string
+	 * Most quicker and native InputStream reading method.
+	 *
+	 * @param inputStream Input stream to convert
+	 * @param encoding encoding used to parse input stream
+	 * @return Content of inputStream as a String
+	 * @throws IOException
+	 */
+	static String convertStreamToString(InputStream inputStream, Charset encoding) throws IOException {
+
+		ByteArrayOutputStream result = new ByteArrayOutputStream();
+		byte[] buffer = new byte[1024];
+		int length;
+		while ((length = inputStream.read(buffer)) != -1) {
+			result.write(buffer, 0, length);
+		}
+		return result.toString(encoding);
+
+	}
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/MuPasswordManagerModule.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/MuPasswordManagerModule.java
@@ -8,51 +8,36 @@ import cz.metacentrum.perun.core.api.SponsoredUserData;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.UserExtSource;
 import cz.metacentrum.perun.core.api.exceptions.ExtSourceNotExistsException;
-import cz.metacentrum.perun.core.api.exceptions.IllegalArgumentException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.InvalidLoginException;
 import cz.metacentrum.perun.core.api.exceptions.PasswordStrengthException;
 import cz.metacentrum.perun.core.api.exceptions.UserExtSourceExistsException;
 import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.implApi.modules.pwdmgr.ISResponseData;
+import cz.metacentrum.perun.core.implApi.modules.pwdmgr.ISServiceCaller;
 import cz.metacentrum.perun.core.implApi.modules.pwdmgr.PasswordManagerModule;
-import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.StringEscapeUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
-import org.xml.sax.InputSource;
-import org.xml.sax.SAXException;
-import org.xml.sax.SAXParseException;
 
-import javax.net.ssl.HttpsURLConnection;
-import javax.net.ssl.SSLSocketFactory;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpression;
 import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.OutputStreamWriter;
-import java.io.PrintWriter;
-import java.io.StringReader;
-import java.net.HttpURLConnection;
-import java.net.URL;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.regex.Pattern;
+
+import static cz.metacentrum.perun.core.implApi.modules.pwdmgr.ISServiceCaller.IS_ERROR_STATUS;
+import static cz.metacentrum.perun.core.implApi.modules.pwdmgr.ISServiceCaller.IS_OK_STATUS;
 
 /**
  * Password manager implementation for MU login-namespace.
@@ -63,7 +48,8 @@ import java.util.regex.Pattern;
 public class MuPasswordManagerModule implements PasswordManagerModule {
 
 	private final static Logger log = LoggerFactory.getLogger(MuPasswordManagerModule.class);
-	private final static String CRLF = "\r\n"; // Line separator required by multipart/form-data.
+
+	private static ISServiceCaller isServiceCaller = ISServiceCallerImpl.getInstance();
 
 	protected int randomPasswordLength = 24;
 	protected char[] randomPasswordCharacters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%&*()-_=+;:,<.>/?".toCharArray();
@@ -98,9 +84,12 @@ public class MuPasswordManagerModule implements PasswordManagerModule {
 
 		try {
 			int requestID = (new Random()).nextInt(1000000) + 1;
-			InputStream response = makeCall(getGenerateAccountRequest(session, parameters, requestID), requestID);
-			Document document = parseResponse(response, requestID);
-			return parseUCO(document, requestID);
+			String requestBody = getGenerateAccountRequest(session, parameters, requestID);
+			ISResponseData responseData = isServiceCaller.call(requestBody, requestID);
+			if (!IS_OK_STATUS.equals(responseData.getStatus())) {
+				throw new InternalErrorException("IS MU (password manager backend) responded with error to a Request ID: " + requestID + " Error: "+ responseData.getError());
+			}
+			return parseUCO(responseData.getResponse(), requestID);
 		} catch (IOException e) {
 			throw new InternalErrorException(e);
 		}
@@ -126,15 +115,7 @@ public class MuPasswordManagerModule implements PasswordManagerModule {
 	public void changePassword(PerunSession sess, String userLogin, String newPassword) throws PasswordStrengthException {
 		checkPasswordStrength(sess, userLogin, newPassword);
 
-		try {
-			int requestID = (new Random()).nextInt(1000000) + 1;
-			InputStream response = makeCall(getPwdChangeRequest(sess, userLogin, newPassword, requestID), requestID);
-			// if error, throws exception, otherwise it's ok
-			parseResponse(response, requestID);
-		} catch (IOException e) {
-			throw new InternalErrorException(e);
-		}
-
+		changePasswordWithoutCheck(sess, userLogin, newPassword);
 	}
 
 	@Override
@@ -196,7 +177,6 @@ public class MuPasswordManagerModule implements PasswordManagerModule {
 
 	@Override
 	public void checkPasswordStrength(PerunSession sess, String login, String password) throws PasswordStrengthException {
-
 		if (StringUtils.isBlank(password)) {
 			log.warn("Password for {}:{} cannot be empty.", "mu", login);
 			throw new PasswordStrengthException("Password for mu:" + login + " cannot be empty.");
@@ -219,6 +199,10 @@ public class MuPasswordManagerModule implements PasswordManagerModule {
 			throw new PasswordStrengthException("Password for mu:" + login + " is too weak. It has to contain at least 3 kinds of characters from: lower-case letter, upper-case letter, digit, spec. character.");
 		}
 
+		// The IS password check is performed by trying to change a password to a user, which has been specifically
+		// created for this purpose.
+		String passwordTestUco = getPasswordTestUco();
+		changePasswordWithoutCheck(sess, passwordTestUco, password);
 	}
 
 	@Override
@@ -243,101 +227,22 @@ public class MuPasswordManagerModule implements PasswordManagerModule {
 
 	}
 
-	/**
-	 * Makes secure SSL connection to IS MU and perform required password manager action
-	 *
-	 * @param dataToPass XML request body
-	 * @param requestId unique ID of a request
-	 * @return InputStream response to be parsed
-	 * @throws InternalErrorException
-	 * @throws IOException
-	 */
-	private InputStream makeCall(String dataToPass, int requestId) throws IOException {
+	public String getPasswordTestUco() {
+		return BeansUtils.getPropertyFromCustomConfiguration("pwchange.mu.is", "muPasswordStrengthTestLogin");
+	}
 
-		//prepare sslFactory
-		SSLSocketFactory factory = (SSLSocketFactory) SSLSocketFactory.getDefault();
-		HttpsURLConnection.setDefaultSSLSocketFactory(factory);
-
-		// we want to log what we send
-		StringBuilder logBuilder = new StringBuilder();
-
-		String uri = BeansUtils.getPropertyFromCustomConfiguration("pwchange.mu.is", "uri");
-		String login = BeansUtils.getPropertyFromCustomConfiguration("pwchange.mu.is", "login");
-		String password = BeansUtils.getPropertyFromCustomConfiguration("pwchange.mu.is", "password");
-
-		URL myurl = new URL(uri);
-		HttpURLConnection con = (HttpURLConnection) myurl.openConnection();
-		String boundary = Long.toHexString(System.currentTimeMillis()); //random number for purpose of creating boundaries in multipart
-
-		// Prepare the basic auth, if the username and password was specified
-		if (login != null && password != null) {
-			String val = login + ":" + password;
-			Base64 encoder = new Base64();
-			String base64Encoded = new String(encoder.encode(val.getBytes()));
-			base64Encoded = base64Encoded.trim();
-			String authorizationString = "Basic " + base64Encoded;
-			con.setRequestProperty("Authorization", authorizationString);
-		}
-		con.setAllowUserInteraction(false);
-
-		//set request header if is required (set in extSource xml)
-		con.setDoOutput(true);
-		con.setRequestProperty("Content-Type", "multipart/form-data; boundary=" + boundary);
-		log.trace("[IS Request {}] Content-Type: multipart/form-data; boundary={}", requestId, boundary);
-
-		try (
-				OutputStream output = con.getOutputStream();
-				PrintWriter writer = new PrintWriter(new OutputStreamWriter(output, StandardCharsets.UTF_8), true)
-		) {
-			// Send param about return
-			writer.append("--" + boundary).append(CRLF);
-			logBuilder.append("--" + boundary).append(CRLF);
-			writer.append("Content-Disposition: form-data; name=\"out\"").append(CRLF);
-			logBuilder.append("Content-Disposition: form-data; name=\"out\"").append(CRLF);
-			writer.append(CRLF).append("xml").append(CRLF).flush();
-			logBuilder.append(CRLF).append("xml").append(CRLF);
-
-			// Send xml file.
-			writer.append("--" + boundary).append(CRLF);
-			logBuilder.append("--" + boundary).append(CRLF);
-			writer.append("Content-Disposition: form-data; name=\"xml\"; filename=\"perun-pwd-manager.xml\"").append(CRLF);
-			logBuilder.append("Content-Disposition: form-data; name=\"xml\"; filename=\"perun-pwd-manager.xml\"").append(CRLF);
-			writer.append("Content-Type: text/xml; charset=" + StandardCharsets.UTF_8).append(CRLF); // Text file itself must be saved in this charset!
-			logBuilder.append("Content-Type: text/xml; charset=" + StandardCharsets.UTF_8).append(CRLF);
-			writer.append(CRLF).flush();
-			logBuilder.append(CRLF);
-			writer.append(dataToPass);
-			logBuilder.append("\n--File content is logged separately--\n");
-			output.flush(); // Important before continuing with writer!
-			writer.append(CRLF).flush(); // CRLF is important! It indicates end of boundary.
-			logBuilder.append(CRLF);
-
-			// End of multipart/form-data.
-			writer.append("--" + boundary + "--").append(CRLF).flush();
-			logBuilder.append("--" + boundary + "--").append(CRLF);
-
-			log.trace("[IS Request {}] {}", requestId, logBuilder.toString());
-
-		}
-
-		int responseCode = con.getResponseCode();
-		if (responseCode == 200) {
-			return con.getInputStream();
-		} else {
-
-			String response = null;
-			try {
-				response = convertStreamToString(con.getErrorStream(), StandardCharsets.UTF_8);
-			} catch (IOException ex) {
-				log.error("Unable to convert InputStream to String.", ex);
+	private void changePasswordWithoutCheck(PerunSession sess, String login, String password) throws PasswordStrengthException {
+		try {
+			int requestID = (new Random()).nextInt(1000000) + 1;
+			String requestBody = getPwdChangeRequest(sess, login, password, requestID);
+			// if error, throws exception, otherwise it's ok
+			ISResponseData responseData = isServiceCaller.call(requestBody, requestID);
+			if (IS_ERROR_STATUS.equals(responseData.getStatus())) {
+				throw new PasswordStrengthException(responseData.getError());
 			}
-
-			log.trace("[IS Request {}] Response: {}", requestId, response);
-
+		} catch (IOException e) {
+			throw new InternalErrorException(e);
 		}
-
-		throw new InternalErrorException("Wrong response code while opening connection on uri '" + uri + "'. Response code: " + responseCode + ". Request ID: " + requestId);
-
 	}
 
 	/**
@@ -502,112 +407,6 @@ public class MuPasswordManagerModule implements PasswordManagerModule {
 	}
 
 	/**
-	 * Parse XML response from IS MU to XML document.
-	 *
-	 * @param inputStream Stream to be parsed to Document
-	 * @param requestID ID of request made to IS MU.
-	 * @return XML document for further processing
-	 * @throws InternalErrorException
-	 */
-	private Document parseResponse(InputStream inputStream, int requestID) {
-
-		//Create new document factory builder
-		DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-		DocumentBuilder builder;
-		try {
-			builder = factory.newDocumentBuilder();
-		} catch (ParserConfigurationException ex) {
-			throw new InternalErrorException("Error when creating newDocumentBuilder. Request ID: " + requestID, ex);
-		}
-
-		String response;
-		try {
-			response = convertStreamToString(inputStream, StandardCharsets.UTF_8);
-		} catch (IOException ex) {
-			throw new IllegalArgumentException("Unable to convert InputStream to String.", ex);
-		}
-
-		log.trace("[IS Request {}] Response: {}", requestID, response);
-		log.debug("[IS Request {}] Processing response from IS MU.", requestID);
-
-		Document doc;
-		try {
-			doc = builder.parse(new InputSource(new StringReader(response)));
-		} catch (SAXParseException ex) {
-			throw new InternalErrorException("Error when parsing uri by document builder. Request ID: " + requestID, ex);
-		} catch (SAXException ex) {
-			throw new InternalErrorException("Problem with parsing is more complex, not only invalid characters. Request ID: " + requestID, ex);
-		} catch (IOException ex) {
-			throw new InternalErrorException("Error when parsing uri by document builder. Problem with input or output. Request ID: " + requestID, ex);
-		}
-
-		//Prepare xpath expression
-		XPathFactory xPathfactory = XPathFactory.newInstance();
-		XPath xpath = xPathfactory.newXPath();
-		XPathExpression isErrorExpr;
-		XPathExpression getErrorTextExpr;
-		XPathExpression getDbErrorTextExpr;
-		try {
-			isErrorExpr = xpath.compile("//resp/stav/text()");
-			getErrorTextExpr = xpath.compile("//resp/error/text()");
-			getDbErrorTextExpr = xpath.compile("//resp/dberror/text()");
-		} catch (XPathExpressionException ex) {
-			throw new InternalErrorException("Error when compiling xpath query. Request ID: " + requestID, ex);
-		}
-
-		// OK or ERROR
-		String responseStatus;
-		try {
-			responseStatus = (String) isErrorExpr.evaluate(doc, XPathConstants.STRING);
-		} catch (XPathExpressionException ex) {
-			throw new InternalErrorException("Error when evaluate xpath query on document to resolve response status. Request ID: " + requestID, ex);
-		}
-
-		log.trace("[IS Request {}] Response of request from IS MU has status: {}", requestID, responseStatus);
-		log.debug("[IS Request {}] Response of request from IS MU has status: {}", requestID, responseStatus);
-
-		if ("OK".equals(responseStatus)) {
-
-			return doc;
-
-		} else {
-
-			try {
-				String error = (String) getErrorTextExpr.evaluate(doc, XPathConstants.STRING);
-				if (error == null || error.isEmpty()) {
-					error = (String) getDbErrorTextExpr.evaluate(doc, XPathConstants.STRING);
-				}
-				throw new InternalErrorException("IS MU (password manager backend) responded with error to a Request ID: " + requestID + " Error: "+ error);
-			} catch (XPathExpressionException ex) {
-				throw new InternalErrorException("Error when evaluate xpath query on document to resolve error status. Request ID: " + requestID, ex);
-			}
-
-		}
-
-	}
-
-	/**
-	 * Based on tests from: http://stackoverflow.com/questions/309424/read-convert-an-inputstream-to-a-string
-	 * Most quicker and native InputStream reading method.
-	 *
-	 * @param inputStream Input stream to convert
-	 * @param encoding encoding used to parse input stream
-	 * @return Content of inputStream as a String
-	 * @throws IOException
-	 */
-	static String convertStreamToString(InputStream inputStream, Charset encoding) throws IOException {
-
-		ByteArrayOutputStream result = new ByteArrayOutputStream();
-		byte[] buffer = new byte[1024];
-		int length;
-		while ((length = inputStream.read(buffer)) != -1) {
-			result.write(buffer, 0, length);
-		}
-		return result.toString(encoding);
-
-	}
-
-	/**
 	 * Return MU UCO of a pwdmanager method caller from his UserExtSource in MU IdP.
 	 *
 	 * @param session Session to get user and identity from
@@ -652,4 +451,11 @@ public class MuPasswordManagerModule implements PasswordManagerModule {
 		return StringEscapeUtils.escapeXml10(input);
 	}
 
+	public ISServiceCaller getIsServiceCaller() {
+		return isServiceCaller;
+	}
+
+	public void setIsServiceCaller(ISServiceCaller isServiceCaller) {
+		MuPasswordManagerModule.isServiceCaller = isServiceCaller;
+	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/pwdmgr/ISResponseData.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/pwdmgr/ISResponseData.java
@@ -1,0 +1,39 @@
+package cz.metacentrum.perun.core.implApi.modules.pwdmgr;
+
+import org.w3c.dom.Document;
+
+/**
+ * This class represents the response returned from the IS. It contains the returned status,
+ * error (if present) and the whole response itself, in a Document class.
+ *
+ * @author Vojtech Sassmann <vojtech.sassmann@gmail.com>
+ */
+public class ISResponseData {
+	private String status;
+	private String error;
+	private Document response;
+
+	public String getStatus() {
+		return status;
+	}
+
+	public void setStatus(String status) {
+		this.status = status;
+	}
+
+	public Document getResponse() {
+		return response;
+	}
+
+	public void setResponse(Document response) {
+		this.response = response;
+	}
+
+	public String getError() {
+		return error;
+	}
+
+	public void setError(String error) {
+		this.error = error;
+	}
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/pwdmgr/ISServiceCaller.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/pwdmgr/ISServiceCaller.java
@@ -1,0 +1,24 @@
+package cz.metacentrum.perun.core.implApi.modules.pwdmgr;
+
+import java.io.IOException;
+
+/**
+ * Service used to communicate with the IS MU.
+ *
+ * @author Vojtech Sassmann <vojtech.sassmann@gmail.com>
+ */
+public interface ISServiceCaller {
+	String IS_ERROR_STATUS = "ERR";
+	String IS_OK_STATUS = "OK";
+
+	/**
+	 * Sends a request to the IS with the given body. The received response is returned,
+	 * with the status code and an error (if some has occurred).
+	 *
+	 * @param requestBody body of the http request, that will be send (xml format)
+	 * @param requestId id of the request
+	 * @return response data
+	 * @throws IOException if the connection to the IS failed
+	 */
+	ISResponseData call(String requestBody, int requestId) throws IOException;
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/ISServiceCallerTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/ISServiceCallerTest.java
@@ -1,0 +1,61 @@
+package cz.metacentrum.perun.core.impl;
+
+import cz.metacentrum.perun.core.impl.modules.pwdmgr.ISServiceCallerImpl;
+import cz.metacentrum.perun.core.implApi.modules.pwdmgr.ISResponseData;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+
+import static cz.metacentrum.perun.core.implApi.modules.pwdmgr.ISServiceCaller.IS_ERROR_STATUS;
+import static cz.metacentrum.perun.core.implApi.modules.pwdmgr.ISServiceCaller.IS_OK_STATUS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Vojtech Sassmann <vojtech.sassmann@gmail.com>
+ */
+public class ISServiceCallerTest {
+
+	private static final String TEST_ERR_RESPONSE_ERROR = "Navrhované heslo nelze použít, protože začíná nebo končí mezerou. Zvolte si prosím jiné.";
+	private static final String TEST_ERR_RESPONSE = """
+			<?xml version="1.0" encoding="utf-8"?>
+			<response><resp reqid="297965"><stav>ERR</stav>
+			    <error>""" + TEST_ERR_RESPONSE_ERROR + """
+			    </error>
+			    <uco></uco></resp>
+			</response>
+			""";
+
+	private static final String TEST_OK_RESPONSE = """
+			<?xml version="1.0" encoding="utf-8"?>
+			<response>
+			    <resp reqid="143002">
+			        <stav>OK</stav>
+			        <uco>9021006</uco>
+			    </resp>
+			</response>
+			""";
+
+	private final ISServiceCallerImpl isServiceCaller = ISServiceCallerImpl.getInstance();
+
+	@Test
+	public void testParseOkResponse() {
+		int reqId = 1;
+		ISResponseData data = isServiceCaller
+				.parseResponse(new ByteArrayInputStream(TEST_OK_RESPONSE.getBytes()), reqId);
+
+		assertThat(data.getStatus()).isEqualTo(IS_OK_STATUS);
+		assertThat(data.getError()).isNull();
+		assertThat(data.getResponse()).isNotNull();
+	}
+
+	@Test
+	public void testParseErrResponse() {
+		int reqId = 1;
+		ISResponseData data = isServiceCaller
+				.parseResponse(new ByteArrayInputStream(TEST_ERR_RESPONSE.getBytes()), reqId);
+
+		assertThat(data.getStatus()).isEqualTo(IS_ERROR_STATUS);
+		assertThat(data.getError()).isEqualTo(TEST_ERR_RESPONSE_ERROR);
+		assertThat(data.getResponse()).isNotNull();
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/MuPasswordManagerModuleTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/MuPasswordManagerModuleTest.java
@@ -1,0 +1,74 @@
+package cz.metacentrum.perun.core.impl.modules.pwdmgr;
+
+import cz.metacentrum.perun.core.AbstractPerunIntegrationTest;
+import cz.metacentrum.perun.core.api.exceptions.PasswordStrengthException;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.implApi.modules.pwdmgr.ISResponseData;
+import cz.metacentrum.perun.core.implApi.modules.pwdmgr.ISServiceCaller;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static cz.metacentrum.perun.core.implApi.modules.pwdmgr.ISServiceCaller.IS_ERROR_STATUS;
+import static cz.metacentrum.perun.core.implApi.modules.pwdmgr.ISServiceCaller.IS_OK_STATUS;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Vojtech Sassmann <vojtech.sassmann@gmail.com>
+ */
+public class MuPasswordManagerModuleTest extends AbstractPerunIntegrationTest {
+
+	private MuPasswordManagerModule module;
+	private final ISServiceCaller isServiceCallerMock = mock(ISServiceCaller.class);
+
+	@Before
+	public void setUp() throws Exception {
+		this.module = (MuPasswordManagerModule)((PerunBl)sess.getPerun()).getUsersManagerBl().getPasswordManagerModule(sess, "mu");
+		this.module = spy(this.module);
+
+		doReturn("999809098")
+				.when(this.module)
+				.getPasswordTestUco();
+
+		this.module.setIsServiceCaller(isServiceCallerMock);
+	}
+
+	@After
+	public void tearDown() {
+		Mockito.reset(isServiceCallerMock);
+	}
+
+	@Test
+	public void changePassword() throws Exception {
+		ISResponseData okResponseData = new ISResponseData();
+		okResponseData.setStatus(IS_OK_STATUS);
+
+		when(isServiceCallerMock.call(anyString(), anyInt()))
+				.thenReturn(okResponseData);
+
+		module.checkPasswordStrength(sess, null, "randomPassword2.");
+	}
+
+	@Test
+	public void changePasswordExceptionIsThrownIfIsReturnsAnError() throws Exception {
+		String errorMessage = "Invalid password";
+
+		ISResponseData errResponseData = new ISResponseData();
+		errResponseData.setStatus(IS_ERROR_STATUS);
+		errResponseData.setError(errorMessage);
+
+		when(isServiceCallerMock.call(anyString(), anyInt()))
+				.thenReturn(errResponseData);
+
+		assertThatExceptionOfType(PasswordStrengthException.class)
+				.isThrownBy(() -> module.checkPasswordStrength(sess, null, "Adf.,.2;..df,"))
+				.withMessageEndingWith(errorMessage);
+	}
+}

--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -7555,6 +7555,22 @@ paths:
         default:
           $ref: '#/components/responses/ExceptionResponse'
 
+  /json/usersManager/checkPasswordStrength:
+    get:
+      tags:
+        - UsersManager
+      operationId: checkPasswordStrength
+      summary: Check password strength for the given namespace.
+      description: If the check fails, the PasswordStrengthException error is returned.
+      parameters:
+        - $ref: '#/components/parameters/password'
+        - $ref: '#/components/parameters/namespace'
+      responses:
+        '200':
+          $ref: '#/components/responses/VoidResponse'
+        default:
+          $ref: '#/components/responses/ExceptionResponse'
+
   /json/usersManager/getGroupsWhereUserIsActive/facility:
     get:
       tags:

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/UsersManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/UsersManagerMethod.java
@@ -1446,6 +1446,26 @@ public enum UsersManagerMethod implements ManagerMethod {
 	},
 
 	/*#
+	 * Check password strength for the given namespace. If the password is too weak,
+	 * the PasswordStrengthException is thrown
+	 *
+	 * @param password String password, that will be checked
+	 * @param namespace String namespace, that will be used to check the strength of the password
+	 *
+	 * @throw PasswordStrengthException When password doesn't match expected strength by namespace configuration
+	 */
+	checkPasswordStrength {
+		@Override
+		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
+			ac.getUsersManager().checkPasswordStrength(ac.getSession(),
+					parms.readString("password"),
+					parms.readString("namespace"));
+
+			return null;
+		}
+	},
+
+	/*#
 	 * Get list of groups of user on specified resource where use is active,
 	 * that means User is a VALID in the VO and the Group and groups are assigned to the resource.
 	 *


### PR DESCRIPTION
* Added new method to the RPC API, that can be used to check the
strength of the given password, for the given namespace.
* For the MU namespace, the method is now calling the IS and returning
any errors received by the call.
* It is necessary to set the `perun.muPasswordStrengthTestLogin` with
the uco of a specific user created for the password test purpose.
* The logic responsible for the communication with the IS has been moved to a separate service.
