### PR TITLE
Core - fixed optional ns config options

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/SponsoredAccountsConfigLoader.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/SponsoredAccountsConfigLoader.java
@@ -40,7 +40,7 @@ public class SponsoredAccountsConfigLoader {
 
 		} catch(RuntimeException e) {
 			throw new InternalErrorException("Configuration file has invalid syntax. Configuration file: " +
-				configurationPath.getFilename());
+				configurationPath.getFilename(), e);
 		}
 
 		return namespacesRules;
@@ -69,9 +69,9 @@ public class SponsoredAccountsConfigLoader {
 			namespaceRules.setDefaultEmail(defaultEmail.asText());
 			namespaceRules.setRequiredAttributes(requiredAttributes);
 			namespaceRules.setOptionalAttributes(optionalAttributes);
-			if (!csvGenHeader.isNull())
+			if (csvGenHeader != null && !csvGenHeader.isNull())
 				namespaceRules.setCsvGenHeader(csvGenHeader.asText());
-			if (!csvGenPlaceholder.isNull())
+			if (csvGenPlaceholder != null && !csvGenPlaceholder.isNull())
 				namespaceRules.setCsvGenPlaceholder(csvGenPlaceholder.asText());
 
 			rules.add(namespaceRules);


### PR DESCRIPTION
* The new csvGenHeader and csvGenPlaceholder options should be optional.
However, the previous check was not working properly, and the whole
application would fail to start because of NullPointerExceptions.