### PR TITLE
Core - new methods for activating group-resource assignments

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/GroupResourceStatusException.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/GroupResourceStatusException.java
@@ -1,0 +1,38 @@
+package cz.metacentrum.perun.core.api.exceptions;
+
+/**
+ * This exception is thrown when it is not possible to perform an action on
+ * a group-resource assignment because of its status.
+ *
+ * @author Radoslav Čerhák <r.cerhak@gmail.com>
+ */
+public class GroupResourceStatusException extends PerunException {
+
+	/**
+	 * Simple constructor with a message.
+	 *
+	 * @param message message with details about the cause
+	 */
+	public GroupResourceStatusException(String message) {
+		super(message);
+	}
+
+	/**
+	 * Constructor with a message and Throwable object.
+	 *
+	 * @param message message with details about the cause
+	 * @param cause Throwable that caused throwing of this exception
+	 */
+	public GroupResourceStatusException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	/**
+	 * Constructor with a Throwable object.
+	 *
+	 * @param cause Throwable that caused throwing of this exception
+	 */
+	public GroupResourceStatusException(Throwable cause) {
+		super(cause);
+	}
+}

--- a/perun-base/src/main/resources/perun-roles.yml
+++ b/perun-base/src/main/resources/perun-roles.yml
@@ -3934,6 +3934,28 @@ perun_policies:
     include_policies:
       - default_policy
 
+  activateGroupResourceAssignment_Group_Resource_boolean_policy:
+    policy_roles:
+      - RESOURCEADMIN: Resource
+      - VOADMIN: Vo
+      - RESOURCESELFSERVICE: Resource
+        GROUPADMIN: Group
+      - TRUSTEDFACILITYADMIN: Vo
+        FACILITYADMIN: Facility
+    include_policies:
+      - default_policy
+
+  deactivateGroupResourceAssignment_Group_Resource_policy:
+    policy_roles:
+      - RESOURCEADMIN: Resource
+      - VOADMIN: Vo
+      - RESOURCESELFSERVICE: Resource
+        GROUPADMIN: Group
+      - TRUSTEDFACILITYADMIN: Vo
+        FACILITYADMIN: Facility
+    include_policies:
+      - default_policy
+
   #SearcherEntry
   getUsers_Map<String_String>_policy:
     policy_roles:

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/ResourcesManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/ResourcesManager.java
@@ -9,6 +9,7 @@ import cz.metacentrum.perun.core.api.exceptions.GroupNotAdminException;
 import cz.metacentrum.perun.core.api.exceptions.GroupNotDefinedOnResourceException;
 import cz.metacentrum.perun.core.api.exceptions.GroupNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.GroupResourceMismatchException;
+import cz.metacentrum.perun.core.api.exceptions.GroupResourceStatusException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.MemberNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
@@ -1192,4 +1193,38 @@ public interface ResourcesManager {
 	 * @throws ResourceNotExistsException when the resource doesn't exist
 	 */
 	List<AssignedGroup> getGroupAssignments(PerunSession session, Resource resource, List<String> attrNames) throws PrivilegeException, ResourceNotExistsException;
+
+	/**
+	 * Try to activate the group-resource status. If the async is set to false, the validation is performed
+	 * synchronously. The assignment will be either ACTIVE, in case of a successful synchronous call, or it will be
+	 * PROCESSING in case of an asynchronous call. After the async validation, the state can be either ACTIVE or
+	 * FAILED.
+	 *
+	 * @param session
+	 * @param group group
+	 * @param resource resource
+	 * @param async if true the validation is performed asynchronously
+	 * @throws PrivilegeException insufficient permissions
+	 * @throws GroupNotExistsException when the group doesn't exist
+	 * @throws ResourceNotExistsException when the resource doesn't exist
+	 * @throws WrongAttributeValueException when an attribute value has wrong/illegal syntax
+	 * @throws WrongReferenceAttributeValueException when an attribute value has wrong/illegal semantics
+	 * @throws GroupResourceMismatchException when the given group and resource are not from the same VO
+	 * @throws GroupNotDefinedOnResourceException when the group-resource assignment doesn't exist
+	 */
+	void activateGroupResourceAssignment(PerunSession session, Group group, Resource resource, boolean async) throws ResourceNotExistsException, GroupNotExistsException, PrivilegeException, WrongReferenceAttributeValueException, GroupNotDefinedOnResourceException, GroupResourceMismatchException, WrongAttributeValueException;
+
+	/**
+	 * Deactivates the group-resource assignment. The assignment will become INACTIVE and will not be used to
+	 * allow users from the given group to the resource.
+	 *
+	 * @param group group
+	 * @param resource resource
+	 * @throws PrivilegeException insufficient permissions
+	 * @throws GroupNotExistsException when the group doesn't exist
+	 * @throws ResourceNotExistsException when the resource doesn't exist
+	 * @throws GroupNotDefinedOnResourceException when the group-resource assignment doesn't exist
+	 * @throws GroupResourceStatusException when trying to deactivate an assignment in PROCESSING state
+	 */
+	void deactivateGroupResourceAssignment(PerunSession session, Group group, Resource resource) throws PrivilegeException, ResourceNotExistsException, GroupNotExistsException, GroupNotDefinedOnResourceException, GroupResourceStatusException;
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ResourcesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ResourcesManagerBlImpl.java
@@ -22,6 +22,7 @@ import cz.metacentrum.perun.core.api.BanOnResource;
 import cz.metacentrum.perun.core.api.EnrichedResource;
 import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.GroupResourceStatus;
 import cz.metacentrum.perun.core.api.Member;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.Resource;
@@ -47,6 +48,7 @@ import cz.metacentrum.perun.core.api.exceptions.GroupAlreadyRemovedFromResourceE
 import cz.metacentrum.perun.core.api.exceptions.GroupNotAdminException;
 import cz.metacentrum.perun.core.api.exceptions.GroupNotDefinedOnResourceException;
 import cz.metacentrum.perun.core.api.exceptions.GroupResourceMismatchException;
+import cz.metacentrum.perun.core.api.exceptions.GroupResourceStatusException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.MemberResourceMismatchException;
 import cz.metacentrum.perun.core.api.exceptions.ResourceAlreadyRemovedException;
@@ -70,6 +72,7 @@ import cz.metacentrum.perun.core.bl.ResourcesManagerBl;
 import cz.metacentrum.perun.core.implApi.ResourcesManagerImplApi;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Async;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -1077,6 +1080,93 @@ public class ResourcesManagerBlImpl implements ResourcesManagerBl {
 				.convertToEnrichedGroup(sess, assignedGroup.getEnrichedGroup().getGroup(), attrNames)));
 
 		return assignedGroups;
+	}
+
+	@Override
+	public void activateGroupResourceAssignment(PerunSession sess, Group group, Resource resource, boolean async) throws WrongReferenceAttributeValueException, GroupResourceMismatchException, WrongAttributeValueException, GroupNotDefinedOnResourceException {
+		GroupResourceStatus status = getResourcesManagerImpl().getGroupResourceStatus(sess, group, resource);
+		if (status == GroupResourceStatus.ACTIVE) {
+			// silently skip
+			return;
+		}
+
+		if (async) {
+			getResourcesManagerImpl().setGroupResourceStatus(sess, group, resource, GroupResourceStatus.PROCESSING);
+			getPerunBl().getResourcesManagerBl().processGroupResourceActivationAsync(sess, group, resource);
+		} else {
+			processGroupResourceActivation(sess, group, resource);
+		}
+	}
+
+	@Async
+	@Override
+	public void processGroupResourceActivationAsync(PerunSession sess, Group group, Resource resource) {
+		try {
+			processGroupResourceActivation(sess, group, resource);
+		} catch (Exception e) {
+			log.error("Activation of group-resource assignment failed.", e);
+			try {
+				getResourcesManagerImpl().setGroupResourceStatus(sess, group, resource, GroupResourceStatus.FAILED);
+			} catch (GroupNotDefinedOnResourceException groupNotDefinedOnResourceException) {
+				log.error("Group-resource assignment doesn't exist.", groupNotDefinedOnResourceException);
+			}
+		}
+	}
+
+	/**
+	 * Sets assignment status of given group and resource to ACTIVE. Check if attributes for each member
+	 * from group are valid. Fill members' attributes with missing values.
+	 *
+	 * @param sess session
+	 * @param group group
+	 * @param resource resource
+	 * @throws WrongAttributeValueException when an attribute value has wrong/illegal syntax
+	 * @throws WrongReferenceAttributeValueException when an attribute value has wrong/illegal semantics
+	 * @throws GroupResourceMismatchException when the given group and resource are not from the same VO
+	 * @throws GroupNotDefinedOnResourceException when there is no such group-resource assignment
+	 */
+	private void processGroupResourceActivation(PerunSession sess, Group group, Resource resource) throws GroupResourceMismatchException, WrongReferenceAttributeValueException, WrongAttributeValueException, GroupNotDefinedOnResourceException {
+		getPerunBl().getAttributesManagerBl().checkGroupIsFromTheSameVoLikeResource(sess, group, resource);
+
+		// set status as ACTIVE first because methods checkAttributesSemantics and fillAttribute need active state to work correctly
+		getResourcesManagerImpl().setGroupResourceStatus(sess, group, resource, GroupResourceStatus.ACTIVE);
+
+		// if there are no services, the members are empty and there is nothing more to process
+		if (getAssignedServices(sess, resource).isEmpty()) return;
+
+		// get/fill/set all required group and group-resource attributes
+		try {
+			List<Attribute> attributes = getPerunBl().getAttributesManagerBl().getResourceRequiredAttributes(sess, resource, resource, group, true);
+			attributes = getPerunBl().getAttributesManagerBl().fillAttributes(sess, resource, group, attributes, true);
+			getPerunBl().getAttributesManagerBl().setAttributes(sess, resource, group, attributes, true);
+		} catch (WrongAttributeAssignmentException | GroupResourceMismatchException ex) {
+			throw new ConsistencyErrorException(ex);
+		}
+
+		List<Member> members = getPerunBl().getGroupsManagerBl().getGroupMembersExceptInvalidAndDisabled(sess, group);
+
+		// get all "allowed" group members and get/fill/set required attributes for them
+		Facility facility = getPerunBl().getResourcesManagerBl().getFacility(sess, resource);
+		for (Member member : members) {
+			User user = getPerunBl().getUsersManagerBl().getUserByMember(sess, member);
+			try {
+				getPerunBl().getAttributesManagerBl().setRequiredAttributes(sess, facility, resource, user, member, true);
+			} catch (WrongAttributeAssignmentException | MemberResourceMismatchException | AttributeNotExistsException ex) {
+				throw new ConsistencyErrorException(ex);
+			}
+		}
+
+		// TODO: set and check member-group attributes
+	}
+
+	@Override
+	public void deactivateGroupResourceAssignment(PerunSession sess, Group group, Resource resource) throws GroupNotDefinedOnResourceException, GroupResourceStatusException {
+		GroupResourceStatus status = getResourcesManagerImpl().getGroupResourceStatus(sess, group, resource);
+		if (status == GroupResourceStatus.PROCESSING) {
+			throw new GroupResourceStatusException("Cannot deactivate an assignment in PROCESSING state.");
+		}
+
+		getResourcesManagerImpl().setGroupResourceStatus(sess, group, resource, GroupResourceStatus.INACTIVE);
 	}
 
 	/**

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ResourcesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ResourcesManagerEntry.java
@@ -31,6 +31,7 @@ import cz.metacentrum.perun.core.api.exceptions.GroupNotAdminException;
 import cz.metacentrum.perun.core.api.exceptions.GroupNotDefinedOnResourceException;
 import cz.metacentrum.perun.core.api.exceptions.GroupNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.GroupResourceMismatchException;
+import cz.metacentrum.perun.core.api.exceptions.GroupResourceStatusException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.MemberNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
@@ -1340,6 +1341,34 @@ public class ResourcesManagerEntry implements ResourcesManager {
 			assignedGroup.setEnrichedGroup(getPerunBl().getGroupsManagerBl().filterOnlyAllowedAttributes(sess, assignedGroup.getEnrichedGroup())));
 
 		return filteredGroups;
+	}
+
+	@Override
+	public void activateGroupResourceAssignment(PerunSession sess, Group group, Resource resource, boolean async) throws ResourceNotExistsException, GroupNotExistsException, PrivilegeException, WrongReferenceAttributeValueException, GroupNotDefinedOnResourceException, GroupResourceMismatchException, WrongAttributeValueException {
+		Utils.checkPerunSession(sess);
+		getResourcesManagerBl().checkResourceExists(sess, resource);
+		getPerunBl().getGroupsManagerBl().checkGroupExists(sess, group);
+
+		// Authorization
+		if (!AuthzResolver.authorizedInternal(sess, "activateGroupResourceAssignment_Group_Resource_boolean_policy", group, resource)) {
+			throw new PrivilegeException(sess, "activateGroupResourceAssignment");
+		}
+
+		getResourcesManagerBl().activateGroupResourceAssignment(sess, group, resource, async);
+	}
+
+	@Override
+	public void deactivateGroupResourceAssignment(PerunSession sess, Group group, Resource resource) throws PrivilegeException, ResourceNotExistsException, GroupNotExistsException, GroupNotDefinedOnResourceException, GroupResourceStatusException {
+		Utils.checkPerunSession(sess);
+		getResourcesManagerBl().checkResourceExists(sess, resource);
+		getPerunBl().getGroupsManagerBl().checkGroupExists(sess, group);
+
+		// Authorization
+		if (!AuthzResolver.authorizedInternal(sess, "deactivateGroupResourceAssignment_Group_Resource_policy", group, resource)) {
+			throw new PrivilegeException(sess, "deactivateGroupResourceAssignment");
+		}
+
+		getResourcesManagerBl().deactivateGroupResourceAssignment(sess, group, resource);
 	}
 
 	/**

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ResourcesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ResourcesManagerImpl.java
@@ -24,6 +24,7 @@ import cz.metacentrum.perun.core.api.exceptions.BanNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ConsistencyErrorException;
 import cz.metacentrum.perun.core.api.exceptions.GroupAlreadyAssignedException;
 import cz.metacentrum.perun.core.api.exceptions.GroupAlreadyRemovedFromResourceException;
+import cz.metacentrum.perun.core.api.exceptions.GroupNotDefinedOnResourceException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.ResourceAlreadyRemovedException;
 import cz.metacentrum.perun.core.api.exceptions.ResourceNotExistsException;
@@ -1211,6 +1212,33 @@ public class ResourcesManagerImpl implements ResourcesManagerImplApi {
 			return jdbc.query("select " + GroupsManagerImpl.assignedGroupMappingSelectQuery + " from groups join " +
 					" groups_resources on groups.id=groups_resources.group_id " +
 					" where groups_resources.resource_id=?", GroupsManagerImpl.ASSIGNED_GROUP_MAPPER, resource.getId());
+		} catch (RuntimeException e) {
+			throw new InternalErrorException(e);
+		}
+	}
+
+	@Override
+	public GroupResourceStatus getGroupResourceStatus(PerunSession sess, Group group, Resource resource) throws GroupNotDefinedOnResourceException {
+		try {
+			String status = jdbc.queryForObject("select status from groups_resources where group_id=? and resource_id=?",
+				String.class, group.getId(), resource.getId());
+			return GroupResourceStatus.valueOf(status);
+		} catch (EmptyResultDataAccessException ex) {
+			throw new GroupNotDefinedOnResourceException("Group " + group.getId() + " is not defined on resource " + resource.getId());
+		} catch (RuntimeException e) {
+			throw new InternalErrorException(e);
+		}
+	}
+
+	@Override
+	public void setGroupResourceStatus(PerunSession sess, Group group, Resource resource, GroupResourceStatus status) throws GroupNotDefinedOnResourceException {
+		try {
+			int numAffected = jdbc.update("update groups_resources set status=?::group_resource_status, modified_by=?, modified_by_uid=?, " +
+					" modified_at=statement_timestamp() where group_id=? and resource_id=?", status.toString(),
+				sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getUserId(), group.getId(), resource.getId());
+			if (numAffected == 0) {
+				throw new GroupNotDefinedOnResourceException("Group " + group.getId() + " is not defined on resource " + resource.getId());
+			}
 		} catch (RuntimeException e) {
 			throw new InternalErrorException(e);
 		}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/ResourcesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/ResourcesManagerImplApi.java
@@ -6,6 +6,7 @@ import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.BanOnResource;
 import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.GroupResourceStatus;
 import cz.metacentrum.perun.core.api.Member;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.Resource;
@@ -17,6 +18,7 @@ import cz.metacentrum.perun.core.api.Vo;
 import cz.metacentrum.perun.core.api.exceptions.BanNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.GroupAlreadyAssignedException;
 import cz.metacentrum.perun.core.api.exceptions.GroupAlreadyRemovedFromResourceException;
+import cz.metacentrum.perun.core.api.exceptions.GroupNotDefinedOnResourceException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.ResourceAlreadyRemovedException;
 import cz.metacentrum.perun.core.api.exceptions.ResourceNotExistsException;
@@ -785,4 +787,28 @@ public interface ResourcesManagerImplApi {
 	 * @throws InternalErrorException
 	 */
 	List<AssignedGroup> getGroupAssignments(PerunSession sess, Resource resource);
+
+	/**
+	 * Gets status of given group-resource assignment.
+	 *
+	 * @param sess session
+	 * @param group group
+	 * @param resource resource
+	 * @return assignment status of the given group and resource
+	 * @throws GroupNotDefinedOnResourceException if there is no such group-resource assignment
+	 * @throws InternalErrorException
+	 */
+	GroupResourceStatus getGroupResourceStatus(PerunSession sess, Group group, Resource resource) throws GroupNotDefinedOnResourceException;
+
+	/**
+	 * Sets status of given group-resource assignment to the specified status.
+	 *
+	 * @param sess session
+	 * @param group group
+	 * @param resource resource
+	 * @param status new status of the group-resource assignment
+	 * @throws GroupNotDefinedOnResourceException if there is no such group-resource assignment
+	 * @throws InternalErrorException
+	 */
+	void setGroupResourceStatus(PerunSession sess, Group group, Resource resource, GroupResourceStatus status) throws GroupNotDefinedOnResourceException;
 }

--- a/perun-core/src/main/resources/perun-core.xml
+++ b/perun-core/src/main/resources/perun-core.xml
@@ -5,12 +5,13 @@
 	   xmlns:aop="http://www.springframework.org/schema/aop"
 	   xmlns:jdbc="http://www.springframework.org/schema/jdbc"
 	   xmlns:context="http://www.springframework.org/schema/context"
-	   xsi:schemaLocation="
-	   http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+	   xmlns:task="http://www.springframework.org/schema/task"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd
 http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
 http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc.xsd
-http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd"
+http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
+http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task.xsd"
 >
 
 	<import resource="classpath:perun-base.xml"/>
@@ -30,6 +31,7 @@ http://www.springframework.org/schema/context http://www.springframework.org/sch
 		<aop:advisor advice-ref="txAdviceNestedTransaction" pointcut="execution(* cz.metacentrum.perun.core.blImpl.MembersManagerBlImpl.validateMember(..))"/>
 		<aop:advisor advice-ref="txAdviceNestedTransaction" pointcut="execution(* cz.metacentrum.perun.core.blImpl.MembersManagerBlImpl.expireMember(..))"/>
 		<aop:advisor advice-ref="txAdviceNestedTransaction" pointcut="execution(* cz.metacentrum.perun.core.blImpl.MembersManagerBlImpl.createMemberSync(..))"/>
+		<aop:advisor advice-ref="txAdviceNestedTransaction" pointcut="execution(* cz.metacentrum.perun.core.blImpl.ResourcesManagerBlImpl.processGroupResourceActivationAsync(..))"/>
 		<aop:advisor advice-ref="txAdviceNestedTransaction" pointcut="execution(* cz.metacentrum.perun.core.blImpl.GroupsManagerBlImpl.removeFormerMemberWhileSynchronization(..))"/>
 		<aop:advisor advice-ref="txAdviceNestedTransaction" pointcut="execution(* cz.metacentrum.perun.core.blImpl.GroupsManagerBlImpl.updateExistingMemberWhileSynchronization(..))"/>
 		<aop:advisor advice-ref="txAdviceNestedTransaction" pointcut="execution(* cz.metacentrum.perun.core.blImpl.GroupsManagerBlImpl.addMissingMemberWhileSynchronization(..))"/>
@@ -164,6 +166,10 @@ http://www.springframework.org/schema/context http://www.springframework.org/sch
 			<tx:method name="*" read-only="false" propagation="REQUIRES_NEW"/>
 		</tx:attributes>
 	</tx:advice>
+
+	<!-- Enabling Spring's @Async execution	-->
+	<task:executor id="asyncExecutor" pool-size="10-1000" queue-capacity="1"/>
+	<task:annotation-driven executor="asyncExecutor"/>
 
 	<!--FIXME   a hack which forces Spring to call a static method -->
 	<bean class="cz.metacentrum.perun.core.blImpl.AuthzResolverBlImpl" factory-method="setAuthzResolverImpl" scope="singleton">

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ResourcesManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ResourcesManagerEntryIntegrationTest.java
@@ -2138,6 +2138,93 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 			.isThrownBy(() -> resourcesManager.getGroupAssignments(sess, new Resource(), null));
 	}
 
+	@Test
+	public void activateGroupResourceAssignment() throws Exception {
+		System.out.println(CLASS_NAME + "activateGroupResourceAssignment");
+
+		vo = setUpVo();
+		member = setUpMember(vo);
+		group = setUpGroup(vo, member);
+		facility = setUpFacility();
+		resource = setUpResource();
+
+		resourcesManager.assignGroupToResource(sess, group, resource);
+		resourcesManager.deactivateGroupResourceAssignment(sess, group, resource);
+		resourcesManager.activateGroupResourceAssignment(sess, group, resource, false);
+
+		List<AssignedGroup> groups = resourcesManager.getGroupAssignments(sess, resource, null);
+
+		assertThat(groups.size()).isEqualTo(1);
+		assertThat(groups.get(0).getStatus()).isEqualTo(GroupResourceStatus.ACTIVE);
+	}
+
+	@Test
+	public void activateGroupResourceAssignmentWhenResourceNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "activateGroupResourceAssignmentWhenResourceNotExists");
+
+		vo = setUpVo();
+		member = setUpMember(vo);
+		group = setUpGroup(vo, member);
+
+		assertThatExceptionOfType(ResourceNotExistsException.class)
+			.isThrownBy(() -> resourcesManager.activateGroupResourceAssignment(sess, group, new Resource(), false));
+	}
+
+	@Test
+	public void activateGroupResourceAssignmentWhenGroupNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "activateGroupResourceAssignmentWhenGroupNotExists");
+
+		vo = setUpVo();
+		facility = setUpFacility();
+		resource = setUpResource();
+
+		assertThatExceptionOfType(GroupNotExistsException.class)
+			.isThrownBy(() -> resourcesManager.activateGroupResourceAssignment(sess, new Group(), resource, false));
+	}
+
+	@Test
+	public void deactivateGroupResourceAssignment() throws Exception {
+		System.out.println(CLASS_NAME + "deactivateGroupResourceAssignment");
+
+		vo = setUpVo();
+		member = setUpMember(vo);
+		group = setUpGroup(vo, member);
+		facility = setUpFacility();
+		resource = setUpResource();
+
+		resourcesManager.assignGroupToResource(sess, group, resource);
+		resourcesManager.deactivateGroupResourceAssignment(sess, group, resource);
+
+		List<AssignedGroup> groups = resourcesManager.getGroupAssignments(sess, resource, null);
+
+		assertThat(groups.size()).isEqualTo(1);
+		assertThat(groups.get(0).getStatus()).isEqualTo(GroupResourceStatus.INACTIVE);
+	}
+
+	@Test
+	public void deactivateGroupResourceAssignmentWhenResourceNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "deactivateGroupResourceAssignmentWhenResourceNotExists");
+
+		vo = setUpVo();
+		member = setUpMember(vo);
+		group = setUpGroup(vo, member);
+
+		assertThatExceptionOfType(ResourceNotExistsException.class)
+			.isThrownBy(() -> resourcesManager.deactivateGroupResourceAssignment(sess, group, new Resource()));
+	}
+
+	@Test
+	public void deactivateGroupResourceAssignmentWhenGroupNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "deactivateGroupResourceAssignmentWhenGroupNotExists");
+
+		vo = setUpVo();
+		facility = setUpFacility();
+		resource = setUpResource();
+
+		assertThatExceptionOfType(GroupNotExistsException.class)
+			.isThrownBy(() -> resourcesManager.deactivateGroupResourceAssignment(sess, new Group(), resource));
+	}
+
 	// PRIVATE METHODS -----------------------------------------------------------
 
 	private User setUpUser(String firstName, String lastName) throws Exception {

--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -12151,7 +12151,7 @@ paths:
       summary: Try to activate the group-resource status. If the async is set to false, the validation is performed
           synchronously. The assignment will be either ACTIVE, in case of a sucessfull synchronous call, or it will be
           PROCESSING in case of an asynchronous call. After the async validation, the state can be either ACTIVE or
-          FAILING.
+          FAILED.
       parameters:
         - $ref: '#/components/parameters/groupId'
         - $ref: '#/components/parameters/resourceId'

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/ResourcesManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/ResourcesManagerMethod.java
@@ -1419,5 +1419,55 @@ public enum ResourcesManagerMethod implements ManagerMethod {
 			return ac.getResourcesManager().getGroupAssignments(ac.getSession(),
 				ac.getResourceById(parms.readInt("resource")), attrNames);
 		}
+	},
+
+	/*#
+	 * Try to activate the group-resource status. If the async is set to false, the validation is performed
+	 * synchronously. The assignment will be either ACTIVE, in case of a successful synchronous call, or it will be
+	 * PROCESSING in case of an asynchronous call. After the async validation, the state can be either ACTIVE or
+	 * FAILED.
+	 *
+	 * @param group int Group <code>id</code>
+	 * @param resource int Resource <code>id</code>
+	 * @param async boolean if true the validation is performed asynchronously, default value is false
+	 * @throw GroupNotExistsException when the group doesn't exist
+	 * @throw ResourceNotExistsException when the resource doesn't exist
+	 * @throw WrongAttributeValueException when an attribute value has wrong/illegal syntax
+	 * @throw WrongReferenceAttributeValueException when an attribute value has wrong/illegal semantics
+	 * @throw GroupResourceMismatchException when the given group and resource are not from the same VO
+	 * @throw GroupNotDefinedOnResourceException when the group-resource assignment doesn't exist
+	 */
+	activateGroupResourceAssignment {
+		@Override
+		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
+			ac.getResourcesManager().activateGroupResourceAssignment(ac.getSession(),
+				ac.getGroupById(parms.readInt("group")),
+				ac.getResourceById(parms.readInt("resource")),
+				parms.contains("async") ? parms.readBoolean("async") : false);
+
+			return null;
+		}
+	},
+
+	/*#
+	 * Deactivates the group-resource assignment. The assignment will become INACTIVE and will not be used to
+	 * allow users from the given group to the resource.
+	 *
+	 * @param group int Group <code>id</code>
+	 * @param resource int Resource <code>id</code>
+	 * @throw GroupNotExistsException when the group doesn't exist
+	 * @throw ResourceNotExistsException when the resource doesn't exist
+	 * @throw GroupNotDefinedOnResourceException when the group-resource assignment doesn't exist
+	 * @throw GroupResourceStatusException when trying to deactivate an assignment in PROCESSING state
+	 */
+	deactivateGroupResourceAssignment {
+		@Override
+		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
+			ac.getResourcesManager().deactivateGroupResourceAssignment(ac.getSession(),
+				ac.getGroupById(parms.readInt("group")),
+				ac.getResourceById(parms.readInt("resource")));
+
+			return null;
+		}
 	}
 }


### PR DESCRIPTION
- New methods were added - activateGroupResourceAssignment and
deactivateGroupResourceAssignment with simple tests.
- New public method processGroupResourceActivation was also added to BL
 layer. This method runs in separete transaction so the activation of an assignment can be done asynchronously.
- New methods for getting and setting the group-resource status in DB
were added to impl layer.