### PR TITLE
update to java 16

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '15' ]
+        java: [ '16' ]
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK ${{ matrix.java }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       - name: "Set up JDK"
         uses: actions/setup-java@v1
         with:
-          java-version: 15
+          java-version: 16
       - name: "Cache"
         uses: actions/cache@v1
         with:

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 	<properties>
 		<!-- property used by spring-boot-starter-parent project to define maven.compiler.source and maven.compiler.target
 		     properties that in turn are used by maven-compiler-plugin to specify java source and target version -->
-		<java.version>15</java.version>
+		<java.version>16</java.version>
 
 		<!-- USE UTF-8 in whole project -->
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
- updates the source and target levels of compiling to Java 16
- changes GitHub Actions to use OpenJDK 16
- beware, IntelliJ IDEA 2021.1 is needed to handle source level 16