### PR TITLE
GUI - disable member groups for autoreg groups

### DIFF
--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/AddAutoRegGroupTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/AddAutoRegGroupTabItem.java
@@ -70,7 +70,7 @@ public class AddAutoRegGroupTabItem implements TabItem {
 		menu.addWidget(new HTML(""));
 
 		final GetAllGroups groups = new GetAllGroups(vo.getId());
-		groups.setCoreGroupsCheckable(true);
+		groups.setCoreGroupsCheckable(false);
 
 		// remove already added union groups from offering
 		JsonCallbackEvents localEvents = new JsonCallbackEvents() {


### PR DESCRIPTION
* The member groups should not be allowed to be added to the list of
groups for auto registration.