### PR TITLE
Core - members pagination

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/MembersOrderColumn.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/MembersOrderColumn.java
@@ -1,0 +1,57 @@
+package cz.metacentrum.perun.core.api;
+
+import java.util.function.Function;
+
+/**
+ * Class representing columns, that can be used to sort paginated members.
+ *
+ * For each such column, this instances also contain sql parts that are specific for them.
+ * This class can be extended, in the future, if for example, we would like to sort by some attributes.
+ *
+ * @author Vojtech Sassmann <vojtech.sassmann@gmail.com>
+ */
+public enum MembersOrderColumn {
+	NAME(
+			", users.first_name, users.last_name ",
+			" LEFT JOIN users on members.user_id = users.id ",
+			query -> "users.last_name " + getLangSql(query) + query.getOrder().getSqlValue() + ", " +
+	                 "users.first_name " + getLangSql(query) + query.getOrder().getSqlValue()
+	),
+
+	ID("", "", query -> "members.id " + query.getOrder().getSqlValue());
+
+	private final Function<MembersPageQuery, String> orderBySqlFunction;
+	private final String selectSql;
+	private final String joinSql;
+
+	MembersOrderColumn(String selectSql, String joinSql, Function<MembersPageQuery, String> sqlFunction) {
+		this.selectSql = selectSql;
+		this.joinSql = joinSql;
+		this.orderBySqlFunction = sqlFunction;
+	}
+
+	public String getSqlOrderBy(MembersPageQuery query) {
+		return this.orderBySqlFunction.apply(query);
+	}
+
+	public String getSqlSelect() {
+		return this.selectSql;
+	}
+
+	public String getSqlJoin() {
+		return this.joinSql;
+	}
+
+	private static String getLangSql(MembersPageQuery query) {
+		return "";
+		// TODO add support for other languages
+		// to make this work, Czech collation has to be created in DB - create COLLATION cs_CZ (locale="cs_CZ.UTF-8");
+		// However, this COLLATION can be only created, if the OS has this language installed. Therefore, we must install
+		// this language in the test container and also, we need to make sure in is available at the production.
+
+		// We also need to figure out, when to use the Czech collation. Maybe we can create a Vo attribute, that could
+		// be set for this purposes, or we can create a new property in the Perun configuration.
+		//
+		// " collate \"cs_CZ\" "
+	}
+}

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/MembersPageQuery.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/MembersPageQuery.java
@@ -1,0 +1,75 @@
+package cz.metacentrum.perun.core.api;
+
+/**
+ * Class representing a query requesting a specific page of members.
+ *
+ * @author Vojtech Sassmann <vojtech.sassmann@gmail.com>
+ */
+public class MembersPageQuery {
+	private int pageSize;
+	private int offset;
+	private SortingOrder order;
+	private MembersOrderColumn sortColumn;
+
+	public MembersPageQuery() { }
+	public MembersPageQuery(int pageSize, int offset, SortingOrder sortingOrder, MembersOrderColumn sortColumn) {
+		this.pageSize = pageSize;
+		this.offset = offset;
+		this.order = sortingOrder;
+		this.sortColumn = sortColumn;
+	}
+
+	public int getPageSize() {
+		return pageSize;
+	}
+
+	public void setPageSize(int pageSize) {
+		this.pageSize = pageSize;
+	}
+
+	public int getOffset() {
+		return offset;
+	}
+
+	public void setOffset(int offset) {
+		this.offset = offset;
+	}
+
+	public SortingOrder getOrder() {
+		return order;
+	}
+
+	public void setOrder(SortingOrder order) {
+		this.order = order;
+	}
+
+	public MembersOrderColumn getSortColumn() {
+		return sortColumn;
+	}
+
+	public void setSortColumn(MembersOrderColumn sortColumn) {
+		this.sortColumn = sortColumn;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (!(o instanceof MembersPageQuery)) return false;
+
+		MembersPageQuery that = (MembersPageQuery) o;
+
+		if (getPageSize() != that.getPageSize()) return false;
+		if (getOffset() != that.getOffset()) return false;
+		if (getOrder() != that.getOrder()) return false;
+		return getSortColumn() == that.getSortColumn();
+	}
+
+	@Override
+	public int hashCode() {
+		int result = getPageSize();
+		result = 31 * result + getOffset();
+		result = 31 * result + (getOrder() != null ? getOrder().hashCode() : 0);
+		result = 31 * result + (getSortColumn() != null ? getSortColumn().hashCode() : 0);
+		return result;
+	}
+}

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/Paginated.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/Paginated.java
@@ -1,0 +1,77 @@
+package cz.metacentrum.perun.core.api;
+
+import java.util.List;
+
+/**
+ * This class represents paginated data.
+ *
+ * @author Vojtech Sassmann <vojtech.sassmann@gmail.com>
+ */
+public class Paginated<T> {
+
+	private List<T> data;
+	private int offset;
+	private int pageSize;
+	private int totalCount;
+
+	public Paginated(List<T> data, int offset, int pageSize, int totalCount) {
+		this.data = data;
+		this.offset = offset;
+		this.pageSize = pageSize;
+		this.totalCount = totalCount;
+	}
+
+	public List<T> getData() {
+		return data;
+	}
+
+	public void setData(List<T> data) {
+		this.data = data;
+	}
+
+	public int getOffset() {
+		return offset;
+	}
+
+	public void setOffset(int offset) {
+		this.offset = offset;
+	}
+
+	public int getPageSize() {
+		return pageSize;
+	}
+
+	public void setPageSize(int pageSize) {
+		this.pageSize = pageSize;
+	}
+
+	public int getTotalCount() {
+		return totalCount;
+	}
+
+	public void setTotalCount(int totalCount) {
+		this.totalCount = totalCount;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (!(o instanceof Paginated)) return false;
+
+		Paginated<?> paginated = (Paginated<?>) o;
+
+		if (getOffset() != paginated.getOffset()) return false;
+		if (getPageSize() != paginated.getPageSize()) return false;
+		if (getTotalCount() != paginated.getTotalCount()) return false;
+		return getData() != null ? getData().equals(paginated.getData()) : paginated.getData() == null;
+	}
+
+	@Override
+	public int hashCode() {
+		int result = getData() != null ? getData().hashCode() : 0;
+		result = 31 * result + getOffset();
+		result = 31 * result + getPageSize();
+		result = 31 * result + getTotalCount();
+		return result;
+	}
+}

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/SortingOrder.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/SortingOrder.java
@@ -1,0 +1,19 @@
+package cz.metacentrum.perun.core.api;
+
+/**
+ * @author Vojtech Sassmann <vojtech.sassmann@gmail.com>
+ */
+public enum SortingOrder {
+	ASCENDING("ASC"),
+	DESCENDING("DESC");
+
+	private final String sqlValue;
+
+	SortingOrder(String sqlValue) {
+		this.sqlValue = sqlValue;
+	}
+
+	public String getSqlValue() {
+		return sqlValue;
+	}
+}

--- a/perun-base/src/main/resources/perun-roles.yml
+++ b/perun-base/src/main/resources/perun-roles.yml
@@ -2782,6 +2782,16 @@ perun_policies:
     include_policies:
       - default_policy
 
+  getMembersPage_Vo_MembersPageQuery_List<String>_policy:
+    policy_roles:
+      - GROUPADMIN: Vo
+      - GROUPOBSERVER: Vo
+      - PERUNOBSERVER:
+      - VOOBSERVER: Vo
+      - VOADMIN: Vo
+    include_policies:
+      - default_policy
+
   updateSponsorshipValidity_Member_User_LocalDate:
     policy_roles:
       - VOADMIN: Vo

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/MembersManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/MembersManager.java
@@ -6,7 +6,6 @@ import cz.metacentrum.perun.core.api.exceptions.AlreadySponsoredMemberException;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ExtSourceNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ExtendMembershipException;
-import cz.metacentrum.perun.core.api.exceptions.GroupExistsException;
 import cz.metacentrum.perun.core.api.exceptions.GroupNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.GroupResourceMismatchException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
@@ -1409,6 +1408,19 @@ public interface MembersManager {
 	 * @throws PrivilegeException if not REGISTRAR or VOADMIN
 	 */
 	void removeSponsor(PerunSession sess, Member sponsoredMember, User sponsorToRemove) throws PrivilegeException;
+
+	/**
+	 * Get page of members from the given vo, with the given attributes.
+	 *
+	 * @param sess session
+	 * @param vo vo
+	 * @param query query with page information
+	 * @param attrNames attribute names
+	 * @return page of requested rich members
+	 * @throws VoNotExistsException if there is no such vo
+	 * @throws PrivilegeException insufficient permission
+	 */
+	Paginated<RichMember> getMembersPage(PerunSession sess, Vo vo, MembersPageQuery query, List<String> attrNames) throws VoNotExistsException, PrivilegeException;
 
 	/**
 	 * Update the sponsorship of given member for given sponsor.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/MembersManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/MembersManagerBl.java
@@ -8,9 +8,11 @@ import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.Member;
 import cz.metacentrum.perun.core.api.MemberGroupStatus;
 import cz.metacentrum.perun.core.api.NamespaceRules;
+import cz.metacentrum.perun.core.api.Paginated;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.RichMember;
+import cz.metacentrum.perun.core.api.MembersPageQuery;
 import cz.metacentrum.perun.core.api.SpecificUserType;
 import cz.metacentrum.perun.core.api.Sponsor;
 import cz.metacentrum.perun.core.api.Sponsorship;
@@ -1719,6 +1721,17 @@ public interface MembersManagerBl {
 	 * @throws InternalErrorException
 	 */
 	List<Member> findMembers(PerunSession sess, Vo vo, String searchString, boolean onlySponsored);
+
+	/**
+	 * Get page of members from the given vo, with the given attributes.
+	 *
+	 * @param sess session
+	 * @param vo vo
+	 * @param query query with page information
+	 * @param attrNames attribute names
+	 * @return page of requested rich members
+	 */
+	Paginated<RichMember> getMembersPage(PerunSession sess, Vo vo, MembersPageQuery query, List<String> attrNames);
 
 	/**
 	 * Update the sponsorship of given member for given sponsor.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/MembersManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/MembersManagerEntry.java
@@ -5,6 +5,8 @@ import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AuthzResolver;
 import cz.metacentrum.perun.core.api.Candidate;
 import cz.metacentrum.perun.core.api.NamespaceRules;
+import cz.metacentrum.perun.core.api.Paginated;
+import cz.metacentrum.perun.core.api.MembersPageQuery;
 import cz.metacentrum.perun.core.api.Sponsor;
 import cz.metacentrum.perun.core.api.ExtSource;
 import cz.metacentrum.perun.core.api.Group;
@@ -27,7 +29,6 @@ import cz.metacentrum.perun.core.api.exceptions.AlreadySponsoredMemberException;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ExtSourceNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ExtendMembershipException;
-import cz.metacentrum.perun.core.api.exceptions.GroupExistsException;
 import cz.metacentrum.perun.core.api.exceptions.GroupNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.GroupResourceMismatchException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
@@ -1561,6 +1562,21 @@ public class MembersManagerEntry implements MembersManager {
 		}
 		//remove sponsor
 		membersManagerBl.removeSponsor(sess,sponsoredMember, sponsorToRemove);
+	}
+
+	@Override
+	public Paginated<RichMember> getMembersPage(PerunSession sess, Vo vo, MembersPageQuery query, List<String> attrNames) throws VoNotExistsException, PrivilegeException {
+		Utils.checkPerunSession(sess);
+		perunBl.getVosManagerBl().checkVoExists(sess, vo);
+
+		if (!AuthzResolver.authorizedInternal(sess, "getMembersPage_Vo_MembersPageQuery_List<String>_policy", vo)) {
+			throw new PrivilegeException(sess, "getMembersPage");
+		}
+
+		Paginated<RichMember> result = membersManagerBl.getMembersPage(sess, vo, query, attrNames);
+		result.setData(getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, result.getData()));
+
+		return result;
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/MembersManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/MembersManagerImplApi.java
@@ -4,8 +4,10 @@ import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.Member;
 import cz.metacentrum.perun.core.api.MemberGroupStatus;
 import cz.metacentrum.perun.core.api.NamespaceRules;
+import cz.metacentrum.perun.core.api.Paginated;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.MembersPageQuery;
 import cz.metacentrum.perun.core.api.Sponsorship;
 import cz.metacentrum.perun.core.api.Status;
 import cz.metacentrum.perun.core.api.User;
@@ -390,6 +392,16 @@ public interface MembersManagerImplApi {
 	 * @return all members from specific VO by specific string
 	 */
 	List<Member> findMembers(PerunSession sess, Vo vo, String searchString, boolean onlySponsored);
+
+	/**
+	 * Get page of members from the given vo
+	 *
+	 * @param sess session
+	 * @param vo vo
+	 * @param query query with page information
+	 * @return page of requested rich members
+	 */
+	Paginated<Member> getMembersPage(PerunSession sess, Vo vo, MembersPageQuery query);
 
 	/**
 	 * Update the sponsorship of given member for given sponsor.

--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -1,3 +1,4 @@
+
 openapi: 3.0.2
 info:
   version: 3.20.0
@@ -160,6 +161,42 @@ components:
             - userExtSources
       discriminator:
         propertyName: beanName
+
+    PaginatedRichMembers:
+      properties:
+        offset: { type: integer }
+        pageSize: { type: integer }
+        totalCount: { type: integer }
+        data: { type: array, items: { $ref: '#/components/schemas/RichMember' } }
+      required:
+        - offset
+        - pageSize
+        - totalCount
+        - data
+
+    SortingOrder:
+      type: string
+      enum:
+        - ASCENDING
+        - DESCENDING
+
+    MembersOrderColumn:
+      type: string
+      enum:
+        - ID
+        - NAME
+
+    MembersPageQuery:
+      properties:
+        pageSize: { type: integer }
+        offset: { type: integer }
+        order: { $ref: '#/components/schemas/SortingOrder' }
+        sortColumn: { $ref: '#/components/schemas/MembersOrderColumn' }
+      required:
+        - pageSize
+        - offset
+        - order
+        - sortColumn
 
     UserExtSource:
       allOf:
@@ -1454,6 +1491,13 @@ components:
             type: array
             items:
               $ref: "#/components/schemas/RichGroup"
+
+    PaginatedRichMembersResponse:
+      description: "returns Paginated<RichMember>"
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/PaginatedRichMembers"
 
     ResourceResponse:
       description: "returns Resource"
@@ -8970,6 +9014,34 @@ paths:
           $ref: '#/components/responses/ListOfNamespacesRulesResponse'
         default:
           $ref: '#/components/responses/ExceptionResponse'
+
+  /json/membersManager/getMembersPage:
+    post:
+      tags:
+        - MembersManager
+      operationId: getMembersPage
+      summary: Get page of members from the given vo, with the given attributes.
+      responses:
+        '200':
+          $ref: '#/components/responses/PaginatedRichMembersResponse'
+        default:
+          $ref: '#/components/responses/ExceptionResponse'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              title: InputGetPaginatedMembers
+              description: "input to getPaginatedMembers"
+              type: object
+              required:
+                - vo
+                - query
+                - attrNames
+              properties:
+                vo: { type: integer }
+                attrNames: { type: array, items: { type: string }}
+                query: { $ref: '#/components/schemas/MembersPageQuery' }
 
   #################################################
   #                                               #

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/MembersManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/MembersManagerMethod.java
@@ -19,7 +19,6 @@ import java.util.List;
 import java.util.Map;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
-import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 @SuppressWarnings("unused")
 public enum MembersManagerMethod implements ManagerMethod {
@@ -1858,6 +1857,27 @@ public enum MembersManagerMethod implements ManagerMethod {
 		@Override
 		public List<NamespaceRules> call(ApiCaller ac, Deserializer parms) throws PerunException {
 			return ac.getMembersManager().getAllNamespacesRules();
+		}
+	},
+
+	/*#
+	 * Get page of members from the given vo, with the given attributes.
+	 *
+	 * @param sess session
+	 * @param vo vo
+	 * @param query query with page information
+	 * @param attrNames attribute names
+	 *
+	 * @return Paginated<RichMember> page of requested rich members
+	 * @throw VoNotExistsException if there is no such vo
+	 */
+	getMembersPage {
+		@Override
+		public Object call(ApiCaller ac, Deserializer parms) throws PerunException {
+			return ac.getMembersManager().getMembersPage(ac.getSession(),
+					ac.getVoById(parms.readInt("vo")),
+					parms.read("query", MembersPageQuery.class),
+					parms.readList("attrNames", String.class));
 		}
 	}
 }


### PR DESCRIPTION
* Created method `getMembersPage` that can be used to get a page of
members of a given vo.
* For now, it is possible to specify the page size, the offset (number
of skipped members), sorting order (ASCENDING/DESCENDING). The possible
columns to sort by are, for now, ID and NAME. However, the name can sort
only in the English collation. To sort in the Czech collation, it is
necessary to have the Czech locale (cs_CZ) installed in the hosting OS.
Then, this collation has to be creation in our DB. And lastly, this
would also need to be done in the test docker conainer, otherwise, the
tests won't pass. These changes are NOT part of this PR.