### PR TITLE
fix(openapi): Remove invalid parameter from method

### DIFF
--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -12136,7 +12136,6 @@ paths:
       parameters:
         - $ref: '#/components/parameters/groupIds'
         - $ref: '#/components/parameters/resourceIds'
-        - $ref: '#/components/parameters/async'
       responses:
         '200':
           $ref: '#/components/responses/VoidResponse'


### PR DESCRIPTION
* The unallowGroupsFromResources had async parameter, which shouldn't be supported for this method.