### PR TITLE
Core - attr description fix

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_entityless_attribute_def_def_identityAlertsTemplates.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_entityless_attribute_def_def_identityAlertsTemplates.java
@@ -127,7 +127,7 @@ public class urn_perun_entityless_attribute_def_def_identityAlertsTemplates exte
 		attr.setDescription("Templates for identity alerts. Use 'en' key to set the values. Allowed values are " +
 				"'identityAddedPreferredMail', 'identityAddedPreferredMailSubject', 'identityAddedUESMail', 'identityAddedUESMailSubject', " +
 				"'identityRemovedPreferredMail', 'identityRemovedPreferredMailSubject', 'identityRemovedUESMail', and 'identityRemovedUESMailSubject'. " +
-				"You can use placeholders {organization}, {login} in the templates that will be replaced with actual values.");
+				"You can use placeholders {organization}, {login}, {time} in the templates that will be replaced with actual values.");
 		return attr;
 	}
 }


### PR DESCRIPTION
* The attribute identityAlertsTemplates had a missing information in the
description about the {time} placeholder.