### PR TITLE
feat(core): store cause of group-resource assignment failure

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/AssignedGroup.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/AssignedGroup.java
@@ -10,10 +10,12 @@ import java.util.Objects;
 public class AssignedGroup {
 	private EnrichedGroup enrichedGroup;
 	private GroupResourceStatus status;
+	private String failureCause;
 
-	public AssignedGroup(EnrichedGroup enrichedGroup, GroupResourceStatus status) {
+	public AssignedGroup(EnrichedGroup enrichedGroup, GroupResourceStatus status, String failureCause) {
 		this.enrichedGroup = enrichedGroup;
 		this.status = status;
+		this.failureCause = failureCause;
 	}
 
 	public EnrichedGroup getEnrichedGroup() {
@@ -30,6 +32,14 @@ public class AssignedGroup {
 
 	public void setStatus(GroupResourceStatus status) {
 		this.status = status;
+	}
+
+	public String getFailureCause() {
+		return failureCause;
+	}
+
+	public void setFailureCause(String failureCause) {
+		this.failureCause = failureCause;
 	}
 
 	@Override
@@ -50,6 +60,7 @@ public class AssignedGroup {
 		return "AssignedGroup{" +
 			"enrichedGroup=" + enrichedGroup +
 			", status=" + status +
+			", failureCause=" + failureCause +
 			'}';
 	}
 }

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/AssignedResource.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/AssignedResource.java
@@ -11,12 +11,14 @@ import java.util.Objects;
 public class AssignedResource {
 	private EnrichedResource enrichedResource;
 	private GroupResourceStatus status;
+	private String failureCause;
 	private Facility facility;
 	private List<ResourceTag> resourceTags;
 
-	public AssignedResource(EnrichedResource enrichedResource, GroupResourceStatus status, Facility facility) {
+	public AssignedResource(EnrichedResource enrichedResource, GroupResourceStatus status, String failureCause, Facility facility) {
 		this.enrichedResource = enrichedResource;
 		this.status = status;
+		this.failureCause = failureCause;
 		this.facility = facility;
 	}
 
@@ -52,6 +54,14 @@ public class AssignedResource {
 		this.resourceTags = resourceTags;
 	}
 
+	public String getFailureCause() {
+		return this.failureCause;
+	}
+
+	public void setFailureCause(String failureCause) {
+		this.failureCause = failureCause;
+	}
+
 	@Override
 	public boolean equals(Object o) {
 		if (this == o) return true;
@@ -71,6 +81,7 @@ public class AssignedResource {
 		return "AssignedResource{" +
 			"enrichedResource=" + enrichedResource +
 			", status=" + status +
+			", failureCause=" + failureCause +
 			", facility=" + facility +
 			", resourceTags=" + resourceTags +
 			'}';

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/GroupResourceAssignment.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/GroupResourceAssignment.java
@@ -11,11 +11,13 @@ public class GroupResourceAssignment {
 	private Group group;
 	private Resource resource;
 	private GroupResourceStatus status;
+	private String failureCause;
 
-	public GroupResourceAssignment(Group group, Resource resource, GroupResourceStatus status) {
+	public GroupResourceAssignment(Group group, Resource resource, GroupResourceStatus status, String failureCause) {
 		this.group = group;
 		this.resource = resource;
 		this.status = status;
+		this.failureCause = failureCause;
 	}
 
 	public Group getGroup() {
@@ -42,6 +44,14 @@ public class GroupResourceAssignment {
 		this.status = status;
 	}
 
+	public String getFailureCause() {
+		return this.failureCause;
+	}
+
+	public void setFailureCause(String failureCause) {
+		this.failureCause = failureCause;
+	}
+
 	@Override
 	public boolean equals(Object o) {
 		if (this == o) return true;
@@ -62,6 +72,7 @@ public class GroupResourceAssignment {
 			"group=" + group +
 			", resource=" + resource +
 			", status=" + status +
+			", failureCause=" + failureCause +
 			'}';
 	}
 }

--- a/perun-base/src/test/resources/test-schema.sql
+++ b/perun-base/src/test/resources/test-schema.sql
@@ -1,4 +1,4 @@
--- database version 3.1.83 (don't forget to update insert statement at the end of file)
+-- database version 3.1.84 (don't forget to update insert statement at the end of file)
 CREATE EXTENSION IF NOT EXISTS "unaccent";
 CREATE EXTENSION IF NOT EXISTS "pgcrypto";
 
@@ -761,6 +761,7 @@ create table groups_resources (
 								   modified_by varchar default user not null,
 								   created_by_uid integer,
 								   modified_by_uid integer,
+								   failure_cause varchar default null,
 								   constraint grres_grp_res_u unique (group_id,resource_id),
 								   constraint grres_gr_fk foreign key (group_id) references groups(id),
 								   constraint grres_res_fk foreign key (resource_id) references resources(id)
@@ -1655,7 +1656,7 @@ CREATE INDEX ufauv_idx ON user_facility_attr_u_values (user_id, facility_id, att
 CREATE INDEX vauv_idx ON vo_attr_u_values (vo_id, attr_id);
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.1.83');
+insert into configurations values ('DATABASE VERSION','3.1.84');
 -- insert membership types
 insert into membership_types (id, membership_type, description) values (1, 'DIRECT', 'Member is directly added into group');
 insert into membership_types (id, membership_type, description) values (2, 'INDIRECT', 'Member is added indirectly through UNION relation');

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/GroupsManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/GroupsManagerImpl.java
@@ -70,7 +70,8 @@ public class GroupsManagerImpl implements GroupsManagerImplApi {
 			+ "groups.vo_id as groups_vo_id, groups.created_at as groups_created_at, groups.created_by as groups_created_by, groups.modified_by as groups_modified_by, groups.modified_at as groups_modified_at, "
 			+ "groups.modified_by_uid as groups_modified_by_uid, groups.created_by_uid as groups_created_by_uid ";
 
-	protected final static String assignedGroupMappingSelectQuery = groupMappingSelectQuery + ", groups_resources.status as groups_resources_status";
+	protected final static String assignedGroupMappingSelectQuery = groupMappingSelectQuery + ", groups_resources.status as groups_resources_status" +
+		", groups_resources.failure_cause as groups_resources_failure_cause";
 
 	// http://static.springsource.org/spring/docs/3.0.x/spring-framework-reference/html/jdbc.html
 	private final JdbcPerunTemplate jdbc;
@@ -102,7 +103,8 @@ public class GroupsManagerImpl implements GroupsManagerImplApi {
 	protected static final RowMapper<AssignedGroup> ASSIGNED_GROUP_MAPPER = (resultSet, i) -> {
 		Group group = GROUP_MAPPER.mapRow(resultSet, i);
 		EnrichedGroup enrichedGroup = new EnrichedGroup(group, null);
-		return new AssignedGroup(enrichedGroup, GroupResourceStatus.valueOf(resultSet.getString("groups_resources_status")));
+		String failureCause = resultSet.getString("groups_resources_failure_cause");
+		return new AssignedGroup(enrichedGroup, GroupResourceStatus.valueOf(resultSet.getString("groups_resources_status")), failureCause);
 	};
 
 	private static final RowMapper<Pair<Group, Resource>> GROUP_RESOURCE_MAPPER = (resultSet, i) -> {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/ResourcesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/ResourcesManagerImplApi.java
@@ -824,4 +824,24 @@ public interface ResourcesManagerImplApi {
 	 * @throws InternalErrorException
 	 */
 	void setGroupResourceStatus(PerunSession sess, Group group, Resource resource, GroupResourceStatus status) throws GroupNotDefinedOnResourceException;
+
+	/**
+	 * Gets the current cause of failed group-resource assignment. Returns null if there is no such group-resource assignment.
+	 * @param sess session
+	 * @param group group
+	 * @param resource resource
+	 * @return error message
+	 */
+	String getFailedGroupResourceAssignmentCause(PerunSession sess, Group group, Resource resource);
+
+	/**
+	 * Sets the cause of failed group-resource assignment
+	 * @param sess session
+	 * @param group group
+	 * @param resource resource
+	 * @param cause the cause of assignment failure
+	 * @throws GroupNotDefinedOnResourceException if there is no such group-resource assignment
+	 */
+	void setFailedGroupResourceAssignmentCause(PerunSession sess, Group group, Resource resource, String cause) throws GroupNotDefinedOnResourceException;
+
 }

--- a/perun-core/src/main/resources/postgresChangelog.txt
+++ b/perun-core/src/main/resources/postgresChangelog.txt
@@ -6,6 +6,10 @@
 -- Directly under version number should be version commands. They will be executed in the order they are written here.
 -- Comments are prefixed with -- and can be written only between version blocks, that means not in the lines with commands. They have to be at the start of the line.
 
+3.1.84
+ALTER TABLE groups_resources ADD COLUMN failure_cause varchar default null;
+UPDATE configurations SET value='3.1.84' WHERE property='DATABASE VERSION';
+
 3.1.83
 DROP TABLE facility_contacts;
 UPDATE configurations SET value='3.1.83' WHERE property='DATABASE VERSION';

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ResourcesManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ResourcesManagerEntryIntegrationTest.java
@@ -28,6 +28,7 @@ import cz.metacentrum.perun.core.api.Vo;
 import cz.metacentrum.perun.core.api.exceptions.FacilityNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.GroupNotDefinedOnResourceException;
 import cz.metacentrum.perun.core.api.exceptions.GroupNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.GroupResourceStatusException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.RelationExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ResourceExistsException;
@@ -2110,7 +2111,7 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 		resourcesManager.assignGroupToResource(sess, group, resource, false);
 
 		List<AssignedResource> resources = resourcesManager.getResourceAssignments(sess, group, null);
-		AssignedResource expectedResource = new AssignedResource(new EnrichedResource(resource, null), GroupResourceStatus.ACTIVE, facility);
+		AssignedResource expectedResource = new AssignedResource(new EnrichedResource(resource, null), GroupResourceStatus.ACTIVE, null, facility);
 
 		assertThat(resources.size()).isEqualTo(1);
 		assertThat(resources).containsExactly(expectedResource);
@@ -2160,7 +2161,7 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 		resourcesManager.assignGroupToResource(sess, group, resource, false);
 
 		List<AssignedGroup> groups = resourcesManager.getGroupAssignments(sess, resource, null);
-		AssignedGroup expectedGroup = new AssignedGroup(new EnrichedGroup(group, null), GroupResourceStatus.ACTIVE);
+		AssignedGroup expectedGroup = new AssignedGroup(new EnrichedGroup(group, null), GroupResourceStatus.ACTIVE, null);
 
 		assertThat(groups.size()).isEqualTo(1);
 		assertThat(groups).containsExactly(expectedGroup);
@@ -2201,8 +2202,8 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 		resourcesManager.assignGroupToResource(sess, group, resource2, false);
 		resourcesManager.deactivateGroupResourceAssignment(sess, group, resource2);
 
-		GroupResourceAssignment expectedAssignment = new GroupResourceAssignment(group, resource, GroupResourceStatus.ACTIVE);
-		GroupResourceAssignment expectedAssignment2 = new GroupResourceAssignment(group, resource2, GroupResourceStatus.INACTIVE);
+		GroupResourceAssignment expectedAssignment = new GroupResourceAssignment(group, resource, GroupResourceStatus.ACTIVE, null);
+		GroupResourceAssignment expectedAssignment2 = new GroupResourceAssignment(group, resource2, GroupResourceStatus.INACTIVE, null);
 
 		List<GroupResourceAssignment> assignments = perun.getResourcesManagerBl().getGroupResourceAssignments(sess, null);
 		assertThat(assignments)
@@ -2237,7 +2238,7 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 		resourcesManager.assignGroupToResource(sess, group, resource2, false);
 		resourcesManager.deactivateGroupResourceAssignment(sess, group, resource2);
 
-		GroupResourceAssignment expectedAssignment = new GroupResourceAssignment(group, resource, GroupResourceStatus.ACTIVE);
+		GroupResourceAssignment expectedAssignment = new GroupResourceAssignment(group, resource, GroupResourceStatus.ACTIVE, null);
 
 		assignments = perun.getResourcesManagerBl().getGroupResourceAssignments(sess, List.of(GroupResourceStatus.ACTIVE));
 		assertThat(assignments)

--- a/perun-db/postgres.sql
+++ b/perun-db/postgres.sql
@@ -1,4 +1,4 @@
--- database version 3.1.83 (don't forget to update insert statement at the end of file)
+-- database version 3.1.84 (don't forget to update insert statement at the end of file)
 
 -- VOS - virtual organizations
 create table vos (
@@ -759,6 +759,7 @@ create table groups_resources (
 	modified_by varchar default user not null,
 	created_by_uid integer,
 	modified_by_uid integer,
+	failure_cause varchar default null,
 	constraint grres_grp_res_u unique (group_id,resource_id),
   constraint grres_gr_fk foreign key (group_id) references groups(id),
   constraint grres_res_fk foreign key (resource_id) references resources(id)
@@ -1752,7 +1753,7 @@ grant all on members_sponsored to perun;
 grant all on groups_to_register to perun;
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.1.83');
+insert into configurations values ('DATABASE VERSION','3.1.84');
 
 -- insert membership types
 insert into membership_types (id, membership_type, description) values (1, 'DIRECT', 'Member is directly added into group');

--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -359,6 +359,7 @@ components:
       properties:
         enrichedResource: { $ref: '#/components/schemas/EnrichedResource' }
         status: { $ref: '#/components/schemas/GroupResourceStatus' }
+        failureCause: { type: string }
         facility: { $ref: '#/components/schemas/Facility'}
         resourceTags: { type: array, items: { $ref: '#/components/schemas/ResourceTag' } }
 
@@ -367,6 +368,7 @@ components:
       properties:
         enrichedGroup: { $ref: '#/components/schemas/EnrichedGroup' }
         status: { $ref: '#/components/schemas/GroupResourceStatus' }
+        failureCause: { type: string }
 
     EnrichedHost:
       type: object

--- a/perun-utils/rpc-methods-javadoc-generator/parseRpcMethods.pl
+++ b/perun-utils/rpc-methods-javadoc-generator/parseRpcMethods.pl
@@ -186,7 +186,7 @@ $objectExamples{"EnrichedResource"} = "{ \"resource\" : " . $objectExamples{"Res
 $objectExamples{"List&lt;EnrichedResource&gt;"} = $listPrepend . $objectExamples{"EnrichedResource"} . $listAppend;
 $objectExamples{"List<EnrichedResource>"} = $objectExamples{"List&lt;EnrichedResource&gt;"};
 
-$objectExamples{"AssignedResource"} = "{ \"enrichedResource\" : " . $objectExamples{"EnrichedResource"} . " , \"status\" : \"ACTIVE\"" . " , \"resourceTags\" : ". $objectExamples{"List<ResourceTag>"} . " }";
+$objectExamples{"AssignedResource"} = "{ \"enrichedResource\" : " . $objectExamples{"EnrichedResource"} . " , \"status\" : \"FAILED\"" . " , \"failureCause\" : \"Wrong attribute value in group 1\"" . " , \"facility\" : " . $objectExamples{"Facility"} . " , \"resourceTags\" : " . $objectExamples{"List<ResourceTag>"} . " }";
 $objectExamples{"List&lt;AssignedResource&gt;"} = $listPrepend . $objectExamples{"AssignedResource"} . $listAppend;
 $objectExamples{"List<AssignedResource>"} = $objectExamples{"List&lt;AssignedResource&gt;"};
 
@@ -194,7 +194,7 @@ $objectExamples{"EnrichedGroup"} = "{ \"group\" : " . $objectExamples{"Group"} .
 $objectExamples{"List&lt;EnrichedGroup&gt;"} = $listPrepend . $objectExamples{"EnrichedGroup"} . $listAppend;
 $objectExamples{"List<EnrichedGroup>"} = $objectExamples{"List&lt;EnrichedGroup&gt;"};
 
-$objectExamples{"AssignedGroup"} = "{ \"enrichedGroup\" : " . $objectExamples{"EnrichedGroup"} . " , \"status\" : \"ACTIVE\" }";
+$objectExamples{"AssignedGroup"} = "{ \"enrichedGroup\" : " . $objectExamples{"EnrichedGroup"} . " , \"status\" : \"FAILED\"" . " , \"failureCause\" : \"Wrong attribute value in group 1\" }";
 $objectExamples{"List&lt;AssignedGroup&gt;"} = $listPrepend . $objectExamples{"AssignedGroup"} . $listAppend;
 $objectExamples{"List<AssignedGroup>"} = $objectExamples{"List&lt;AssignedGroup&gt;"};
 


### PR DESCRIPTION
* The error message is now saved to DB when assignment fails
* When the assignment state is switched to ACTIVE or INACTIVE, previous cause of failure is removed
* The cause can only be retrieved for FAILED assignments