### PR TITLE
feat(registrar): VO and group application notifications adjustment

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
@@ -1302,6 +1302,19 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 		return getPerunBl().getUsersManagerBl().filterOnlyAllowedAttributes(sess, richAdminsWithAttributes);
 	}
 
+	/**
+	 * Get all richUser administrators for complementary object and role without any attributes.
+	 *
+	 * @param sess perun session
+	 * @param complementaryObject for which we will get administrator
+	 * @param role expected role to filter managers by
+	 *
+	 * @return list of richUser administrators for complementary object and role.
+	 */
+	public static List<RichUser> getRichAdmins(PerunSession sess, PerunBean complementaryObject, String role) throws RoleCannotBeManagedException {
+		return getRichAdmins(sess, complementaryObject, Collections.emptyList(), role, false, false);
+	}
+
 	public String toString() {
 		return getClass().getSimpleName() + ":[]";
 	}


### PR DESCRIPTION
Notifications for VO application are based on toEmail attribute (of given VO), if it is null, preferred email is used to notify all VO admins.
Notifications for Group application are based on toEmail attribute of given group, if it is null, preferred email is used to notify all group admins (if there are any), otherwise VO admins are notified.