### PR TITLE
fix(synchronizations): don't validate expired members

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
@@ -3776,11 +3776,7 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 		}
 
 		// Try to validate member
-		try {
-			getPerunBl().getMembersManagerBl().validateMember(sess, member);
-		} catch (AttributeValueException e) {
-			log.warn("Member id {} will be in INVALID status due to wrong attributes {}.", member.getId(), e);
-		}
+		updateMemberStatus(sess, member);
 	}
 
 	/**


### PR DESCRIPTION
* During synchronization, the main method categorizes the candidates into multiple lists. One list
represents candidates who were not present in the group before synchronization. Members for these
candidates were always validated, even though these members already existed (just weren't members of
the group) and were expired in the vo.
* The fix is to call the `updateMemberStatus()` method only validating
the member directly. This method checks, if the user is expired and
should or shouldn't be validated.
* Note: this method is actually called for the member before he is added
to the group, so it is possible, that the call of the `updateMemberStatus`
could be removed. However, we want to make sure that we didn't forget
about some use-cases when adding the member to the group could change
his status.