### PR TITLE
GUI: Disable checkboxes for read only boolean attributes

### DIFF
--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/widgets/cells/PerunAttributeValueCell.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/widgets/cells/PerunAttributeValueCell.java
@@ -473,7 +473,7 @@ public class PerunAttributeValueCell extends AbstractSafeHtmlCell<Attribute> {
 		if (writable) {
 			return "<input type=\"checkbox\" class=\"checkbox-value gwt-CheckBox\" " + value + " />";
 		} else {
-			return "<input title=\"" + WidgetTranslation.INSTANCE.notWritable() + "\" readonly type=\"checkbox\" class=\"checkbox-value gwt-CheckBox gwt-CheckBox-readonly\" " + value + " />";
+			return "<input title=\"" + WidgetTranslation.INSTANCE.notWritable() + "\" readonly disabled=\"disabled\" type=\"checkbox\" class=\"checkbox-value gwt-CheckBox gwt-CheckBox-readonly\" " + value + " />";
 		}
 
 	}


### PR DESCRIPTION
- User was able to change checked/un-checked state of checkbox
  for boolean attributes even if it wasn't writable attribute.
- Added "disabled" property to the generated HTML for checkbox.