### PR TITLE
feat(core): adjustment for generated passwords for Einfra and MU

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/EinfraPasswordManagerModule.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/EinfraPasswordManagerModule.java
@@ -66,7 +66,7 @@ public class EinfraPasswordManagerModule extends GenericPasswordManagerModule {
 		this.randomPasswordLength = 12;
 
 		// omit chars that can be mistaken by users: iI, oO, l, yY, zZ, 0 (zero), most of spec.chars
-		this.randomPasswordCharacters = "ABCDEFGHJKLMNPQRSTUVWXabcdefghjkmnpqrstuvwx23456789,.".toCharArray();
+		this.randomPasswordCharacters = "ABCDEFGHJKLMNPQRSTUVWXabcdefghjkmnpqrstuvwx23456789,.-_".toCharArray();
 
 		// if we are not faking password manager by using /bin/true value in the config,
 		// then append namespace to the script path to trigger correct password manager script.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/EinfraPasswordManagerModule.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/EinfraPasswordManagerModule.java
@@ -63,6 +63,11 @@ public class EinfraPasswordManagerModule extends GenericPasswordManagerModule {
 		// set proper namespace
 		this.actualLoginNamespace = "einfra";
 
+		this.randomPasswordLength = 12;
+
+		// omit chars that can be mistaken by users: iI, oO, l, yY, zZ, 0 (zero), most of spec.chars
+		this.randomPasswordCharacters = "ABCDEFGHJKLMNPQRSTUVWXabcdefghjkmnpqrstuvwx23456789,.".toCharArray();
+
 		// if we are not faking password manager by using /bin/true value in the config,
 		// then append namespace to the script path to trigger correct password manager script.
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/MuPasswordManagerModule.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/MuPasswordManagerModule.java
@@ -54,7 +54,7 @@ public class MuPasswordManagerModule implements PasswordManagerModule {
 	protected int randomPasswordLength = 12;
 
 	// omit chars that can be mistaken by users: iI, oO, l, yY, zZ, 0 (zero), most of spec.chars
-	protected char[] randomPasswordCharacters = "ABCDEFGHJKLMNPQRSTUVWXabcdefghjkmnpqrstuvwx23456789,.".toCharArray();
+	protected char[] randomPasswordCharacters = "ABCDEFGHJKLMNPQRSTUVWXabcdefghjkmnpqrstuvwx23456789,.-_".toCharArray();
 
 	@Override
 	public String handleSponsorship(PerunSession sess, SponsoredUserData userData) throws PasswordStrengthException {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/MuPasswordManagerModule.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/MuPasswordManagerModule.java
@@ -51,8 +51,10 @@ public class MuPasswordManagerModule implements PasswordManagerModule {
 
 	private static ISServiceCaller isServiceCaller = ISServiceCallerImpl.getInstance();
 
-	protected int randomPasswordLength = 24;
-	protected char[] randomPasswordCharacters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%&*()-_=+;:,<.>/?".toCharArray();
+	protected int randomPasswordLength = 12;
+
+	// omit chars that can be mistaken by users: iI, oO, l, yY, zZ, 0 (zero), most of spec.chars
+	protected char[] randomPasswordCharacters = "ABCDEFGHJKLMNPQRSTUVWXabcdefghjkmnpqrstuvwx23456789,.".toCharArray();
 
 	@Override
 	public String handleSponsorship(PerunSession sess, SponsoredUserData userData) throws PasswordStrengthException {

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/EinfraPasswordManagerModuleTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/EinfraPasswordManagerModuleTest.java
@@ -18,8 +18,8 @@ public class EinfraPasswordManagerModuleTest extends AbstractPerunIntegrationTes
 
 	private EinfraPasswordManagerModule module;
 
-	private final int     randomPasswordLength = 12;
-	private final Pattern EinfraPasswordContainsNotAllowedChars = Pattern.compile(".*[^ABCDEFGHJKLMNPQRSTUVWXabcdefghjkmnpqrstuvwx23456789,.].*");
+	private final int randomPasswordLength = 12;
+	private final Pattern EinfraPasswordContainsNotAllowedChars = Pattern.compile(".*[^ABCDEFGHJKLMNPQRSTUVWXabcdefghjkmnpqrstuvwx23456789,._-].*");
 
 	@Before
 	public void setUp() {

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/EinfraPasswordManagerModuleTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/EinfraPasswordManagerModuleTest.java
@@ -2,10 +2,12 @@ package cz.metacentrum.perun.core.impl.modules.pwdmgr;
 
 import cz.metacentrum.perun.core.AbstractPerunIntegrationTest;
 import cz.metacentrum.perun.core.bl.PerunBl;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.List;
+import java.util.regex.Pattern;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -15,6 +17,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class EinfraPasswordManagerModuleTest extends AbstractPerunIntegrationTest {
 
 	private EinfraPasswordManagerModule module;
+
+	private final int     randomPasswordLength = 12;
+	private final Pattern EinfraPasswordContainsNotAllowedChars = Pattern.compile(".*[^ABCDEFGHJKLMNPQRSTUVWXabcdefghjkmnpqrstuvwx23456789,.].*");
 
 	@Before
 	public void setUp() {
@@ -46,5 +51,18 @@ public class EinfraPasswordManagerModuleTest extends AbstractPerunIntegrationTes
 
 		assertThat(allowedLogins)
 				.allMatch(login -> module.isLoginPermitted(sess, login));
+	}
+
+	@Test
+	public void testGeneratedPasswordContainsOnlyAllowedChars() {
+
+		// test that password does not contain any invalid character
+		Assert.assertFalse(EinfraPasswordContainsNotAllowedChars.matcher(module.generateRandomPassword(sess, null))
+			.matches());
+	}
+
+	@Test
+	public void generatedPasswordHasValidLength() {
+		Assert.assertEquals(module.generateRandomPassword(sess, null).length(), randomPasswordLength);
 	}
 }

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/MuPasswordManagerModuleTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/MuPasswordManagerModuleTest.java
@@ -26,13 +26,13 @@ import static org.mockito.Mockito.when;
 /**
  * @author Vojtech Sassmann <vojtech.sassmann@gmail.com>
  */
-public class  MuPasswordManagerModuleTest extends AbstractPerunIntegrationTest {
+public class MuPasswordManagerModuleTest extends AbstractPerunIntegrationTest {
 
 	private MuPasswordManagerModule module;
 	private final ISServiceCaller isServiceCallerMock = mock(ISServiceCaller.class);
 
-	private final int     randomPasswordLength = 12;
-	private final Pattern MUPasswordContainsNotAllowedChars = Pattern.compile(".*[^ABCDEFGHJKLMNPQRSTUVWXabcdefghjkmnpqrstuvwx23456789,.].*");
+	private final int randomPasswordLength = 12;
+	private final Pattern MUPasswordContainsNotAllowedChars = Pattern.compile(".*[^ABCDEFGHJKLMNPQRSTUVWXabcdefghjkmnpqrstuvwx23456789,._-].*");
 
 	@Before
 	public void setUp() throws Exception {

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/MuPasswordManagerModuleTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/MuPasswordManagerModuleTest.java
@@ -6,9 +6,12 @@ import cz.metacentrum.perun.core.bl.PerunBl;
 import cz.metacentrum.perun.core.implApi.modules.pwdmgr.ISResponseData;
 import cz.metacentrum.perun.core.implApi.modules.pwdmgr.ISServiceCaller;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
+
+import java.util.regex.Pattern;
 
 import static cz.metacentrum.perun.core.implApi.modules.pwdmgr.ISServiceCaller.IS_ERROR_STATUS;
 import static cz.metacentrum.perun.core.implApi.modules.pwdmgr.ISServiceCaller.IS_OK_STATUS;
@@ -23,10 +26,13 @@ import static org.mockito.Mockito.when;
 /**
  * @author Vojtech Sassmann <vojtech.sassmann@gmail.com>
  */
-public class MuPasswordManagerModuleTest extends AbstractPerunIntegrationTest {
+public class  MuPasswordManagerModuleTest extends AbstractPerunIntegrationTest {
 
 	private MuPasswordManagerModule module;
 	private final ISServiceCaller isServiceCallerMock = mock(ISServiceCaller.class);
+
+	private final int     randomPasswordLength = 12;
+	private final Pattern MUPasswordContainsNotAllowedChars = Pattern.compile(".*[^ABCDEFGHJKLMNPQRSTUVWXabcdefghjkmnpqrstuvwx23456789,.].*");
 
 	@Before
 	public void setUp() throws Exception {
@@ -43,6 +49,30 @@ public class MuPasswordManagerModuleTest extends AbstractPerunIntegrationTest {
 	@After
 	public void tearDown() {
 		Mockito.reset(isServiceCallerMock);
+	}
+
+	@Test
+	public void generatedPasswordContainsOnlyAllowedChars() throws Exception {
+		ISResponseData okResponseData = new ISResponseData();
+		okResponseData.setStatus(IS_OK_STATUS);
+
+		when(isServiceCallerMock.call(anyString(), anyInt()))
+			.thenReturn(okResponseData);
+
+		// test that password does not contain any invalid character
+		Assert.assertFalse(MUPasswordContainsNotAllowedChars.matcher(module.generateRandomPassword(sess, null))
+			.matches());
+	}
+
+	@Test
+	public void generatedPasswordHasValidLength() throws Exception {
+		ISResponseData okResponseData = new ISResponseData();
+		okResponseData.setStatus(IS_OK_STATUS);
+
+		when(isServiceCallerMock.call(anyString(), anyInt()))
+			.thenReturn(okResponseData);
+
+		Assert.assertEquals(module.generateRandomPassword(sess, null).length(), randomPasswordLength);
 	}
 
 	@Test


### PR DESCRIPTION
Einfra -- 12 digits long passwords, without characters that can be mistaken for another
(iI, yY, oO, zZ, 0, 1), without special characters (except for dot('.') and comma(','))
MU -- 12 digits long passwords, without characters that can be mistaken for another
(iI, yY, oO, zZ, 0, 1), without special characters (except for dot('.') and comma(','))