### PR TITLE
Core - new methods for group stats

### DIFF
--- a/perun-base/src/main/resources/perun-roles.yml
+++ b/perun-base/src/main/resources/perun-roles.yml
@@ -1456,6 +1456,26 @@ perun_policies:
     include_policies:
       - default_policy
 
+  getGroupMembersCountsByVoStatus_Group_policy:
+    policy_roles:
+      - PERUNOBSERVER:
+      - VOOBSERVER: Vo
+      - GROUPADMIN: Group
+      - GROUPOBSERVER: Group
+      - VOADMIN: Vo
+    include_policies:
+      - default_policy
+
+  getGroupMembersCountsByGroupStatus_Group_policy:
+    policy_roles:
+      - PERUNOBSERVER:
+      - VOOBSERVER: Vo
+      - GROUPADMIN: Group
+      - GROUPOBSERVER: Group
+      - VOADMIN: Vo
+    include_policies:
+      - default_policy
+
   addAdmin_Group_User_policy:
     policy_roles:
       - GROUPADMIN: Group

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/GroupsManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/GroupsManager.java
@@ -565,6 +565,28 @@ public interface GroupsManager {
 	int getGroupMembersCount(PerunSession perunSession, Group group) throws GroupNotExistsException, PrivilegeException;
 
 	/**
+	 * Returns counts of group members by their status in VO.
+	 *
+	 * @param sess
+	 * @param group
+	 * @return map of member status in VO to count of group members with the status
+	 * @throws GroupNotExistsException when the group doesn't exist
+	 * @throws PrivilegeException
+	 */
+	Map<Status, Integer> getGroupMembersCountsByVoStatus(PerunSession sess, Group group) throws GroupNotExistsException, PrivilegeException;
+
+	/**
+	 * Returns counts of group members by their group status.
+	 *
+	 * @param sess
+	 * @param group
+	 * @return map of member status in group to count of group members with the status
+	 * @throws GroupNotExistsException when the group doesn't exist
+	 * @throws PrivilegeException
+	 */
+	Map<MemberGroupStatus, Integer> getGroupMembersCountsByGroupStatus(PerunSession sess, Group group) throws GroupNotExistsException, PrivilegeException;
+
+	/**
 	 * Get groups of Vo by ACCESS RIGHTS:
 	 * If user is:
 	 * - PERUNADMIN or VOADMIN : all groups in vo

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/GroupsManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/GroupsManagerBl.java
@@ -656,6 +656,24 @@ public interface GroupsManagerBl {
 	int getGroupMembersCount(PerunSession perunSession, Group group);
 
 	/**
+	 * Returns counts of group members by their status in VO.
+	 *
+	 * @param sess
+	 * @param group
+	 * @return map of member status in VO to count of group members with the status
+	 */
+	Map<Status, Integer> getGroupMembersCountsByVoStatus(PerunSession sess, Group group);
+
+	/**
+	 * Returns counts of group members by their group status.
+	 *
+	 * @param sess
+	 * @param group
+	 * @return map of member status in group to count of group members with the status
+	 */
+	Map<MemberGroupStatus, Integer> getGroupMembersCountsByGroupStatus(PerunSession sess, Group group);
+
+	/**
 	 * Checks whether the user is member of the group.
 	 *
 	 * @param sess

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
@@ -1298,6 +1298,32 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 	}
 
 	@Override
+	public Map<Status, Integer> getGroupMembersCountsByVoStatus(PerunSession sess, Group group) {
+		List<Member> members = this.getGroupMembers(sess, group);
+
+		Map<Status, Integer> counts = new HashMap<>();
+		for (Status status : Status.values()) {
+			counts.put(status, 0);
+		}
+		members.forEach(member -> counts.computeIfPresent(member.getStatus(), (key, value) -> value + 1));
+
+		return counts;
+	}
+
+	@Override
+	public Map<MemberGroupStatus, Integer> getGroupMembersCountsByGroupStatus(PerunSession sess, Group group) {
+		List<Member> members = this.getGroupMembers(sess, group);
+
+		Map<MemberGroupStatus, Integer> counts = new HashMap<>();
+		for (MemberGroupStatus status : MemberGroupStatus.values()) {
+			counts.put(status, 0);
+		}
+		members.forEach(member -> counts.computeIfPresent(member.getGroupStatus(), (key, value) -> value + 1));
+
+		return counts;
+	}
+
+	@Override
 	public List<User> getAdmins(PerunSession perunSession, Group group, boolean onlyDirectAdmins) {
 		if(onlyDirectAdmins) {
 			return getGroupsManagerImpl().getDirectAdmins(perunSession, group);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/GroupsManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/GroupsManagerEntry.java
@@ -622,6 +622,32 @@ public class GroupsManagerEntry implements GroupsManager {
 	}
 
 	@Override
+	public Map<Status, Integer> getGroupMembersCountsByVoStatus(PerunSession sess, Group group) throws GroupNotExistsException, PrivilegeException {
+		Utils.checkPerunSession(sess);
+		getGroupsManagerBl().checkGroupExists(sess, group);
+
+		// Authorization
+		if (!AuthzResolver.authorizedInternal(sess, "getGroupMembersCountsByVoStatus_Group_policy", group)) {
+			throw new PrivilegeException(sess, "getGroupMembersCountsByVoStatus");
+		}
+
+		return getGroupsManagerBl().getGroupMembersCountsByVoStatus(sess, group);
+	}
+
+	@Override
+	public Map<MemberGroupStatus, Integer> getGroupMembersCountsByGroupStatus(PerunSession sess, Group group) throws GroupNotExistsException, PrivilegeException {
+		Utils.checkPerunSession(sess);
+		getGroupsManagerBl().checkGroupExists(sess, group);
+
+		// Authorization
+		if (!AuthzResolver.authorizedInternal(sess, "getGroupMembersCountsByGroupStatus_Group_policy", group)) {
+			throw new PrivilegeException(sess, "getGroupMembersCountsByGroupStatus");
+		}
+
+		return getGroupsManagerBl().getGroupMembersCountsByGroupStatus(sess, group);
+	}
+
+	@Override
 	public void addAdmin(PerunSession sess, Group group, User user) throws AlreadyAdminException, PrivilegeException, GroupNotExistsException, UserNotExistsException, RoleCannotBeManagedException {
 		Utils.checkPerunSession(sess);
 		getGroupsManagerBl().checkGroupExists(sess, group);

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/GroupsManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/GroupsManagerEntryIntegrationTest.java
@@ -3005,6 +3005,60 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 	}
 
 	@Test
+	public void getGroupMembersCountsByVoStatus() throws Exception {
+		System.out.println(CLASS_NAME + "getGroupMembersCountsByVoStatus");
+
+		vo = setUpVo();
+		setUpGroup(vo);
+
+		Member member = setUpMember(vo);
+		groupsManager.addMember(sess, group, member);
+
+		Member disabledMember = setUpMember(vo);
+		groupsManager.addMember(sess, group, disabledMember);
+		perun.getMembersManager().setStatus(sess, disabledMember, Status.DISABLED);
+
+		Map<Status, Integer> counts = groupsManager.getGroupMembersCountsByVoStatus(sess, group);
+		assertThat(counts.get(Status.VALID)).isEqualTo(1);
+		assertThat(counts.get(Status.DISABLED)).isEqualTo(1);
+		assertThat(counts.get(Status.INVALID)).isEqualTo(0);
+		assertThat(counts.get(Status.EXPIRED)).isEqualTo(0);
+	}
+
+	@Test (expected=GroupNotExistsException.class)
+	public void getGroupMembersCountsByVoStatusWhenGroupNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "getGroupMembersCountsByVoStatusWhenGroupNotExists");
+
+		groupsManager.getGroupMembersCountsByVoStatus(sess, new Group());
+	}
+
+	@Test
+	public void getGroupMembersCountsByGroupStatus() throws Exception {
+		System.out.println(CLASS_NAME + "getGroupMembersCountsByGroupStatus");
+
+		vo = setUpVo();
+		setUpGroup(vo);
+
+		Member member = setUpMember(vo);
+		groupsManager.addMember(sess, group, member);
+
+		Member expiredMember = setUpMember(vo);
+		groupsManager.addMember(sess, group, expiredMember);
+		groupsManager.setMemberGroupStatus(sess, expiredMember, group, MemberGroupStatus.EXPIRED);
+
+		Map<MemberGroupStatus, Integer> counts = groupsManager.getGroupMembersCountsByGroupStatus(sess, group);
+		assertThat(counts.get(MemberGroupStatus.VALID)).isEqualTo(1);
+		assertThat(counts.get(MemberGroupStatus.EXPIRED)).isEqualTo(1);
+	}
+
+	@Test (expected=GroupNotExistsException.class)
+	public void getGroupMembersCountsByGroupStatusWhenGroupNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "getGroupMembersCountsByGroupStatusWhenGroupNotExists");
+
+		groupsManager.getGroupMembersCountsByGroupStatus(sess, new Group());
+	}
+
+	@Test
 	public void getAllGroups() throws Exception {
 		System.out.println(CLASS_NAME + "getAllGroups");
 

--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -1146,6 +1146,15 @@ components:
             additionalProperties:
               type: string
 
+    MapStringIntegerResponse:
+      description: "returns Map<String,Integer>"
+      content:
+        application/json:
+          schema:
+            type: object
+            additionalProperties:
+              type: integer
+
     MapStringMapStringStringResponse:
       description: "returns Map<String,Map<String,String>>"
       content:
@@ -11355,6 +11364,34 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/IntegerResponse'
+        default:
+          $ref: '#/components/responses/ExceptionResponse'
+
+  /json/groupsManager/getGroupMembersCountsByVoStatus:
+    get:
+      tags:
+        - GroupsManager
+      operationId: getGroupMembersCountsByVoStatus
+      summary: Returns counts of group members by their status in VO.
+      parameters:
+        - $ref: '#/components/parameters/groupId'
+      responses:
+        '200':
+          $ref: '#/components/responses/MapStringIntegerResponse'
+        default:
+          $ref: '#/components/responses/ExceptionResponse'
+
+  /json/groupsManager/getGroupMembersCountsByGroupStatus:
+    get:
+      tags:
+        - GroupsManager
+      operationId: getGroupMembersCountsByGroupStatus
+      summary: Returns counts of group members by their group status.
+      parameters:
+        - $ref: '#/components/parameters/groupId'
+      responses:
+        '200':
+          $ref: '#/components/responses/MapStringIntegerResponse'
         default:
           $ref: '#/components/responses/ExceptionResponse'
 

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/GroupsManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/GroupsManagerMethod.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.Member;
@@ -13,6 +14,7 @@ import cz.metacentrum.perun.core.api.MembershipType;
 import cz.metacentrum.perun.core.api.RichGroup;
 import cz.metacentrum.perun.core.api.RichMember;
 import cz.metacentrum.perun.core.api.RichUser;
+import cz.metacentrum.perun.core.api.Status;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.Vo;
 import cz.metacentrum.perun.core.api.exceptions.NotGroupMemberException;
@@ -712,6 +714,44 @@ public enum GroupsManagerMethod implements ManagerMethod {
 		public Integer call(ApiCaller ac, Deserializer parms) throws PerunException {
 			return ac.getGroupsManager().getGroupMembersCount(ac.getSession(),
 					ac.getGroupById(parms.readInt("group")));
+		}
+	},
+
+	/*#
+	 * Returns counts of group members by their status in VO.
+	 *
+	 * @throw GroupNotExistsException When the group doesn't exist
+	 *
+	 * @param group int Group <code>id</code>
+	 * @return Map<String, Integer> map of member status in VO to count of group members with the status
+	 */
+	getGroupMembersCountsByVoStatus {
+		@Override
+		public Map<String, Integer> call(ApiCaller ac, Deserializer parms) throws PerunException {
+			Map<Status, Integer> counts = ac.getGroupsManager().getGroupMembersCountsByVoStatus(ac.getSession(),
+				ac.getGroupById(parms.readInt("group")));
+
+			// convert Status to String
+			return counts.entrySet().stream().collect(Collectors.toMap(e -> e.getKey().toString(), Map.Entry::getValue));
+		}
+	},
+
+	/*#
+	 * Returns counts of group members by their group status.
+	 *
+	 * @throw GroupNotExistsException When the group doesn't exist
+	 *
+	 * @param group int Group <code>id</code>
+	 * @return Map<String, Integer> map of member status in group to count of group members with the status
+	 */
+	getGroupMembersCountsByGroupStatus {
+		@Override
+		public Map<String, Integer> call(ApiCaller ac, Deserializer parms) throws PerunException {
+			Map<MemberGroupStatus, Integer> counts = ac.getGroupsManager().getGroupMembersCountsByGroupStatus(ac.getSession(),
+				ac.getGroupById(parms.readInt("group")));
+
+			// convert MemberGroupStatus to String
+			return counts.entrySet().stream().collect(Collectors.toMap(e -> e.getKey().toString(), Map.Entry::getValue));
 		}
 	},
 


### PR DESCRIPTION
- New methods were added to Core, RPC and OpenAPI: getGroupMembersCountsByVoStatus
and getGroupMembersCountsByGroupStatus. They return a map with (group / VO)
member status as key, and count of the group members with the status as value.