### PR TITLE
Modules for adGroupName

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_adGroupName.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_adGroupName.java
@@ -1,0 +1,38 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import cz.metacentrum.perun.core.implApi.modules.attributes.GroupAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.GroupAttributesModuleImplApi;
+
+import java.util.regex.Pattern;
+
+public class urn_perun_group_attribute_def_def_adGroupName extends GroupAttributesModuleAbstract implements GroupAttributesModuleImplApi {
+
+	private static final Pattern pattern = Pattern.compile("[A-Za-z0-9 _]+");
+
+	@Override
+	public void checkAttributeSyntax(PerunSessionImpl sess, Group group, Attribute attribute) throws WrongAttributeValueException {
+		//Attribute can be null
+		if (attribute.getValue() == null) return;
+
+		if (!pattern.matcher(attribute.valueAsString()).matches()) {
+			throw new WrongAttributeValueException(attribute, "Invalid attribute adGroupName value. It should contain only letters, digits, underscores or spaces.");
+		}
+	}
+
+	@Override
+	public AttributeDefinition getAttributeDefinition() {
+		AttributeDefinition attr = new AttributeDefinition();
+		attr.setNamespace(AttributesManager.NS_GROUP_ATTR_DEF);
+		attr.setFriendlyName("adGroupName");
+		attr.setDisplayName("AD Group Name");
+		attr.setType(String.class.getName());
+		attr.setDescription("AD group name which is used to compose full name of the group in AD.");
+		return attr;
+	}
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_virt_adGroupName.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_virt_adGroupName.java
@@ -1,0 +1,81 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.ConsistencyErrorException;
+import cz.metacentrum.perun.core.api.exceptions.ParentGroupNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
+import cz.metacentrum.perun.core.bl.AttributesManagerBl;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import cz.metacentrum.perun.core.implApi.modules.attributes.GroupVirtualAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.GroupVirtualAttributesModuleImplApi;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class urn_perun_group_attribute_def_virt_adGroupName extends GroupVirtualAttributesModuleAbstract implements GroupVirtualAttributesModuleImplApi {
+
+	private static final String SOURCE_ATTR_NAME = AttributesManager.NS_GROUP_ATTR_DEF + ":adGroupName";
+	private static final String DELIMITER = "-";
+
+	@Override
+	public Attribute getAttributeValue(PerunSessionImpl sess, Group group, AttributeDefinition attributeDefinition) {
+		Attribute attribute = new Attribute(attributeDefinition);
+
+		try {
+			List<String> adGroupNames = fetchAdGroupNamesFromGroupAndItsParentGroups(sess, group);
+			if (adGroupNames.contains(null)) {
+				attribute.setValue(null);
+			} else {
+				attribute.setValue(String.join(DELIMITER, adGroupNames));
+			}
+		} catch (WrongAttributeAssignmentException | AttributeNotExistsException e) {
+			attribute.setValue(null);
+		}
+		return attribute;
+	}
+
+	/**
+	 * Recursively fetch adGroupName value from group and its parent groups
+	 * Result names are sorted from root group name to the leaf group name.
+	 *
+	 * @param sess Perun Session
+	 * @param group for which we will be fetching values
+	 * @return List of adGroupName values from group and its parent groups
+	 * @throws WrongAttributeAssignmentException
+	 * @throws AttributeNotExistsException
+	 */
+	private List<String> fetchAdGroupNamesFromGroupAndItsParentGroups(PerunSessionImpl sess, Group group)
+		throws WrongAttributeAssignmentException, AttributeNotExistsException {
+		List<String> resultList = new ArrayList<>();
+		AttributesManagerBl am = sess.getPerunBl().getAttributesManagerBl();
+		Attribute adGroupName = am.getAttribute(sess, group, SOURCE_ATTR_NAME);
+		String value = adGroupName.valueAsString();
+
+		if (group.getParentGroupId() != null) {
+			try {
+				Group parentGroup = sess.getPerunBl().getGroupsManagerBl().getParentGroup(sess, group);
+				resultList.addAll(fetchAdGroupNamesFromGroupAndItsParentGroups(sess, parentGroup));
+			} catch (ParentGroupNotExistsException e) {
+				throw new ConsistencyErrorException(e);
+			}
+		}
+
+		resultList.add(value);
+		return resultList;
+	}
+
+	@Override
+	public AttributeDefinition getAttributeDefinition() {
+		AttributeDefinition attr = new AttributeDefinition();
+		attr.setNamespace(AttributesManager.NS_GROUP_ATTR_VIRT);
+		attr.setFriendlyName("adGroupName");
+		attr.setDisplayName("Composed AD Group Name");
+		attr.setType(String.class.getName());
+		attr.setDescription("AD group name, which is composed from all def AD group names of this group and its parents.");
+		return attr;
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_adGroupNameTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_adGroupNameTest.java
@@ -1,0 +1,40 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.AbstractPerunIntegrationTest;
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+public class urn_perun_group_attribute_def_def_adGroupNameTest extends AbstractPerunIntegrationTest {
+
+	private urn_perun_group_attribute_def_def_adGroupName classInstance;
+	private Attribute attributeToCheck;
+	private Group group;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_group_attribute_def_def_adGroupName();
+		attributeToCheck = new Attribute();
+		group = new Group();
+
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testWrongSyntax() throws Exception {
+		System.out.println("testWrongSyntax()");
+		attributeToCheck.setValue("bad@value");
+
+		classInstance.checkAttributeSyntax((PerunSessionImpl) sess, group, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSyntax() throws Exception {
+		System.out.println("testCorrectSyntax()");
+		attributeToCheck.setValue("correctValue");
+
+		classInstance.checkAttributeSyntax((PerunSessionImpl) sess, group, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_virt_adGroupNameTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_virt_adGroupNameTest.java
@@ -1,0 +1,92 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.bl.AttributesManagerBl;
+import cz.metacentrum.perun.core.bl.GroupsManagerBl;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class urn_perun_group_attribute_def_virt_adGroupNameTest {
+
+	private static final String defAdGroupNameAttributeName = AttributesManager.NS_GROUP_ATTR_DEF + ":adGroupName";
+
+	private final urn_perun_group_attribute_def_virt_adGroupName classInstance = new urn_perun_group_attribute_def_virt_adGroupName();
+	private final AttributeDefinition adDGroupNameDefinition = classInstance.getAttributeDefinition();
+
+	private final Group groupA = setUpGroup(1, null, "groupA", "A");
+	private final Group groupB = setUpGroup(2, 1, "groupB", "B");
+	private final Group groupC = setUpGroup(3, 2, "groupC", "C");
+
+	private final Attribute attributeA = new Attribute();
+	private final Attribute attributeB = new Attribute();
+	private final Attribute attributeC = new Attribute();
+
+	private PerunSessionImpl sess;
+
+	@Before
+	public void setUp() throws Exception {
+		attributeA.setValue("A");
+		attributeB.setValue("B");
+		attributeC.setValue("C");
+
+		//prepare mocks
+		sess = mock(PerunSessionImpl.class);
+		PerunBl perunBl = mock(PerunBl.class);
+		AttributesManagerBl am = mock(AttributesManagerBl.class);
+		GroupsManagerBl gm = mock(GroupsManagerBl.class);
+
+		when(sess.getPerunBl())
+			.thenReturn(perunBl);
+		when(perunBl.getAttributesManagerBl())
+			.thenReturn(am);
+		when(perunBl.getGroupsManagerBl())
+			.thenReturn(gm);
+
+		when(gm.getParentGroup(sess, groupB))
+			.thenReturn(groupA);
+		when(gm.getParentGroup(sess, groupC))
+			.thenReturn(groupB);
+
+		when(am.getAttribute(sess, groupA, defAdGroupNameAttributeName))
+			.thenReturn(attributeA);
+		when(am.getAttribute(sess, groupB, defAdGroupNameAttributeName))
+			.thenReturn(attributeB);
+		when(am.getAttribute(sess, groupC, defAdGroupNameAttributeName))
+			.thenReturn(attributeC);
+	}
+
+	@Test
+	public void testCorrectGetAttributeValue() {
+		System.out.println("testCorrectGetAttributeValue()");
+
+		Attribute result = classInstance.getAttributeValue(sess, groupC, adDGroupNameDefinition);
+		Assert.assertEquals("A-B-C", result.getValue());
+	}
+
+	@Test
+	public void testIncorrectGetAttributeValue() {
+		System.out.println("testIncorrectGetAttributeValue()");
+
+		attributeB.setValue(null);
+		Attribute result = classInstance.getAttributeValue(sess, groupC, adDGroupNameDefinition);
+		Assert.assertNull(result.getValue());
+	}
+
+	private Group setUpGroup(int id, Integer parentGroupId, String name, String description) {
+		Group group = new Group(name, description);
+		group.setId(id);
+		group.setParentGroupId(parentGroupId);
+		return group;
+	}
+}


### PR DESCRIPTION
- module for def adGroupName checks the correct regex.
- module for virt adGroupName compose full name of the group in ad.
  It creates a string which consists of adGroupName def attr values of
  all parents of the given group together with the value of the given
  group itself. Values are sorted from the root group to the leaf group
  (the given one) and "-" is used as a delimiter.
- basic tests included.