### PR TITLE
feat(core): Add ResourceAssignmentActivator component

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/GroupResourceAssignment.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/GroupResourceAssignment.java
@@ -1,0 +1,67 @@
+package cz.metacentrum.perun.core.api;
+
+import java.util.Objects;
+
+/**
+ * Represents group-resource assignment with its status.
+ *
+ * @author Radoslav Čerhák <r.cerhak@gmail.com>
+ */
+public class GroupResourceAssignment {
+	private Group group;
+	private Resource resource;
+	private GroupResourceStatus status;
+
+	public GroupResourceAssignment(Group group, Resource resource, GroupResourceStatus status) {
+		this.group = group;
+		this.resource = resource;
+		this.status = status;
+	}
+
+	public Group getGroup() {
+		return group;
+	}
+
+	public void setGroup(Group group) {
+		this.group = group;
+	}
+
+	public Resource getResource() {
+		return resource;
+	}
+
+	public void setResource(Resource resource) {
+		this.resource = resource;
+	}
+
+	public GroupResourceStatus getStatus() {
+		return status;
+	}
+
+	public void setStatus(GroupResourceStatus status) {
+		this.status = status;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		GroupResourceAssignment that = (GroupResourceAssignment) o;
+		return Objects.equals(getGroup(), that.getGroup()) && Objects.equals(getResource(), that.getResource())
+			&& getStatus() == that.getStatus();
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(getGroup(), getResource(), getStatus());
+	}
+
+	@Override
+	public String toString() {
+		return "GroupResourceAssignment{" +
+			"group=" + group +
+			", resource=" + resource +
+			", status=" + status +
+			'}';
+	}
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ResourcesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ResourcesManagerBl.java
@@ -7,6 +7,8 @@ import cz.metacentrum.perun.core.api.BanOnResource;
 import cz.metacentrum.perun.core.api.EnrichedResource;
 import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.GroupResourceAssignment;
+import cz.metacentrum.perun.core.api.GroupResourceStatus;
 import cz.metacentrum.perun.core.api.Member;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.Resource;
@@ -1187,6 +1189,16 @@ public interface ResourcesManagerBl {
 	 * @return list of assigned groups for given resource with specified attributes
 	 */
 	List<AssignedGroup> getGroupAssignments(PerunSession sess, Resource resource, List<String> attrNames);
+
+	/**
+	 * Lists all group-resource assignments with given statuses. If statuses are empty or null, lists assignments
+	 * with all statuses.
+	 *
+	 * @param sess session
+	 * @param statuses list of allowed statuses
+	 * @return list of group-resource assignments with given statuses
+	 */
+	List<GroupResourceAssignment> getGroupResourceAssignments(PerunSession sess, List<GroupResourceStatus> statuses);
 
 	/**
 	 * Try to activate the group-resource status. If the async is set to false, the validation is performed

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ResourcesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ResourcesManagerBlImpl.java
@@ -21,6 +21,7 @@ import cz.metacentrum.perun.core.api.BanOnResource;
 import cz.metacentrum.perun.core.api.EnrichedResource;
 import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.GroupResourceAssignment;
 import cz.metacentrum.perun.core.api.GroupResourceStatus;
 import cz.metacentrum.perun.core.api.Member;
 import cz.metacentrum.perun.core.api.PerunSession;
@@ -74,11 +75,14 @@ import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.annotation.Async;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import static org.apache.commons.lang3.ObjectUtils.isEmpty;
 
 /**
  *
@@ -1083,6 +1087,15 @@ public class ResourcesManagerBlImpl implements ResourcesManagerBl {
 				.convertToEnrichedGroup(sess, assignedGroup.getEnrichedGroup().getGroup(), attrNames)));
 
 		return assignedGroups;
+	}
+
+	@Override
+	public List<GroupResourceAssignment> getGroupResourceAssignments(PerunSession sess, List<GroupResourceStatus> statuses) {
+		if (isEmpty(statuses)) {
+			statuses = Arrays.asList(GroupResourceStatus.values());
+		}
+
+		return getResourcesManagerImpl().getGroupResourceAssignments(sess, statuses);
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ResourceAssignmentActivator.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ResourceAssignmentActivator.java
@@ -1,0 +1,82 @@
+package cz.metacentrum.perun.core.impl;
+
+import cz.metacentrum.perun.core.api.ExtSourcesManager;
+import cz.metacentrum.perun.core.api.GroupResourceAssignment;
+import cz.metacentrum.perun.core.api.GroupResourceStatus;
+import cz.metacentrum.perun.core.api.PerunClient;
+import cz.metacentrum.perun.core.api.PerunPrincipal;
+import cz.metacentrum.perun.core.api.PerunSession;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.lang.NonNull;
+import org.springframework.scheduling.annotation.Async;
+
+import java.util.List;
+
+/**
+ * Component responsible for activating group-resource assignments in PROCESSING or
+ * FAILED state after Perun startup.
+ *
+ * @author Radoslav Čerhák <r.cerhak@gmail.com>
+ */
+public class ResourceAssignmentActivator implements ApplicationListener<ContextRefreshedEvent> {
+
+	private final static Logger log = LoggerFactory.getLogger(ResourceAssignmentActivator.class);
+
+	private final PerunSession sess;
+	private PerunBl perunBl;
+
+	public ResourceAssignmentActivator(PerunBl perunBl) {
+		this.perunBl = perunBl;
+		this.sess = perunBl.getPerunSession(
+			new PerunPrincipal("perunResourceAssignmentActivator", ExtSourcesManager.EXTSOURCE_NAME_INTERNAL, ExtSourcesManager.EXTSOURCE_INTERNAL),
+			new PerunClient());
+	}
+
+	public PerunBl getPerunBl() {
+		return perunBl;
+	}
+
+	public void setPerunBl(PerunBl perunBl) {
+		this.perunBl = perunBl;
+	}
+
+	/**
+	 * Tries to activate all group-resource assignments in PROCESSING or FAILED state
+	 * after Spring context is refreshed or initialized, e.g. after Perun startup.
+	 *
+	 * This method runs asynchronously so it doesn't block other Spring events.
+	 */
+	@Override
+	@Async
+	public void onApplicationEvent(@NonNull ContextRefreshedEvent contextRefreshedEvent) {
+		activateGroupResourceAssignments();
+	}
+
+	/**
+	 * Tries to activate all group-resource assignments in PROCESSING or FAILED state.
+	 * The activations run synchronously in one thread.
+	 */
+	private void activateGroupResourceAssignments() {
+		try {
+			log.debug("ResourceAssignmentActivator starting to activate group-resource assignments in PROCESSING or FAILED state.");
+
+			List<GroupResourceAssignment> assignments = perunBl.getResourcesManagerBl()
+				.getGroupResourceAssignments(sess, List.of(GroupResourceStatus.PROCESSING, GroupResourceStatus.FAILED));
+
+			for (GroupResourceAssignment assignment : assignments) {
+				try {
+					perunBl.getResourcesManagerBl()
+						.activateGroupResourceAssignment(sess, assignment.getGroup(), assignment.getResource(), false);
+				} catch (Exception e) {
+					log.error("Cannot activate group-resource assignment: " + assignment, e);
+				}
+			}
+		} catch (Exception e) {
+			log.error("Error during activating group-resource assignments: ", e);
+		}
+	}
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/ResourcesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/ResourcesManagerImplApi.java
@@ -6,6 +6,7 @@ import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.BanOnResource;
 import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.GroupResourceAssignment;
 import cz.metacentrum.perun.core.api.GroupResourceStatus;
 import cz.metacentrum.perun.core.api.Member;
 import cz.metacentrum.perun.core.api.PerunSession;
@@ -788,6 +789,17 @@ public interface ResourcesManagerImplApi {
 	 * @throws InternalErrorException
 	 */
 	List<AssignedGroup> getGroupAssignments(PerunSession sess, Resource resource);
+
+	/**
+	 * Lists all group-resource assignments with given statuses. If statuses are empty or null, lists assignments
+	 * with all statuses.
+	 *
+	 * @param sess session
+	 * @param statuses list of allowed statuses
+	 * @return list of group-resource assignments with given statuses
+	 * @throws InternalErrorException
+	 */
+	List<GroupResourceAssignment> getGroupResourceAssignments(PerunSession sess, List<GroupResourceStatus> statuses);
 
 	/**
 	 * Gets status of given group-resource assignment.

--- a/perun-core/src/main/resources/perun-core.xml
+++ b/perun-core/src/main/resources/perun-core.xml
@@ -417,6 +417,10 @@ http://www.springframework.org/schema/task http://www.springframework.org/schema
 		<constructor-arg ref="perun" />
 	</bean>
 
+	<bean id="resourceAssignmentActivator" class="cz.metacentrum.perun.core.impl.ResourceAssignmentActivator" scope="singleton" depends-on="databaseManagerBl">
+		<constructor-arg ref="perun" />
+	</bean>
+
 	<bean class="cz.metacentrum.perun.core.impl.ExtSourceGoogle" factory-method="setPerunBlImpl">
 		<constructor-arg ref="perun" />
 	</bean>

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ResourcesManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ResourcesManagerEntryIntegrationTest.java
@@ -13,6 +13,7 @@ import cz.metacentrum.perun.core.api.EnrichedResource;
 import cz.metacentrum.perun.core.api.ExtSource;
 import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.GroupResourceAssignment;
 import cz.metacentrum.perun.core.api.GroupResourceStatus;
 import cz.metacentrum.perun.core.api.Member;
 import cz.metacentrum.perun.core.api.Resource;
@@ -2137,6 +2138,74 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 
 		assertThatExceptionOfType(ResourceNotExistsException.class)
 			.isThrownBy(() -> resourcesManager.getGroupAssignments(sess, new Resource(), null));
+	}
+
+	@Test
+	public void getGroupResourceAssignmentsReturnsEmptyList() throws Exception {
+		System.out.println(CLASS_NAME + "getGroupResourceAssignmentsReturnsEmptyList");
+
+		List<GroupResourceAssignment> assignments = perun.getResourcesManagerBl()
+			.getGroupResourceAssignments(sess, List.of(GroupResourceStatus.ACTIVE));
+		assertThat(assignments)
+			.isEmpty();
+	}
+
+	@Test
+	public void getGroupResourceAssignmentsWithAllStatuses() throws Exception {
+		System.out.println(CLASS_NAME + "getGroupResourceAssignmentsWithAllStatuses");
+
+		vo = setUpVo();
+		member = setUpMember(vo);
+		group = setUpGroup(vo, member);
+		facility = setUpFacility();
+		resource = setUpResource();
+		Resource resource2 = setUpResource2();
+
+		resourcesManager.assignGroupToResource(sess, group, resource);
+		resourcesManager.assignGroupToResource(sess, group, resource2);
+		resourcesManager.deactivateGroupResourceAssignment(sess, group, resource2);
+
+		GroupResourceAssignment expectedAssignment = new GroupResourceAssignment(group, resource, GroupResourceStatus.ACTIVE);
+		GroupResourceAssignment expectedAssignment2 = new GroupResourceAssignment(group, resource2, GroupResourceStatus.INACTIVE);
+
+		List<GroupResourceAssignment> assignments = perun.getResourcesManagerBl().getGroupResourceAssignments(sess, null);
+		assertThat(assignments)
+			.containsExactlyInAnyOrder(expectedAssignment, expectedAssignment2);
+
+		assignments = perun.getResourcesManagerBl().getGroupResourceAssignments(sess, Collections.emptyList());
+		assertThat(assignments)
+			.containsExactlyInAnyOrder(expectedAssignment, expectedAssignment2);
+
+		assignments = perun.getResourcesManagerBl().getGroupResourceAssignments(sess, Arrays.asList(GroupResourceStatus.values()));
+		assertThat(assignments)
+			.containsExactlyInAnyOrder(expectedAssignment, expectedAssignment2);
+	}
+
+	@Test
+	public void getGroupResourceAssignmentsWithGivenStatus() throws Exception {
+		System.out.println(CLASS_NAME + "getGroupResourceAssignmentsWithGivenStatus");
+
+		vo = setUpVo();
+		member = setUpMember(vo);
+		group = setUpGroup(vo, member);
+		facility = setUpFacility();
+		resource = setUpResource();
+		Resource resource2 = setUpResource2();
+
+		List<GroupResourceAssignment> assignments = perun.getResourcesManagerBl()
+			.getGroupResourceAssignments(sess, List.of(GroupResourceStatus.ACTIVE));
+		assertThat(assignments)
+			.isEmpty();
+
+		resourcesManager.assignGroupToResource(sess, group, resource);
+		resourcesManager.assignGroupToResource(sess, group, resource2);
+		resourcesManager.deactivateGroupResourceAssignment(sess, group, resource2);
+
+		GroupResourceAssignment expectedAssignment = new GroupResourceAssignment(group, resource, GroupResourceStatus.ACTIVE);
+
+		assignments = perun.getResourcesManagerBl().getGroupResourceAssignments(sess, List.of(GroupResourceStatus.ACTIVE));
+		assertThat(assignments)
+			.containsExactly(expectedAssignment);
 	}
 
 	@Test


### PR DESCRIPTION
- New class GroupResourceAssignment was added, it represents a
group-resource assignment with its status.
- New method getGroupResourceAssignments was added and tested, it lists
all group-resource assignments with given statuses.
- ResourceAssignmentActivator component was added. After Perun startup,
the component tries to activate all group-resource assignments in
PROCESSING or FAILED state.