### PR TITLE
Core - new methods getRichUsersByIds

### DIFF
--- a/perun-base/src/main/resources/perun-roles.yml
+++ b/perun-base/src/main/resources/perun-roles.yml
@@ -4693,6 +4693,58 @@ perun_policies:
     include_policies:
       - default_policy
 
+  getRichUsersByIds_List<Integer>_policy:
+    policy_roles:
+      - RPC:
+      - ENGINE:
+      - GROUPADMIN:
+      - GROUPOBSERVER:
+      - VOOBSERVER:
+      - VOADMIN:
+      - SELF:
+      - PERUNOBSERVER:
+    include_policies:
+      - default_policy
+
+  filter-getRichUsersByIds_List<Integer>_policy:
+    policy_roles:
+      - RPC:
+      - ENGINE:
+      - GROUPADMIN:
+      - GROUPOBSERVER:
+      - VOOBSERVER:
+      - VOADMIN:
+      - SELF: User
+      - PERUNOBSERVER:
+    include_policies:
+      - default_policy
+
+  getRichUsersWithAttributesByIds_List<Integer>_policy:
+    policy_roles:
+      - RPC:
+      - ENGINE:
+      - GROUPADMIN:
+      - GROUPOBSERVER:
+      - VOOBSERVER:
+      - VOADMIN:
+      - SELF:
+      - PERUNOBSERVER:
+    include_policies:
+      - default_policy
+
+  filter-getRichUsersWithAttributesByIds_List<Integer>_policy:
+    policy_roles:
+      - RPC:
+      - ENGINE:
+      - GROUPADMIN:
+      - GROUPOBSERVER:
+      - VOOBSERVER:
+      - VOADMIN:
+      - SELF: User
+      - PERUNOBSERVER:
+    include_policies:
+      - default_policy
+
   getRichUsersFromListOfUsers_List<User>_policy:
     policy_roles:
       - PERUNOBSERVER:

--- a/perun-cli/Perun/UsersAgent.pm
+++ b/perun-cli/Perun/UsersAgent.pm
@@ -148,6 +148,16 @@ sub getUsersBySpecificUser
 	return Perun::Common::callManagerMethod('getUsersBySpecificUser', '[]User', @_);
 }
 
+sub getRichUsersByIds
+{
+	return Perun::Common::callManagerMethod('getRichUsersByIds', '[]RichUser', @_);
+}
+
+sub getRichUsersWithAttributesByIds
+{
+	return Perun::Common::callManagerMethod('getRichUsersWithAttributesByIds', '[]RichUser', @_);
+}
+
 sub getRichUsersFromListOfUsersWithAttributes
 {
 	return Perun::Common::callManagerMethod('getRichUsersFromListOfUsersWithAttributes', '[]RichUser', @_);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/UsersManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/UsersManager.java
@@ -250,8 +250,31 @@ public interface UsersManager {
 	List<RichUser> getAllRichUsersWithAttributes(PerunSession sess, boolean includedSpecificUsers) throws PrivilegeException, UserNotExistsException;
 
 	/**
+	 * Returns rich users without attributes by their ids.
+	 *
+	 * @param sess
+	 * @param ids
+	 * @return list of rich users with specified ids
+	 * @throws InternalErrorException
+	 * @throws PrivilegeException
+	 */
+	List<RichUser> getRichUsersByIds(PerunSession sess, List<Integer> ids) throws PrivilegeException;
+
+	/**
+	 * Returns rich users with attributes by their ids.
+	 *
+	 * @param sess
+	 * @param ids
+	 * @return list of rich users with specified ids
+	 * @throws InternalErrorException
+	 * @throws PrivilegeException
+	 */
+	List<RichUser> getRichUsersWithAttributesByIds(PerunSession sess, List<Integer> ids) throws PrivilegeException, UserNotExistsException;
+
+	/**
 	 * From Users makes RichUsers without attributes.
 	 *
+	 * @deprecated - use getRichUsersByIds
 	 * @param sess
 	 * @param users users to convert
 	 * @return list of richUsers
@@ -259,11 +282,13 @@ public interface UsersManager {
 	 * @throws PrivilegeException
 	 * @throws UserNotExistsException
 	 */
+	@Deprecated
 	List<RichUser> getRichUsersFromListOfUsers(PerunSession sess, List<User> users) throws PrivilegeException, UserNotExistsException;
 
 	/**
 	 * From Users makes RichUsers with attributes.
 	 *
+	 * @deprecated - use getRichUsersWithAttributesByIds
 	 * @param sess
 	 * @param users users to convert
 	 * @return list of richUsers
@@ -271,6 +296,7 @@ public interface UsersManager {
 	 * @throws PrivilegeException
 	 * @throws UserNotExistsException
 	 */
+	@Deprecated
 	List<RichUser> getRichUsersWithAttributesFromListOfUsers(PerunSession sess, List<User> users) throws PrivilegeException, UserNotExistsException;
 
 	/**

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
@@ -278,6 +278,27 @@ public interface UsersManagerBl {
 	List<RichUser> getAllRichUsersWithAttributes(PerunSession sess, boolean includedSpecificUsers) throws UserNotExistsException;
 
 	/**
+	 * Returns rich users without attributes by their ids.
+	 *
+	 * @param sess
+	 * @param ids
+	 * @return list of rich users with specified ids
+	 * @throws InternalErrorException
+	 */
+	List<RichUser> getRichUsersByIds(PerunSession sess, List<Integer> ids);
+
+	/**
+	 * Returns rich users with attributes by their ids.
+	 *
+	 * @param sess
+	 * @param ids
+	 * @return list of rich users with specified ids
+	 * @throws InternalErrorException
+	 * @throws UserNotExistsException
+	 */
+	List<RichUser> getRichUsersWithAttributesByIds(PerunSession sess, List<Integer> ids) throws UserNotExistsException;
+
+	/**
 	 * From Users makes RichUsers without attributes.
 	 *
 	 * @param sess

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
@@ -383,6 +383,17 @@ public class UsersManagerBlImpl implements UsersManagerBl {
 		return this.convertRichUsersToRichUsersWithAttributes(sess, richUsers);
 	}
 
+	@Override
+	public List<RichUser> getRichUsersByIds(PerunSession sess, List<Integer> ids) {
+		List<User> users = this.getUsersByIds(sess, ids);
+		return this.convertUsersToRichUsers(sess, users);
+	}
+
+	@Override
+	public List<RichUser> getRichUsersWithAttributesByIds(PerunSession sess, List<Integer> ids) throws UserNotExistsException {
+		List<User> users = this.getUsersByIds(sess, ids);
+		return this.getRichUsersWithAttributesFromListOfUsers(sess, users);
+	}
 
 	@Override
 	public List<RichUser> getRichUsersFromListOfUsers(PerunSession sess, List<User> users) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
@@ -303,6 +303,35 @@ public class UsersManagerEntry implements UsersManager {
 	}
 
 	@Override
+	public List<RichUser> getRichUsersByIds(PerunSession sess, List<Integer> ids) throws PrivilegeException {
+		Utils.checkPerunSession(sess);
+
+		// Authorization
+		if (!AuthzResolver.authorizedInternal(sess, "getRichUsersByIds_List<Integer>_policy")) {
+			throw new PrivilegeException(sess, "getRichUsersByIds");
+		}
+		List<RichUser> richUsers = getUsersManagerBl().getRichUsersByIds(sess, ids);
+		richUsers.removeIf(richUser -> !AuthzResolver.authorizedInternal(sess, "filter-getRichUsersByIds_List<Integer>_policy", richUser));
+
+		return richUsers;
+	}
+
+	@Override
+	public List<RichUser> getRichUsersWithAttributesByIds(PerunSession sess, List<Integer> ids) throws PrivilegeException, UserNotExistsException {
+		Utils.checkPerunSession(sess);
+
+		// Authorization
+		if (!AuthzResolver.authorizedInternal(sess, "getRichUsersWithAttributesByIds_List<Integer>_policy")) {
+			throw new PrivilegeException(sess, "getRichUsersWithAttributesByIds");
+		}
+		List<RichUser> richUsers = getUsersManagerBl().getRichUsersWithAttributesByIds(sess, ids);
+		richUsers.removeIf(richUser -> !AuthzResolver.authorizedInternal(sess, "filter-getRichUsersWithAttributesByIds_List<Integer>_policy", richUser));
+
+		return getPerunBl().getUsersManagerBl().filterOnlyAllowedAttributes(sess, richUsers);
+	}
+
+	@Override
+	@Deprecated
 	public List<RichUser> getRichUsersFromListOfUsers(PerunSession sess, List<User> users) throws PrivilegeException, UserNotExistsException {
 		Utils.checkPerunSession(sess);
 
@@ -329,6 +358,7 @@ public class UsersManagerEntry implements UsersManager {
 	}
 
 	@Override
+	@Deprecated
 	public List<RichUser> getRichUsersWithAttributesFromListOfUsers(PerunSession sess, List<User> users) throws PrivilegeException, UserNotExistsException {
 		Utils.checkPerunSession(sess);
 

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/UsersManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/UsersManagerEntryIntegrationTest.java
@@ -1252,6 +1252,48 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 	}
 
 	@Test
+	public void getRichUsersByIds() throws Exception {
+		System.out.println(CLASS_NAME + "getRichUsersByIds");
+
+		RichUser richUser = new RichUser(user, perun.getUsersManager().getUserExtSources(sess, user));
+		List<RichUser> richUsers = perun.getUsersManager().getRichUsersByIds(sess, Collections.singletonList(user.getId()));
+		assertThat(richUsers).containsExactlyInAnyOrder(richUser);
+		assertThat(richUsers.get(0).getUserExtSources()).containsExactlyInAnyOrderElementsOf(richUser.getUserExtSources());
+
+		User user2 = new User();
+		user2.setFirstName(userFirstName + "2");
+		user2 = perun.getUsersManagerBl().createUser(sess, user2);
+		RichUser richUser2 = new RichUser(user2, perun.getUsersManager().getUserExtSources(sess, user2));
+
+		richUsers = perun.getUsersManager().getRichUsersByIds(sess, Arrays.asList(user.getId(), user2.getId()));
+		assertThat(richUsers).containsExactlyInAnyOrder(richUser, richUser2);
+		assertThat(richUsers.get(richUsers.indexOf(richUser)).getUserExtSources()).containsExactlyInAnyOrderElementsOf(richUser.getUserExtSources());
+		assertThat(richUsers.get(richUsers.indexOf(richUser2)).getUserExtSources()).containsExactlyInAnyOrderElementsOf(richUser2.getUserExtSources());
+	}
+
+	@Test
+	public void getRichUsersWithAttributesByIds() throws Exception {
+		System.out.println(CLASS_NAME + "getRichUsersWithAttributesByIds");
+
+		RichUser richUser = new RichUser(user, perun.getUsersManager().getUserExtSources(sess, user), perun.getAttributesManager().getAttributes(sess, user));
+		List<RichUser> richUsers = perun.getUsersManager().getRichUsersByIds(sess, Collections.singletonList(user.getId()));
+		assertThat(richUsers).containsExactlyInAnyOrder(richUser);
+		assertThat(richUsers.get(0).getUserExtSources()).containsExactlyInAnyOrderElementsOf(richUser.getUserExtSources());
+
+		User user2 = new User();
+		user2.setFirstName(userFirstName + "2");
+		user2 = perun.getUsersManagerBl().createUser(sess, user2);
+		RichUser richUser2 = new RichUser(user2, perun.getUsersManager().getUserExtSources(sess, user2), perun.getAttributesManager().getAttributes(sess, user2));
+
+		richUsers = perun.getUsersManager().getRichUsersWithAttributesByIds(sess, Arrays.asList(user.getId(), user2.getId()));
+		assertThat(richUsers).containsExactlyInAnyOrder(richUser, richUser2);
+		assertThat(richUsers.get(richUsers.indexOf(richUser)).getUserExtSources()).containsExactlyInAnyOrderElementsOf(richUser.getUserExtSources());
+		assertThat(richUsers.get(richUsers.indexOf(richUser2)).getUserExtSources()).containsExactlyInAnyOrderElementsOf(richUser2.getUserExtSources());
+		assertThat(richUsers.get(richUsers.indexOf(user)).getUserAttributes()).containsExactlyInAnyOrderElementsOf(richUser.getUserAttributes());
+		assertThat(richUsers.get(richUsers.indexOf(user2)).getUserAttributes()).containsExactlyInAnyOrderElementsOf(richUser2.getUserAttributes());
+	}
+
+	@Test
 	public void getGroupsWhereUserIsActive() throws Exception {
 		System.out.println(CLASS_NAME + "getGroupsWhereUserIsActive(resource/facility)");
 

--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -7541,6 +7541,34 @@ paths:
         default:
           $ref: '#/components/responses/ExceptionResponse'
 
+  /json/usersManager/getRichUsersByIds:
+    get:
+      tags:
+        - UsersManager
+      operationId: getRichUsersByIds
+      summary: Returns rich users without attributes by their IDs.
+      parameters:
+        - $ref: '#/components/parameters/ids'
+      responses:
+        '200':
+          $ref: '#/components/responses/ListOfRichUsersResponse'
+        default:
+          $ref: '#/components/responses/ExceptionResponse'
+
+  /json/usersManager/getRichUsersWithAttributesByIds:
+    get:
+      tags:
+        - UsersManager
+      operationId: getRichUsersWithAttributesByIds
+      summary: Returns rich users with attributes by their IDs.
+      parameters:
+        - $ref: '#/components/parameters/ids'
+      responses:
+        '200':
+          $ref: '#/components/responses/ListOfRichUsersResponse'
+        default:
+          $ref: '#/components/responses/ExceptionResponse'
+
   /json/usersManager/getUserExtSources:
     get:
       tags:

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/UsersManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/UsersManagerMethod.java
@@ -293,8 +293,37 @@ public enum UsersManagerMethod implements ManagerMethod {
 	},
 
 	/*#
+	 * Returns rich users without attributes by their IDs.
+	 *
+	 * @param ids List<Integer> list of users IDs
+	 * @return List<RichUser> rich users with specified IDs
+	 */
+	getRichUsersByIds {
+
+		@Override
+		public List<RichUser> call(ApiCaller ac, Deserializer parms) throws PerunException {
+			return ac.getUsersManager().getRichUsersByIds(ac.getSession(), parms.readList("ids", Integer.class));
+		}
+	},
+
+	/*#
+	 * Returns rich users with attributes by their IDs.
+	 *
+	 * @param ids List<Integer> list of users IDs
+	 * @return List<RichUser> rich users with specified IDs
+	 */
+	getRichUsersWithAttributesByIds {
+
+		@Override
+		public List<RichUser> call(ApiCaller ac, Deserializer parms) throws PerunException {
+			return ac.getUsersManager().getRichUsersWithAttributesByIds(ac.getSession(), parms.readList("ids", Integer.class));
+		}
+	},
+
+	/*#
 	 * From Users makes RichUsers without attributes.
 	 *
+	 * @deprecated use getRichUsersByIds
 	 * @param users List<RichUser> users to convert
 	 * @return List<RichUser> list of rich users
 	 */
@@ -312,6 +341,7 @@ public enum UsersManagerMethod implements ManagerMethod {
 	/*#
 	 * From Users makes RichUsers with attributes.
 	 *
+	 * @deprecated use getRichUsersWithAttributesByIds
 	 * @param users List<RichUser> users to convert
 	 * @return List<RichUser> list of richUsers
 	 */


### PR DESCRIPTION
- New methods getRichUsersByIds() and getRichUsersWithAttributesByIds()
were added to Core, RPC and OpenAPI. These methods are preferred to
existing methods getRichUsersFromListOfUsers() and
getRichUsersFromListOfUsersWithAttributes(), which were marked as
deprecated.