### PR TITLE
Merging attributes in structure synchronization

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
@@ -4395,6 +4395,23 @@ public interface AttributesManagerBl {
 	 * If the type is list, new values are added to the current stored list.
 	 * It the type is map, new values are added and existing are overwritten with new values, but only if there is some change.
 	 *
+	 * @param sess
+	 * @param group
+	 * @param attribute
+	 * @return attribute with updated value
+	 * @throws InternalErrorException
+	 * @throws WrongAttributeValueException
+	 * @throws WrongReferenceAttributeValueException
+	 * @throws WrongAttributeAssignmentException
+	 */
+	Attribute mergeAttributeValue(PerunSession sess, Group group, Attribute attribute) throws WrongAttributeValueException,
+			WrongReferenceAttributeValueException, WrongAttributeAssignmentException;
+
+	/**
+	 * Merges attribute value if the attribute type is list or map. In other cases it only stores new value.
+	 * If the type is list, new values are added to the current stored list.
+	 * It the type is map, new values are added and existing are overwritten with new values, but only if there is some change.
+	 *
 	 * This method creates nested transaction to prevent storing value to DB if it throws any exception.
 	 *
 	 * @param sess

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -5528,6 +5528,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	 * Supported namespaces
 	 * - user attributes
 	 * - member attributes
+	 * - group attributes
 	 *
 	 * @param sess session
 	 * @param attribute     attribute to merge it's value if possible
@@ -5553,6 +5554,8 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 				storedAttribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, (User) primaryHolder, attribute.getName());
 			} else if (primaryHolder instanceof Member) {
 				storedAttribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, (Member) primaryHolder, attribute.getName());
+			} else if (primaryHolder instanceof Group) {
+				storedAttribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, (Group) primaryHolder, attribute.getName());
 			} else {
 				throw new InternalErrorException("Primary holder for attribute is not supported: " + primaryHolder);
 			}
@@ -5591,12 +5594,11 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		//Other types as String, Integer, Boolean etc. will be replaced by new value (no way how to merge them properly)
 		if (primaryHolder instanceof User) {
 			getPerunBl().getAttributesManagerBl().setAttribute(sess, (User) primaryHolder, attribute);
-		} else //noinspection ConstantConditions
-			if (primaryHolder instanceof Member) {
-				getPerunBl().getAttributesManagerBl().setAttribute(sess, (Member) primaryHolder, attribute);
-			} else {
-				throw new InternalErrorException("Primary holder for attribute is not supported: " + primaryHolder);
-			}
+		} else if (primaryHolder instanceof Member) {
+			getPerunBl().getAttributesManagerBl().setAttribute(sess, (Member) primaryHolder, attribute);
+		} else {
+			getPerunBl().getAttributesManagerBl().setAttribute(sess, (Group) primaryHolder, attribute);
+		}
 
 		return attribute;
 	}
@@ -5611,6 +5613,12 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	public Attribute mergeAttributeValue(PerunSession sess, Member member, Attribute attribute) throws WrongAttributeValueException,
 			WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
 		return this.mergeAttributeValue(sess, attribute, member);
+	}
+
+	@Override
+	public Attribute mergeAttributeValue(PerunSession sess, Group group, Attribute attribute) throws WrongAttributeValueException,
+			WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+		return this.mergeAttributeValue(sess, attribute, group);
 	}
 
 	@Override


### PR DESCRIPTION
- added support of merging attributes in structure synchronizations
- group attributes are during structure synchronization overwritten by default but if an attribute is in "mergeGroupAttributes" of ext source and its value is map or list, the value is merged instead
- added support of merging group attributes in attributeManager
- also added simple test