### PR TITLE
Registrar - prefill group check box

### DIFF
--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
@@ -2431,9 +2431,37 @@ public class RegistrarManagerImpl implements RegistrarManager {
 			throw new MissingRequiredDataException("Your IDP doesn't provide data required by this application form.", itemsWithMissingData);
 		}
 
+		itemsWithValues.stream()
+				.filter(item -> item.getFormItem().getType() == EMBEDDED_GROUP_APPLICATION)
+				.forEach(item -> setGroupsToCheckBoxForGroups(sess, item, vo));
+
 		// return prefilled form
 		return itemsWithValues;
 
+	}
+
+	/**
+	 * To the given EMBEDDED_GROUP_APPLICATION item, sets options of allowed groups.
+	 *
+	 * Example format:
+	 * 111#GroupA|222#GroupB
+	 *
+	 * @param sess session
+	 * @param item item, to which the group options will be set, only EMBEDDED_GROUP_APPLICATION is supported
+	 * @param vo vo, from which the groups for auto registration are taken
+	 */
+	private void setGroupsToCheckBoxForGroups(PerunSession sess, ApplicationFormItemWithPrefilledValue item, Vo vo) {
+		if (item.getFormItem().getType() != EMBEDDED_GROUP_APPLICATION) {
+			throw new InternalErrorException("Group options can be set only to the EMBEDDED_GROUP_APPLICATION item.");
+		}
+		List<Group> groups = perun.getGroupsManagerBl().getGroupsForAutoRegistration(sess, vo);
+
+		String groupOptions = groups.stream()
+				.map(group -> group.getId() + "#" + group.getName())
+				.collect(Collectors.joining("|"));
+
+		item.getFormItem().getI18n().get(ApplicationFormItem.CS).setOptions(groupOptions);
+		item.getFormItem().getI18n().get(ApplicationFormItem.EN).setOptions(groupOptions);
 	}
 
 	/**

--- a/perun-registrar-lib/src/test/java/cz/metacentrum/perun/registrar/RegistrarBaseIntegrationTest.java
+++ b/perun-registrar-lib/src/test/java/cz/metacentrum/perun/registrar/RegistrarBaseIntegrationTest.java
@@ -1,6 +1,7 @@
 package cz.metacentrum.perun.registrar;
 
 import cz.metacentrum.perun.core.api.ExtSourcesManager;
+import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.PerunClient;
 import cz.metacentrum.perun.core.api.PerunPrincipal;
 import cz.metacentrum.perun.core.api.PerunSession;
@@ -489,6 +490,33 @@ System.out.println("APPS ["+result.size()+"]:" + result);
 			.isEqualTo(items.get(2).getId());
 		assertThat(items.get(1).getDisabledDependencyItemId())
 			.isEqualTo(items.get(2).getId());
+	}
+
+	@Test
+	@SuppressWarnings("unchecked") // we know the exact type of the data
+	public void setGroupOptionsToGroupCheckbox() throws Exception {
+		Group groupA = new Group("A", "test");
+		groupA = perun.getGroupsManagerBl().createGroup(session, vo, groupA);
+
+		ApplicationForm formForVo = registrarManager.getFormForVo(vo);
+
+		ApplicationFormItem groupCheckboxItem = new ApplicationFormItem();
+		groupCheckboxItem.setShortname("groups");
+		groupCheckboxItem.setType(ApplicationFormItem.Type.EMBEDDED_GROUP_APPLICATION);
+
+		registrarManager.addFormItem(session, formForVo, groupCheckboxItem);
+
+		perun.getGroupsManagerBl().addGroupsToAutoRegistration(session, List.of(groupA));
+
+		Map<String, Object> data = registrarManager.initRegistrar(session, vo.getShortName(), null);
+		var items = (List<ApplicationFormItemWithPrefilledValue>)data.get("voFormInitial");
+
+		String expectedOptions = groupA.getId() + "#A";
+
+		assertThat(items.get(0).getFormItem().getI18n().get(ApplicationFormItem.EN).getOptions())
+				.isEqualTo(expectedOptions);
+		assertThat(items.get(0).getFormItem().getI18n().get(ApplicationFormItem.CS).getOptions())
+				.isEqualTo(expectedOptions);
 	}
 
 	private static void applyForMembershipInVO(RegistrarManager registrarManager, PerunBl perun, Vo vo,PerunSession user) throws PerunException {


### PR DESCRIPTION
* When initializing registrar application, we need to set groups, which
the user can select for the automatic group registration. From now, this
is supported. Example of the filled options format:
`21#GroupA|22#GroupB`.