### PR TITLE
ci(githubci): allow commenting of PRs of commits which were released

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -11,7 +11,6 @@
 		"message": "chore(release): ${nextRelease.version} \n\n${nextRelease.notes}"
     }],
     ["@semantic-release/github", {
-	  "successComment": false,
 	  "assets": [
 	    {"path": "perun-rpc/target/perun-rpc.war"},
 	    {"path": "perun-engine/target/perun-engine.jar"},


### PR DESCRIPTION
* We want the semantic release bot to comment PRs, which were added to a release. This can help us
track in which release the changes were published.