### PR TITLE
Reducing logging in eduPersonScopedAffiliations

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_eduPersonScopedAffiliations.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_eduPersonScopedAffiliations.java
@@ -183,9 +183,19 @@ public class urn_perun_user_attribute_def_virt_eduPersonScopedAffiliations exten
 
 		GroupsManagerBl groupsManagerBl = sess.getPerunBl().getGroupsManagerBl();
 
-		List<Group> groupsForAttrCheck = new ArrayList<>();
+		Set<Group> groupsForAttrCheck = new HashSet<>();
 		for (Member member : validVoMembers) {
 			groupsForAttrCheck.addAll(groupsManagerBl.getGroupsWhereMemberIsActive(sess, member));
+		}
+
+		if (!groupsForAttrCheck.isEmpty()) {
+			try {
+				// check, if attribute exists
+				sess.getPerunBl().getAttributesManagerBl().getAttributeDefinition(sess, getTertiarySourceAttributeName());
+			} catch (AttributeNotExistsException e) {
+				log.debug("Attribute " + getTertiarySourceAttributeFriendlyName() + " does not exist", e);
+				return result;
+			}
 		}
 
 		for (Group group : groupsForAttrCheck) {


### PR DESCRIPTION
* Some instancies do not include groupAffiliations as attribute
* Missing attribute was logged excessively in such cases