### PR TITLE
Core - bugfix identities alerts

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Utils.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Utils.java
@@ -144,7 +144,7 @@ public class Utils {
 
 	private static final String A_U_MAIL = AttributesManager.NS_USER_ATTR_DEF + ":preferredMail";
 	private static final String A_UES_MAIL = AttributesManager.NS_UES_ATTR_DEF + ":mail";
-	private static final String A_E_IDENTITY_ALERTS = AttributesManager.NS_ENTITYLESS_ATTR_DEF + ":identityAlerts";
+	private static final String A_E_IDENTITY_ALERTS = AttributesManager.NS_ENTITYLESS_ATTR_DEF + ":identityAlertsTemplates";
 	private static final String A_UES_ORGANIZATION = AttributesManager.NS_UES_ATTR_DEF + ":o";
 
 	/**
@@ -2213,7 +2213,7 @@ public class Utils {
 		String organization = ORG_UNKNOWN_TEXT;
 		try {
 			Attribute orgAttr = ((PerunBl)sess.getPerun()).getAttributesManagerBl().getAttribute(sess, newUes, A_UES_ORGANIZATION);
-			if (orgAttr != null) {
+			if (orgAttr.getValue() != null) {
 				organization = orgAttr.valueAsString();
 			}
 		} catch (WrongAttributeAssignmentException e) {
@@ -2258,7 +2258,7 @@ public class Utils {
 
 	/**
 	 * Returns alert template for the given templateName. The templates should be stored in
-	 * entityless:def:identityAlerts attribute, under the 'en' key.
+	 * entityless:def:identityAlertsTemplates attribute, under the 'en' key.
 	 * If the templateName is not present or has an empty value, the default value is used.
 	 *
 	 * @param sess session


### PR DESCRIPTION
* There was a bug with sending alerts when an identity was added by a
user. The problem was with an invalid if condition. The condition should
check that the attribute's value is not null but actually the attribute
itself was checked.
* There was also another bug. When trying to retreive attribute with
notifications templates, invalid attribute name was used -
`identityAlerts`. The correct name is `identityAlertsTemplates`.