### PR TITLE
Searching users and members by user UUID

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/UsersManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/UsersManager.java
@@ -633,7 +633,7 @@ public interface UsersManager {
 	List<RichResource> getAssignedRichResources(PerunSession sess, User user) throws UserNotExistsException, PrivilegeException;
 
 	/**
-	 * Returns list of users who matches the searchString, searching name, email, logins.
+	 * Returns list of users who matches the searchString, searching name, id, uuid, email, logins.
 	 *
 	 * @param sess
 	 * @param searchString
@@ -643,7 +643,7 @@ public interface UsersManager {
 	List<User> findUsers(PerunSession sess, String searchString) throws PrivilegeException;
 
 	/**
-	 * Returns list of RichUsers with attributes who matches the searchString, searching name, email, logins.
+	 * Returns list of RichUsers with attributes who matches the searchString, searching name, id, uuid, email, logins.
 	 *
 	 * @param sess
 	 * @param searchString
@@ -1033,7 +1033,7 @@ public interface UsersManager {
 		throws PrivilegeException, UserNotExistsException;
 
 	/**
-	 * Returns list of RichUsers with attributes who matches the searchString, searching name, email, logins.
+	 * Returns list of RichUsers with attributes who matches the searchString, searching name, id, uuid, email, logins.
 	 *
 	 * @param sess
 	 * @param searchString
@@ -1047,7 +1047,7 @@ public interface UsersManager {
 		throws UserNotExistsException, PrivilegeException;
 
 	/**
-	 * Returns list of RichUsers with attributes who matches the searchString, searching name, email, logins.
+	 * Returns list of RichUsers with attributes who matches the searchString, searching name, id, uuid, email, logins.
 	 * Name part is searched for exact match.
 	 *
 	 * @param sess

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/MembersManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/MembersManagerBl.java
@@ -1078,7 +1078,7 @@ public interface MembersManagerBl {
 	List<Member> findMembersInVo(PerunSession sess, Vo vo, String searchString);
 
 	/**
-	 * Return list of rich members by theirs name or login or email under defined VO.
+	 * Return list of rich members by theirs name, id, uuid, login or email under defined VO.
 	 * @param sess
 	 * @param searchString
 	 * @param vo
@@ -1089,7 +1089,7 @@ public interface MembersManagerBl {
 	List<RichMember> findRichMembersInVo(PerunSession sess, Vo vo, String searchString, boolean onlySponsored);
 
 	/**
-	 * Return list of rich members by theirs name or login or email
+	 * Return list of rich members by theirs name, id, uuid, login or email
 	 * @param sess
 	 * @param searchString
 	 * @param onlySponsored return only sponsored members
@@ -1711,7 +1711,7 @@ public interface MembersManagerBl {
 	/**
 	 * Return list of members VO by specific string.
 	 * All searches are case insensitive.
-	 * Looking for searchString in member mail, user preferredMail, logins, name and IDs (user and member).
+	 * Looking for searchString in member mail, user preferredMail, logins, name, IDs (user and member) and user UUID.
 	 * If parameter onlySponsored is true, it will return only sponsored members by searchString.
 	 * If vo is null, looking for any members in whole Perun. If vo is not null, looking only in specific VO.<
 	 *

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
@@ -786,7 +786,7 @@ public interface UsersManagerBl {
 	List<User> getUsersByAttributeValue(PerunSession sess, String attributeName, String attributeValue);
 
 	/**
-	 * Returns list of users' who matches the searchString, searching name, email and logins.
+	 * Returns list of users' who matches the searchString, searching name, id, uuid, email and logins.
 	 *
 	 * @param sess
 	 * @param searchString
@@ -796,7 +796,7 @@ public interface UsersManagerBl {
 	List<User> findUsers(PerunSession sess, String searchString);
 
 	/**
-	 * Returns list of richusers with attributes who matches the searchString, searching name, email, logins.
+	 * Returns list of richusers with attributes who matches the searchString, searching name, id, uuid, email, logins.
 	 *
 	 * @param sess
 	 * @param searchString
@@ -807,7 +807,7 @@ public interface UsersManagerBl {
 	List<RichUser> findRichUsers(PerunSession sess, String searchString) throws UserNotExistsException;
 
 	/**
-	 * Returns list of richusers with attributes who matches the searchString, searching name, email, logins.
+	 * Returns list of richusers with attributes who matches the searchString, searching name, id, uuid, email, logins.
 	 * Name part is searched for exact match.
 	 *
 	 * @param sess
@@ -1241,7 +1241,7 @@ public interface UsersManagerBl {
 	List<RichUser> getRichUsersWithoutVoWithAttributes(PerunSession sess, List<String> attrsName) throws UserNotExistsException;
 
 	/**
-	 * Returns list of RichUsers with selected attributes who matches the searchString, searching name, email, logins.
+	 * Returns list of RichUsers with selected attributes who matches the searchString, searching name, id, uuid, email, logins.
 	 *
 	 * @param sess
 	 * @param searchString
@@ -1253,7 +1253,7 @@ public interface UsersManagerBl {
 	List<RichUser> findRichUsersWithAttributes(PerunSession sess, String searchString, List<String> attrNames) throws UserNotExistsException;
 
 	/**
-	 * Returns list of RichUsers with selected attributes who matches the searchString, searching name, email, logins.
+	 * Returns list of RichUsers with selected attributes who matches the searchString, searching name, id, uuid, email, logins.
 	 * Name part is searched for exact match.
 	 *
 	 * @param sess

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/UsersManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/UsersManagerImpl.java
@@ -848,7 +848,7 @@ public class UsersManagerImpl implements UsersManagerImplApi {
 	}
 
 	/**
-	 * Returns list of users who matches the searchString, searching name, id, member attributes, user attributes
+	 * Returns list of users who matches the searchString, searching name, id, uuid, member attributes, user attributes
 	 * and userExtSource attributes (listed in CoreConfig).
 	 *
 	 * @param searchString string used to search by
@@ -882,11 +882,21 @@ public class UsersManagerImpl implements UsersManagerImplApi {
 
 		MapSqlParameterSource namedParams = Utils.getMapSqlParameterSourceToSearchUsersOrMembers(searchString, attributesToSearchBy);
 
+		String uuidQueryString = "";
+		try {
+			UUID uuid = UUID.fromString(searchString);
+			uuidQueryString = " users.uu_id=:uuid or ";
+			namedParams.addValue("uuid", uuid);
+		} catch (IllegalArgumentException ex) {
+			// IGNORE wrong format of UUID
+		}
+
 		// Search by member attributes
 		// Search by user attributes
 		// Search by login in userExtSources
 		// Search by userExtSource attributes
 		// Search by user id
+		// Search by user uuid
 		// Search by name for user
 		Set<User> users = new HashSet<>(namedParameterJdbcTemplate.query("select distinct " + userMappingSelectQuery +
 			" from users " +
@@ -902,6 +912,7 @@ public class UsersManagerImpl implements UsersManagerImplApi {
 			attributesToSearchByQueries.get("userAttributesQuery").getRight() +
 			attributesToSearchByQueries.get("uesAttributesQuery").getRight() +
 			idQueryString +
+			uuidQueryString +
 			userNameQueryString +
 			" ) ", namedParams, USER_MAPPER));
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/MembersManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/MembersManagerImplApi.java
@@ -381,7 +381,7 @@ public interface MembersManagerImplApi {
 
 	/**
 	 * Return list of members by specific string.
-	 * Looking for searchString in user name, member and user id, member, users and userExtSource attributes specified by perun.properties.
+	 * Looking for searchString in user name, member and user id, user uuid, member, users and userExtSource attributes specified by perun.properties.
 	 * All searches are case insensitive.
 	 * If parameter onlySponsored is true, it will return only sponsored members by searchString.
 	 * If vo is null, looking for any members in whole Perun. If vo is not null, looking only in specific VO.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/UsersManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/UsersManagerImplApi.java
@@ -530,7 +530,7 @@ public interface UsersManagerImplApi {
 	List<Vo> getVosWhereUserIsMember(PerunSession sess, User user);
 
 	/**
-	 * Returns list of users who matches the searchString, searching name, id, member attributes, user attributes
+	 * Returns list of users who matches the searchString, searching name, id, uuid, member attributes, user attributes
 	 * and userExtSource attributes (listed in perun.properties).
 	 *
 	 * @param sess perun session
@@ -540,7 +540,7 @@ public interface UsersManagerImplApi {
 	List<User> findUsers(PerunSession sess, String searchString);
 
 	/**
-	 * Returns list of users who matches the searchString, searching name (exact match), id, member attributes, user attributes
+	 * Returns list of users who matches the searchString, searching name (exact match), id, uuid, member attributes, user attributes
 	 * and userExtSource attributes (listed in perun.properties).
 	 *
 	 * @param sess perun session

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/MembersManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/MembersManagerEntryIntegrationTest.java
@@ -2263,6 +2263,17 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 	}
 
 	@Test
+	public void findMemberByUserUuid() throws Exception {
+		System.out.println(CLASS_NAME + "findMemberByUserUuid");
+
+		Member member = setUpMember(createdVo);
+		User user = perun.getUsersManagerBl().getUserByMember(sess, member);
+
+		List<Member> members = perun.getMembersManagerBl().findMembers(sess, createdVo, user.getUuid().toString(), false);
+		assertThat(members).containsExactly(member);
+	}
+
+	@Test
 	public void removeLastSponsorWithoutExpiration() throws Exception {
 		System.out.println(CLASS_NAME + "removeLastSponsorWithoutExpiration");
 
@@ -2749,6 +2760,27 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 
 		assertThat(returnedMemberIds)
 			.containsExactly(member2.getId());
+	}
+
+	@Test
+	public void getMembersPageBasedOnUserUuidSearchString() throws Exception {
+		System.out.println(CLASS_NAME + "getMembersPageBasedOnUserUuidSearchString");
+
+		Vo vo = perun.getVosManager().createVo(sess, new Vo(0, "testPagination", "tp"));
+
+		Member member1 = setUpMember(vo, "Doe", "John");
+		User user1 = perun.getUsersManager().getUserByMember(sess, member1);
+		Member member2 = setUpMember(vo, "Stinson", "Barney");
+
+		MembersPageQuery query = new MembersPageQuery(3, 0, SortingOrder.ASCENDING, MembersOrderColumn.NAME, user1.getUuid().toString());
+
+		Paginated<RichMember> result = perun.getMembersManager().getMembersPage(sess, vo, query, List.of());
+		List<Integer> returnedMemberIds = result.getData().stream()
+			.map(PerunBean::getId)
+			.collect(toList());
+
+		assertThat(returnedMemberIds)
+			.containsExactly(member1.getId());
 	}
 
 	@Test

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/UsersManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/UsersManagerEntryIntegrationTest.java
@@ -1481,6 +1481,14 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 	}
 
 	@Test
+	public void findUserByUuid() {
+		System.out.println(CLASS_NAME + "findUserByUuid");
+
+		List<User> users = perun.getUsersManagerBl().findUsers(sess, user.getUuid().toString());
+		assertThat(users).containsExactly(user);
+	}
+
+	@Test
 	public void findUserByMemberAttribute() throws Exception {
 		System.out.println(CLASS_NAME + "findUserByMemberAttribute");
 

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/MembersManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/MembersManagerMethod.java
@@ -1899,7 +1899,7 @@ public enum MembersManagerMethod implements ManagerMethod {
 	/*#
 	 * Get page of members from the given vo, with the given attributes.
 	 * Query parameter specifies offset, page size, sorting order, sorting column, statuses in vo and string to search
-	 * members by (by default it searches in names, emails, logins of member or other attributes based on perun
+	 * members by (by default it searches in names, user and member ids, user uuids, emails, logins of member or other attributes based on perun
 	 * configuration), last two parameters are optional and by default it finds all members.
 	 *
 	 * @param vo int Vo <code>id</code>

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/UsersManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/UsersManagerMethod.java
@@ -721,7 +721,7 @@ public enum UsersManagerMethod implements ManagerMethod {
 	},
 
 	/*#
-	 * Returns list of users who matches the searchString, searching name, email, logins.
+	 * Returns list of users who matches the searchString, searching name, id, uuid, email, logins.
 	 *
 	 * @param searchString String String to search by
 	 * @return List<User> Found users
@@ -736,7 +736,7 @@ public enum UsersManagerMethod implements ManagerMethod {
 	},
 
 	/*#
-	 * Returns list of RichUsers with attributes who matches the searchString, searching name, email, logins.
+	 * Returns list of RichUsers with attributes who matches the searchString, searching name, id, uuid, email, logins.
 	 *
 	 * @param searchString String searched string
 	 * @return List<RichUser> list of RichUsers


### PR DESCRIPTION
- Methods findUsers, findMembers and getMembersPage in impl layer can
now search users and members by user UUID search string.
- Simple test were added for each method.
- Javadoc was updated so it mentions that the methods search in user
UUID as well.