### PR TITLE
OpenAPI fix in method deleteAuthorship

### DIFF
--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -7027,8 +7027,8 @@ paths:
       operationId: deleteAuthorship
       summary: Delete Authorship by its userId and publicationId.
       parameters:
-        - $ref: '#/components/parameters/publicationId'
-        - $ref: '#/components/parameters/userId'
+        - { name: publicationId, schema: { type: integer }, in: query, required: true, description: 'id of publication' }
+        - { name: userId, schema: { type: integer }, in: query, required: true, description: 'id of user' }
       responses:
         '200':
           $ref: '#/components/responses/VoidResponse'


### PR DESCRIPTION
* In OpenAPI definition were params names `publication` and `user`, but this method expects names `publicationId` and `userId`.