### PR TITLE
fix(core): fix generating of email validation links

### DIFF
--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/UsersManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/UsersManagerMethod.java
@@ -1320,7 +1320,9 @@ public enum UsersManagerMethod implements ManagerMethod {
 					throw new RpcException(RpcException.Type.INVALID_URL, "Invalid custom verification link.");
 				}
 				referer = customUrl;
-				customPath = url.getPath();
+				if (customPath == null) {
+					customPath = url.getPath();
+				}
 			}
 
 			ac.getUsersManager().requestPreferredEmailChange(ac.getSession(),


### PR DESCRIPTION
* When the client provided to the API customUrl together with customPath, the customPath was ignored
and the path was taken from the url.