### PR TITLE
Fixed subgroup statuses in group members page 

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/MembersPageQuery.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/MembersPageQuery.java
@@ -14,6 +14,8 @@ public class MembersPageQuery {
 	private MembersOrderColumn sortColumn;
 	private String searchString = "";
 	private List<Status> statuses;
+	private Group group;
+	private List<MemberGroupStatus> groupStatuses;
 
 	public MembersPageQuery() { }
 	public MembersPageQuery(int pageSize, int offset, SortingOrder sortingOrder, MembersOrderColumn sortColumn) {
@@ -46,6 +48,17 @@ public class MembersPageQuery {
 		this.order = sortingOrder;
 		this.sortColumn = sortColumn;
 		this.statuses = statuses;
+	}
+
+	public MembersPageQuery(int pageSize, int offset, SortingOrder order, MembersOrderColumn sortColumn, String searchString, List<Status> statuses, Group group, List<MemberGroupStatus> groupStatuses) {
+		this.pageSize = pageSize;
+		this.offset = offset;
+		this.order = order;
+		this.sortColumn = sortColumn;
+		this.searchString = searchString;
+		this.statuses = statuses;
+		this.group = group;
+		this.groupStatuses = groupStatuses;
 	}
 
 	public int getPageSize() {
@@ -96,6 +109,22 @@ public class MembersPageQuery {
 		this.statuses = statuses;
 	}
 
+	public Group getGroup() {
+		return group;
+	}
+
+	public void setGroup(Group group) {
+		this.group = group;
+	}
+
+	public List<MemberGroupStatus> getGroupStatuses() {
+		return groupStatuses;
+	}
+
+	public void setGroupStatuses(List<MemberGroupStatus> groupStatuses) {
+		this.groupStatuses = groupStatuses;
+	}
+
 	@Override
 	public boolean equals(Object o) {
 		if (this == o) return true;
@@ -108,6 +137,8 @@ public class MembersPageQuery {
 		if (getOrder() != that.getOrder()) return false;
 		if (getSortColumn() != that.getSortColumn()) return false;
 		if (!getSearchString().equals(that.getSearchString())) return false;
+		if (getGroup() != that.getGroup()) return false;
+		if (getGroupStatuses() != that.getGroupStatuses()) return false;
 		return getStatuses() != that.getStatuses();
 	}
 
@@ -119,6 +150,8 @@ public class MembersPageQuery {
 		result = 31 * result + (getSortColumn() != null ? getSortColumn().hashCode() : 0);
 		result = 31 * result + (getSearchString() != null ? getSearchString().hashCode() : 0);
 		result = 31 * result + (getStatuses() != null ? getStatuses().hashCode() : 0);
+		result = 31 * result + (getGroup() != null ? getGroup().hashCode() : 0);
+		result = 31 * result + (getGroupStatuses() != null ? getGroupStatuses().hashCode() : 0);
 		return result;
 	}
 }

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/MembersPageQuery.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/MembersPageQuery.java
@@ -1,6 +1,7 @@
 package cz.metacentrum.perun.core.api;
 
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Class representing a query requesting a specific page of members.
@@ -14,7 +15,7 @@ public class MembersPageQuery {
 	private MembersOrderColumn sortColumn;
 	private String searchString = "";
 	private List<Status> statuses;
-	private Group group;
+	private Integer groupId;
 	private List<MemberGroupStatus> groupStatuses;
 
 	public MembersPageQuery() { }
@@ -50,14 +51,14 @@ public class MembersPageQuery {
 		this.statuses = statuses;
 	}
 
-	public MembersPageQuery(int pageSize, int offset, SortingOrder order, MembersOrderColumn sortColumn, String searchString, List<Status> statuses, Group group, List<MemberGroupStatus> groupStatuses) {
+	public MembersPageQuery(int pageSize, int offset, SortingOrder order, MembersOrderColumn sortColumn, String searchString, List<Status> statuses, Integer groupId, List<MemberGroupStatus> groupStatuses) {
 		this.pageSize = pageSize;
 		this.offset = offset;
 		this.order = order;
 		this.sortColumn = sortColumn;
 		this.searchString = searchString;
 		this.statuses = statuses;
-		this.group = group;
+		this.groupId = groupId;
 		this.groupStatuses = groupStatuses;
 	}
 
@@ -109,12 +110,12 @@ public class MembersPageQuery {
 		this.statuses = statuses;
 	}
 
-	public Group getGroup() {
-		return group;
+	public Integer getGroupId() {
+		return groupId;
 	}
 
-	public void setGroup(Group group) {
-		this.group = group;
+	public void setGroupId(Integer groupId) {
+		this.groupId = groupId;
 	}
 
 	public List<MemberGroupStatus> getGroupStatuses() {
@@ -137,7 +138,7 @@ public class MembersPageQuery {
 		if (getOrder() != that.getOrder()) return false;
 		if (getSortColumn() != that.getSortColumn()) return false;
 		if (!getSearchString().equals(that.getSearchString())) return false;
-		if (getGroup() != that.getGroup()) return false;
+		if (!Objects.equals(getGroupId(), that.getGroupId())) return false;
 		if (getGroupStatuses() != that.getGroupStatuses()) return false;
 		return getStatuses() != that.getStatuses();
 	}
@@ -150,7 +151,7 @@ public class MembersPageQuery {
 		result = 31 * result + (getSortColumn() != null ? getSortColumn().hashCode() : 0);
 		result = 31 * result + (getSearchString() != null ? getSearchString().hashCode() : 0);
 		result = 31 * result + (getStatuses() != null ? getStatuses().hashCode() : 0);
-		result = 31 * result + (getGroup() != null ? getGroup().hashCode() : 0);
+		result = 31 * result + (getGroupId() != null ? getGroupId().hashCode() : 0);
 		result = 31 * result + (getGroupStatuses() != null ? getGroupStatuses().hashCode() : 0);
 		return result;
 	}

--- a/perun-base/src/main/resources/perun-roles.yml
+++ b/perun-base/src/main/resources/perun-roles.yml
@@ -2843,6 +2843,13 @@ perun_policies:
     include_policies:
       - default_policy
 
+  group-getMembersPage_Vo_MembersPageQuery_List<String>_policy:
+    policy_roles:
+      - GROUPADMIN: Group
+      - GROUPOBSERVER: Group
+    include_policies:
+      - default_policy
+
   updateSponsorshipValidity_Member_User_LocalDate:
     policy_roles:
       - VOADMIN: Vo

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/MembersManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/MembersManager.java
@@ -1420,9 +1420,10 @@ public interface MembersManager {
 	 * @param attrNames attribute names
 	 * @return page of requested rich members
 	 * @throws VoNotExistsException if there is no such vo
+	 * @throws GroupNotExistsException if there is no such query group
 	 * @throws PrivilegeException insufficient permission
 	 */
-	Paginated<RichMember> getMembersPage(PerunSession sess, Vo vo, MembersPageQuery query, List<String> attrNames) throws VoNotExistsException, PrivilegeException;
+	Paginated<RichMember> getMembersPage(PerunSession sess, Vo vo, MembersPageQuery query, List<String> attrNames) throws VoNotExistsException, PrivilegeException, GroupNotExistsException;
 
 	/**
 	 * Update the sponsorship of given member for given sponsor.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/MembersManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/MembersManagerEntry.java
@@ -1569,7 +1569,8 @@ public class MembersManagerEntry implements MembersManager {
 		Utils.checkPerunSession(sess);
 		perunBl.getVosManagerBl().checkVoExists(sess, vo);
 
-		if (!AuthzResolver.authorizedInternal(sess, "getMembersPage_Vo_MembersPageQuery_List<String>_policy", vo)) {
+		if (!AuthzResolver.authorizedInternal(sess, "getMembersPage_Vo_MembersPageQuery_List<String>_policy", vo)
+			&& (query.getGroup() != null && !AuthzResolver.authorizedInternal(sess, "group-getMembersPage_Vo_MembersPageQuery_List<String>_policy", query.getGroup()))) {
 			throw new PrivilegeException(sess, "getMembersPage");
 		}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/MembersManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/MembersManagerEntry.java
@@ -1570,7 +1570,7 @@ public class MembersManagerEntry implements MembersManager {
 		perunBl.getVosManagerBl().checkVoExists(sess, vo);
 
 		if (!AuthzResolver.authorizedInternal(sess, "getMembersPage_Vo_MembersPageQuery_List<String>_policy", vo)
-			&& (query.getGroup() != null && !AuthzResolver.authorizedInternal(sess, "group-getMembersPage_Vo_MembersPageQuery_List<String>_policy", query.getGroup()))) {
+			&& (query.getGroup() == null || !AuthzResolver.authorizedInternal(sess, "group-getMembersPage_Vo_MembersPageQuery_List<String>_policy", query.getGroup()))) {
 			throw new PrivilegeException(sess, "getMembersPage");
 		}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/MembersManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/MembersManagerEntry.java
@@ -1565,12 +1565,14 @@ public class MembersManagerEntry implements MembersManager {
 	}
 
 	@Override
-	public Paginated<RichMember> getMembersPage(PerunSession sess, Vo vo, MembersPageQuery query, List<String> attrNames) throws VoNotExistsException, PrivilegeException {
+	public Paginated<RichMember> getMembersPage(PerunSession sess, Vo vo, MembersPageQuery query, List<String> attrNames) throws VoNotExistsException, PrivilegeException, GroupNotExistsException {
 		Utils.checkPerunSession(sess);
 		perunBl.getVosManagerBl().checkVoExists(sess, vo);
 
 		if (!AuthzResolver.authorizedInternal(sess, "getMembersPage_Vo_MembersPageQuery_List<String>_policy", vo)
-			&& (query.getGroup() == null || !AuthzResolver.authorizedInternal(sess, "group-getMembersPage_Vo_MembersPageQuery_List<String>_policy", query.getGroup()))) {
+			&& (query.getGroupId() == null ||
+				!AuthzResolver.authorizedInternal(sess, "group-getMembersPage_Vo_MembersPageQuery_List<String>_policy",
+				perunBl.getGroupsManagerBl().getGroupById(sess, query.getGroupId())))) {
 			throw new PrivilegeException(sess, "getMembersPage");
 		}
 

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/MembersManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/MembersManagerEntryIntegrationTest.java
@@ -18,6 +18,7 @@ import cz.metacentrum.perun.core.api.MemberGroupStatus;
 import cz.metacentrum.perun.core.api.MemberWithSponsors;
 import cz.metacentrum.perun.core.api.MembersManager;
 import cz.metacentrum.perun.core.api.MembersOrderColumn;
+import cz.metacentrum.perun.core.api.MembershipType;
 import cz.metacentrum.perun.core.api.NamespaceRules;
 import cz.metacentrum.perun.core.api.SortingOrder;
 import cz.metacentrum.perun.core.api.Paginated;
@@ -2765,7 +2766,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 		perun.getGroupsManager().addMember(sess, group, member1);
 		perun.getGroupsManager().addMember(sess, group, member3);
 
-		MembersPageQuery query = new MembersPageQuery(3, 0, SortingOrder.ASCENDING, MembersOrderColumn.NAME, "doe", List.of(), group, List.of());
+		MembersPageQuery query = new MembersPageQuery(3, 0, SortingOrder.ASCENDING, MembersOrderColumn.NAME, "doe", List.of(), group.getId(), List.of());
 
 		Paginated<RichMember> result = perun.getMembersManager().getMembersPage(sess, vo, query, List.of());
 		List<Integer> returnedMemberIds = result.getData().stream()
@@ -2774,6 +2775,8 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 
 		assertThat(returnedMemberIds)
 			.containsExactly(member3.getId(), member1.getId());
+		assertThat(result.getData().get(0).getMembershipType())
+			.isEqualTo(MembershipType.DIRECT);
 
 		query.setSearchString("barn");
 
@@ -2804,7 +2807,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 		perun.getGroupsManager().setMemberGroupStatus(sess, member1, group, MemberGroupStatus.VALID);
 		perun.getGroupsManager().setMemberGroupStatus(sess, member2, group, MemberGroupStatus.EXPIRED);
 
-		MembersPageQuery query = new MembersPageQuery(3, 0, SortingOrder.ASCENDING, MembersOrderColumn.NAME, "", List.of(), group, List.of(MemberGroupStatus.VALID));
+		MembersPageQuery query = new MembersPageQuery(3, 0, SortingOrder.ASCENDING, MembersOrderColumn.NAME, "", List.of(), group.getId(), List.of(MemberGroupStatus.VALID));
 
 		Paginated<RichMember> result = perun.getMembersManager().getMembersPage(sess, vo, query, List.of());
 		List<Integer> returnedMemberIds = result.getData().stream()
@@ -2813,6 +2816,8 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 
 		assertThat(returnedMemberIds)
 			.containsExactly(member1.getId());
+		assertThat(result.getData().get(0).getMembershipType())
+			.isEqualTo(MembershipType.DIRECT);
 
 		query.setGroupStatuses(List.of(MemberGroupStatus.EXPIRED));
 
@@ -2824,6 +2829,56 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 
 		assertThat(returnedMemberIds)
 			.containsExactly(member2.getId());
+		assertThat(result.getData().get(0).getMembershipType())
+			.isEqualTo(MembershipType.DIRECT);
+	}
+
+	@Test
+	public void getGroupMembersPageOnDifferentSubgroupStatuses() throws Exception {
+		System.out.println(CLASS_NAME + "getGroupMembersPageOnDifferentSubgroupStatuses");
+
+		Vo vo = perun.getVosManager().createVo(sess, new Vo(0, "testPagination", "tp"));
+
+		Group group = perun.getGroupsManager().createGroup(sess, vo, new Group("test", "testPaginationInGroup"));
+		Group subgroup = perun.getGroupsManager().createGroup(sess, group, new Group("subgroup", "testPaginationInSubGroup"));
+
+		Member member1 = setUpMember(vo, "Doe", "John");
+		Member member2 = setUpMember(vo, "Stinson", "Barney");
+		Member member3 = setUpMember(vo, "Wo", "Jane");
+
+		perun.getGroupsManager().addMember(sess, group, member1);
+		perun.getGroupsManager().addMember(sess, subgroup, member1);
+		perun.getGroupsManager().addMember(sess, group, member2);
+		perun.getGroupsManager().addMember(sess, subgroup, member2);
+		perun.getGroupsManager().addMember(sess, subgroup, member3);
+
+		perun.getGroupsManager().setMemberGroupStatus(sess, member1, group, MemberGroupStatus.VALID);
+		perun.getGroupsManager().setMemberGroupStatus(sess, member1, subgroup, MemberGroupStatus.EXPIRED);
+		perun.getGroupsManager().setMemberGroupStatus(sess, member2, group, MemberGroupStatus.EXPIRED);
+		perun.getGroupsManager().setMemberGroupStatus(sess, member2, subgroup, MemberGroupStatus.EXPIRED);
+		perun.getGroupsManager().setMemberGroupStatus(sess, member3, subgroup, MemberGroupStatus.VALID);
+
+		MembersPageQuery query = new MembersPageQuery(3, 0, SortingOrder.ASCENDING, MembersOrderColumn.NAME, "", List.of(), group.getId(), List.of(MemberGroupStatus.VALID));
+
+		Paginated<RichMember> result = perun.getMembersManager().getMembersPage(sess, vo, query, List.of());
+		List<Integer> returnedMemberIds = result.getData().stream()
+			.map(PerunBean::getId)
+			.collect(toList());
+
+		assertThat(returnedMemberIds).containsExactly(member1.getId(), member3.getId());
+		assertThat(result.getData().get(0).getMembershipType()).isEqualTo(MembershipType.DIRECT);
+		assertThat(result.getData().get(1).getMembershipType()).isEqualTo(MembershipType.INDIRECT);
+
+		query.setGroupStatuses(List.of(MemberGroupStatus.EXPIRED));
+
+		result = perun.getMembersManager().getMembersPage(sess, vo, query, List.of());
+
+		returnedMemberIds = result.getData().stream()
+			.map(PerunBean::getId)
+			.collect(toList());
+
+		assertThat(returnedMemberIds).containsExactly(member2.getId());
+		assertThat(result.getData().get(0).getMembershipType()).isEqualTo(MembershipType.DIRECT);
 	}
 
 	private Member setUpMember(Vo vo, String lastName, String firstName) throws Exception {

--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -186,6 +186,13 @@ components:
         - ID
         - NAME
 
+    MemberGroupStatus:
+      type: string
+      description: 'statuses of a member in a group'
+      enum:
+        - VALID
+        - EXPIRED
+
     MembersPageQuery:
       properties:
         pageSize: { type: integer }
@@ -194,6 +201,8 @@ components:
         sortColumn: { $ref: '#/components/schemas/MembersOrderColumn' }
         searchString : { type: string }
         statuses: { type: array, items: { $ref: '#/components/schemas/VoMemberStatuses' } }
+        group: { $ref: '#/components/schemas/Group' }
+        groupStatuses: { type: array, items: { $ref: '#/components/schemas/MemberGroupStatus' } }
       required:
         - pageSize
         - offset

--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -201,7 +201,7 @@ components:
         sortColumn: { $ref: '#/components/schemas/MembersOrderColumn' }
         searchString : { type: string }
         statuses: { type: array, items: { $ref: '#/components/schemas/VoMemberStatuses' } }
-        group: { $ref: '#/components/schemas/Group' }
+        groupId: { type: integer }
         groupStatuses: { type: array, items: { $ref: '#/components/schemas/MemberGroupStatus' } }
       required:
         - pageSize

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/MembersManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/MembersManagerMethod.java
@@ -1889,6 +1889,7 @@ public enum MembersManagerMethod implements ManagerMethod {
 	 *
 	 * @return Paginated<RichMember> page of requested rich members
 	 * @throw VoNotExistsException if there is no such vo
+	 * @throw GroupNotExistsException if there is no such query group
 	 */
 	getMembersPage {
 		@Override

--- a/perun-utils/rpc-methods-javadoc-generator/parseRpcMethods.pl
+++ b/perun-utils/rpc-methods-javadoc-generator/parseRpcMethods.pl
@@ -190,7 +190,7 @@ $objectExamples{"MemberWithSponsors"} = "{ \"member\" : " . $objectExamples{"Ric
 $objectExamples{"List&lt;MemberWithSponsors&gt;"} = $listPrepend . $objectExamples{"MemberWithSponsors"} . $listAppend;
 $objectExamples{"List<MemberWithSponsors>"} = $objectExamples{"List&lt;MemberWithSponsors&gt;"};
 
-$objectExamples{"MembersPageQuery"} = "{ \"pageSize\" : 3 , \"offset\" : 0 , \"order\" : \"ASCENDING\" , \"sortColumn\" : \"ID\" , \"searchString\" : \"Doe\" }";
+$objectExamples{"MembersPageQuery"} = "{ \"pageSize\" : 3 , \"offset\" : 0 , \"order\" : \"ASCENDING\" , \"sortColumn\" : \"ID\" , \"searchString\" : \"Doe\" , \"statuses\" : [\"VALID\" , \"EXPIRED\"] , \"groupId\" : 10 , \"groupStatuses\" : [\"VALID\"] }";
 $objectExamples{"List&lt;MembersPageQuery&gt;"} = $listPrepend . $objectExamples{"MembersPageQuery"} . $listAppend;
 $objectExamples{"List<MembersPageQuery>"} = $objectExamples{"List&lt;MembersPageQuery&gt;"};
 


### PR DESCRIPTION
- This is a fix for CESNET/perun/#3220 - page of group members with
selected group status could contain members with wrong status if they
have different status in subgroups. 
- When getting page of group members with selected group status, all
records with the same group_id and member_id in group_members table are
merged into one row. The group status is evaluated as MIN of all the
group statuses since the member is valid (0) in the group if and only if
he is valid in at least one of the groups. Otherwise, he is expired (1).
- Using group members mapping so membership types can be set to returned
members.
- Added test and modified existing tests to check membership types of
members.