### PR TITLE
fix(core): email change - don't append idpFilter if blank

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Utils.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Utils.java
@@ -1435,7 +1435,7 @@ public class Utils {
 			link.append("&m=");
 			link.append(URLEncoder.encode(m, StandardCharsets.UTF_8));
 			link.append("&u=" + user.getId());
-			if (idp != null) {
+			if (isNotBlank(idp)) {
 				link.append("&idpFilter=");
 				link.append(URLEncoder.encode(idp, StandardCharsets.UTF_8));
 			}


### PR DESCRIPTION
* When generating link to confirm email change, we don't want to add idpFilter parameter if it is
blank.