### PR TITLE
Registrar - use initial templates for embedded app

### DIFF
--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/MailManagerImpl.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/MailManagerImpl.java
@@ -641,6 +641,11 @@ public class MailManagerImpl implements MailManager {
 	private ApplicationMail getMailByParams(Integer formId, AppType appType, MailType mailType) {
 		ApplicationMail mail;
 
+		// We want to use the initial notifications for the embedded applications
+		if (appType == AppType.EMBEDDED) {
+			appType = AppType.INITIAL;
+		}
+
 		// get mail def
 		try {
 			List<ApplicationMail> mails = jdbc.query(MAILS_SELECT_BY_PARAMS, (resultSet, arg1) -> new ApplicationMail(resultSet.getInt("id"),


### PR DESCRIPTION
* For embedded applications, we want to use templates of initial
applications.