### PR TITLE
Registrar - visibility and disabled fields

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/registrar/model/ApplicationFormItem.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/registrar/model/ApplicationFormItem.java
@@ -16,6 +16,7 @@ public class ApplicationFormItem {
 	private int id;
 	private String shortname;
 	private boolean required = false;
+	private boolean updatable;
 	private Type type = Type.TEXTFIELD;
 	private String federationAttribute;
 	private String perunSourceAttribute;
@@ -24,6 +25,11 @@ public class ApplicationFormItem {
 	private List<AppType> applicationTypes = Arrays.asList(AppType.INITIAL,AppType.EXTENSION);
 
 	private Integer ordnum;
+
+	private Integer hiddenDependencyItemId;
+	private Integer disabledDependencyItemId;
+	private Disabled disabled = Disabled.NEVER;
+	private Hidden hidden = Hidden.NEVER;
 
 	/**
 	 * Field for GUI purpose - tells updateFromItems()
@@ -120,6 +126,60 @@ public class ApplicationFormItem {
 		this.forDelete = forDelete;
 	}
 
+	public Integer getHiddenDependencyItemId() {
+		return hiddenDependencyItemId;
+	}
+
+	public void setHiddenDependencyItemId(Integer hiddenDependencyItemId) {
+		this.hiddenDependencyItemId = hiddenDependencyItemId;
+	}
+
+	public Integer getDisabledDependencyItemId() {
+		return disabledDependencyItemId;
+	}
+
+	public void setDisabledDependencyItemId(Integer disabledDependencyItemId) {
+		this.disabledDependencyItemId = disabledDependencyItemId;
+	}
+
+	public Disabled getDisabled() {
+		return disabled;
+	}
+
+	public void setDisabled(Disabled disabled) {
+		this.disabled = disabled;
+	}
+
+	public Hidden getHidden() {
+		return hidden;
+	}
+
+	public void setHidden(Hidden hidden) {
+		this.hidden = hidden;
+	}
+
+	public boolean isUpdatable() {
+		return updatable;
+	}
+
+	public void setUpdatable(boolean updatable) {
+		this.updatable = updatable;
+	}
+
+	public enum Hidden {
+		NEVER,
+		ALWAYS,
+		IF_PREFILLED,
+		IF_EMPTY
+	}
+
+	public enum Disabled {
+		NEVER,
+		ALWAYS,
+		IF_PREFILLED,
+		IF_EMPTY
+	}
+
 	/**
 	 * Enumeration for types of application form items. For example text fields, checkboxes and so on.
 	 */
@@ -137,14 +197,6 @@ public class ApplicationFormItem {
 		 * automatically submitted. When validation fails, user have to fix it and submit form manually.
 		 */
 		AUTO_SUBMIT_BUTTON,
-		/**
-		 * For read-only fields with values taken from identity federation.
-		 */
-		FROM_FEDERATION_SHOW,
-		/**
-		 * For hidden fields with values taken from identity federation.
-		 */
-		FROM_FEDERATION_HIDDEN,
 		/**
 		 * For password, which needs to be typed twice.
 		 */
@@ -363,16 +415,25 @@ public class ApplicationFormItem {
 
 	@Override
 	public String toString() {
-		return this.getClass().getSimpleName()+":[" +
-				"id='" + getId() + '\'' +
-				", shortname='" + getShortname() + '\'' +
-				", ordnum='" + getOrdnum() + '\'' +
-				", required='" + isRequired() + '\'' +
-				", type='" + getType().toString() + '\'' +
-				", federationAttribute='" + getFederationAttribute() + '\'' +
-				", regex='" + getRegex() + '\'' +
-				", i18n='" + getI18n().toString() + '\'' +
-				"]";
+		return "ApplicationFormItem[" +
+				"id=" + id +
+				", shortname='" + shortname + '\'' +
+				", required=" + required +
+				", updatable=" + updatable +
+				", type=" + type +
+				", federationAttribute='" + federationAttribute + '\'' +
+				", perunSourceAttribute='" + perunSourceAttribute + '\'' +
+				", perunDestinationAttribute='" + perunDestinationAttribute + '\'' +
+				", regex='" + regex + '\'' +
+				", applicationTypes=" + applicationTypes +
+				", ordnum=" + ordnum +
+				", hiddenDependencyItemId=" + hiddenDependencyItemId +
+				", disabledDependencyItemId=" + disabledDependencyItemId +
+				", disabled=" + disabled +
+				", hidden=" + hidden +
+				", forDelete=" + forDelete +
+				", i18n=" + i18n +
+				']';
 	}
 
 	@Override

--- a/perun-base/src/test/resources/test-schema.sql
+++ b/perun-base/src/test/resources/test-schema.sql
@@ -1,4 +1,4 @@
--- database version 3.1.76 (don't forget to update insert statement at the end of file)
+-- database version 3.1.77 (don't forget to update insert statement at the end of file)
 CREATE EXTENSION IF NOT EXISTS "unaccent";
 CREATE EXTENSION IF NOT EXISTS "pgcrypto";
 
@@ -488,10 +488,29 @@ create table application_form (
 								   constraint applform_group_fk foreign key (group_id) references groups(id) on delete cascade
 );
 
+create type app_item_disabled as enum (
+	'NEVER',
+	'ALWAYS',
+	'IF_PREFILLED',
+	'IF_EMPTY'
+	);
+
+create type app_item_hidden as enum (
+	'NEVER',
+	'ALWAYS',
+	'IF_PREFILLED',
+	'IF_EMPTY'
+	);
+
 -- APPLICATION_FORM_ITEMS - items of application form
 create table application_form_items (
 										 id integer not null,
 										 form_id integer not null,  --identifier of form (application_form.id)
+										 hidden app_item_hidden not null default 'NEVER',
+										 disabled app_item_disabled not null default 'NEVER',
+										 updatable boolean not null default true,
+										 hidden_dependency_item_id integer,
+										 disabled_dependency_item_id integer,
 										 ordnum integer not null,   --order of item
 										 shortname varchar not null,  --name of item
 										 required boolean default false not null,          --value for item is mandatory
@@ -503,7 +522,9 @@ create table application_form_items (
 										 created_by_uid integer,
 										 modified_by_uid integer,
 										 constraint applfrmit_pk primary key (id),
-										 constraint applfrmit_applform foreign key (form_id) references application_form(id) on delete cascade
+										 constraint applfrmit_applform foreign key (form_id) references application_form(id) on delete cascade,
+										 constraint applfrmit_hd foreign key (hidden_dependency_item_id) references application_form_items(id) ON DELETE SET NULL,
+										 constraint applfrmit_dd foreign key (disabled_dependency_item_id) references application_form_items(id) ON DELETE SET NULL
 );
 
 -- APPLICATION_FORM_ITEM_APPTYPES - possible types of app. form items
@@ -1641,7 +1662,7 @@ CREATE INDEX ufauv_idx ON user_facility_attr_u_values (user_id, facility_id, att
 CREATE INDEX vauv_idx ON vo_attr_u_values (vo_id, attr_id);
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.1.76');
+insert into configurations values ('DATABASE VERSION','3.1.77');
 -- insert membership types
 insert into membership_types (id, membership_type, description) values (1, 'DIRECT', 'Member is directly added into group');
 insert into membership_types (id, membership_type, description) values (2, 'INDIRECT', 'Member is added indirectly through UNION relation');

--- a/perun-core/src/main/resources/postgresChangelog.txt
+++ b/perun-core/src/main/resources/postgresChangelog.txt
@@ -6,6 +6,21 @@
 -- Directly under version number should be version commands. They will be executed in the order they are written here.
 -- Comments are prefixed with -- and can be written only between version blocks, that means not in the lines with commands. They have to be at the start of the line.
 
+3.1.77
+create type app_item_disabled as enum ('NEVER','ALWAYS','IF_PREFILLED','IF_EMPTY');
+create type app_item_hidden as enum ('NEVER','ALWAYS','IF_PREFILLED','IF_EMPTY');
+ALTER TABLE application_form_items ADD COLUMN hidden app_item_hidden not null default 'NEVER';
+ALTER TABLE application_form_items ADD COLUMN disabled app_item_disabled not null default 'NEVER';
+ALTER TABLE application_form_items ADD COLUMN hidden_dependency_item_id integer;
+ALTER TABLE application_form_items ADD COLUMN disabled_dependency_item_id integer;
+ALTER TABLE application_form_items ADD COLUMN updatable boolean default true not null;
+ALTER TABLE application_form_items ADD CONSTRAINT applfrmit_hd foreign key (hidden_dependency_item_id) references application_form_items(id) ON DELETE SET NULL;
+ALTER TABLE application_form_items ADD CONSTRAINT applfrmit_dd foreign key (disabled_dependency_item_id) references application_form_items(id) ON DELETE SET NULL;
+UPDATE application_form_items SET hidden = 'ALWAYS' where type = 'FROM_FEDERATION_HIDDEN';
+UPDATE application_form_items SET disabled = 'ALWAYS' where type = 'FROM_FEDERATION_SHOW';
+UPDATE application_form_items SET updatable = false, type = 'TEXTFIELD' where type = 'FROM_FEDERATION_SHOW' OR type = 'FROM_FEDERATION_HIDDEN';
+UPDATE configurations SET value='3.1.77' WHERE property='DATABASE VERSION';
+
 3.1.76
 ALTER TABLE pwdreset ADD COLUMN uu_id uuid not null default gen_random_uuid();
 UPDATE configurations SET value='3.1.76' WHERE property='DATABASE VERSION';

--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -690,6 +690,7 @@ components:
         id: { type: integer }
         shortname: { type: string }
         required: { type: boolean }
+        updatable: { type: boolean }
         type: { $ref: '#/components/schemas/Type' }
         federationAttribute: { type: string }
         perunSourceAttribute: { type: string }
@@ -703,6 +704,10 @@ components:
         i18n:
           type: object
           additionalProperties: { $ref: '#/components/schemas/ItemTexts' }
+        hiddenDependencyItemId: { type: integer }
+        disabledDependencyItemId: { type: integer }
+        hidden: { type: string, enum: [ 'NEVER', 'ALWAYS', 'IF_PREFILLED', 'IF_EMPTY' ]}
+        disabled: { type: string, enum: [ 'NEVER', 'ALWAYS', 'IF_PREFILLED', 'IF_EMPTY' ]}
         forDelete: { type: boolean }
 
     ApplicationFormItemData:

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/applicationresources/RegistrarFormItemGenerator.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/applicationresources/RegistrarFormItemGenerator.java
@@ -203,8 +203,7 @@ public class RegistrarFormItemGenerator {
 
 				// missing?
 				valid = (!(item.isRequired() && getValue().equals("")));
-				if(!valid && !item.getType().equalsIgnoreCase("FROM_FEDERATION_SHOW")){
-					// from_federation_show can be valid when empty
+				if(!valid && !item.getDisabled().equalsIgnoreCase("ALWAYS")){
 					statusCellWrapper.setWidget(new FormInputStatusWidget(ApplicationMessages.INSTANCE.missingValue(), Status.ERROR));
 					return false;
 				}
@@ -454,13 +453,14 @@ public class RegistrarFormItemGenerator {
 			return generateTimezoneListBox();
 		}
 
-		if(item.getType().equals("FROM_FEDERATION_HIDDEN")){
+		// FIXME we can only detect always hidden items
+		if(item.getHidden().equals("ALWAYS")) {
 			this.visibleOnlyToAdmin = true;
 			this.visible = false;
 			return generateHidden();
 		}
 
-		if(item.getType().equals("FROM_FEDERATION_SHOW")){
+		if (item.getDisabled().equals("ALWAYS")) {
 			this.visible = true;
 			return generateReadonlyTextBox();
 		}
@@ -483,14 +483,13 @@ public class RegistrarFormItemGenerator {
 	}
 
 	public boolean isUpdatable() {
-		return !"FROM_FEDERATION_HIDDEN".equalsIgnoreCase(item.getType()) &&
-				!"FROM_FEDERATION_SHOW".equalsIgnoreCase(item.getType()) &&
-				!"USERNAME".equalsIgnoreCase(item.getType()) &&
+		return !"USERNAME".equalsIgnoreCase(item.getType()) &&
 				!"PASSWORD".equalsIgnoreCase(item.getType()) &&
 				!"HEADING".equalsIgnoreCase(item.getType()) &&
 				!"HTML_COMMENT".equalsIgnoreCase(item.getType()) &&
 				!"SUBMIT_BUTTON".equalsIgnoreCase(item.getType()) &&
-				!"AUTO_SUBMIT_BUTTON".equalsIgnoreCase(item.getType());
+				!"AUTO_SUBMIT_BUTTON".equalsIgnoreCase(item.getType()) &&
+				item.isUpdatable();
 	}
 
 	/**

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/registrarManager/GetApplicationDataById.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/registrarManager/GetApplicationDataById.java
@@ -197,10 +197,12 @@ public class GetApplicationDataById implements JsonCallback{
 				if (!item.getFormItem().getType().equalsIgnoreCase("PASSWORD")) {
 
 					// 0 = label or shortname
-					if (item.getFormItem().getType().startsWith("FROM_FEDERATION_HIDDEN")) {
+					// FIXME for now, we can only detect that the item was hidden for the 'ALWAYS' option. This will be for the most cases.
+					if (item.getFormItem().getHidden().equals("ALWAYS")) {
 						// hidden
 						ft.setHTML(i, 0, "<strong>" + SafeHtmlUtils.fromString(gen.getLabelOrShortname()).asString() + "</strong><br /><i>(value provided by external source)</i>");
-					} else if (item.getFormItem().getType().startsWith("FROM_FEDERATION_SHOW")) {
+					// FIXME for now, we can only detect that the item was disabled for the 'ALWAYS' option. This will be for the most cases.
+					} else if (item.getFormItem().getDisabled().equals("ALWAYS")) {
 						// show
 						ft.setHTML(i, 0, "<strong>" + SafeHtmlUtils.fromString(gen.getLabelOrShortname()).asString() + "</strong><br /><i>(value provided by external source)</i>");
 					} else {

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/registrarManager/GetFormItems.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/registrarManager/GetFormItems.java
@@ -387,7 +387,7 @@ public class GetFormItems implements JsonCallback {
 			CustomButton editButton = new CustomButton(ButtonTranslation.INSTANCE.editFormItemButton(), ButtonTranslation.INSTANCE.editFormItem(), SmallIcons.INSTANCE.applicationFormEditIcon());
 			editButton.addClickHandler(new ClickHandler() {
 				public void onClick(ClickEvent event) {
-					session.getTabManager().addTabToCurrentTab(new EditFormItemTabItem(item, group != null, refreshEvents));
+					session.getTabManager().addTabToCurrentTab(new EditFormItemTabItem(item, group != null, applFormItems, refreshEvents));
 				}
 			});
 			editTable.setWidget(0, 2, editButton);

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/registrarManager/UpdateFormItems.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/registrarManager/UpdateFormItems.java
@@ -131,6 +131,11 @@ public class UpdateFormItems {
 			newItem.put("ordnum", obj.get("ordnum"));
 			newItem.put("forDelete", obj.get("forDelete"));
 			newItem.put("applicationTypes", obj.get("applicationTypes"));
+			newItem.put("updatable", obj.get("updatable"));
+			newItem.put("disabled", obj.get("disabled"));
+			newItem.put("hidden", obj.get("hidden"));
+			newItem.put("hiddenDependencyItemId", obj.get("hiddenDependencyItemId"));
+			newItem.put("disabledDependencyItemId", obj.get("disabledDependencyItemId"));
 
 			// recreate i18n
 			JSONObject i18n = new JSONObject();

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/ApplicationFormItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/ApplicationFormItem.java
@@ -66,6 +66,59 @@ public class ApplicationFormItem extends JavaScriptObject {
 		return this.type;
 	}-*/;
 
+	public final native String getDisabled() /*-{
+		return this.disabled;
+	}-*/;
+
+	public final native String getHidden() /*-{
+        return this.hidden;
+    }-*/;
+
+	public final native void setDisabled(String disabled) /*-{
+        this.disabled = disabled;
+    }-*/;
+
+	public final native void setHidden(String hidden) /*-{
+        this.hidden = hidden;
+    }-*/;
+
+	public final native int getHiddenDependencyItemId() /*-{
+        if (this.hiddenDependencyItemId == null) {
+            return 0;
+        }
+        return this.hiddenDependencyItemId;
+    }-*/;
+
+	public final native int getDisabledDependencyItemId() /*-{
+        if (this.disabledDependencyItemId == null) {
+            return 0;
+        }
+        return this.disabledDependencyItemId;
+    }-*/;
+
+	public final native void setHiddenDependencyItemId(int itemId) /*-{
+        if (itemId === 0) {
+        	this.hiddenDependencyItemId = null;
+        } else {
+        	this.hiddenDependencyItemId = itemId;
+        }
+    }-*/;
+
+	public final native void setDisabledDependencyItemId(int itemId) /*-{
+        if (itemId === 0) {
+            this.disabledDependencyItemId = null;
+        } else {
+            this.disabledDependencyItemId = itemId;
+        }
+    }-*/;
+
+	public final native boolean isUpdatable() /*-{
+		return this.updatable;
+	}-*/;
+
+	public final native void setUpdatable(boolean updatable) /*-{
+        this.updatable = updatable;
+    }-*/;
 	/**
 	 * Get federationAttribute
 	 * @return federationAttribute

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/CreateFormItemTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/CreateFormItemTabItem.java
@@ -75,8 +75,6 @@ public class CreateFormItemTabItem implements TabItem {
 		aMap.put("HTML_COMMENT", "Custom HTML text");
 		aMap.put("HEADING", "Header");
 		aMap.put("TIMEZONE", "Selection of timezone");
-		aMap.put("FROM_FEDERATION_HIDDEN", "Hidden input text pre-filled from external source");
-		aMap.put("FROM_FEDERATION_SHOW", "Input text field pre-filled from external source");
 		inputTypes = Collections.unmodifiableMap(aMap);
 	}
 
@@ -217,10 +215,6 @@ public class CreateFormItemTabItem implements TabItem {
 					layout.setHTML(3,0,"Item is used to display customizable heading of form. Can have any HTML content.");
 				} else if (type.equals("TIMEZONE")) {
 					layout.setHTML(3,0,"Selection box with pre-defined values of UTC timezones.");
-				} else if (type.equals("FROM_FEDERATION_HIDDEN")) {
-					layout.setHTML(3,0,"Non-editable and hidden form item. Form is submitted even on invalid input ! Useful to automatically gather information provided by AUTH mechanism (IdP federation, certificate).");
-				} else if (type.equals("FROM_FEDERATION_SHOW")) {
-					layout.setHTML(3,0,"Non-editable and visible form item. Form is submitted even on invalid input ! Useful to automatically gather information provided by AUTH mechanism (IdP federation, certificate).");
 				} else {
 					layout.setHTML(3,0,"");
 				}
@@ -286,7 +280,7 @@ public class CreateFormItemTabItem implements TabItem {
 		item.setOrdnum(positionToAdd);
 		sourceList.add(positionToAdd, item);
 
-		session.getTabManager().addTabToCurrentTab(new EditFormItemTabItem(item, forGroup, events));
+		session.getTabManager().addTabToCurrentTab(new EditFormItemTabItem(item, forGroup, sourceList, events));
 
 		events.onFinished(item);
 


### PR DESCRIPTION
* For some use-cases, users need to be able to specify fields, that
should be hidden or disabled in some cases. Therefore, new
applicationFormItem fields were created - `hidden` and `disabled`. There
is also a new flag called `updatable`. This flag can be used to
determine if some application field can be updated after submission.
However, some item types cannot still be updated, even if this flag is
set to true (e.g. username).
* It is possible to specify 4 situations, when items should be hidden or
disabled - ALWAYS, NEVER, IF_PREFILLED, IF_EMPTY.
* It is also possible to reference a different item in the form, which
is then used to evaluate the conditions.
* The application types FROM_FEDERATION_SHOW and FROM_FEDERATION_HIDDEN
were merged into a FROM_FEDERATION type. In the dbchangelog, there are
commands, that will transform the old types into the new one, with also
setting the `hidden` and `disabled` columns accordingly.
