### PR TITLE
Core - identity alerts

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/CoreConfig.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/CoreConfig.java
@@ -75,6 +75,7 @@ public class CoreConfig {
 	private boolean smtpAuth;
 	private boolean smtpStartTls;
 	private boolean mailDebug;
+	private boolean sendIdentityAlert;
 	private String smtpUser;
 	private String smtpPass;
 	private List<String> autocreatedNamespaces;
@@ -692,5 +693,13 @@ public class CoreConfig {
 
 	public void setAttributesToKeep(List<String> attributesToKeep) {
 		this.attributesToKeep = attributesToKeep;
+	}
+
+	public boolean isSendIdentityAlerts() {
+		return sendIdentityAlert;
+	}
+
+	public void setSendIdentityAlerts(boolean sendIdentityAlerts) {
+		this.sendIdentityAlert = sendIdentityAlerts;
 	}
 }

--- a/perun-base/src/main/resources/perun-base.xml
+++ b/perun-base/src/main/resources/perun-base.xml
@@ -67,6 +67,7 @@
 		<property name="attributesToSearchUsersAndMembersBy" value="#{'${perun.attributesToSearchUsersAndMembersBy}'.split('\s*,\s*')}"/>
 		<property name="attributesToAnonymize" value="#{'${perun.attributesToAnonymize}'.split('\s*,\s*')}"/>
 		<property name="attributesToKeep" value="#{'${perun.attributesToKeep}'.split('\s*,\s*')}"/>
+		<property name="sendIdentityAlerts" value="${perun.sendIdentityAlerts}"/>
 	</bean>
 
 
@@ -155,6 +156,7 @@
 				<prop key="perun.smtp.pass"></prop>
 
 				<prop key="perun.autocreatedNamespaces"></prop>
+				<prop key="perun.sendIdentityAlerts">false</prop>
 
 			</props>
 		</property>

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -93,6 +93,7 @@ import cz.metacentrum.perun.core.bl.AttributesManagerBl;
 import cz.metacentrum.perun.core.bl.PerunBl;
 import cz.metacentrum.perun.core.impl.AttributesManagerImpl;
 import cz.metacentrum.perun.core.impl.Utils;
+import cz.metacentrum.perun.core.impl.modules.attributes.urn_perun_entityless_attribute_def_def_identityAlertsTemplates;
 import cz.metacentrum.perun.core.impl.modules.attributes.urn_perun_entityless_attribute_def_def_namespace_GIDRanges;
 import cz.metacentrum.perun.core.impl.modules.attributes.urn_perun_facility_attribute_def_virt_GIDRanges;
 import cz.metacentrum.perun.core.impl.modules.attributes.urn_perun_group_attribute_def_def_applicationAutoRejectMessages;
@@ -7760,6 +7761,12 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		attr.setDisplayName("Random password reset templates");
 		attr.setDescription("Random password reset templates. Each value should be String representing an HTML page." +
 				" Keywords {password} and {login} will be replaced.");
+
+		rights = new ArrayList<>();
+		attributes.put(attr, rights);
+
+		//urn:perun:entityless:attribute-def:def:identityAlerts
+		attr = new urn_perun_entityless_attribute_def_def_identityAlertsTemplates().getAttributeDefinition();
 
 		rights = new ArrayList<>();
 		attributes.put(attr, rights);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_entityless_attribute_def_def_identityAlertsTemplates.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_entityless_attribute_def_def_identityAlertsTemplates.java
@@ -1,0 +1,133 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import cz.metacentrum.perun.core.implApi.modules.attributes.EntitylessAttributesModuleAbstract;
+
+import java.time.format.DateTimeFormatter;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+/**
+ * Templates, for identity changes alerts.
+ *
+ * @author vojtech.sassmann@gmail.com
+ */
+public class urn_perun_entityless_attribute_def_def_identityAlertsTemplates extends EntitylessAttributesModuleAbstract {
+
+	public static final String UES_ADDED_PREFERRED_MAIL = "uesAddedPreferredMail";
+	public static final String UES_ADDED_PREFERRED_MAIL_SUBJECT = "uesAddedPreferredMailSubject";
+	public static final String UES_ADDED_UES_MAIL = "uesAddedUESMail";
+	public static final String UES_ADDED_UES_MAIL_SUBJECT = "uesAddedUESMailSubject";
+
+	public static final String UES_REMOVED_PREF_MAIL = "uesRemovedPreferredMail";
+	public static final String UES_REMOVED_PREF_MAIL_SUBJECT = "uesRemovedPreferredMailSubject";
+	public static final String UES_REMOVED_UES_MAIL = "uesRemovedUESMail";
+	public static final String UES_REMOVED_UES_MAIL_SUBJECT = "uesRemovedUESMailSubject";
+
+	public static final String LOGIN_PLACEHOLDER = "{login}";
+	public static final String ORG_PLACEHOLDER = "{organization}";
+	public static final String TIME_PLACEHOLDER = "{time}";
+
+	public static final String ORG_UNKNOWN_TEXT = "<unknown>";
+	public static final DateTimeFormatter ALERT_TIME_FORMATTER = DateTimeFormatter.ofPattern("MM/dd/yyyy - HH:mm:ss z");
+
+	public static final String KEY_EN = "en";
+
+	public static final String DEFAULT_IDENTITY_ADDED_PREF_MAIL_SUBJECT = "New identity added";
+	public static final String DEFAULT_IDENTITY_ADDED_UES_MAIL_SUBJECT = "Account linked";
+	public static final String DEFAULT_IDENTITY_ADDED_PREF_MAIL = """
+			A new identity has been added to your account. If you don't recognize this activity, please contact our support at perun@cesnet.cz.
+			
+			Identity organization: {organization} 
+			Identity login: {login}
+			
+			Time of change: {time}
+			
+			Message is automatically generated.
+			----------------------------------------------------------------
+			Perun - Identity & Access Management System""";
+	public static final String DEFAULT_IDENTITY_ADDED_UES_MAIL = """
+			Your account has been linked with an account in the Perun system. If you don't recognize this activity, please contact our support at perun@cesnet.cz.
+			
+			Identity organization: {organization}
+			Identity login: {login}
+			
+			Time of change: {time}
+			
+			Message is automatically generated.
+			----------------------------------------------------------------
+			Perun - Identity & Access Management System""";
+
+	public static final String DEFAULT_IDENTITY_REMOVED_PREF_MAIL_SUBJECT = "Identity removed";
+	public static final String DEFAULT_IDENTITY_REMOVED_UES_MAIL_SUBJECT = "Account unlinked";
+	public static final String DEFAULT_IDENTITY_REMOVED_PREF_MAIL = """
+			An identity has been removed from your account. If you don't recognize this activity, please contact our support at perun@cesnet.cz.
+			
+			Identity organization: {organization} 
+			Identity login: {login}
+			
+			Time of change: {time}
+			
+			Message is automatically generated.
+			----------------------------------------------------------------
+			Perun - Identity & Access Management System""";
+	public static final String DEFAULT_IDENTITY_REMOVED_UES_MAIL = """
+			Your account has been unlinked from an account in the Perun system. If you don't recognize this activity, please contact our support at perun@cesnet.cz.
+			
+			Identity organization: {organization}
+			Identity login: {login}
+			
+			Time of change: {time}
+			
+			Message is automatically generated.
+			----------------------------------------------------------------
+			Perun - Identity & Access Management System""";
+
+	public static final Set<String> ALLOWED_TEMPLATES = Set.of(
+			UES_ADDED_PREFERRED_MAIL,
+			UES_ADDED_PREFERRED_MAIL_SUBJECT,
+			UES_ADDED_UES_MAIL,
+			UES_ADDED_UES_MAIL_SUBJECT,
+			UES_REMOVED_PREF_MAIL,
+			UES_REMOVED_PREF_MAIL_SUBJECT,
+			UES_REMOVED_UES_MAIL,
+			UES_REMOVED_UES_MAIL_SUBJECT
+			);
+
+	@Override
+	public void checkAttributeSyntax(PerunSessionImpl perunSession, String key, Attribute attribute) throws WrongAttributeValueException {
+		if (!KEY_EN.equals(key)) {
+			throw new WrongAttributeValueException("Invalid key. The only allowed key is 'en'.");
+		}
+		Map<String, String> value = attribute.valueAsMap();
+		if (value == null) return;
+
+
+		for (String templateName : value.keySet()) {
+			if (ALLOWED_TEMPLATES.stream()
+					.noneMatch(templateName::equals)) {
+				throw new WrongAttributeValueException("The given template name '" + templateName + "' is not allowed.");
+			}
+		}
+	}
+
+	@Override
+	public AttributeDefinition getAttributeDefinition() {
+		AttributeDefinition attr = new AttributeDefinition();
+		attr.setNamespace(AttributesManager.NS_ENTITYLESS_ATTR_DEF);
+		attr.setType(LinkedHashMap.class.getName());
+		attr.setFriendlyName("identityAlerts");
+		attr.setDisplayName("Identity alerts");
+		attr.setDescription("Templates for identity alerts. Use 'en' key to set the values. Allowed values are " +
+				"'identityAddedPreferredMail', 'identityAddedPreferredMailSubject', 'identityAddedUESMail', 'identityAddedUESMailSubject', " +
+				"'identityRemovedPreferredMail', 'identityRemovedPreferredMailSubject', 'identityRemovedUESMail', and 'identityRemovedUESMailSubject'. " +
+				"You can use placeholders {organization}, {login} in the templates that will be replaced with actual values.");
+		return attr;
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_entityless_attribute_def_def_identityAlertTemplatesTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_entityless_attribute_def_def_identityAlertTemplatesTest.java
@@ -1,0 +1,68 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.LinkedHashMap;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.Mockito.mock;
+
+public class urn_perun_entityless_attribute_def_def_identityAlertTemplatesTest {
+	private static urn_perun_entityless_attribute_def_def_identityAlertsTemplates classInstance;
+	private static PerunSessionImpl session;
+	private static Attribute attributeToCheck;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_entityless_attribute_def_def_identityAlertsTemplates();
+		session = mock(PerunSessionImpl.class);
+		attributeToCheck = new Attribute();
+	}
+
+	@Test
+	public void testAllowedKey() {
+		System.out.println("testAllowedKey");
+
+		assertThatNoException()
+				.isThrownBy(() -> classInstance.checkAttributeSyntax(session, "en", attributeToCheck));
+	}
+
+	@Test
+	public void testNotAllowedKey() {
+		System.out.println("testNotAllowedKey");
+
+		assertThatExceptionOfType(WrongAttributeValueException.class)
+				.isThrownBy(() -> classInstance.checkAttributeSyntax(session, "cc", attributeToCheck))
+				.withMessageContaining("Invalid key");
+	}
+
+	@Test
+	public void testAllowedTemplate() {
+		System.out.println("testAllowedTemplate");
+
+		var value = new LinkedHashMap<String, String>();
+		value.put("uesAddedPreferredMail", "Hi!");
+		attributeToCheck.setValue(value);
+
+		assertThatNoException()
+				.isThrownBy(() -> classInstance.checkAttributeSyntax(session, "en", attributeToCheck));
+	}
+
+	@Test
+	public void testNotAllowedTemplate() {
+		System.out.println("testNotAllowedTemplate");
+
+		var value = new LinkedHashMap<String, String>();
+		value.put("uesEditedPreferredMail", "Hi!");
+		attributeToCheck.setValue(value);
+
+		assertThatExceptionOfType(WrongAttributeValueException.class)
+				.isThrownBy(() -> classInstance.checkAttributeSyntax(session, "en", attributeToCheck))
+				.withMessageContaining("'uesEditedPreferredMail' is not allowed");
+	}
+}


### PR DESCRIPTION
* Implemented logic that can be used to sned alerts to users about an
identity being added or removed.
* This behaviour can be enabled by setting the perun.sendIdentityAlerts
property to true.
* Created entityless attribute that can be used to define templates for
these alerts.
* There can be 4 types of alerts: identityAdded(to preferred mail / to
the new identity email), and identityRemoved(to preferred mail / to the
removed identity email)
* In the templates, it is possible to user placeholders {organization}
and {login} where the actual data will be placed.
* These alerts should be send only if they were caused by the user
itself, not by admins for example.