### PR TITLE
Added check while enabling sync for groups in auto registration

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_groupStructureSynchronizationEnabled.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_groupStructureSynchronizationEnabled.java
@@ -44,6 +44,16 @@ public class urn_perun_group_attribute_def_def_groupStructureSynchronizationEnab
 				throw new InternalErrorException("Synchronization is already enabled for one of the parent groups.");
 			}
 
+			if (perunSession.getPerunBl().getGroupsManagerBl().isGroupForAutoRegistration(perunSession, group)) {
+				throw new WrongReferenceAttributeValueException(attribute, "Structure synchronization cannot be enabled for group in auto registration.");
+			}
+
+			for (Group subgroup : perunSession.getPerunBl().getGroupsManagerBl().getAllSubGroups(perunSession, group)) {
+				if (perunSession.getPerunBl().getGroupsManagerBl().isGroupForAutoRegistration(perunSession, subgroup)) {
+					throw new WrongReferenceAttributeValueException(attribute, "Structure synchronization cannot be enabled for group with subgroup in auto registration: " + subgroup.toString());
+				}
+			}
+
 			try {
 				Attribute attrSynchronizeEnabled = perunSession.getPerunBl().getAttributesManagerBl().getAttribute(perunSession, group, GroupsManager.GROUPSYNCHROENABLED_ATTRNAME);
 				if (Objects.equals("true", attrSynchronizeEnabled.getValue())) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_synchronizationEnabled.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_synchronizationEnabled.java
@@ -43,6 +43,10 @@ public class urn_perun_group_attribute_def_def_synchronizationEnabled extends Gr
 		if (attribute.getValue() == null) return;
 		try {
 			if (attribute.valueAsString().equals("true")) {
+				if (sess.getPerunBl().getGroupsManagerBl().isGroupForAutoRegistration(sess, group)) {
+					throw new WrongReferenceAttributeValueException(attribute, "Synchronization cannot be enabled for groups in auto registration.");
+				}
+
 				Attribute requiredAttribute = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, group, GroupsManager.GROUPMEMBERSQUERY_ATTRNAME);
 				if (requiredAttribute.getValue() == null) {
 					throw new WrongReferenceAttributeValueException(attribute, requiredAttribute, group, null, group, null, requiredAttribute.toString() + " must be set in order to enable synchronization.");

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_groupStructureSynchronizationEnabledTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_groupStructureSynchronizationEnabledTest.java
@@ -11,6 +11,8 @@ import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Arrays;
+
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -63,6 +65,15 @@ public class urn_perun_group_attribute_def_def_groupStructureSynchronizationEnab
 		classInstance.checkAttributeSemantics(sess, group, attributeToCheck);
 	}
 
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testGroupInAutoRegister() throws Exception {
+		System.out.println("testGroupInAutoRegister()");
+		attributeToCheck.setValue(true);
+
+		when(sess.getPerunBl().getGroupsManagerBl().isGroupForAutoRegistration(sess, group)).thenReturn(true);
+
+		classInstance.checkAttributeSemantics(sess, group, attributeToCheck);
+	}
 
 	@Test
 	public void testCorrectSemantics() throws Exception {

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_synchronizationEnabledTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_synchronizationEnabledTest.java
@@ -51,6 +51,16 @@ public class urn_perun_group_attribute_def_def_synchronizationEnabledTest {
 		classInstance.checkAttributeSemantics(sess, group, attributeToCheck);
 	}
 
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testGroupInAutoRegister() throws Exception {
+		System.out.println("testMissingGroupInAutoRegister()");
+		attributeToCheck.setValue("true");
+
+		when(sess.getPerunBl().getGroupsManagerBl().isGroupForAutoRegistration(sess, group)).thenReturn(true);
+
+		classInstance.checkAttributeSemantics(sess, group, attributeToCheck);
+	}
+
 	@Test
 	public void testCorrectSemantics() throws Exception {
 		System.out.println("testCorrectSemantics()");


### PR DESCRIPTION
- group cannot be added to group synchronization while in auto registration
- group cannot be added to group structure synchronization while the group or any of its subgroups are in auto registration
- also added simple tests for these two modules