### PR TITLE
Removed deprecated methods from UsersManager

### DIFF
--- a/perun-base/src/main/resources/perun-roles.yml
+++ b/perun-base/src/main/resources/perun-roles.yml
@@ -4900,19 +4900,6 @@ perun_policies:
     include_policies:
       - default_policy
 
-  getRichUsersFromListOfUsers_List<User>_policy:
-    policy_roles:
-      - PERUNOBSERVER:
-    include_policies:
-      - default_policy
-
-  getRichUsersWithAttributesFromListOfUsers_List<User>_policy:
-    policy_roles:
-      - ENGINE:
-      - PERUNOBSERVER:
-    include_policies:
-      - default_policy
-
   setSpecificUser_User_SpecificUserType_User_policy:
     policy_roles: []
     include_policies:

--- a/perun-cli/Perun/UsersAgent.pm
+++ b/perun-cli/Perun/UsersAgent.pm
@@ -158,11 +158,6 @@ sub getRichUsersWithAttributesByIds
 	return Perun::Common::callManagerMethod('getRichUsersWithAttributesByIds', '[]RichUser', @_);
 }
 
-sub getRichUsersFromListOfUsersWithAttributes
-{
-	return Perun::Common::callManagerMethod('getRichUsersFromListOfUsersWithAttributes', '[]RichUser', @_);
-}
-
 sub changePassword
 {
 	return Perun::Common::callManagerMethod('changePassword', 'null', @_);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/UsersManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/UsersManager.java
@@ -272,34 +272,6 @@ public interface UsersManager {
 	List<RichUser> getRichUsersWithAttributesByIds(PerunSession sess, List<Integer> ids) throws PrivilegeException, UserNotExistsException;
 
 	/**
-	 * From Users makes RichUsers without attributes.
-	 *
-	 * @deprecated - use getRichUsersByIds
-	 * @param sess
-	 * @param users users to convert
-	 * @return list of richUsers
-	 * @throws InternalErrorException
-	 * @throws PrivilegeException
-	 * @throws UserNotExistsException
-	 */
-	@Deprecated
-	List<RichUser> getRichUsersFromListOfUsers(PerunSession sess, List<User> users) throws PrivilegeException, UserNotExistsException;
-
-	/**
-	 * From Users makes RichUsers with attributes.
-	 *
-	 * @deprecated - use getRichUsersWithAttributesByIds
-	 * @param sess
-	 * @param users users to convert
-	 * @return list of richUsers
-	 * @throws InternalErrorException
-	 * @throws PrivilegeException
-	 * @throws UserNotExistsException
-	 */
-	@Deprecated
-	List<RichUser> getRichUsersWithAttributesFromListOfUsers(PerunSession sess, List<User> users) throws PrivilegeException, UserNotExistsException;
-
-	/**
 	 *  Inserts user into DB.
 	 *
 	 * @param perunSession

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
@@ -338,60 +338,6 @@ public class UsersManagerEntry implements UsersManager {
 
 	@Override
 	@Deprecated
-	public List<RichUser> getRichUsersFromListOfUsers(PerunSession sess, List<User> users) throws PrivilegeException, UserNotExistsException {
-		Utils.checkPerunSession(sess);
-
-		if(users == null || users.isEmpty()) return new ArrayList<>();
-
-		for(User user: users) {
-			getPerunBl().getUsersManagerBl().checkUserExists(sess, user);
-		}
-
-		// Authorization
-		for (User user: users) {
-			if (!AuthzResolver.authorizedInternal(sess, "getRichUsersFromListOfUsers_List<User>_policy", user)) {
-				throw new PrivilegeException(sess, "getRichUsersFromListOfUsers");
-			}
-		}
-
-		List<Integer> userIds = users.stream()
-				.map(User::getId)
-				.collect(Collectors.toList());
-
-		List<User> usersFromDB = getPerunBl().getUsersManagerBl().getUsersByIds(sess, userIds);
-
-		return getPerunBl().getUsersManagerBl().filterOnlyAllowedAttributes(sess, getUsersManagerBl().getRichUsersFromListOfUsers(sess, usersFromDB));
-	}
-
-	@Override
-	@Deprecated
-	public List<RichUser> getRichUsersWithAttributesFromListOfUsers(PerunSession sess, List<User> users) throws PrivilegeException, UserNotExistsException {
-		Utils.checkPerunSession(sess);
-
-		if(users == null || users.isEmpty()) return new ArrayList<>();
-
-		for(User user: users) {
-			getPerunBl().getUsersManagerBl().checkUserExists(sess, user);
-		}
-
-		// Authorization
-		for (User user: users) {
-			if (!AuthzResolver.authorizedInternal(sess, "getRichUsersWithAttributesFromListOfUsers_List<User>_policy", user)) {
-				throw new PrivilegeException(sess, "getRichUsersWithAttributesFromListOfUsers");
-			}
-		}
-
-		List<Integer> userIds = users.stream()
-				.map(User::getId)
-				.collect(Collectors.toList());
-
-		List<User> usersFromDB = getPerunBl().getUsersManagerBl().getUsersByIds(sess, userIds);
-
-		return getPerunBl().getUsersManagerBl().filterOnlyAllowedAttributes(sess, getUsersManagerBl().getRichUsersWithAttributesFromListOfUsers(sess, usersFromDB));
-	}
-
-	@Override
-	@Deprecated
 	public User createUser(PerunSession sess, User user) throws PrivilegeException {
 		Utils.checkPerunSession(sess);
 		Utils.notNull(user, "user");

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/UsersManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/UsersManagerMethod.java
@@ -323,42 +323,6 @@ public enum UsersManagerMethod implements ManagerMethod {
 	},
 
 	/*#
-	 * From Users makes RichUsers without attributes.
-	 *
-	 * @deprecated use getRichUsersByIds
-	 * @param users List<RichUser> users to convert
-	 * @return List<RichUser> list of rich users
-	 */
-	getRichUsersFromListOfUsers {
-
-		@Override
-		public List<RichUser> call(ApiCaller ac, Deserializer parms) throws PerunException {
-			parms.stateChangingCheck();
-
-			return ac.getUsersManager().getRichUsersFromListOfUsers(ac.getSession(),
-					parms.readList("users", User.class));
-		}
-	},
-
-	/*#
-	 * From Users makes RichUsers with attributes.
-	 *
-	 * @deprecated use getRichUsersWithAttributesByIds
-	 * @param users List<RichUser> users to convert
-	 * @return List<RichUser> list of richUsers
-	 */
-	getRichUsersFromListOfUsersWithAttributes {
-
-		@Override
-		public List<RichUser> call(ApiCaller ac, Deserializer parms) throws PerunException {
-			parms.stateChangingCheck();
-
-			return ac.getUsersManager().getRichUsersWithAttributesFromListOfUsers(ac.getSession(),
-					parms.readList("users", User.class));
-		}
-	},
-
-	/*#
 	 * Returns all RichUsers with attributes who are not member of any VO.
 	 *
 	 * @return List<RichUser> list of richUsers who are not member of any VO


### PR DESCRIPTION
- removed methods getRichUsersFromListOfUsers and getRichUsersWithAttributesFromListOfUsers from entry, cli and rpc
- the methods already have alternative using ids instead of user objects