### PR TITLE
feat(core): add async mode for assignGroupToResource method

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/ResourcesManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/ResourcesManager.java
@@ -231,14 +231,15 @@ public interface ResourcesManager {
 
 	/**
 	 * Assign group to a resource. Check if attributes for each member form group are valid.
-	 * Fill members' attributes with missing value.
+	 * Fill members' attributes with missing value. Work in sync/async mode.
 	 *
 	 * If the group is already assigned, nothing it performed.
 	 *
 	 * @param perunSession
 	 * @param group
 	 * @param resource
-
+	 * @param async
+	 *
 	 * @throws InternalErrorException
 	 * @throws GroupNotExistsException
 	 * @throws ResourceNotExistsException
@@ -247,14 +248,15 @@ public interface ResourcesManager {
 	 * @throws WrongReferenceAttributeValueException
 	 * @throws GroupResourceMismatchException
 	 */
-	void assignGroupToResource(PerunSession perunSession, Group group, Resource resource) throws PrivilegeException, GroupNotExistsException, ResourceNotExistsException, WrongAttributeValueException, WrongReferenceAttributeValueException, GroupResourceMismatchException;
+	void assignGroupToResource(PerunSession perunSession, Group group, Resource resource, boolean async) throws PrivilegeException, GroupNotExistsException, ResourceNotExistsException, WrongAttributeValueException, WrongReferenceAttributeValueException, GroupResourceMismatchException;
 
 	/**
-	 * Assign groups to a resource. Check if attributes for each member from all groups are valid. Fill members' attributes with missing values.
+	 * Assign groups to a resource. Check if attributes for each member from all groups are valid. Fill members' attributes with missing values. Work in sync/async mode.
 	 *
 	 * @param perunSession
 	 * @param groups list of resources
 	 * @param resource
+	 * @param async
 	 *
 	 * @throws InternalErrorException
 	 * @throws PrivilegeException
@@ -264,14 +266,15 @@ public interface ResourcesManager {
 	 * @throws WrongReferenceAttributeValueException
 	 * @throws GroupResourceMismatchException
 	 */
-	void assignGroupsToResource(PerunSession perunSession, List<Group> groups, Resource resource) throws PrivilegeException, GroupNotExistsException, ResourceNotExistsException, WrongAttributeValueException, WrongReferenceAttributeValueException, GroupResourceMismatchException;
+	void assignGroupsToResource(PerunSession perunSession, List<Group> groups, Resource resource, boolean async) throws PrivilegeException, GroupNotExistsException, ResourceNotExistsException, WrongAttributeValueException, WrongReferenceAttributeValueException, GroupResourceMismatchException;
 
 	/**
-	 * Assign group to the resources. Check if attributes for each member from group are valid. Fill members' attributes with missing values.
+	 * Assign group to the resources. Check if attributes for each member from group are valid. Fill members' attributes with missing values. Work in sync/async mode.
 	 *
 	 * @param perunSession
 	 * @param group the group
 	 * @param resources list of resources
+	 * @param async
 	 *
 	 * @throws InternalErrorException
 	 * @throws PrivilegeException
@@ -281,7 +284,7 @@ public interface ResourcesManager {
 	 * @throws WrongReferenceAttributeValueException
 	 * @throws GroupResourceMismatchException
 	 */
-	void assignGroupToResources(PerunSession perunSession, Group group, List<Resource> resources) throws PrivilegeException, GroupNotExistsException, ResourceNotExistsException, WrongAttributeValueException, WrongReferenceAttributeValueException, GroupResourceMismatchException;
+	void assignGroupToResources(PerunSession perunSession, Group group, List<Resource> resources, boolean async) throws PrivilegeException, GroupNotExistsException, ResourceNotExistsException, WrongAttributeValueException, WrongReferenceAttributeValueException, GroupResourceMismatchException;
 
 	/**
 	 * Remove group from a resource.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ResourcesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ResourcesManagerBl.java
@@ -24,11 +24,9 @@ import cz.metacentrum.perun.core.api.exceptions.BanNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.GroupAlreadyRemovedFromResourceException;
 import cz.metacentrum.perun.core.api.exceptions.GroupNotAdminException;
 import cz.metacentrum.perun.core.api.exceptions.GroupNotDefinedOnResourceException;
-import cz.metacentrum.perun.core.api.exceptions.GroupNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.GroupResourceMismatchException;
 import cz.metacentrum.perun.core.api.exceptions.GroupResourceStatusException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
-import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
 import cz.metacentrum.perun.core.api.exceptions.ResourceAlreadyRemovedException;
 import cz.metacentrum.perun.core.api.exceptions.ResourceExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ResourceNotExistsException;
@@ -298,12 +296,13 @@ public interface ResourcesManagerBl {
 	 * @param group
 	 * @param resource
 
+	 * @param async
 	 * @throws InternalErrorException
 	 * @throws WrongAttributeValueException
 	 * @throws WrongReferenceAttributeValueException
 	 * @throws GroupResourceMismatchException
 	 */
-	void assignGroupToResource(PerunSession perunSession, Group group, Resource resource) throws WrongAttributeValueException, WrongReferenceAttributeValueException, GroupResourceMismatchException;
+	void assignGroupToResource(PerunSession perunSession, Group group, Resource resource, boolean async) throws WrongAttributeValueException, WrongReferenceAttributeValueException, GroupResourceMismatchException;
 
 	/**
 	 * Assign groups to a resource. Check if attributes for each member from all groups are valid.
@@ -315,12 +314,13 @@ public interface ResourcesManagerBl {
 	 * @param groups groups to assign
 	 * @param resource
 	 *
+	 * @param async
 	 * @throws InternalErrorException
 	 * @throws WrongAttributeValueException
 	 * @throws WrongReferenceAttributeValueException
 	 * @throws GroupResourceMismatchException
 	 */
-	void assignGroupsToResource(PerunSession perunSession, Iterable<Group> groups, Resource resource) throws WrongAttributeValueException, WrongReferenceAttributeValueException, GroupResourceMismatchException;
+	void assignGroupsToResource(PerunSession perunSession, Iterable<Group> groups, Resource resource, boolean async) throws WrongAttributeValueException, WrongReferenceAttributeValueException, GroupResourceMismatchException;
 
 	/**
 	 * Assign group to the resources. Check if attributes for each member from group are valid.
@@ -332,12 +332,13 @@ public interface ResourcesManagerBl {
 	 * @param group the group
 	 * @param resources list of resources
 	 *
+	 * @param async
 	 * @throws InternalErrorException
 	 * @throws WrongAttributeValueException
 	 * @throws WrongReferenceAttributeValueException
 	 * @throws GroupResourceMismatchException
 	 */
-	void assignGroupToResources(PerunSession perunSession, Group group, List<Resource> resources) throws WrongAttributeValueException, WrongReferenceAttributeValueException, GroupResourceMismatchException;
+	void assignGroupToResources(PerunSession perunSession, Group group, List<Resource> resources, boolean async) throws WrongAttributeValueException, WrongReferenceAttributeValueException, GroupResourceMismatchException;
 
 	/**
 	 * Remove group from a resource.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
@@ -1937,7 +1937,6 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 	/**
 	 * Assign resource to the given groups. If some of the groups
 	 * is already assigned, the group is skipped silently.
-	 *
 	 * @param sess perun session
 	 * @param groups groups which should be assigned to the given resource
 	 * @param resource resource
@@ -1947,7 +1946,7 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 		groupsToAssign.removeAll(perunBl.getResourcesManagerBl().getAssignedGroups(sess, resource));
 
 		try {
-			perunBl.getResourcesManagerBl().assignGroupsToResource(sess, groupsToAssign, resource);
+			perunBl.getResourcesManagerBl().assignGroupsToResource(sess, groupsToAssign, resource, false);
 		} catch (WrongAttributeValueException | WrongReferenceAttributeValueException | GroupResourceMismatchException e) {
 			log.error("Failed to assign groups during group structure synchronization. Groups {}, resource {}," +
 					" exception: {}", groups, resource, e);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ResourcesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ResourcesManagerBlImpl.java
@@ -165,7 +165,7 @@ public class ResourcesManagerBlImpl implements ResourcesManagerBl {
 			try {
 				for (AssignedGroup assignedGroup : templateResourceGroups) {
 					//TODO: if INACTIVE, assign as INACTIVE
-					assignGroupToResource(sess, assignedGroup.getEnrichedGroup().getGroup(), newResource);
+					assignGroupToResource(sess, assignedGroup.getEnrichedGroup().getGroup(), newResource, false);
 					List<Attribute> templateGroupResourceAttributes = perunBl.getAttributesManagerBl().getAttributes(sess, templateResource, assignedGroup.getEnrichedGroup().getGroup());
 					//Remove all virt attributes before setting
 					templateGroupResourceAttributes.removeIf(groupResourceAttribute -> groupResourceAttribute.getNamespace().startsWith(AttributesManager.NS_GROUP_RESOURCE_ATTR_VIRT));
@@ -375,64 +375,33 @@ public class ResourcesManagerBlImpl implements ResourcesManagerBl {
 
 
 	@Override
-	public void assignGroupToResource(PerunSession sess, Group group, Resource resource) throws WrongAttributeValueException, WrongReferenceAttributeValueException, GroupResourceMismatchException {
-		assignGroupsToResource(sess, Collections.singletonList(group), resource);
+	public void assignGroupToResource(PerunSession sess, Group group, Resource resource, boolean async) throws WrongAttributeValueException, WrongReferenceAttributeValueException, GroupResourceMismatchException {
+		assignGroupsToResource(sess, Collections.singletonList(group), resource, async);
 	}
 
 	@Override
-	public void assignGroupsToResource(PerunSession perunSession, Iterable<Group> groups, Resource resource) throws WrongAttributeValueException, WrongReferenceAttributeValueException, GroupResourceMismatchException {
-		Set<Member> members = new HashSet<>();
-
-		// skip processing of required attributes, if there are no services
-		boolean skipAttributes = getAssignedServices(perunSession, resource).isEmpty();
+	public void assignGroupsToResource(PerunSession perunSession, Iterable<Group> groups, Resource resource, boolean async) throws WrongAttributeValueException, WrongReferenceAttributeValueException, GroupResourceMismatchException {
 
 		for(Group g: groups) {
 			getPerunBl().getAttributesManagerBl().checkGroupIsFromTheSameVoLikeResource(perunSession, g, resource);
 
-			//first we must assign group to resource and then set and check attributes, because methods checkAttributesSemantics and fillAttribute need actual state to work correctly
+			//first we must assign group
 			try {
-				getResourcesManagerImpl().assignGroupToResource(perunSession, g, resource, GroupResourceStatus.ACTIVE);
+				getResourcesManagerImpl().assignGroupToResource(perunSession, g, resource, GroupResourceStatus.PROCESSING);
+				activateGroupResourceAssignment(perunSession, g, resource, async);
 			} catch (GroupAlreadyAssignedException e) {
 				// silently skip
-				continue;
-			}
-			getPerunBl().getAuditer().log(perunSession, new GroupAssignedToResource(g, resource));
-
-			if (skipAttributes) continue;
-
-			// get/fill/set all required group and group-resource attributes
-			try {
-				List<Attribute> attributes = getPerunBl().getAttributesManagerBl().getResourceRequiredAttributes(perunSession, resource, resource, g, true);
-				attributes = getPerunBl().getAttributesManagerBl().fillAttributes(perunSession, resource, g, attributes, true);
-				getPerunBl().getAttributesManagerBl().setAttributes(perunSession, resource, g, attributes, true);
-			} catch(WrongAttributeAssignmentException | GroupResourceMismatchException ex) {
-				throw new ConsistencyErrorException(ex);
-			}
-
-			members.addAll(getPerunBl().getGroupsManagerBl().getGroupMembersExceptInvalidAndDisabled(perunSession, g));
-		}
-
-		// if there are no services, the members are empty and there is nothing more to process
-		if (skipAttributes) return;
-
-		// get all "allowed" group members and get/fill/set required attributes for them
-		Facility facility = getPerunBl().getResourcesManagerBl().getFacility(perunSession, resource);
-		for(Member member : members) {
-			User user = getPerunBl().getUsersManagerBl().getUserByMember(perunSession, member);
-			try {
-				getPerunBl().getAttributesManagerBl().setRequiredAttributes(perunSession, facility, resource, user, member, true);
-			} catch(WrongAttributeAssignmentException | MemberResourceMismatchException | AttributeNotExistsException ex) {
+			} catch (GroupNotDefinedOnResourceException ex) {
 				throw new ConsistencyErrorException(ex);
 			}
 		}
 
-		// TODO: set and check member-group attributes
 	}
 
 	@Override
-	public void assignGroupToResources(PerunSession perunSession, Group group, List<Resource> resources) throws WrongAttributeValueException, WrongReferenceAttributeValueException, GroupResourceMismatchException {
+	public void assignGroupToResources(PerunSession perunSession, Group group, List<Resource> resources, boolean async) throws WrongAttributeValueException, WrongReferenceAttributeValueException, GroupResourceMismatchException {
 		for(Resource r: resources) {
-			this.assignGroupToResource(perunSession, group, r);
+			this.assignGroupToResource(perunSession, group, r, async);
 		}
 	}
 
@@ -843,7 +812,7 @@ public class ResourcesManagerBlImpl implements ResourcesManagerBl {
 		for (AssignedGroup group: getGroupAssignments(sess, sourceResource, List.of())) {
 			try {
 				//TODO: if INACTIVE, assign as inactive
-				assignGroupToResource(sess, group.getEnrichedGroup().getGroup(), destinationResource);
+				assignGroupToResource(sess, group.getEnrichedGroup().getGroup(), destinationResource, false);
 			} catch (GroupResourceMismatchException ex) {
 				// we can ignore the exception in this particular case, group can exists in both of the resources
 			} catch (WrongAttributeValueException | WrongReferenceAttributeValueException ex) {
@@ -1165,6 +1134,7 @@ public class ResourcesManagerBlImpl implements ResourcesManagerBl {
 			}
 		}
 
+		getPerunBl().getAuditer().log(sess, new GroupAssignedToResource(group, resource));
 		// TODO: set and check member-group attributes
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ResourcesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ResourcesManagerEntry.java
@@ -8,7 +8,6 @@ import cz.metacentrum.perun.core.api.EnrichedResource;
 import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.Member;
-import cz.metacentrum.perun.core.api.PerunBean;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.ResourceTag;
@@ -53,7 +52,6 @@ import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.bl.PerunBl;
 import cz.metacentrum.perun.core.bl.ResourcesManagerBl;
-import cz.metacentrum.perun.core.blImpl.AuthzResolverBlImpl;
 import cz.metacentrum.perun.core.impl.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -337,7 +335,7 @@ public class ResourcesManagerEntry implements ResourcesManager {
 	}
 
 	@Override
-	public void assignGroupToResource(PerunSession sess, Group group, Resource resource) throws PrivilegeException, GroupNotExistsException, ResourceNotExistsException, WrongAttributeValueException, WrongReferenceAttributeValueException, GroupResourceMismatchException {
+	public void assignGroupToResource(PerunSession sess, Group group, Resource resource, boolean async) throws PrivilegeException, GroupNotExistsException, ResourceNotExistsException, WrongAttributeValueException, WrongReferenceAttributeValueException, GroupResourceMismatchException {
 		Utils.checkPerunSession(sess);
 		getResourcesManagerBl().checkResourceExists(sess, resource);
 		getPerunBl().getGroupsManagerBl().checkGroupExists(sess, group);
@@ -347,11 +345,11 @@ public class ResourcesManagerEntry implements ResourcesManager {
 			throw new PrivilegeException(sess, "assignGroupToResource");
 		}
 
-		getResourcesManagerBl().assignGroupToResource(sess, group, resource);
+		getResourcesManagerBl().assignGroupToResource(sess, group, resource, async);
 	}
 
 	@Override
-	public void assignGroupsToResource(PerunSession perunSession, List<Group> groups, Resource resource) throws PrivilegeException, GroupNotExistsException, ResourceNotExistsException, WrongAttributeValueException, WrongReferenceAttributeValueException, GroupResourceMismatchException {
+	public void assignGroupsToResource(PerunSession perunSession, List<Group> groups, Resource resource, boolean async) throws PrivilegeException, GroupNotExistsException, ResourceNotExistsException, WrongAttributeValueException, WrongReferenceAttributeValueException, GroupResourceMismatchException {
 		Utils.checkPerunSession(perunSession);
 		Utils.notNull(groups, "groups");
 		getResourcesManagerBl().checkResourceExists(perunSession, resource);
@@ -363,11 +361,11 @@ public class ResourcesManagerEntry implements ResourcesManager {
 			}
 		}
 
-		getResourcesManagerBl().assignGroupsToResource(perunSession, groups, resource);
+		getResourcesManagerBl().assignGroupsToResource(perunSession, groups, resource, async);
 	}
 
 	@Override
-	public void assignGroupToResources(PerunSession perunSession, Group group, List<Resource> resources) throws PrivilegeException, GroupNotExistsException, ResourceNotExistsException, WrongAttributeValueException, WrongReferenceAttributeValueException, GroupResourceMismatchException {
+	public void assignGroupToResources(PerunSession perunSession, Group group, List<Resource> resources, boolean async) throws PrivilegeException, GroupNotExistsException, ResourceNotExistsException, WrongAttributeValueException, WrongReferenceAttributeValueException, GroupResourceMismatchException {
 		Utils.checkPerunSession(perunSession);
 		Utils.notNull(resources, "resources");
 		getPerunBl().getGroupsManagerBl().checkGroupExists(perunSession, group);
@@ -382,7 +380,7 @@ public class ResourcesManagerEntry implements ResourcesManager {
 			}
 		}
 
-		getResourcesManagerBl().assignGroupToResources(perunSession, group, resources);
+		getResourcesManagerBl().assignGroupToResources(perunSession, group, resources, async);
 	}
 
 	@Override

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/bl/FacilitiesManagerBlImplTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/bl/FacilitiesManagerBlImplTest.java
@@ -102,7 +102,7 @@ public class FacilitiesManagerBlImplTest {
 		resource = new Resource(0, "testRes", null, facility.getId(), vo.getId());
 		resource = perun.getResourcesManagerBl().createResource(sess, resource, vo ,facility);
 
-		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource, false);
 
 		// second branch
 
@@ -127,7 +127,7 @@ public class FacilitiesManagerBlImplTest {
 		resource3 = new Resource(0, "testRes3", null, facility2.getId(), vo2.getId());
 		resource3 = perun.getResourcesManagerBl().createResource(sess, resource3, vo2 ,facility2);
 
-		perun.getResourcesManagerBl().assignGroupToResources(sess, group2, Arrays.asList(resource2, resource3));
+		perun.getResourcesManagerBl().assignGroupToResources(sess, group2, Arrays.asList(resource2, resource3), false);
 
 		user = perun.getUsersManagerBl().getUserByMember(sess, member);
 

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/bl/ResourcesManagerBlImplTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/bl/ResourcesManagerBlImplTest.java
@@ -97,7 +97,7 @@ public class ResourcesManagerBlImplTest {
 		resource = new Resource(0, "testRes", null, facility.getId(), vo.getId());
 		resource = perun.getResourcesManagerBl().createResource(sess, resource, vo, facility);
 
-		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource, false);
 
 		// second branch
 
@@ -122,7 +122,7 @@ public class ResourcesManagerBlImplTest {
 		resource3 = new Resource(0, "testRes3", null, facility2.getId(), vo2.getId());
 		resource3 = perun.getResourcesManagerBl().createResource(sess, resource3, vo2, facility2);
 
-		perun.getResourcesManagerBl().assignGroupToResources(sess, group2, Arrays.asList(resource2, resource3));
+		perun.getResourcesManagerBl().assignGroupToResources(sess, group2, Arrays.asList(resource2, resource3), false);
 
 		user = perun.getUsersManagerBl().getUserByMember(sess, member);
 

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/bl/UsersManagerBlImplTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/bl/UsersManagerBlImplTest.java
@@ -98,7 +98,7 @@ public class UsersManagerBlImplTest {
 		resource = new Resource(0, "testRes", null, facility.getId(), vo.getId());
 		resource = perun.getResourcesManagerBl().createResource(sess, resource, vo, facility);
 
-		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource, false);
 
 		// second branch
 
@@ -123,7 +123,7 @@ public class UsersManagerBlImplTest {
 		resource3 = new Resource(0, "testRes3", null, facility2.getId(), vo2.getId());
 		resource3 = perun.getResourcesManagerBl().createResource(sess, resource3, vo2, facility2);
 
-		perun.getResourcesManagerBl().assignGroupToResources(sess, group2, Arrays.asList(resource2, resource3));
+		perun.getResourcesManagerBl().assignGroupToResources(sess, group2, Arrays.asList(resource2, resource3), false);
 
 		user = perun.getUsersManagerBl().getUserByMember(sess, member);
 

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/AttributesManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/AttributesManagerEntryIntegrationTest.java
@@ -393,12 +393,12 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		resource2InVo1 = perun.getResourcesManagerBl().createResource(sess, new Resource(0, "testResource2InVo1", "", facility2.getId(), vo1.getId()), vo1, facility2);
 		resource1InVo2 = perun.getResourcesManagerBl().createResource(sess, new Resource(0, "testResource1InVo2", "", facility2.getId(), vo2.getId()), vo2, facility2);
 		resource2InVo2 = perun.getResourcesManagerBl().createResource(sess, new Resource(0, "testResource2InVo2", "", facility3.getId(), vo2.getId()), vo2, facility3);
-		perun.getResourcesManagerBl().assignGroupToResource(sess, group1InVo1, resource1InVo1);
-		perun.getResourcesManagerBl().assignGroupToResource(sess, group2InVo1, resource1InVo1);
-		perun.getResourcesManagerBl().assignGroupToResource(sess, group2InVo1, resource2InVo1);
-		perun.getResourcesManagerBl().assignGroupToResource(sess, group1InVo2, resource1InVo2);
-		perun.getResourcesManagerBl().assignGroupToResource(sess, group2InVo2, resource1InVo2);
-		perun.getResourcesManagerBl().assignGroupToResource(sess, group2InVo2, resource2InVo2);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group1InVo1, resource1InVo1, false);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group2InVo1, resource1InVo1, false);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group2InVo1, resource2InVo1, false);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group1InVo2, resource1InVo2, false);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group2InVo2, resource1InVo2, false);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group2InVo2, resource2InVo2, false);
 	}
 
 	// ==============  1. GET ATTRIBUTES ================================
@@ -493,8 +493,8 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 		Group g1 = new Group("Testing_group01", "Testing group01");
 		g1 = perun.getGroupsManagerBl().createGroup(sess, v1, g1);
-		perun.getResourcesManagerBl().assignGroupToResource(sess, g1, r1);
-		perun.getResourcesManagerBl().assignGroupToResource(sess, g1, r2);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, g1, r1, false);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, g1, r2, false);
 
 		//Create attribute def entityless gidRanges
 		AttributeDefinition gidRangesAttrDef = perun.getAttributesManagerBl().getAttributeDefinition(sess, AttributesManager.NS_ENTITYLESS_ATTR_DEF + ":namespace-GIDRanges");
@@ -563,7 +563,7 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 		facility = setUpFacility();
 		resource = setUpResource();
-		perun.getResourcesManagerBl().assignGroupToResource(sess, topGroup, resource);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, topGroup, resource, false);
 		service = setUpService();
 		perun.getResourcesManagerBl().assignService(sess, resource, service);
 
@@ -928,7 +928,7 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		group = setUpGroup();
 		facility = setUpFacility();
 		resource = setUpResource();
-		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource, false);
 		member = setUpMember();
 		perun.getGroupsManagerBl().addMember(sess, group, member);
 		User user = perun.getUsersManagerBl().getUserByMember(sess, member);
@@ -1363,7 +1363,7 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		facility = setUpFacility();
 		group = setUpGroup();
 		resource = setUpResource();
-		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource, false);
 
 		List<Attribute> groupResourceAttrs = setUpGroupResourceAttribute();
 		perun.getAttributesManagerBl().setAttributes(sess, resource, group, groupResourceAttrs);
@@ -3625,7 +3625,7 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		group = setUpGroup();
 		member = setUpMember();
 
-		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource, false);
 		perun.getGroupsManagerBl().addMember(sess, group, member);
 
 		Attribute attr = setUpSpecificMemberResourceAttribute(member, resource);
@@ -6398,7 +6398,7 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		attributes = setUpRequiredAttributes();
 		perun.getResourcesManager().assignService(sess, resource, service);
 		group = setUpGroup();
-		perun.getResourcesManager().assignGroupToResource(sess, group, resource);
+		perun.getResourcesManager().assignGroupToResource(sess, group, resource, false);
 		perun.getGroupsManager().addMember(sess, group, member);
 
 		User user = perun.getUsersManager().getUserByMember(sess, member);
@@ -6969,7 +6969,7 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		service = setUpService();
 		attributes = setUpRequiredAttributes();
 		group = setUpGroup(vo, member);
-		resourcesManager.assignGroupToResource(sess, group, resource);
+		resourcesManager.assignGroupToResource(sess, group, resource, false);
 		perun.getResourcesManager().assignService(sess, resource, service);
 
 		HashMap<Member, List<Attribute>> reqAttr = attributesManager.getRequiredAttributes(sess, service, resource, members);
@@ -7114,7 +7114,7 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		service = setUpService();
 		attributes = setUpRequiredAttributes();
 		group = setUpGroup(vo, member);
-		resourcesManager.assignGroupToResource(sess, group, resource);
+		resourcesManager.assignGroupToResource(sess, group, resource, false);
 		perun.getResourcesManager().assignService(sess, resource, service);
 
 		HashMap<Member, List<Attribute>> reqAttr = attributesManager.getRequiredAttributes(sess, resource, service, members);
@@ -14947,7 +14947,7 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 	private void setUpMemberToResource() throws Exception {
 
 		perun.getGroupsManager().addMember(sess, group, member);
-		perun.getResourcesManager().assignGroupToResource(sess, group, resource);
+		perun.getResourcesManager().assignGroupToResource(sess, group, resource, false);
 	}
 
 	private List<Host> setUpHost() throws Exception {

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntryIntegrationTest.java
@@ -433,7 +433,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		Member member = setUpMember(vo);
 		User user = perun.getUsersManagerBl().getUserByMember(sess, member);
 		Group group = setUpGroup(vo, member);
-		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource, false);
 
 		List<User> users = perun.getFacilitiesManager().getAllowedUsers(sess, facility);
 		assertTrue("our facility should have 1 allowed user", users.size() == 1);
@@ -453,8 +453,8 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		User user = perun.getUsersManagerBl().getUserByMember(sess, member);
 		Group group = setUpGroup(vo, member);
 		Group group2 = setUpGroup2(vo, member);
-		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource1);
-		perun.getResourcesManagerBl().assignGroupToResource(sess, group2, resource2);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource1, false);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group2, resource2, false);
 
 		List<User> users = perun.getFacilitiesManager().getAllowedUsers(sess, facility);
 		assertTrue("our facility should have 1 allowed user", users.size() == 1);
@@ -478,7 +478,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		Member member = setUpMember(vo);
 		User user = perun.getUsersManagerBl().getUserByMember(sess, member);
 		Group group = setUpGroup(vo, member);
-		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource, false);
 
 		// second vo and member, assign group but no service
 		Vo vo2 = new Vo();
@@ -492,7 +492,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		Group group2 = setUpGroup(vo2, member2);
 		Resource resource2 = setUpResource(vo2);
 		perun.getResourcesManager().assignService(sess, resource2, serv);
-		perun.getResourcesManagerBl().assignGroupToResource(sess, group2, resource2);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group2, resource2, false);
 
 		List<User> users = perun.getFacilitiesManager().getAllowedUsers(sess, facility, vo, serv);
 		assertTrue("our facility should have 1 allowed user",users.size() == 1);
@@ -1414,7 +1414,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		Member member = setUpMember(vo);
 		User user = perun.getUsersManagerBl().getUserByMember(sess, member);
 		Group group = setUpGroup(vo, member);
-		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource, false);
 
 		BanOnFacility banOnFacility = new BanOnFacility();
 		banOnFacility.setUserId(user.getId());
@@ -1436,7 +1436,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		Member member = setUpMember(vo);
 		User user = perun.getUsersManagerBl().getUserByMember(sess, member);
 		Group group = setUpGroup(vo, member);
-		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource, false);
 
 		BanOnFacility banOnFacility = new BanOnFacility();
 		banOnFacility.setUserId(user.getId());
@@ -1458,7 +1458,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		Member member = setUpMember(vo);
 		User user = perun.getUsersManagerBl().getUserByMember(sess, member);
 		Group group = setUpGroup(vo, member);
-		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource, false);
 
 		BanOnFacility banOnFacility = new BanOnFacility();
 		banOnFacility.setUserId(user.getId());
@@ -1480,7 +1480,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		Member member = setUpMember(vo);
 		User user = perun.getUsersManagerBl().getUserByMember(sess, member);
 		Group group = setUpGroup(vo, member);
-		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource, false);
 
 		BanOnFacility banOnFacility = new BanOnFacility();
 		banOnFacility.setUserId(user.getId());
@@ -1502,7 +1502,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		Member member = setUpMember(vo);
 		User user = perun.getUsersManagerBl().getUserByMember(sess, member);
 		Group group = setUpGroup(vo, member);
-		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource, false);
 
 		BanOnFacility banOnFacility = new BanOnFacility();
 		banOnFacility.setUserId(user.getId());
@@ -1524,7 +1524,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		Member member = setUpMember(vo);
 		User user = perun.getUsersManagerBl().getUserByMember(sess, member);
 		Group group = setUpGroup(vo, member);
-		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource, false);
 
 		BanOnFacility banOnFacility = new BanOnFacility();
 		banOnFacility.setUserId(user.getId());
@@ -1549,7 +1549,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		Member member = setUpMember(vo);
 		User user = perun.getUsersManagerBl().getUserByMember(sess, member);
 		Group group = setUpGroup(vo, member);
-		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource, false);
 
 		BanOnFacility banOnFacility = new BanOnFacility();
 		banOnFacility.setUserId(user.getId());
@@ -1576,7 +1576,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		Member member = setUpMember(vo);
 		User user = perun.getUsersManagerBl().getUserByMember(sess, member);
 		Group group = setUpGroup(vo, member);
-		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource, false);
 
 		BanOnFacility banOnFacility = new BanOnFacility();
 		banOnFacility.setUserId(user.getId());
@@ -1603,7 +1603,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		Member member = setUpMember(vo);
 		User user = perun.getUsersManagerBl().getUserByMember(sess, member);
 		Group group = setUpGroup(vo, member);
-		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource, false);
 
 		BanOnFacility banOnFacility = new BanOnFacility();
 		banOnFacility.setUserId(user.getId());
@@ -1632,7 +1632,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		Member member = setUpMember(vo);
 		User user = perun.getUsersManagerBl().getUserByMember(sess, member);
 		Group group = setUpGroup(vo, member);
-		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource, false);
 
 		BanOnFacility banOnFacility = new BanOnFacility();
 		banOnFacility.setUserId(user.getId());
@@ -1963,8 +1963,8 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		perun.getGroupsManager().addMember(sess, group1, member12);
 		perun.getGroupsManager().addMember(sess, group2, member22);
 
-		perun.getResourcesManager().assignGroupToResource(sess, group1, resource1);
-		perun.getResourcesManager().assignGroupToResource(sess, group2, resource2);
+		perun.getResourcesManager().assignGroupToResource(sess, group1, resource1, false);
+		perun.getResourcesManager().assignGroupToResource(sess, group2, resource2, false);
 
 		// test new way - single select
 		List<Member> members = perun.getFacilitiesManagerBl().getAllowedMembers(sess, facility);
@@ -2018,8 +2018,8 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		perun.getGroupsManager().addMember(sess, group1, member12);
 		perun.getGroupsManager().addMember(sess, group2, member22);
 
-		perun.getResourcesManager().assignGroupToResource(sess, group1, resource1);
-		perun.getResourcesManager().assignGroupToResource(sess, group2, resource2);
+		perun.getResourcesManager().assignGroupToResource(sess, group1, resource1, false);
+		perun.getResourcesManager().assignGroupToResource(sess, group2, resource2, false);
 
 		// test new way - single select
 		List<Member> members = perun.getFacilitiesManagerBl().getAllowedMembers(sess, facility);

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/GroupsManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/GroupsManagerEntryIntegrationTest.java
@@ -24,10 +24,8 @@ import cz.metacentrum.perun.core.api.Vo;
 import cz.metacentrum.perun.core.api.VosManager;
 import cz.metacentrum.perun.core.api.exceptions.AlreadyAdminException;
 import cz.metacentrum.perun.core.api.exceptions.AlreadyMemberException;
-import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ExtendMembershipException;
 import cz.metacentrum.perun.core.api.exceptions.ExternallyManagedException;
-import cz.metacentrum.perun.core.api.exceptions.GroupAlreadyRemovedException;
 import cz.metacentrum.perun.core.api.exceptions.GroupExistsException;
 import cz.metacentrum.perun.core.api.exceptions.GroupMoveNotAllowedException;
 import cz.metacentrum.perun.core.api.exceptions.GroupNotAllowedToAutoRegistrationException;
@@ -37,21 +35,15 @@ import cz.metacentrum.perun.core.api.exceptions.GroupRelationCannotBeRemoved;
 import cz.metacentrum.perun.core.api.exceptions.GroupRelationDoesNotExist;
 import cz.metacentrum.perun.core.api.exceptions.GroupRelationNotAllowed;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
-import cz.metacentrum.perun.core.api.exceptions.InvalidDestinationException;
 import cz.metacentrum.perun.core.api.exceptions.InvalidGroupNameException;
 import cz.metacentrum.perun.core.api.exceptions.MemberNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.NotGroupMemberException;
-import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
 import cz.metacentrum.perun.core.api.exceptions.RelationExistsException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotAdminException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.VoNotExistsException;
-import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
-import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
-import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.bl.GroupsManagerBl;
 import cz.metacentrum.perun.core.bl.UsersManagerBl;
-import cz.metacentrum.perun.core.impl.Utils;
 import cz.metacentrum.perun.core.implApi.modules.attributes.AbstractMembershipExpirationRulesModule;
 import org.junit.Before;
 import org.junit.Test;
@@ -581,7 +573,7 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 		Facility f = perun.getFacilitiesManager().createFacility(sess, new Facility(0, "test", "test"));
 		Resource r = perun.getResourcesManager().createResource(sess, new Resource(0, "test", "test", f.getId()), vo, f);
 
-		perun.getResourcesManager().assignGroupToResource(sess, g, r);
+		perun.getResourcesManager().assignGroupToResource(sess, g, r, false);
 		perun.getGroupsManager().addMember(sess, g, m);
 
 		AttributeDefinition attrDef = new AttributeDefinition();
@@ -632,8 +624,8 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 		Facility f = perun.getFacilitiesManager().createFacility(sess, new Facility(0, "test", "test"));
 		Resource r = perun.getResourcesManager().createResource(sess, new Resource(0, "test", "test", f.getId()), vo, f);
 
-		perun.getResourcesManager().assignGroupToResource(sess, g, r);
-		perun.getResourcesManager().assignGroupToResource(sess, g2, r);
+		perun.getResourcesManager().assignGroupToResource(sess, g, r, false);
+		perun.getResourcesManager().assignGroupToResource(sess, g2, r, false);
 		perun.getGroupsManager().addMember(sess, g, m);
 		perun.getGroupsManager().addMember(sess, g2, m);
 
@@ -704,7 +696,7 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 		Resource r = perun.getResourcesManager().createResource(sess, new Resource(0, "test", "test", f.getId()), vo, f);
 		Resource r2 = perun.getResourcesManager().createResource(sess, new Resource(0, "test", "test", f.getId()), vo2, f);
 
-		perun.getResourcesManager().assignGroupToResource(sess, g, r);
+		perun.getResourcesManager().assignGroupToResource(sess, g, r, false);
 		perun.getGroupsManager().addMember(sess, g, m);
 
 		AttributeDefinition attrDef = new AttributeDefinition();
@@ -738,7 +730,7 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 		// put member back
 		perun.getGroupsManager().addMember(sess, g, m);
 		// create second assignment
-		perun.getResourcesManager().assignGroupToResource(sess, g2, r2);
+		perun.getResourcesManager().assignGroupToResource(sess, g2, r2, false);
 		perun.getGroupsManager().addMember(sess, g2, m2);
 
 		withValue = perun.getAttributesManager().getAttribute(sess, f, user, attrDef.getName());
@@ -2615,8 +2607,8 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 		resource.setName("TestForGetSubgroups");
 		resource.setDescription("Testovaci");
 		resource = sess.getPerun().getResourcesManager().createResource(sess, resource, createdVo, facility);
-		sess.getPerun().getResourcesManager().assignGroupToResource(sess, parentGroup, resource);
-		sess.getPerun().getResourcesManager().assignGroupToResource(sess, subgroup1, resource);
+		sess.getPerun().getResourcesManager().assignGroupToResource(sess, parentGroup, resource, false);
+		sess.getPerun().getResourcesManager().assignGroupToResource(sess, subgroup1, resource, false);
 
 		List<Group> groupsList = groupsManagerBl.getAssignedGroupsToResource(sess, resource, true);
 		assertNotNull(groupsList);
@@ -2701,8 +2693,8 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 		resource.setName("TestForGetSubgroups");
 		resource.setDescription("Testovaci");
 		resource = sess.getPerun().getResourcesManager().createResource(sess, resource, createdVo, facility);
-		sess.getPerun().getResourcesManager().assignGroupToResource(sess, parentGroup, resource);
-		sess.getPerun().getResourcesManager().assignGroupToResource(sess, subgroup1, resource);
+		sess.getPerun().getResourcesManager().assignGroupToResource(sess, parentGroup, resource, false);
+		sess.getPerun().getResourcesManager().assignGroupToResource(sess, subgroup1, resource, false);
 
 		List<Group> groupsList = groupsManagerBl.getAssignedGroupsToResource(sess, resource, false);
 		assertNotNull(groupsList);
@@ -3735,7 +3727,7 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 		setUpGroup(vo);
 		Facility facility = setUpFacility();
 		Resource resource = setUpResource(vo, facility);
-		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource, false);
 		List<Attribute> groupAttributes = setUpGroupAttributes();
 		List<Attribute> groupResourceAttributes = setUpGroupResourceAttribute();
 		List<Attribute> allAttributes = new ArrayList<>();
@@ -3765,7 +3757,7 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 		List<Group> groups = setUpGroups(vo);
 		Facility facility = setUpFacility();
 		Resource resource = setUpResource(vo, facility);
-		for(Group group: groups) perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource);
+		for(Group group: groups) perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource, false);
 
 		List<Attribute> groupAttributes = setUpGroupAttributes();
 		List<Attribute> groupResourceAttributes = setUpGroupResourceAttribute();
@@ -3800,7 +3792,7 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 
 		Facility facility = setUpFacility();
 		Resource resource = setUpResource(vo, facility);
-		for(Group group: groups) perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource);
+		for(Group group: groups) perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource, false);
 
 		List<Attribute> groupAttributes = setUpGroupAttributes();
 		List<Attribute> groupResourceAttributes = setUpGroupResourceAttribute();
@@ -4055,8 +4047,8 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 		group21 = perun.getGroupsManager().createGroup(sess, vo2, group21);
 		group22 = perun.getGroupsManager().createGroup(sess, vo2, group22);
 
-		perun.getResourcesManager().assignGroupToResource(sess, group11, resource1);
-		perun.getResourcesManager().assignGroupToResource(sess, group21, resource2);
+		perun.getResourcesManager().assignGroupToResource(sess, group11, resource1, false);
+		perun.getResourcesManager().assignGroupToResource(sess, group21, resource2, false);
 
 		// test new way - single select
 		List<Group> groups = perun.getGroupsManagerBl().getAssignedGroupsToFacility(sess, facility);

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/MembersManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/MembersManagerEntryIntegrationTest.java
@@ -307,7 +307,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 		facility = perun.getFacilitiesManagerBl().createFacility(sess, facility);
 		Resource resource = new Resource(0, "TESTING Resource", "TESTING Resource", facility.getId(), createdVo.getId());
 		resource = perun.getResourcesManagerBl().createResource(sess, resource, createdVo, facility);
-		perun.getResourcesManagerBl().assignGroupToResource(sess, createdGroup, resource);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, createdGroup, resource, false);
 		perun.getGroupsManagerBl().addMember(sess, createdGroup, createdMember);
 
 		Attribute userAttribute1 = setUpAttribute(String.class.getName(), "testUserAttribute1", AttributesManager.NS_USER_ATTR_DEF, "TEST VALUE");
@@ -398,7 +398,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 		facility = perun.getFacilitiesManagerBl().createFacility(sess, facility);
 		Resource resource = new Resource(0, "TESTING Resource", "TESTING Resource", facility.getId(), createdVo.getId());
 		resource = perun.getResourcesManagerBl().createResource(sess, resource, createdVo, facility);
-		perun.getResourcesManagerBl().assignGroupToResource(sess, createdGroup, resource);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, createdGroup, resource, false);
 		perun.getGroupsManagerBl().addMember(sess, createdGroup, createdMember);
 
 		Attribute userAttribute1 = setUpAttribute(String.class.getName(), "testUserAttribute1", AttributesManager.NS_USER_ATTR_DEF, "TEST VALUE");
@@ -2370,7 +2370,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 		facility = perun.getFacilitiesManagerBl().createFacility(sess, facility);
 		Resource resource = new Resource(0, "TESTING Resource", "TESTING Resource", facility.getId(), createdVo.getId());
 		resource = perun.getResourcesManagerBl().createResource(sess, resource, createdVo, facility);
-		perun.getResourcesManagerBl().assignGroupToResource(sess, createdGroup, resource);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, createdGroup, resource, false);
 
 		// set attributes
 		Attribute memberAttribute = setUpAttribute(Integer.class.getName(), "testMemberAttribute", AttributesManager.NS_MEMBER_ATTR_DEF, 15);
@@ -2458,7 +2458,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 		facility = perun.getFacilitiesManagerBl().createFacility(sess, facility);
 		Resource resource = new Resource(0, "TESTING Resource", "TESTING Resource", facility.getId(), createdVo.getId());
 		resource = perun.getResourcesManagerBl().createResource(sess, resource, createdVo, facility);
-		perun.getResourcesManagerBl().assignGroupToResource(sess, createdGroup, resource);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, createdGroup, resource, false);
 
 		LocalDate today = LocalDate.now();
 		Date tommorow = Date.from(today.plusDays(1).atStartOfDay(ZoneId.systemDefault()).toInstant());

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ModulesUtilsEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ModulesUtilsEntryIntegrationTest.java
@@ -216,7 +216,7 @@ public class ModulesUtilsEntryIntegrationTest extends AbstractPerunIntegrationTe
 
 		perun.getAttributesManagerBl().setAttribute(sess, namespace, gidRanges);
 
-		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource, false);
 
 		List<Attribute> attributes = setUpGroupNamesAndGIDForGroupAndResource();
 		Attribute groupGID = null;
@@ -474,7 +474,7 @@ public class ModulesUtilsEntryIntegrationTest extends AbstractPerunIntegrationTe
 		gidRanges.setValue(gidRangesValue);
 		perun.getAttributesManagerBl().setAttribute(sess, namespace, gidRanges);
 
-		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource, false);
 
 		List<Attribute> attributes = setUpGroupNamesAndGIDForGroupAndResource();
 		List<Attribute> facilityAttributes = setUpFacilityGroupNameAndGIDNamespaceAttributes();

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ResourcesManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ResourcesManagerEntryIntegrationTest.java
@@ -276,7 +276,7 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 		service = setUpService();
 		ResourceTag resTag = setUpResourceTag();
 		resourcesManager.assignService(sess, resource, service);
-		resourcesManager.assignGroupToResource(sess, group, resource);
+		resourcesManager.assignGroupToResource(sess, group, resource, false);
 		resourcesManager.assignResourceTagToResource(sess, resTag, resource);
 
 		Resource destinationResource = new Resource();
@@ -339,7 +339,7 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 		assertNotNull("unable to create resource before deletion",resource);
 		member = setUpMember(vo);
 		group = setUpGroup(vo, member);
-		resourcesManager.assignGroupToResource(sess, group, resource);
+		resourcesManager.assignGroupToResource(sess, group, resource, false);
 
 		resourcesManager.deleteResource(sess, resource);
 		// shouldn't delete resource with assigned group
@@ -380,7 +380,7 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 		member = setUpMember(vo);
 		group = setUpGroup(vo, member);
 
-		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource, false);
 		List<Attribute> attributes = setUpGroupResourceAttribute(group, resource);
 
 		List<Attribute> retAttributes = perun.getAttributesManagerBl().getAttributes(sess, resource, group, false);
@@ -448,7 +448,7 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 		assertNotNull("unable to create resource",resource);
 		member = setUpMember(vo);
 		group = setUpGroup(vo, member);
-		resourcesManager.assignGroupToResource(sess, group, resource);
+		resourcesManager.assignGroupToResource(sess, group, resource, false);
 
 		List<Member> members = resourcesManager.getAllowedMembers(sess, resource);
 		assertTrue("our resource should have 1 allowed member",members.size() == 1);
@@ -467,7 +467,7 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 		member = setUpMember(vo);
 		User user = perun.getUsersManagerBl().getUserByMember(sess, member);
 		group = setUpGroup(vo, member);
-		resourcesManager.assignGroupToResource(sess, group, resource);
+		resourcesManager.assignGroupToResource(sess, group, resource, false);
 
 		List<User> users = resourcesManager.getAllowedUsers(sess, resource);
 		assertTrue("our resource should have 1 allowed user",users.size() == 1);
@@ -494,7 +494,7 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 		assertNotNull("unable to create resource",resource);
 		member = setUpMember(vo);
 		group = setUpGroup(vo, member);
-		resourcesManager.assignGroupToResource(sess, group, resource);
+		resourcesManager.assignGroupToResource(sess, group, resource, false);
 
 		List<Group> assignedGroups = resourcesManager.getAssignedGroups(sess, resource);
 		assertTrue("one group should be assigned to our Resource",assignedGroups.size() == 1);
@@ -510,7 +510,7 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 		facility = setUpFacility();
 		resource = setUpResource();
 		assertNotNull("unable to create resource",resource);
-		resourcesManager.assignGroupToResource(sess, new Group(), resource);
+		resourcesManager.assignGroupToResource(sess, new Group(), resource, false);
 		// shouldn't find group
 
 	}
@@ -523,7 +523,7 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 		facility = setUpFacility();
 		member = setUpMember(vo);
 		group = setUpGroup(vo, member);
-		resourcesManager.assignGroupToResource(sess, group, new Resource());
+		resourcesManager.assignGroupToResource(sess, group, new Resource(), false);
 		// shouldn't find resource
 
 	}
@@ -537,8 +537,8 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 		group = setUpGroup(vo, member);
 		resource = setUpResource();
 
-		resourcesManager.assignGroupToResource(sess, group, resource);
-		resourcesManager.assignGroupToResource(sess, group, resource);
+		resourcesManager.assignGroupToResource(sess, group, resource, false);
+		resourcesManager.assignGroupToResource(sess, group, resource, false);
 		// shouldn't add group twice
 
 	}
@@ -565,7 +565,7 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 		groups.add(group);
 		groups.add(group2);
 		resourcesManager.assignService(sess, resource, service);
-		resourcesManager.assignGroupsToResource(sess, groups, resource);
+		resourcesManager.assignGroupsToResource(sess, groups, resource, false);
 
 		List<Group> assignedGroups = resourcesManager.getAssignedGroups(sess, resource);
 		assertEquals("all groups should be assigned to our Resource", assignedGroups.size(), groups.size());
@@ -581,7 +581,7 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 		member = setUpMember(vo);
 		group = setUpGroup(vo, member);
 		resource = setUpResource();
-		resourcesManager.assignGroupToResource(sess, group, resource);
+		resourcesManager.assignGroupToResource(sess, group, resource, false);
 
 		resourcesManager.removeGroupFromResource(sess, group, resource);
 		List<Group> groups = resourcesManager.getAssignedGroups(sess, resource);
@@ -626,7 +626,7 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 		subGroup = setUpSubGroup(group);
 		facility = setUpFacility();
 		resource = setUpResource();
-		resourcesManager.assignGroupToResource(sess, group, resource);
+		resourcesManager.assignGroupToResource(sess, group, resource, false);
 
 		resourcesManager.removeGroupFromResource(sess, subGroup, resource);
 		// shouldn't remove subGroup when parent group was assigned
@@ -656,7 +656,7 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 		group = setUpGroup(vo, member);
 		facility = setUpFacility();
 		resource = setUpResource();
-		resourcesManager.assignGroupToResource(sess, group, resource);
+		resourcesManager.assignGroupToResource(sess, group, resource, false);
 		resourcesManager.deactivateGroupResourceAssignment(sess, group, resource);
 
 		assertThatNoException().isThrownBy(() -> resourcesManager.removeGroupFromResource(sess, group, resource));
@@ -672,7 +672,7 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 		facility = setUpFacility();
 		resource = setUpResource();
 
-		resourcesManager.assignGroupToResource(sess, group, resource);
+		resourcesManager.assignGroupToResource(sess, group, resource, false);
 
 		List<Group> groups = resourcesManager.getAssignedGroups(sess, resource);
 		assertTrue("only one group should be assigned",groups.size() == 1);
@@ -690,7 +690,7 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 		facility = setUpFacility();
 		resource = setUpResource();
 
-		resourcesManager.assignGroupToResource(sess, group, resource);
+		resourcesManager.assignGroupToResource(sess, group, resource, false);
 
 		List<Group> groups = resourcesManager.getAssignedGroups(sess, resource, member);
 		assertTrue("only one group should be assigned",groups.size() == 1);
@@ -716,7 +716,7 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 		facility = setUpFacility();
 		resource = setUpResource();
 
-		resourcesManager.assignGroupToResource(sess, group, resource);
+		resourcesManager.assignGroupToResource(sess, group, resource, false);
 
 		List<Resource> resources = resourcesManager.getAssignedResources(sess, group);
 		assertTrue("group should have be on 1 resource",resources.size() == 1);
@@ -745,7 +745,7 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 		RichResource rr = new RichResource(resource);
 		rr.setFacility(perun.getResourcesManager().getFacility(sess, resource));
 
-		resourcesManager.assignGroupToResource(sess, group, resource);
+		resourcesManager.assignGroupToResource(sess, group, resource, false);
 
 		List<RichResource> resources = resourcesManager.getAssignedRichResources(sess, group);
 		assertTrue("group should have be on 1 rich resource",resources.size() == 1);
@@ -778,8 +778,8 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 		service = setUpService();
 
 		// both the resources assign to the group
-		resourcesManager.assignGroupToResource(sess, group, resource);
-		resourcesManager.assignGroupToResource(sess, group, sndResource);
+		resourcesManager.assignGroupToResource(sess, group, resource, false);
+		resourcesManager.assignGroupToResource(sess, group, sndResource, false);
 		// but only one of them assign to the service
 		resourcesManager.assignService(sess, resource, service);
 
@@ -800,8 +800,8 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 		Resource sndResource = setUpResource2();
 
 		// both the resources assign to the group
-		resourcesManager.assignGroupToResource(sess, group, resource);
-		resourcesManager.assignGroupToResource(sess, group, sndResource);
+		resourcesManager.assignGroupToResource(sess, group, resource, false);
+		resourcesManager.assignGroupToResource(sess, group, sndResource, false);
 
 		List<Resource> resources = resourcesManager.getAssignedResources(sess, member);
 		assertTrue("member should be assigned to 2 resources",resources.size() == 2);
@@ -839,8 +839,8 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 		service = setUpService();
 
 		// both the resources assign to the group
-		resourcesManager.assignGroupToResource(sess, group, resource);
-		resourcesManager.assignGroupToResource(sess, group, sndResource);
+		resourcesManager.assignGroupToResource(sess, group, resource, false);
+		resourcesManager.assignGroupToResource(sess, group, sndResource, false);
 		// but only one of them assign to the service
 		resourcesManager.assignService(sess, resource, service);
 
@@ -864,8 +864,8 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 		richResource.setVo(vo);
 		Resource sndResource = setUpResource2();
 
-		resourcesManager.assignGroupToResource(sess, group, resource);
-		resourcesManager.assignGroupToResource(sess, group, sndResource);
+		resourcesManager.assignGroupToResource(sess, group, resource, false);
+		resourcesManager.assignGroupToResource(sess, group, sndResource, false);
 
 		RichResource rr = perun.getResourcesManagerBl().getRichResourceById(sess, resource.getId());
 		RichResource rr2 = perun.getResourcesManagerBl().getRichResourceById(sess, sndResource.getId());
@@ -902,8 +902,8 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 		Resource sndResource = setUpResource2();
 
 		// both the resources assign to the group
-		resourcesManager.assignGroupToResource(sess, group, resource);
-		resourcesManager.assignGroupToResource(sess, group, sndResource);
+		resourcesManager.assignGroupToResource(sess, group, resource, false);
+		resourcesManager.assignGroupToResource(sess, group, sndResource, false);
 
 		List<Member> members = resourcesManager.getAssignedMembers(sess, resource);
 		assertTrue(members.size() == 1);
@@ -1398,7 +1398,7 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 		resource = setUpResource();
 		member = setUpMember(vo);
 		group = setUpGroup(vo, member);
-		resourcesManager.assignGroupToResource(sess, group, resource);
+		resourcesManager.assignGroupToResource(sess, group, resource, false);
 
 		// set up second resource
 		Resource newResource = new Resource();
@@ -1432,7 +1432,7 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 		resource = setUpResource();
 		member = setUpMember(vo);
 		group = setUpGroup(vo, member);
-		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource, false);
 
 		BanOnResource banOnResource = new BanOnResource();
 		banOnResource.setMemberId(member.getId());
@@ -1453,7 +1453,7 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 		resource = setUpResource();
 		member = setUpMember(vo);
 		group = setUpGroup(vo, member);
-		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource, false);
 
 		BanOnResource banOnResource = new BanOnResource();
 		banOnResource.setMemberId(member.getId());
@@ -1474,7 +1474,7 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 		resource = setUpResource();
 		member = setUpMember(vo);
 		group = setUpGroup(vo, member);
-		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource, false);
 
 		BanOnResource banOnResource = new BanOnResource();
 		banOnResource.setMemberId(member.getId());
@@ -1495,7 +1495,7 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 		resource = setUpResource();
 		member = setUpMember(vo);
 		group = setUpGroup(vo, member);
-		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource, false);
 
 		BanOnResource banOnResource = new BanOnResource();
 		banOnResource.setMemberId(member.getId());
@@ -1516,7 +1516,7 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 		resource = setUpResource();
 		member = setUpMember(vo);
 		group = setUpGroup(vo, member);
-		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource, false);
 
 		BanOnResource banOnResource = new BanOnResource();
 		banOnResource.setMemberId(member.getId());
@@ -1537,7 +1537,7 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 		resource = setUpResource();
 		member = setUpMember(vo);
 		group = setUpGroup(vo, member);
-		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource, false);
 
 		BanOnResource banOnResource = new BanOnResource();
 		banOnResource.setMemberId(member.getId());
@@ -1561,7 +1561,7 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 		resource = setUpResource();
 		member = setUpMember(vo);
 		group = setUpGroup(vo, member);
-		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource, false);
 
 		BanOnResource banOnResource = new BanOnResource();
 		banOnResource.setMemberId(member.getId());
@@ -1587,7 +1587,7 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 		resource = setUpResource();
 		member = setUpMember(vo);
 		group = setUpGroup(vo, member);
-		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource, false);
 
 		BanOnResource banOnResource = new BanOnResource();
 		banOnResource.setMemberId(member.getId());
@@ -1613,7 +1613,7 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 		resource = setUpResource();
 		member = setUpMember(vo);
 		group = setUpGroup(vo, member);
-		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource, false);
 
 		BanOnResource banOnResource = new BanOnResource();
 		banOnResource.setMemberId(member.getId());
@@ -1641,7 +1641,7 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 		resource = setUpResource();
 		member = setUpMember(vo);
 		group = setUpGroup(vo, member);
-		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource, false);
 
 		BanOnResource banOnResource = new BanOnResource();
 		banOnResource.setMemberId(member.getId());
@@ -2106,7 +2106,7 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 		facility = setUpFacility();
 		resource = setUpResource();
 
-		resourcesManager.assignGroupToResource(sess, group, resource);
+		resourcesManager.assignGroupToResource(sess, group, resource, false);
 
 		List<AssignedResource> resources = resourcesManager.getResourceAssignments(sess, group, null);
 		AssignedResource expectedResource = new AssignedResource(new EnrichedResource(resource, null), GroupResourceStatus.ACTIVE, facility);
@@ -2130,7 +2130,7 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 		ResourceTag resourceTag = new ResourceTag(1, "This is a tag", vo.getId());
 		resourcesManager.createResourceTag(sess, resourceTag, vo);
 
-		resourcesManager.assignGroupToResource(sess, group, resource);
+		resourcesManager.assignGroupToResource(sess, group, resource, false);
 		resourcesManager.assignResourceTagToResource(sess, resourceTag, resource);
 
 		List<AssignedResource> resources = resourcesManager.getResourceAssignments(sess, group, null);
@@ -2156,7 +2156,7 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 		facility = setUpFacility();
 		resource = setUpResource();
 
-		resourcesManager.assignGroupToResource(sess, group, resource);
+		resourcesManager.assignGroupToResource(sess, group, resource, false);
 
 		List<AssignedGroup> groups = resourcesManager.getGroupAssignments(sess, resource, null);
 		AssignedGroup expectedGroup = new AssignedGroup(new EnrichedGroup(group, null), GroupResourceStatus.ACTIVE);
@@ -2185,7 +2185,7 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 		facility = setUpFacility();
 		resource = setUpResource();
 
-		resourcesManager.assignGroupToResource(sess, group, resource);
+		resourcesManager.assignGroupToResource(sess, group, resource, false);
 		resourcesManager.deactivateGroupResourceAssignment(sess, group, resource);
 		resourcesManager.activateGroupResourceAssignment(sess, group, resource, false);
 
@@ -2229,7 +2229,7 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 		facility = setUpFacility();
 		resource = setUpResource();
 
-		resourcesManager.assignGroupToResource(sess, group, resource);
+		resourcesManager.assignGroupToResource(sess, group, resource, false);
 		resourcesManager.deactivateGroupResourceAssignment(sess, group, resource);
 
 		List<AssignedGroup> groups = resourcesManager.getGroupAssignments(sess, resource, null);

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/SearcherEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/SearcherEntryIntegrationTest.java
@@ -327,13 +327,13 @@ public class SearcherEntryIntegrationTest extends AbstractPerunIntegrationTest {
 		Resource resource3 = new Resource(0, "testName03", "testName03", facility.getId(), vo.getId());
 		resource3 = perun.getResourcesManagerBl().createResource(sess,resource3, vo, facility);
 
-		perun.getResourcesManagerBl().assignGroupToResource(sess, group1, resource1);
-		perun.getResourcesManagerBl().assignGroupToResource(sess, group1, resource2);
-		perun.getResourcesManagerBl().assignGroupToResource(sess, group2, resource1);
-		perun.getResourcesManagerBl().assignGroupToResource(sess, group2, resource2);
-		perun.getResourcesManagerBl().assignGroupToResource(sess, group2, resource3);
-		perun.getResourcesManagerBl().assignGroupToResource(sess, group3, resource2);
-		perun.getResourcesManagerBl().assignGroupToResource(sess, group3, resource3);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group1, resource1, false);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group1, resource2, false);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group2, resource1, false);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group2, resource2, false);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group2, resource3, false);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group3, resource2, false);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group3, resource3, false);
 
 		Attribute groupResourceAttr01 = new Attribute(setUpGroupResourceAttribute());
 		groupResourceAttr01.setValue("VALUE01");

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ServicesManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ServicesManagerEntryIntegrationTest.java
@@ -1176,7 +1176,7 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 		member = setUpMember();
 		group = setUpGroup();
 		perun.getGroupsManager().addMember(sess, group, member);
-		perun.getResourcesManager().assignGroupToResource(sess, group, resource);
+		perun.getResourcesManager().assignGroupToResource(sess, group, resource, false);
 
 		// set element's name/id as required attributes to get some attributes for every element
 		Attribute reqFacAttr;
@@ -1195,7 +1195,7 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 		// create second (but same) resource
 		resource.setName("HierarchDataResource");
 		resource = perun.getResourcesManager().createResource(sess, resource, vo, facility);
-		perun.getResourcesManager().assignGroupToResource(sess, group, resource);
+		perun.getResourcesManager().assignGroupToResource(sess, group, resource, false);
 		perun.getResourcesManager().assignService(sess, resource, service);
 		// get it's required attribute with value for testing purpose
 		Attribute reqResAttr2 = perun.getAttributesManager().getAttribute(sess, resource, "urn:perun:resource:attribute-def:core:name");
@@ -1293,7 +1293,7 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 		group = setUpGroup();
 		perun.getGroupsManager().addMember(sess, group, member);
 		perun.getGroupsManager().addMember(sess, group, member2);
-		perun.getResourcesManager().assignGroupToResource(sess, group, resource);
+		perun.getResourcesManager().assignGroupToResource(sess, group, resource, false);
 		perun.getGroupsManager().setMemberGroupStatus(sess, member2, group, MemberGroupStatus.EXPIRED);
 
 		// set element's name/id as required attributes to get some attributes for every element
@@ -1352,7 +1352,7 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 		User user = perun.getUsersManagerBl().getUserByMember(sess, member);
 		group = setUpGroup();
 		perun.getGroupsManager().addMember(sess, group, member);
-		perun.getResourcesManager().assignGroupToResource(sess, group, resource);
+		perun.getResourcesManager().assignGroupToResource(sess, group, resource, false);
 
 		// set element's name/id as required attributes to get some attributes for every element
 		Attribute reqFacAttr;
@@ -1439,8 +1439,8 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 		perun.getGroupsManager().addMember(sess, group, member3);
 		perun.getGroupsManager().addMember(sess, group, member4);
 		perun.getGroupsManager().addMember(sess, group2, member5);
-		perun.getResourcesManager().assignGroupToResource(sess, group, resource);
-		perun.getResourcesManager().assignGroupToResource(sess, group2, resource2);
+		perun.getResourcesManager().assignGroupToResource(sess, group, resource, false);
+		perun.getResourcesManager().assignGroupToResource(sess, group2, resource2, false);
 		perun.getGroupsManager().setMemberGroupStatus(sess, member2, group2, MemberGroupStatus.EXPIRED);
 		perun.getGroupsManager().setMemberGroupStatus(sess, member, group, MemberGroupStatus.EXPIRED);
 		perun.getGroupsManager().setMemberGroupStatus(sess, member4, group, MemberGroupStatus.EXPIRED);
@@ -1473,7 +1473,7 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 		member = setUpMember();
 		group = setUpGroup();
 		perun.getGroupsManager().addMember(sess, group, member);
-		perun.getResourcesManager().assignGroupToResource(sess, group, resource);
+		perun.getResourcesManager().assignGroupToResource(sess, group, resource, false);
 
 		// set element's name/id as required attributes to get some attributes for every element
 		Attribute reqFacAttr;
@@ -1495,7 +1495,7 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 		// create second (but same) resource
 		resource.setName("HierarchDataResource");
 		resource = perun.getResourcesManager().createResource(sess, resource, vo, facility);
-		perun.getResourcesManager().assignGroupToResource(sess, group, resource);
+		perun.getResourcesManager().assignGroupToResource(sess, group, resource, false);
 		perun.getResourcesManager().assignService(sess, resource, service);
 		// get it's required attribute with value for testing purpose
 		Attribute reqResAttr2 = perun.getAttributesManager().getAttribute(sess, resource, "urn:perun:resource:attribute-def:core:name");
@@ -1643,8 +1643,8 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 		perun.getGroupsManager().addMember(sess, group, member3);
 		perun.getGroupsManager().addMember(sess, group2, member2);
 		perun.getGroupsManager().addMember(sess, group2, member3);
-		perun.getResourcesManager().assignGroupToResource(sess, group, resource);
-		perun.getResourcesManager().assignGroupToResource(sess, group2, resource);
+		perun.getResourcesManager().assignGroupToResource(sess, group, resource, false);
+		perun.getResourcesManager().assignGroupToResource(sess, group2, resource, false);
 
 		// set element's name/id as required attributes to get some attributes for every element
 		Attribute reqFacAttr;
@@ -1717,7 +1717,7 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 		member = setUpMember();
 		group = setUpGroup();
 		perun.getGroupsManager().addMember(sess, group, member);
-		perun.getResourcesManager().assignGroupToResource(sess, group, resource);
+		perun.getResourcesManager().assignGroupToResource(sess, group, resource, false);
 
 		// set element's name/id as required attributes to get some attributes for every element
 		Attribute reqFacAttr;
@@ -1812,8 +1812,8 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 		perun.getGroupsManager().addMember(sess, group, member3);
 		perun.getGroupsManager().addMember(sess, group2, member2);
 		perun.getGroupsManager().addMember(sess, group2, member3);
-		perun.getResourcesManager().assignGroupToResource(sess, group, resource);
-		perun.getResourcesManager().assignGroupToResource(sess, group2, resource);
+		perun.getResourcesManager().assignGroupToResource(sess, group, resource, false);
+		perun.getResourcesManager().assignGroupToResource(sess, group2, resource, false);
 
 		perun.getGroupsManager().setMemberGroupStatus(sess, member2, group, MemberGroupStatus.EXPIRED);
 		perun.getGroupsManager().setMemberGroupStatus(sess, member3, group, MemberGroupStatus.EXPIRED);
@@ -1920,7 +1920,7 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 		member = setUpMember();
 		group = setUpGroup();
 		perun.getGroupsManager().addMember(sess, group, member);
-		perun.getResourcesManager().assignGroupToResource(sess, group, resource);
+		perun.getResourcesManager().assignGroupToResource(sess, group, resource, false);
 
 		// set element's name/id as required attributes to get some attributes for every element
 		Attribute reqFacAttr;
@@ -1946,7 +1946,7 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 		Resource resource2 = new Resource();
 		resource2.setName("HierarchDataResource");
 		resource2 = perun.getResourcesManager().createResource(sess, resource2, vo, facility);
-		perun.getResourcesManager().assignGroupToResource(sess, group, resource2);
+		perun.getResourcesManager().assignGroupToResource(sess, group, resource2, false);
 		perun.getResourcesManager().assignService(sess, resource2, service);
 
 		//create third resource but without service
@@ -2033,7 +2033,7 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 		member = setUpMember();
 		group = setUpGroup();
 		perun.getGroupsManager().addMember(sess, group, member);
-		perun.getResourcesManager().assignGroupToResource(sess, group, resource);
+		perun.getResourcesManager().assignGroupToResource(sess, group, resource, false);
 
 		// set element's name/id as required attributes to get some attributes for every element
 		Attribute reqFacAttr;
@@ -2059,7 +2059,7 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 		Resource resource2 = new Resource();
 		resource2.setName("HierarchDataResource");
 		resource2 = perun.getResourcesManager().createResource(sess, resource2, vo, facility);
-		perun.getResourcesManager().assignGroupToResource(sess, group, resource2);
+		perun.getResourcesManager().assignGroupToResource(sess, group, resource2, false);
 		perun.getResourcesManager().assignService(sess, resource2, service);
 
 		//create third resource but without service

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/UsersManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/UsersManagerEntryIntegrationTest.java
@@ -1042,7 +1042,7 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 		resource.setName("UsersManagerTestResource");
 		resource.setDescription("Testovaci");
 		resource = perun.getResourcesManager().createResource(sess, resource, vo, facility);
-		perun.getResourcesManager().assignGroupToResource(sess, group, resource);
+		perun.getResourcesManager().assignGroupToResource(sess, group, resource, false);
 		// create resource, assign group with our member
 
 		User user = usersManager.getUserByMember(sess, member);
@@ -1309,7 +1309,7 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 		Group g1 = setUpGroup(vo, member, "group1");
 		Group g2 = setUpGroup(vo, member, "group2");
 
-		perun.getResourcesManager().assignGroupToResource(sess, g1, r);
+		perun.getResourcesManager().assignGroupToResource(sess, g1, r, false);
 
 		// more groups case
 
@@ -1325,7 +1325,7 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 		assertTrue("Should have no groups, since member should be VO expired", groups.isEmpty());
 
 		perun.getMembersManager().setStatus(sess, member, Status.VALID);
-		perun.getResourcesManager().assignGroupToResource(sess, g2, r);
+		perun.getResourcesManager().assignGroupToResource(sess, g2, r, false);
 
 		groups = perun.getUsersManager().getGroupsWhereUserIsActive(sess, f, u);
 		assertTrue("Should have 2 groups", groups.size() == 2);
@@ -1356,7 +1356,7 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 		assertTrue("Should be empty since there are no groups on R2 resource.", groups.size() == 0);
 
 		perun.getResourcesManager().removeGroupFromResource(sess, g2, r);
-		perun.getResourcesManager().assignGroupToResource(sess, g2, r2);
+		perun.getResourcesManager().assignGroupToResource(sess, g2, r2, false);
 
 		perun.getGroupsManager().setMemberGroupStatus(sess, member, g1, MemberGroupStatus.VALID);
 

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/AttributesManagerImplIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/AttributesManagerImplIntegrationTest.java
@@ -210,7 +210,7 @@ public class AttributesManagerImplIntegrationTest extends AbstractPerunIntegrati
 		perunBlImpl.getServicesManagerBl().addRequiredAttribute(sess, service2, groupResourceAttribute2);
 		perunBlImpl.getServicesManagerBl().addRequiredAttribute(sess, service2, groupAttribute2);
 
-		perunBlImpl.getResourcesManagerBl().assignGroupToResource(sess, group, resource);
+		perunBlImpl.getResourcesManagerBl().assignGroupToResource(sess, group, resource, false);
 		perunBlImpl.getResourcesManagerBl().assignService(sess, resource, service1);
 		perunBlImpl.getResourcesManagerBl().assignService(sess, resource, service2);
 	}

--- a/perun-dispatcher/src/test/java/cz/metacentrum/perun/dispatcher/unit/EventProcessorTest.java
+++ b/perun-dispatcher/src/test/java/cz/metacentrum/perun/dispatcher/unit/EventProcessorTest.java
@@ -58,7 +58,7 @@ public class EventProcessorTest extends AbstractDispatcherTest {
 		perun.getGroupsManagerBl().addMember(sess, group1, member1);
 
 		// assign the group to resource
-		perun.getResourcesManagerBl().assignGroupToResource(sess, group1, resource1);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group1, resource1, false);
 
 	}
 

--- a/perun-dispatcher/src/test/java/cz/metacentrum/perun/dispatcher/unit/EventServiceResolverTest.java
+++ b/perun-dispatcher/src/test/java/cz/metacentrum/perun/dispatcher/unit/EventServiceResolverTest.java
@@ -9,7 +9,6 @@ import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.Service;
 import cz.metacentrum.perun.core.api.User;
-import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
 import cz.metacentrum.perun.core.api.exceptions.ServiceNotExistsException;
 import cz.metacentrum.perun.core.bl.PerunBl;
@@ -56,7 +55,7 @@ public class EventServiceResolverTest extends AbstractDispatcherTest {
 		perun.getGroupsManagerBl().addMember(sess, group1, member1);
 
 		// assign the group to resource
-		perun.getResourcesManagerBl().assignGroupToResource(sess, group1, resource1);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group1, resource1, false);
 
 	}
 

--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -11827,10 +11827,11 @@ paths:
       tags:
         - ResourcesManager
       operationId: assignGroupToResource
-      summary: Assigns a group to a resource. Check if attributes for each member from group are valid. Fill members' attributes with missing value.
+      summary: Assigns a group to a resource. Check if attributes for each member from group are valid. Fill members' attributes with missing value. Work in sync/async mode.
       parameters:
         - $ref: '#/components/parameters/groupId'
         - $ref: '#/components/parameters/resourceId'
+        - $ref: '#/components/parameters/async'
       responses:
         '200':
           $ref: '#/components/responses/VoidResponse'
@@ -11842,10 +11843,11 @@ paths:
       tags:
         - ResourcesManager
       operationId: assignGroupsToResource
-      summary: Assigns groups to a resource. Check if attributes for each member from groups are valid. Fill members' attributes with missing values.
+      summary: Assigns groups to a resource. Check if attributes for each member from groups are valid. Fill members' attributes with missing values. Work in sync/async mode.
       parameters:
         - $ref: '#/components/parameters/groupIds'
         - $ref: '#/components/parameters/resourceId'
+        - $ref: '#/components/parameters/async'
       responses:
         '200':
           $ref: '#/components/responses/VoidResponse'
@@ -11857,10 +11859,11 @@ paths:
       tags:
         - ResourcesManager
       operationId: assignGroupToResources
-      summary: Assigns a group to resources. Check if attributes for each member from group are valid. Fill members' attributes with missing values.
+      summary: Assigns a group to resources. Check if attributes for each member from group are valid. Fill members' attributes with missing values. Work in sync/async mode.
       parameters:
         - $ref: '#/components/parameters/groupId'
         - $ref: '#/components/parameters/resourceIds'
+        - $ref: '#/components/parameters/async'
       responses:
         '200':
           $ref: '#/components/responses/VoidResponse'

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/ResourcesManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/ResourcesManagerMethod.java
@@ -2,7 +2,6 @@ package cz.metacentrum.perun.rpc.methods;
 
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import cz.metacentrum.perun.core.api.*;
@@ -283,7 +282,7 @@ public enum ResourcesManagerMethod implements ManagerMethod {
 	},
 
 	/*#
-	 * Assign group to a resource. Check if attributes for each member from group are valid. Fill members' attributes with missing value.
+	 * Assign group to a resource. Check if attributes for each member from group are valid. Fill members' attributes with missing value. Work in sync/async mode.
 	 *
 	 * @param group int Group <code>id</code>
 	 * @param resource int Resource <code>id</code>
@@ -294,15 +293,19 @@ public enum ResourcesManagerMethod implements ManagerMethod {
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
 			parms.stateChangingCheck();
 
+			boolean async = parms.contains("async") ? parms.readBoolean("async") : false;
+
 			ac.getResourcesManager().assignGroupToResource(ac.getSession(),
 					ac.getGroupById(parms.readInt("group")),
-					ac.getResourceById(parms.readInt("resource")));
+					ac.getResourceById(parms.readInt("resource")),
+					async
+				);
 			return null;
 		}
 	},
 
 	/*#
-	 * Assign groups to a resource. Check if attributes for each member from groups are valid. Fill members' attributes with missing values.
+	 * Assign groups to a resource. Check if attributes for each member from groups are valid. Fill members' attributes with missing values. Work in sync/async mode.
 	 *
 	 * @param groups List<Integer> list of groups IDs
 	 * @param resource int Resource <code>id</code>
@@ -313,6 +316,8 @@ public enum ResourcesManagerMethod implements ManagerMethod {
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
 			parms.stateChangingCheck();
 
+			boolean async = parms.contains("async") ? parms.readBoolean("async") : false;
+
 			List<Integer> ids = parms.readList("groups", Integer.class);
 			List<Group> groups = new ArrayList<Group>();
 			for (Integer i : ids) {
@@ -320,13 +325,14 @@ public enum ResourcesManagerMethod implements ManagerMethod {
 			}
 			ac.getResourcesManager().assignGroupsToResource(ac.getSession(),
 					groups,
-					ac.getResourceById(parms.readInt("resource")));
+					ac.getResourceById(parms.readInt("resource")),
+					async);
 			return null;
 		}
 	},
 
 	/*#
-	 * Assign group to resources. Check if attributes for each member from group are valid. Fill members' attributes with missing values.
+	 * Assign group to resources. Check if attributes for each member from group are valid. Fill members' attributes with missing values. Work in sync/async mode.
 	 *
 	 * @param group int Group <code>id</code>
 	 * @param resources List<Integer> list of resources IDs
@@ -337,6 +343,8 @@ public enum ResourcesManagerMethod implements ManagerMethod {
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
 			parms.stateChangingCheck();
 
+			boolean async = parms.contains("async") ? parms.readBoolean("async") : false;
+
 			List<Integer> ids = parms.readList("resources", Integer.class);
 			List<Resource> resources = new ArrayList<Resource>();
 			for (Integer i : ids) {
@@ -344,7 +352,8 @@ public enum ResourcesManagerMethod implements ManagerMethod {
 			}
 			ac.getResourcesManager().assignGroupToResources(ac.getSession(),
 					ac.getGroupById(parms.readInt("group")),
-					resources);
+					resources,
+					async);
 			return null;
 		}
 	},


### PR DESCRIPTION
* RPC level checks presence of "async" parameter in provided params and
reads it
(in case of missing parameter, default false value is used).
* New parameter added into assignGroupToResource() method signatures in
entry and bl level,
where it is promoted from rpc level and promoted higher.
* BL level ensures sync/async mode itself -- GroupResourceStatus value
combined with activateGroupResourceAssignment() method.
* openAPI updated