### PR TITLE
Added attribute modules for o365 sendAs/onBehalf

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ModulesUtilsBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ModulesUtilsBl.java
@@ -4,6 +4,7 @@ import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.Member;
 import cz.metacentrum.perun.core.api.Pair;
 import cz.metacentrum.perun.core.api.PerunBean;
 import cz.metacentrum.perun.core.api.PerunSession;
@@ -534,4 +535,27 @@ public interface ModulesUtilsBl {
 	 * @return found user or null if no user was found
 	 */
 	User getUserByLoginInNamespace(PerunSession sess, String login, String namespace);
+
+	/**
+	 * Calculates value of o365SendAs/o365SendOnBehalf attribute based on values of o365SendAs/o365SendOnBehalf
+	 * member-group attribute and o365SendAsGroups/o365SendOnBehalfGroups group attribute.
+	 *
+	 * @param sess
+	 * @param member member of the group
+	 * @param group parent group
+	 * @param booleanAttribute name of o365SendAs/o365SendOnBehalf attribute
+	 * @param listAttribute name of o365SendAsGroups/o365SendOnBehalfGroups attribute
+	 * @return boolean
+	 */
+	boolean getSendRightFromAttributes(PerunSessionImpl sess, Member member, Group group, String booleanAttribute, String listAttribute);
+
+	/**
+	 * Checks whether all values of attribute are ids of subgroups of group.
+	 *
+	 * @param sess
+	 * @param group parent group
+	 * @param attribute attribute to check
+	 * @throws WrongReferenceAttributeValueException if any value of attribute is not a subgroup id
+	 */
+	void checkAttributeValueIsSubgroupId(PerunSessionImpl sess, Group group, Attribute attribute) throws WrongReferenceAttributeValueException;
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_o365SendAsGroups.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_o365SendAsGroups.java
@@ -1,0 +1,50 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import cz.metacentrum.perun.core.implApi.modules.attributes.GroupAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.GroupAttributesModuleImplApi;
+
+import java.util.ArrayList;
+
+/**
+ * @author Metodej Klang <metodej.klang@gmail.com>
+ */
+public class urn_perun_group_attribute_def_def_o365SendAsGroups extends GroupAttributesModuleAbstract implements GroupAttributesModuleImplApi {
+
+	@Override
+	public void checkAttributeSyntax(PerunSessionImpl sess, Group group, Attribute attribute) throws WrongAttributeValueException {
+		if (attribute.getValue() == null) {
+			return;
+		}
+
+		for (String groupId : attribute.valueAsList()) {
+			try {
+				Integer.valueOf(groupId);
+			} catch (NumberFormatException ex) {
+				throw new WrongAttributeValueException(groupId + " is not a correct subgroup id.");
+			}
+		}
+	}
+
+	@Override
+	public void checkAttributeSemantics(PerunSessionImpl sess, Group group, Attribute attribute) throws WrongReferenceAttributeValueException {
+		sess.getPerunBl().getModulesUtilsBl().checkAttributeValueIsSubgroupId(sess, group, attribute);
+	}
+
+	@Override
+	public AttributeDefinition getAttributeDefinition() {
+		AttributeDefinition attr = new AttributeDefinition();
+		attr.setNamespace(AttributesManager.NS_GROUP_ATTR_DEF);
+		attr.setFriendlyName("o365SendAsGroups");
+		attr.setDisplayName("O365 Send as Groups");
+		attr.setType(ArrayList.class.getName());
+		attr.setDescription("List of subgroups with rights to send as.");
+		return attr;
+	}
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_o365SendOnBehalfGroups.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_o365SendOnBehalfGroups.java
@@ -1,0 +1,50 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import cz.metacentrum.perun.core.implApi.modules.attributes.GroupAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.GroupAttributesModuleImplApi;
+
+import java.util.ArrayList;
+
+/**
+ * @author Metodej Klang <metodej.klang@gmail.com>
+ */
+public class urn_perun_group_attribute_def_def_o365SendOnBehalfGroups extends GroupAttributesModuleAbstract implements GroupAttributesModuleImplApi {
+
+	@Override
+	public void checkAttributeSyntax(PerunSessionImpl sess, Group group, Attribute attribute) throws WrongAttributeValueException {
+		if (attribute.getValue() == null) {
+			return;
+		}
+
+		for (String groupId : attribute.valueAsList()) {
+			try {
+				Integer.valueOf(groupId);
+			} catch (NumberFormatException ex) {
+				throw new WrongAttributeValueException(groupId + " is not a correct subgroup id.");
+			}
+		}
+	}
+
+	@Override
+	public void checkAttributeSemantics(PerunSessionImpl sess, Group group, Attribute attribute) throws WrongReferenceAttributeValueException {
+		sess.getPerunBl().getModulesUtilsBl().checkAttributeValueIsSubgroupId(sess, group, attribute);
+	}
+
+	@Override
+	public AttributeDefinition getAttributeDefinition() {
+		AttributeDefinition attr = new AttributeDefinition();
+		attr.setNamespace(AttributesManager.NS_GROUP_ATTR_DEF);
+		attr.setFriendlyName("o365SendOnBehalfGroups");
+		attr.setDisplayName("O365 Send on behalf of Groups");
+		attr.setType(ArrayList.class.getName());
+		attr.setDescription("List of subgroups with rights to send on behalf of.");
+		return attr;
+	}
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_group_attribute_def_virt_o365SendAs.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_group_attribute_def_virt_o365SendAs.java
@@ -1,0 +1,48 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.Member;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import cz.metacentrum.perun.core.implApi.modules.attributes.MemberGroupVirtualAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.MemberGroupVirtualAttributesModuleImplApi;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Metodej Klang <metodej.klang@gmail.com>
+ */
+public class urn_perun_member_group_attribute_def_virt_o365SendAs extends MemberGroupVirtualAttributesModuleAbstract implements MemberGroupVirtualAttributesModuleImplApi {
+
+	private static final String A_MG_o365SendAs = AttributesManager.NS_MEMBER_GROUP_ATTR_DEF + ":o365SendAs";
+	private static final String A_G_o365SendAsGroups = AttributesManager.NS_GROUP_ATTR_DEF + ":o365SendAsGroups";
+
+	@Override
+	public Attribute getAttributeValue(PerunSessionImpl sess, Member member, Group group, AttributeDefinition attribute) {
+		boolean value = sess.getPerunBl().getModulesUtilsBl().getSendRightFromAttributes(sess, member, group, A_MG_o365SendAs, A_G_o365SendAsGroups);
+
+		return new Attribute(attribute, value);
+	}
+
+	@Override
+	public List<String> getStrongDependencies() {
+		List<String> strongDependencies = new ArrayList<>();
+		strongDependencies.add(A_MG_o365SendAs);
+		strongDependencies.add(A_G_o365SendAsGroups);
+		return strongDependencies;
+	}
+
+	@Override
+	public AttributeDefinition getAttributeDefinition() {
+		AttributeDefinition attr = new AttributeDefinition();
+		attr.setNamespace(AttributesManager.NS_MEMBER_GROUP_ATTR_VIRT);
+		attr.setFriendlyName("o365SendAs");
+		attr.setDisplayName("O365 Send as");
+		attr.setType(Boolean.class.getName());
+		attr.setDescription("Whether member has a right to send as a group.");
+		return attr;
+	}
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_group_attribute_def_virt_o365SendOnBehalfGroups.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_group_attribute_def_virt_o365SendOnBehalfGroups.java
@@ -1,0 +1,48 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.Member;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import cz.metacentrum.perun.core.implApi.modules.attributes.MemberGroupVirtualAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.MemberGroupVirtualAttributesModuleImplApi;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Metodej Klang <metodej.klang@gmail.com>
+ */
+public class urn_perun_member_group_attribute_def_virt_o365SendOnBehalfGroups extends MemberGroupVirtualAttributesModuleAbstract implements MemberGroupVirtualAttributesModuleImplApi {
+
+	private static final String A_MG_o365SendOnBehalf = AttributesManager.NS_MEMBER_GROUP_ATTR_DEF + ":o365SendOnBehalf";
+	private static final String A_G_o365SendOnBehalfGroups = AttributesManager.NS_GROUP_ATTR_DEF + ":o365SendOnBehalfGroups";
+
+	@Override
+	public Attribute getAttributeValue(PerunSessionImpl sess, Member member, Group group, AttributeDefinition attribute) {
+		boolean value = sess.getPerunBl().getModulesUtilsBl().getSendRightFromAttributes(sess, member, group, A_MG_o365SendOnBehalf, A_G_o365SendOnBehalfGroups);
+
+		return new Attribute(attribute, value);
+	}
+
+	@Override
+	public List<String> getStrongDependencies() {
+		List<String> strongDependencies = new ArrayList<>();
+		strongDependencies.add(A_MG_o365SendOnBehalf);
+		strongDependencies.add(A_G_o365SendOnBehalfGroups);
+		return strongDependencies;
+	}
+
+	@Override
+	public AttributeDefinition getAttributeDefinition() {
+		AttributeDefinition attr = new AttributeDefinition();
+		attr.setNamespace(AttributesManager.NS_MEMBER_GROUP_ATTR_VIRT);
+		attr.setFriendlyName("o365SendOnBehalf");
+		attr.setDisplayName("O365 Send on behalf");
+		attr.setType(Boolean.class.getName());
+		attr.setDescription("Whether member has a right to send on behalf of a group.");
+		return attr;
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_o365SendAsGroupsTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_o365SendAsGroupsTest.java
@@ -1,0 +1,60 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.Mockito.mock;
+
+/**
+ * @author Metodej Klang <metodej.klang@gmail.com>
+ */
+public class urn_perun_group_attribute_def_def_o365SendAsGroupsTest {
+
+	private urn_perun_group_attribute_def_def_o365SendAsGroups classInstance;
+	private Attribute attributeToCheck;
+	private Group group = new Group(1,"group1","Group 1",null,null,null,null,0,0);
+	private PerunSessionImpl sess;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_group_attribute_def_def_o365SendAsGroups();
+		sess = mock(PerunSessionImpl.class);
+		attributeToCheck = new Attribute(classInstance.getAttributeDefinition());
+	}
+
+	@Test
+	public void testCheckCorrectSyntax() throws Exception {
+		System.out.println("testCheckCorrectSyntax");
+		List<String> value = new ArrayList<>();
+		value.add("123");
+		attributeToCheck.setValue(value);
+
+		assertThatNoException().isThrownBy(() -> classInstance.checkAttributeSyntax(sess, group, attributeToCheck));
+	}
+
+	@Test
+	public void testCheckCorrectSyntaxNull() throws Exception {
+		System.out.println("testCheckCorrectSyntaxNull");
+		attributeToCheck.setValue(null);
+
+		assertThatNoException().isThrownBy(() -> classInstance.checkAttributeSyntax(sess, group, attributeToCheck));
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckIncorrectSyntaxIdNotNumber() throws Exception {
+		System.out.println("testCheckIncorrectSyntaxIdNotNumber");
+		List<String> value = new ArrayList<>();
+		value.add("ahoj");
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSyntax(sess, group, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_o365SendOnBehalfGroupsTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_o365SendOnBehalfGroupsTest.java
@@ -1,0 +1,60 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.Mockito.mock;
+
+/**
+ * @author Metodej Klang <metodej.klang@gmail.com>
+ */
+public class urn_perun_group_attribute_def_def_o365SendOnBehalfGroupsTest {
+
+	private urn_perun_group_attribute_def_def_o365SendOnBehalfGroups classInstance;
+	private Attribute attributeToCheck;
+	private Group group = new Group(1,"group1","Group 1",null,null,null,null,0,0);
+	private PerunSessionImpl sess;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_group_attribute_def_def_o365SendOnBehalfGroups();
+		sess = mock(PerunSessionImpl.class);
+		attributeToCheck = new Attribute(classInstance.getAttributeDefinition());
+	}
+
+	@Test
+	public void testCheckCorrectSyntax() throws Exception {
+		System.out.println("testCheckCorrectSyntax");
+		List<String> value = new ArrayList<>();
+		value.add("123");
+		attributeToCheck.setValue(value);
+
+		assertThatNoException().isThrownBy(() -> classInstance.checkAttributeSyntax(sess, group, attributeToCheck));
+	}
+
+	@Test
+	public void testCheckCorrectSyntaxNull() throws Exception {
+		System.out.println("testCheckCorrectSyntaxNull");
+		attributeToCheck.setValue(null);
+
+		assertThatNoException().isThrownBy(() -> classInstance.checkAttributeSyntax(sess, group, attributeToCheck));
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckIncorrectSyntaxIdNotNumber() throws Exception {
+		System.out.println("testCheckIncorrectSyntaxIdNotNumber");
+		List<String> value = new ArrayList<>();
+		value.add("ahoj");
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSyntax(sess, group, attributeToCheck);
+	}
+}


### PR DESCRIPTION
- added modules for storing ids of subgroups that check whether there are indeed ids of subgroups stored
- added virtual modules that calculates whether member has right to send as or on behalf of groups
- also added tests for the check and the calculation