### PR TITLE
autoRegistrationEnabled attribute updated

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/VosManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/VosManagerBl.java
@@ -544,4 +544,13 @@ public interface VosManagerBl {
 	 * @param newSponsor user, who will be set as a sponsor to the sponsored members
 	 */
 	void convertSponsoredUsersWithNewSponsor(PerunSession sess, Vo vo, User newSponsor);
+
+	/**
+	 * Returns true, if the given vo uses EMBEDDED_GROUP_APPLICATION item in its form.
+	 *
+	 * @param sess session
+	 * @param vo vo
+	 * @return true, if the given vo uses EMBEDDED_GROUP_APPLICATION item in its form, false otherwise.
+	 */
+	boolean usesEmbeddedGroupRegistrations(PerunSession sess, Vo vo);
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/VosManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/VosManagerBlImpl.java
@@ -877,6 +877,11 @@ public class VosManagerBlImpl implements VosManagerBl {
 				.forEach(user -> convertToSponsoredMemberWithNewSponsor(sess, user, newSponsor, vo));
 	}
 
+	@Override
+	public boolean usesEmbeddedGroupRegistrations(PerunSession sess, Vo vo) {
+		return vosManagerImpl.hasEmbeddedGroupsItemInForm(sess, vo.getId());
+	}
+
 	/**
 	 * Sponsor given user by the given newSponsor in the given vo. If the newSponsor doesn't have
 	 * the SPONSOR role, it will be set to him.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/VosManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/VosManagerImpl.java
@@ -519,4 +519,11 @@ public class VosManagerImpl implements VosManagerImplApi {
 			throw new InternalErrorException(ex);
 		}
 	}
+
+	@Override
+	public boolean hasEmbeddedGroupsItemInForm(PerunSession sess, int voId) {
+		int count = jdbc.queryForInt("SELECT count(*) FROM application_form_items WHERE form_id = " +
+					"(SELECT id FROM application_form WHERE vo_id = ? AND group_id IS NULL) AND type = 'EMBEDDED_GROUP_APPLICATION';", voId);
+		return count > 0;
+	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_virt_autoRegistrationEnabled.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_virt_autoRegistrationEnabled.java
@@ -4,9 +4,9 @@ import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.Group;
-import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
-import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
-import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.api.Vo;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.VoNotExistsException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.GroupVirtualAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.GroupVirtualAttributesModuleImplApi;
@@ -16,9 +16,24 @@ public class urn_perun_group_attribute_def_virt_autoRegistrationEnabled extends 
 	@Override
 	public Attribute getAttributeValue(PerunSessionImpl sess, Group group, AttributeDefinition attributeDefinition) {
 		Attribute attribute = new Attribute(attributeDefinition);
-		boolean value = sess.getPerunBl().getGroupsManagerBl().isGroupForAutoRegistration(sess, group);
+		Boolean value = null;
+		if (isAutoRegistrationActiveInVo(sess, group)) {
+			value = sess.getPerunBl().getGroupsManagerBl().isGroupForAutoRegistration(sess, group);
+		}
 		attribute.setValue(value);
 		return attribute;
+	}
+
+
+	private boolean isAutoRegistrationActiveInVo(PerunSessionImpl sess, Group group) {
+		Vo vo;
+		try {
+			vo = sess.getPerunBl().getVosManagerBl().getVoById(sess, group.getVoId());
+		} catch (VoNotExistsException e) {
+			throw new InternalErrorException(e);
+		}
+
+		return sess.getPerunBl().getVosManagerBl().usesEmbeddedGroupRegistrations(sess, vo);
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/VosManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/VosManagerImplApi.java
@@ -316,4 +316,15 @@ public interface VosManagerImplApi {
 	 * @return true, if member with given id is banned, false otherwise
 	 */
 	boolean isMemberBanned(PerunSession sess, int memberId);
+
+	/**
+	 * Returns true, if there is a vo with given id which has application form with the
+	 * EMBEDDED_GROUP_APPLICATION item in it.
+	 *
+	 * @param sess session
+	 * @param voId vo id
+	 * @return true, if there is a vo with given id which has application form with the
+	 * EMBEDDED_GROUP_APPLICATION item in it, false otherwise
+	 */
+	boolean hasEmbeddedGroupsItemInForm(PerunSession sess, int voId);
 }

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_virt_autoRegistrationEnabledTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_virt_autoRegistrationEnabledTest.java
@@ -1,15 +1,16 @@
 package cz.metacentrum.perun.core.impl.modules.attributes;
 
-import cz.metacentrum.perun.core.AbstractPerunIntegrationTest;
-import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.Vo;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class urn_perun_group_attribute_def_virt_autoRegistrationEnabledTest {
 
@@ -17,6 +18,7 @@ public class urn_perun_group_attribute_def_virt_autoRegistrationEnabledTest {
 	private PerunSessionImpl session;
 	private Group groupA;
 	private Group groupB;
+	private Vo vo;
 	private AttributeDefinition attrDef;
 
 	@Before
@@ -25,22 +27,54 @@ public class urn_perun_group_attribute_def_virt_autoRegistrationEnabledTest {
 		session = mock(PerunSessionImpl.class, RETURNS_DEEP_STUBS);
 		this.attrDef = classInstance.getAttributeDefinition();
 		this.groupA = new Group("GroupA", "Group with auto registration enabled");
+		this.groupA.setVoId(1);
 		this.groupB = new Group("GroupB", "Group with auto registration disabled");
+		this.groupB.setVoId(1);
+		this.vo = new Vo(1, "vo", "");
 	}
 
 	@Test
 	public void testAutoRegistrationEnabledGetAttributeValue() throws Exception {
 		System.out.println("testAutoRegistrationEnabledGetAttributeValue()");
-		when(session.getPerunBl().getGroupsManagerBl().isGroupForAutoRegistration(session, groupA)).thenReturn(true);
-		boolean attributeValue = classInstance.getAttributeValue(session, groupA, attrDef).valueAsBoolean();
-		assertTrue(attributeValue);
+		when(session.getPerunBl().getGroupsManagerBl().isGroupForAutoRegistration(session, groupA))
+				.thenReturn(true);
+		when(session.getPerunBl().getVosManagerBl().getVoById(session, groupA.getVoId()))
+				.thenReturn(vo);
+		when(session.getPerunBl().getVosManagerBl().usesEmbeddedGroupRegistrations(session, vo))
+				.thenReturn(true);
+
+		Boolean attributeValue = classInstance.getAttributeValue(session, groupA, attrDef).valueAsBoolean();
+		assertThat(attributeValue)
+				.isTrue();
 	}
 
 	@Test
 	public void testAutoRegistrationDisabledGetAttributeValue() throws Exception {
 		System.out.println("testAutoRegistrationDisabledAttributeValue()");
-		when(session.getPerunBl().getGroupsManagerBl().isGroupForAutoRegistration(session, groupB)).thenReturn(false);
-		boolean attributeValue = classInstance.getAttributeValue(session, groupB, attrDef).valueAsBoolean();
-		assertFalse(attributeValue);
+		when(session.getPerunBl().getGroupsManagerBl().isGroupForAutoRegistration(session, groupB))
+				.thenReturn(false);
+		when(session.getPerunBl().getVosManagerBl().getVoById(session, groupB.getVoId()))
+				.thenReturn(vo);
+		when(session.getPerunBl().getVosManagerBl().usesEmbeddedGroupRegistrations(session, vo))
+				.thenReturn(true);
+
+		Boolean attributeValue = classInstance.getAttributeValue(session, groupB, attrDef).valueAsBoolean();
+		assertThat(attributeValue)
+				.isFalse();
+	}
+
+	@Test
+	public void testAutoRegistrationNotUsed() throws Exception {
+		System.out.println("testAutoRegistrationNotUsed()");
+		when(session.getPerunBl().getGroupsManagerBl().isGroupForAutoRegistration(session, groupB))
+				.thenReturn(false);
+		when(session.getPerunBl().getVosManagerBl().getVoById(session, groupB.getVoId()))
+				.thenReturn(vo);
+		when(session.getPerunBl().getVosManagerBl().usesEmbeddedGroupRegistrations(session, vo))
+				.thenReturn(false);
+
+		Boolean attributeValue = classInstance.getAttributeValue(session, groupB, attrDef).valueAsBoolean();
+		assertThat(attributeValue)
+				.isNull();
 	}
 }


### PR DESCRIPTION
* The `autoRegistrationEnabled` attribute now returns null, it the
group's vo doesn't use the embedded group registrations.