### PR TITLE
member attr o365EmailAddresses_mu fix

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_attribute_def_def_o365EmailAddresses_mu.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_attribute_def_def_o365EmailAddresses_mu.java
@@ -77,18 +77,6 @@ public class urn_perun_member_attribute_def_def_o365EmailAddresses_mu extends Me
 	}
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl sess, Member member, Attribute attribute) throws WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
-		log.trace("checkAttributeSemantics(member={},attribute={})", member, attribute);
-
-		//get values
-		if (attribute.getValue() == null) {
-			throw new WrongReferenceAttributeValueException(attribute, "can't be null.");
-		}
-
-		//No need to check duplicities, attribute is unique
-	}
-
-	@Override
 	public AttributeDefinition getAttributeDefinition() {
 		AttributeDefinition attr = new AttributeDefinition();
 		attr.setNamespace(NAMESPACE);


### PR DESCRIPTION
- This module didn't allow to set null value. However, the specific fill
  method which was used for this attribute was erased and the generic fill
  method always sets the attribute to null.
- Therefore the null check has to be erased as well.
- Whole checkAttributeSemantics method was erased as it contained only
  the null check.