### PR TITLE
Recover connection between dispatcher and engine

### DIFF
--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/jms/JMSQueueManager.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/jms/JMSQueueManager.java
@@ -57,6 +57,7 @@ public class JMSQueueManager {
 	 *
 	 */
 	public void initiateConnection() {
+		receivingMessages = false;
 		while (needToConnect) {
 
 			try {


### PR DESCRIPTION
1. Now the auto reconnection of JMS queue is working, when the server is restarted.
* In the `JMSQueueManager` class in method `registerForReceivingMessages()` is if condition, which is sending the registration message only if the variable `receivingMessages` is `false`. But if the server is restarted, this variable stays in `true` state, so the registration message couldn't be sent again.
* In the initial method in `JMSQueueManager` class I set this variable to `false`, so the registration message can be sent after restarting the server.

2. Logging was fixed too.
* I added the `Theard.sleep()` to catch block, so the next potential message will be sent after the wait time, which is mentioned in log error message.