### PR TITLE
Email change using UUID as token

### DIFF
--- a/perun-base/src/main/resources/perun-roles.yml
+++ b/perun-base/src/main/resources/perun-roles.yml
@@ -5273,6 +5273,12 @@ perun_policies:
     include_policies:
       - default_policy
 
+  validatePreferredEmailChange_User_String_policy:
+    policy_roles:
+      - SELF: User
+    include_policies:
+      - default_policy
+
   getPendingPreferredEmailChanges_User_policy:
     policy_roles:
       - PERUNOBSERVER:

--- a/perun-base/src/test/resources/test-schema.sql
+++ b/perun-base/src/test/resources/test-schema.sql
@@ -1,4 +1,4 @@
--- database version 3.1.80 (don't forget to update insert statement at the end of file)
+-- database version 3.1.81 (don't forget to update insert statement at the end of file)
 CREATE EXTENSION IF NOT EXISTS "unaccent";
 CREATE EXTENSION IF NOT EXISTS "pgcrypto";
 
@@ -1269,6 +1269,7 @@ create table configurations (
 -- MAILCHANGE - allow to user to change mail address, temporairly saved mails during change is in progress
 create table mailchange (
 							 id integer not null,
+							 uu_id uuid not null default gen_random_uuid(),
 							 value text not null,      --
 							 user_id integer not null, --identifier of user (users.id)
 							 created_at timestamp default statement_timestamp() not null,
@@ -1668,7 +1669,7 @@ CREATE INDEX ufauv_idx ON user_facility_attr_u_values (user_id, facility_id, att
 CREATE INDEX vauv_idx ON vo_attr_u_values (vo_id, attr_id);
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.1.80');
+insert into configurations values ('DATABASE VERSION','3.1.81');
 -- insert membership types
 insert into membership_types (id, membership_type, description) values (1, 'DIRECT', 'Member is directly added into group');
 insert into membership_types (id, membership_type, description) values (2, 'INDIRECT', 'Member is added indirectly through UNION relation');

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/UsersManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/UsersManager.java
@@ -1145,7 +1145,29 @@ public interface UsersManager {
 	 *
 	 * @return String return new preferred email
 	 */
+	@Deprecated
 	String validatePreferredEmailChange(PerunSession sess, User user, String i, String m) throws PrivilegeException, UserNotExistsException, WrongAttributeAssignmentException, AttributeNotExistsException, WrongReferenceAttributeValueException, WrongAttributeValueException;
+
+	/**
+	 * Validate change of user's preferred email address.
+	 * New email address is set as value of
+	 * urn:perun:user:attribute-def:def:preferredMail attribute.
+	 *
+	 * @param sess PerunSession
+	 * @param user User to validate email address for
+	 * @param token token for the email change request to validate
+	 *
+	 * @throws InternalErrorException
+	 * @throws PrivilegeException
+	 * @throws UserNotExistsException
+	 * @throws WrongAttributeAssignmentException
+	 * @throws AttributeNotExistsException
+	 * @throws WrongReferenceAttributeValueException
+	 * @throws WrongAttributeValueException
+	 *
+	 * @return String return new preferred email
+	 */
+	String validatePreferredEmailChange(PerunSession sess, User user, String token) throws PrivilegeException, UserNotExistsException, WrongAttributeAssignmentException, AttributeNotExistsException, WrongReferenceAttributeValueException, WrongAttributeValueException;
 
 	/**
 	 * Return list of email addresses of user, which are

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
@@ -1300,6 +1300,23 @@ public interface UsersManagerBl {
 	String validatePreferredEmailChange(PerunSession sess, User user, String i, String m) throws WrongAttributeValueException, WrongAttributeAssignmentException, AttributeNotExistsException, WrongReferenceAttributeValueException;
 
 	/**
+	 * Validate change of user's preferred email address.
+	 * New email address is set as value of
+	 * urn:perun:user:attribute-def:def:preferredEmail attribute.
+	 *
+	 * @param sess PerunSession
+	 * @param user User to validate email address for
+	 * @param token token for the email change request to validate
+	 * @return String return new preferred email
+	 * @throws InternalErrorException
+	 * @throws WrongAttributeValueException          If new email address is in wrong format
+	 * @throws WrongAttributeAssignmentException
+	 * @throws AttributeNotExistsException           If user:preferredEmail attribute doesn't exists.
+	 * @throws WrongReferenceAttributeValueException
+	 */
+	String validatePreferredEmailChange(PerunSession sess, User user, String token) throws WrongAttributeValueException, WrongAttributeAssignmentException, AttributeNotExistsException, WrongReferenceAttributeValueException;
+
+	/**
 	 * Return list of email addresses of user, which are
 	 * awaiting validation and are inside time window
 	 * for validation.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
@@ -1636,7 +1636,7 @@ public class UsersManagerBlImpl implements UsersManagerBl {
 	@Override
 	public void requestPreferredEmailChange(PerunSession sess, String url, User user, String email, String lang, String path, String idp) {
 
-		int changeId = getUsersManagerImpl().requestPreferredEmailChange(sess, user, email);
+		UUID changeUuid = getUsersManagerImpl().requestPreferredEmailChange(sess, user, email);
 
 		if (lang == null || lang.isEmpty()) lang = "en";
 
@@ -1668,7 +1668,7 @@ public class UsersManagerBlImpl implements UsersManagerBl {
 			throw new InternalErrorException(ex);
 		}
 
-		Utils.sendValidationEmail(user, url, email, changeId, subject, message, path, idp);
+		Utils.sendValidationEmail(user, url, email, changeUuid, subject, message, path, idp);
 
 	}
 
@@ -1688,6 +1688,22 @@ public class UsersManagerBlImpl implements UsersManagerBl {
 
 		return email;
 
+	}
+
+	@Override
+	public String validatePreferredEmailChange(PerunSession sess, User user, String token) throws WrongAttributeValueException, WrongAttributeAssignmentException, AttributeNotExistsException, WrongReferenceAttributeValueException {
+		String email = getUsersManagerImpl().getPreferredEmailChangeRequest(sess, user, UUID.fromString(token));
+
+		AttributeDefinition def = getPerunBl().getAttributesManagerBl().getAttributeDefinition(sess, AttributesManager.NS_USER_ATTR_DEF+":preferredMail");
+		Attribute a = new Attribute(def);
+		a.setValue(email);
+
+		// store attribute
+		getPerunBl().getAttributesManagerBl().setAttribute(sess, user, a);
+
+		getUsersManagerImpl().removeAllPreferredEmailChangeRequests(sess, user);
+
+		return email;
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
@@ -1346,6 +1346,19 @@ public class UsersManagerEntry implements UsersManager {
 	}
 
 	@Override
+	public String validatePreferredEmailChange(PerunSession sess, User user, String token) throws PrivilegeException, UserNotExistsException, WrongAttributeAssignmentException, AttributeNotExistsException, WrongReferenceAttributeValueException, WrongAttributeValueException {
+		Utils.checkPerunSession(sess);
+		getPerunBl().getUsersManagerBl().checkUserExists(sess, user);
+
+		// Authorization
+		if (!AuthzResolver.authorizedInternal(sess, "validatePreferredEmailChange_User_String_policy", user)) {
+			throw new PrivilegeException(sess, "validatePreferredEmailChange");
+		}
+
+		return getPerunBl().getUsersManagerBl().validatePreferredEmailChange(sess, user, token);
+	}
+
+	@Override
 	public List<String> getPendingPreferredEmailChanges(PerunSession sess, User user) throws PrivilegeException, UserNotExistsException, WrongAttributeAssignmentException, AttributeNotExistsException {
 
 		Utils.checkPerunSession(sess);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Utils.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Utils.java
@@ -1001,17 +1001,16 @@ public class Utils {
 
 	/**
 	 * Send validation email related to requested change of users preferred email.
-	 *
 	 * @param user user to change preferred email for
 	 * @param url base URL of running perun instance passed from RPC
 	 * @param email new email address to send notification to
-	 * @param changeId ID of change request in DB
+	 * @param changeUuid UUID of change request in DB
 	 * @param subject Template subject or null
 	 * @param content Template message or null
 	 * @param customUrlPath custom path to be used in generated URL
 	 * @param idp Authentication to be added as query parameter in generated URL
 	 */
-	public static void sendValidationEmail(User user, String url, String email, int changeId, String subject, String content, String customUrlPath, String idp) {
+	public static void sendValidationEmail(User user, String url, String email, UUID changeUuid, String subject, String content, String customUrlPath, String idp) {
 		String instanceName = BeansUtils.getCoreConfig().getInstanceName();
 
 		// use default if unknown rpc path
@@ -1044,7 +1043,7 @@ public class Utils {
 		} catch (MalformedURLException ex) {
 			throw new InternalErrorException("Not valid URL of running Perun instance.", ex);
 		}
-		String validationLink = prepareValidationLinkForEmailChange(url, linkLocation, changeId, user, idp);
+		String validationLink = prepareValidationLinkForEmailChange(url, linkLocation, changeUuid, user, idp);
 
 		String defaultSubject = "["+instanceName+"] New email address verification";
 		String defaultBody = "Dear "+user.getDisplayName()+",\n\nWe've received request to change your preferred email address to: "+email+"."+
@@ -1406,20 +1405,16 @@ public class Utils {
 	 *
 	 * @param url base URL of Perun instance
 	 * @param linkLocation location of validation link under specific Perun instance (for example '/non/pwd-reset/')
-	 * @param changeId ID of request
+	 * @param changeUuid UUID of request
 	 * @param user user to who link will be send
 	 * @param idp authentication method for query parameter
 	 *
 	 * @return link of validation as String
 	 */
-	private static String prepareValidationLinkForEmailChange(String url, String linkLocation, int changeId, User user, String idp) {
+	private static String prepareValidationLinkForEmailChange(String url, String linkLocation, UUID changeUuid, User user, String idp) {
 		notNull(user, "user");
 		notNull(url, "url");
 		notNull(linkLocation, "linkLocation");
-
-		// prepare arguments
-		String i = Integer.toString(changeId, Character.MAX_RADIX);
-		String m = Utils.getMessageAuthenticationCode(i);
 
 		StringBuilder link = new StringBuilder();
 
@@ -1430,10 +1425,8 @@ public class Utils {
 			link.append("://");
 			link.append(urlObject.getHost());
 			link.append(linkLocation);
-			link.append("?i=");
-			link.append(URLEncoder.encode(i, StandardCharsets.UTF_8));
-			link.append("&m=");
-			link.append(URLEncoder.encode(m, StandardCharsets.UTF_8));
+			link.append("?token=");
+			link.append(URLEncoder.encode(changeUuid.toString(), StandardCharsets.UTF_8));
 			link.append("&u=" + user.getId());
 			if (isNotBlank(idp)) {
 				link.append("&idpFilter=");

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/UsersManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/UsersManagerImplApi.java
@@ -680,9 +680,9 @@ public interface UsersManagerImplApi {
 	 * @param user
 	 * @param email
 	 * @throws InternalErrorException
-	 * @return ID of change request
+	 * @return UUID of change request
 	 */
-	int requestPreferredEmailChange(PerunSession sess, User user, String email);
+	UUID requestPreferredEmailChange(PerunSession sess, User user, String email);
 
 	/**
 	 * Get new preferred email value from user's original request
@@ -695,6 +695,17 @@ public interface UsersManagerImplApi {
 	 * @return String return new preferred email
 	 */
 	String getPreferredEmailChangeRequest(PerunSession sess, User user, String i, String m);
+
+	/**
+	 * Get new preferred email value from user's original request
+	 *
+	 * @param sess PerunSession
+	 * @param user User to get new email address for
+	 * @param uuid UUID of the email change request
+	 * @throws InternalErrorException
+	 * @return String return new preferred email
+	 */
+	String getPreferredEmailChangeRequest(PerunSession sess, User user, UUID uuid);
 
 	/**
 	 * Removes all mail change requests related to user.

--- a/perun-core/src/main/resources/postgresChangelog.txt
+++ b/perun-core/src/main/resources/postgresChangelog.txt
@@ -6,6 +6,10 @@
 -- Directly under version number should be version commands. They will be executed in the order they are written here.
 -- Comments are prefixed with -- and can be written only between version blocks, that means not in the lines with commands. They have to be at the start of the line.
 
+3.1.81
+ALTER TABLE mailchange ADD COLUMN uu_id uuid not null default gen_random_uuid();
+UPDATE configurations SET value='3.1.81' WHERE property='DATABASE VERSION';
+
 3.1.80
 alter table groups_to_register drop constraint grpreg_group_fk;
 alter table groups_to_register add constraint grpreg_group_fk foreign key (group_id) references groups(id) on delete cascade;

--- a/perun-db/postgres.sql
+++ b/perun-db/postgres.sql
@@ -1,4 +1,4 @@
--- database version 3.1.80 (don't forget to update insert statement at the end of file)
+-- database version 3.1.81 (don't forget to update insert statement at the end of file)
 
 -- VOS - virtual organizations
 create table vos (
@@ -1267,6 +1267,7 @@ create table configurations (
 -- MAILCHANGE - allow to user to change mail address, temporairly saved mails during change is in progress
 create table mailchange (
 	id integer not null,
+	uu_id uuid not null default gen_random_uuid(),
 	value text not null,      --
 	user_id integer not null, --identifier of user (users.id)
 	created_at timestamp default statement_timestamp() not null,
@@ -1766,7 +1767,7 @@ grant all on members_sponsored to perun;
 grant all on groups_to_register to perun;
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.1.80');
+insert into configurations values ('DATABASE VERSION','3.1.81');
 
 -- insert membership types
 insert into membership_types (id, membership_type, description) values (1, 'DIRECT', 'Member is directly added into group');

--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -8053,6 +8053,21 @@ paths:
         default:
           $ref: '#/components/responses/ExceptionResponse'
 
+  /urlinjsonout/usersManager/validatePreferredEmailChange/token:
+    post:
+      tags:
+        - UsersManager
+      operationId: validatePreferredEmailChangeWithToken
+      summary: Validate new preferred email address. Request to validate is determined based on token parameter sent in email notice by requestPreferredEmailChange() method.
+      parameters:
+        - { name: token, description: "token for the email change request", schema: { type: string }, in: query, required: true }
+        - { name: u, description: "id of user you want to validate preferred email request", schema: { type: integer }, in: query, required: true }
+      responses:
+        '200':
+          $ref: '#/components/responses/StringResponse'
+        default:
+          $ref: '#/components/responses/ExceptionResponse'
+
   /json/usersManager/getPendingPreferredEmailChanges:
     get:
       tags:

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/UsersManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/UsersManagerMethod.java
@@ -1340,9 +1340,22 @@ public enum UsersManagerMethod implements ManagerMethod {
 	 * Validate new preferred email address.
 	 *
 	 * Request to validate is determined based
+	 * on token parameter sent in email notice
+	 * by requestPreferredEmailChange() method.
+	 *
+	 * @param token String token for the email change request to validate
+	 * @param u int <code>id</code> of user you want to validate preferred email request
+	 *
+	 * @return String new validated email address
+	 */
+	/*#
+	 * Validate new preferred email address.
+	 *
+	 * Request to validate is determined based
 	 * on encrypted parameters sent in email notice
 	 * by requestPreferredEmailChange() method.
 	 *
+	 * @deprecated
 	 * @param i String encrypted request parameter
 	 * @param m String encrypted request parameter
 	 * @param u int <code>id</code> of user you want to validate preferred email request
@@ -1352,12 +1365,20 @@ public enum UsersManagerMethod implements ManagerMethod {
 	validatePreferredEmailChange {
 		@Override
 		public String call(ApiCaller ac, Deserializer parms) throws PerunException {
+			parms.stateChangingCheck();
 
-			return ac.getUsersManager().validatePreferredEmailChange(ac.getSession(),
+			if (parms.contains("token")) {
+				return ac.getUsersManager().validatePreferredEmailChange(ac.getSession(),
+					ac.getUserById(parms.readInt("u")),
+					parms.readString("token"));
+			} else if (parms.contains("i") && parms.contains("m")) {
+				return ac.getUsersManager().validatePreferredEmailChange(ac.getSession(),
 					ac.getUserById(parms.readInt("u")),
 					parms.readString("i"),
 					parms.readString("m"));
-
+			} else {
+				throw new RpcException(RpcException.Type.MISSING_VALUE, "token or (i and m)");
+			}
 		}
 	},
 


### PR DESCRIPTION
- Email change link used to contain parameters "i" and "m".
- Now, newly created email change links contain parameter "token" which
represents UUID of the email change request.
- Already existing links with parameters "i" and "m" can still be used
for email change validation.