### PR TITLE
fix(registrar): Fix embedded groups item without CS locale

### DIFF
--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
@@ -2601,7 +2601,9 @@ public class RegistrarManagerImpl implements RegistrarManager {
 				.map(group -> group.getId() + "#" + group.getName())
 				.collect(Collectors.joining("|"));
 
-		item.getFormItem().getI18n().get(ApplicationFormItem.CS).setOptions(groupOptions);
+		if (ApplicationFormItem.CS != null) {
+			item.getFormItem().getI18n().get(ApplicationFormItem.CS).setOptions(groupOptions);
+		}
 		item.getFormItem().getI18n().get(ApplicationFormItem.EN).setOptions(groupOptions);
 	}
 


### PR DESCRIPTION
* The code expected the CS locale to be always present. However, on some instances it is not. In that case, the code would throw a null pointer exception because of the CS locale being null.