### PR TITLE
build(openapi): updated OpenAPI Generator version to 5.2.0

### DIFF
--- a/perun-openapi/pom.xml
+++ b/perun-openapi/pom.xml
@@ -28,7 +28,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>5.1.0</version>
+				<version>5.2.0</version>
 				<executions>
 					<execution>
 						<goals>


### PR DESCRIPTION
The Maven generator plugin for generating Java code from openapi.yml was upgraded from 5.1.0 to
5.2.0