### PR TITLE
build(core): Enable M1 support for tests

### DIFF
--- a/perun-base/pom.xml
+++ b/perun-base/pom.xml
@@ -108,6 +108,23 @@
 			<artifactId>jaxb-api</artifactId>
 		</dependency>
 
+
+		<!-- Redefine this dependency as a compile dependency to get tests running -->
+		<!-- This is here just to get a correct JNA version for the testcontainers,
+		     it is possible that this wont be needed in the future versions of testcontainers. -->
+		<dependency>
+			<groupId>com.github.docker-java</groupId>
+			<artifactId>docker-java-api</artifactId>
+			<version>${docker-java.version}</version>
+			<scope>compile</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.github.docker-java</groupId>
+			<artifactId>docker-java-transport-zerodep</artifactId>
+			<version>${docker-java.version}</version>
+			<scope>compile</scope>
+		</dependency>
+
 		<!-- Redefine testcontainers as compile dependency to get tests running for other modules in IDE -->
 		<dependency>
 			<groupId>org.testcontainers</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,7 @@
 		<!-- versions of libraries not defined by the Spring Boot Starter Parent -->
 		<commons-cli.version>1.4</commons-cli.version>
 		<commons-text.version>1.9</commons-text.version>
+		<docker-java.version>3.2.8</docker-java.version>
 		<dumbster.version>1.6</dumbster.version>
 		<expiringmap.version>0.5.9</expiringmap.version>
 		<flying-saucer-pdf.version>9.1.18</flying-saucer-pdf.version>
@@ -327,6 +328,23 @@
 				<groupId>org.reflections</groupId>
 				<artifactId>reflections</artifactId>
 				<version>${reflections.version}</version>
+			</dependency>
+
+			<!-- Define globally as "test" scope so it gets excluded from resulting JARs/WARs -->
+			<!-- Its overridden in base module to get tests running -->
+			<!-- This is here just to get a correct JNA version for the testcontainers,
+			     it is possible that this wont be needed in the future versions of testcontainers. -->
+			<dependency>
+				<groupId>com.github.docker-java</groupId>
+				<artifactId>docker-java-api</artifactId>
+				<version>${docker-java.version}</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>com.github.docker-java</groupId>
+				<artifactId>docker-java-transport-zerodep</artifactId>
+				<version>${docker-java.version}</version>
+				<scope>test</scope>
 			</dependency>
 
 			<!-- Define globally as "test" scope so it gets excluded from resulting JARs/WARs -->


### PR DESCRIPTION
* To run the postgres container on the M1 chip, we need a correct version of JNA 5.8
This version should be set as a dependency of org.testcontainers of version
1.15.3 however, for some reason, it doesn't work. As a fix, we can set the
correct version with the added dependency.
* For more information, see
 https://github.com/testcontainers/testcontainers-java/issues/3610