### PR TITLE
fix(registrar): Constant-time MAC comparison

### DIFF
--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
@@ -15,6 +15,8 @@ import cz.metacentrum.perun.audit.events.RegistrarManagerEvents.MembershipExtend
 import cz.metacentrum.perun.core.api.*;
 import cz.metacentrum.perun.core.api.exceptions.*;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 import java.time.LocalDate;
 import java.util.*;
 import java.util.function.Function;
@@ -2858,7 +2860,9 @@ public class RegistrarManagerImpl implements RegistrarManager {
 	public boolean validateEmailFromLink(Map<String, String> urlParameters) throws PerunException {
 
 		String idStr = urlParameters.get("i");
-		if (mailManager.getMessageAuthenticationCode(idStr).equals(urlParameters.get("m"))) {
+		byte[] mac = mailManager.getMessageAuthenticationCode(idStr).getBytes(StandardCharsets.UTF_8);
+		byte[] m = urlParameters.get("m").getBytes(StandardCharsets.UTF_8);
+		if (MessageDigest.isEqual(mac, m)) {
 			int appDataId = Integer.parseInt(idStr, Character.MAX_RADIX);
 			// validate mail
 			jdbc.update("update application_data set assurance_level=1 where id = ?", appDataId);


### PR DESCRIPTION
- While validating user email, message authentication code (MAC) used to
be compared as String. This could lead to a timing attack, because
String.equals() doesn't implement constant-time algorithm.
- Now, MACs are compared using constant-time MessageDigest.isEqual().