### PR TITLE
Check number of embedded groups form items

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/MultipleApplicationFormItemsException.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/MultipleApplicationFormItemsException.java
@@ -1,0 +1,36 @@
+package cz.metacentrum.perun.core.api.exceptions;
+
+
+/**
+ * Thrown when application form contains multiple application form items of such type that maximum 1 is allowed.
+ *
+ * @author Johana Supikova
+ */
+public class MultipleApplicationFormItemsException extends PerunException {
+	static final long serialVersionUID = 0;
+
+	/**
+	 * Simple constructor with a message
+	 * @param message message with details about the cause
+	 */
+	public MultipleApplicationFormItemsException(String message) {
+		super(message);
+	}
+
+	/**
+	 * Constructor with a message and Throwable object
+	 * @param message message with details about the cause
+	 * @param cause Throwable that caused throwing of this exception
+	 */
+	public MultipleApplicationFormItemsException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	/**
+	 * Constructor with a Throwable object
+	 * @param cause Throwable that caused throwing of this exception
+	 */
+	public MultipleApplicationFormItemsException(Throwable cause) {
+		super(cause);
+	}
+}

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/RegistrarManager.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/RegistrarManager.java
@@ -123,7 +123,7 @@ public interface RegistrarManager {
 	 * @throws InternalErrorException
 	 * @return created ApplicationFormItem with id and ordnum property set
 	 */
-	ApplicationFormItem addFormItem(PerunSession user, ApplicationForm applicationForm, ApplicationFormItem formItem) throws PrivilegeException;
+	ApplicationFormItem addFormItem(PerunSession user, ApplicationForm applicationForm, ApplicationFormItem formItem) throws PerunException;
 
 	/**
 	 * Updates whole FormItem object including ItemTexts and associated AppTypes
@@ -135,7 +135,7 @@ public interface RegistrarManager {
 	 * @throws PrivilegeException
 	 * @throws InternalErrorException
 	 */
-	int updateFormItems(PerunSession sess, ApplicationForm form, List<ApplicationFormItem> items) throws PrivilegeException;
+	int updateFormItems(PerunSession sess, ApplicationForm form, List<ApplicationFormItem> items) throws PerunException;
 
 	/**
 	 * Updates the form attributes, not the form items.

--- a/perun-registrar-lib/src/test/java/cz/metacentrum/perun/registrar/RegistrarBaseIntegrationTest.java
+++ b/perun-registrar-lib/src/test/java/cz/metacentrum/perun/registrar/RegistrarBaseIntegrationTest.java
@@ -40,6 +40,7 @@ import static cz.metacentrum.perun.registrar.model.ApplicationFormItem.CS;
 import static cz.metacentrum.perun.registrar.model.ApplicationFormItem.EN;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -668,6 +669,24 @@ System.out.println("APPS ["+result.size()+"]:" + result);
 		application.setExtSourceName("ExtSource");
 		application.setExtSourceType(ExtSourcesManager.EXTSOURCE_IDP);
 		return application;
+	}
+
+	@Test
+	public void testAddFormItem_multipleEmbeddedGroupsItems() throws PerunException {
+		ApplicationForm form = registrarManager.getFormForVo(vo);
+
+		// create 2 embedded groups form items
+		ApplicationFormItem embeddedGroupsItem = new ApplicationFormItem();
+		embeddedGroupsItem.setType(ApplicationFormItem.Type.EMBEDDED_GROUP_APPLICATION);
+		embeddedGroupsItem.setShortname("embeddedGroups");
+		registrarManager.addFormItem(session, form, embeddedGroupsItem);
+
+		ApplicationFormItem embeddedGroupsItem2 = new ApplicationFormItem();
+		embeddedGroupsItem2.setType(ApplicationFormItem.Type.EMBEDDED_GROUP_APPLICATION);
+		embeddedGroupsItem2.setShortname("embeddedGroups2");
+		assertThrows(MultipleApplicationFormItemsException.class, () -> {
+			registrarManager.addFormItem(session, form, embeddedGroupsItem2);
+		});
 	}
 
 	/*


### PR DESCRIPTION
* Maximum one application form item for embedded groups is allowed in VO application
* Exception is thrown if multiple definitions are found when updating application