### PR TITLE
feat(core): New table groups_resources_state

### DIFF
--- a/perun-base/src/test/resources/test-schema.sql
+++ b/perun-base/src/test/resources/test-schema.sql
@@ -1,4 +1,4 @@
--- database version 3.1.84 (don't forget to update insert statement at the end of file)
+-- database version 3.1.85 (don't forget to update insert statement at the end of file)
 CREATE EXTENSION IF NOT EXISTS "unaccent";
 CREATE EXTENSION IF NOT EXISTS "pgcrypto";
 
@@ -754,18 +754,42 @@ create type group_resource_status as enum (
 create table groups_resources (
 								   group_id integer not null,     --identifier of group (groups.id)
 								   resource_id integer not null,  --identifier of resource (resources.id)
-								   status group_resource_status not null default 'PROCESSING',
 								   created_at timestamp default statement_timestamp() not null,
 								   created_by varchar default user not null,
 								   modified_at timestamp default statement_timestamp() not null,
 								   modified_by varchar default user not null,
 								   created_by_uid integer,
 								   modified_by_uid integer,
-								   failure_cause varchar default null,
 								   constraint grres_grp_res_u unique (group_id,resource_id),
 								   constraint grres_gr_fk foreign key (group_id) references groups(id),
 								   constraint grres_res_fk foreign key (resource_id) references resources(id)
 );
+
+create function relation_group_resource_exist(integer, integer) returns integer
+	as 'select count(1) from groups_resources where group_id=$1 and resource_id=$2;'
+	language sql;
+
+create table groups_resources_state (
+										group_id integer not null,
+										resource_id integer not null,
+										status group_resource_status not null default 'PROCESSING',
+										failure_cause varchar default null,
+										constraint grres_s_grp_res_u unique (group_id,resource_id),
+										constraint grres_s_gr_fk foreign key (group_id) references groups(id),
+										constraint grres_s_res_fk foreign key (resource_id) references resources(id),
+                                        check ( relation_group_resource_exist(group_id, resource_id) != 0 )
+);
+
+create function delete_group_resource_status() returns trigger as
+	'
+	begin
+		delete from groups_resources_state where group_id=OLD.group_id and resource_id=OLD.resource_id;
+    	return OLD;
+	end;
+	' language plpgsql;
+
+create trigger after_deleting_from_groups_resources after delete on groups_resources
+	for each row execute procedure delete_group_resource_status();
 
 -- MEMBER_ATTR_VALUES - values of attributes assigned to members
 create table member_attr_values (
@@ -1587,6 +1611,8 @@ create index idx_fk_authz_sec_team on authz(security_team_id);
 create index idx_fk_authz_sponsu on authz(sponsored_user_id);
 create index idx_fk_grres_gr on groups_resources(group_id);
 create index idx_fk_grres_res on groups_resources(resource_id);
+create index idx_fk_grres_s_gr on groups_resources_state(group_id);
+create index idx_fk_grres_s_res on groups_resources_state(resource_id);
 create index idx_fk_grpmem_gr on groups_members(group_id);
 create index idx_fk_grpmem_mem on groups_members(member_id);
 create index idx_fk_grpmem_memtype on groups_members(membership_type);
@@ -1656,7 +1682,7 @@ CREATE INDEX ufauv_idx ON user_facility_attr_u_values (user_id, facility_id, att
 CREATE INDEX vauv_idx ON vo_attr_u_values (vo_id, attr_id);
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.1.84');
+insert into configurations values ('DATABASE VERSION','3.1.85');
 -- insert membership types
 insert into membership_types (id, membership_type, description) values (1, 'DIRECT', 'Member is directly added into group');
 insert into membership_types (id, membership_type, description) values (2, 'INDIRECT', 'Member is added indirectly through UNION relation');

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ResourcesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ResourcesManagerBlImpl.java
@@ -393,7 +393,8 @@ public class ResourcesManagerBlImpl implements ResourcesManagerBl {
 
 			//first we must assign group
 			try {
-				getResourcesManagerImpl().assignGroupToResource(perunSession, g, resource, GroupResourceStatus.PROCESSING);
+				getResourcesManagerImpl().assignGroupToResource(perunSession, g, resource);
+				getResourcesManagerImpl().assignGroupToResourceState(perunSession, g, resource, GroupResourceStatus.PROCESSING);
 				activateGroupResourceAssignment(perunSession, g, resource, async);
 			} catch (GroupAlreadyAssignedException e) {
 				// silently skip

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/FacilitiesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/FacilitiesManagerImpl.java
@@ -360,11 +360,11 @@ public class FacilitiesManagerImpl implements FacilitiesManagerImplApi {
 	public List<Member> getAllowedMembers(PerunSession sess, Facility facility) {
 		try  {
 			// we do include all group statuses for such members
-			return jdbc.query("select distinct " + MembersManagerImpl.groupsMembersMappingSelectQuery + " from groups_resources" +
-							" join groups on groups_resources.group_id=groups.id and groups_resources.status=?::group_resource_status" +
+			return jdbc.query("select distinct " + MembersManagerImpl.groupsMembersMappingSelectQuery + " from groups_resources_state" +
+							" join groups on groups_resources_state.group_id=groups.id and groups_resources_state.status=?::group_resource_status" +
 							" join groups_members on groups.id=groups_members.group_id" +
 							" join members on groups_members.member_id=members.id " +
-							" join resources on groups_resources.resource_id=resources.id " +
+							" join resources on groups_resources_state.resource_id=resources.id " +
 							" where resources.facility_id=? and members.status!=? and members.status!=?",
 					MembersManagerImpl.MEMBERS_WITH_GROUP_STATUSES_SET_EXTRACTOR, GroupResourceStatus.ACTIVE.toString(),
 					facility.getId(), Status.INVALID.getCode(), Status.DISABLED.getCode());
@@ -379,8 +379,8 @@ public class FacilitiesManagerImpl implements FacilitiesManagerImplApi {
 	public List<User> getAllowedUsers(PerunSession sess, Facility facility) {
 		try  {
 			return jdbc.query("select distinct " + UsersManagerImpl.userMappingSelectQuery + " from resources" +
-							" join groups_resources on groups_resources.resource_id=resources.id and groups_resources.status=?::group_resource_status"+
-							" join groups_members on groups_resources.group_id=groups_members.group_id" +
+							" join groups_resources_state on groups_resources_state.resource_id=resources.id and groups_resources_state.status=?::group_resource_status"+
+							" join groups_members on groups_resources_state.group_id=groups_members.group_id" +
 							" join members on groups_members.member_id=members.id" +
 							" join users on members.user_id=users.id" +
 							" where resources.facility_id=? and members.status!=? and members.status!=?",
@@ -394,11 +394,11 @@ public class FacilitiesManagerImpl implements FacilitiesManagerImplApi {
 	@Override
 	public List<Facility> getAllowedFacilities(PerunSession sess, User user) {
 		try  {
-			return jdbc.query("select distinct " + facilityMappingSelectQuery + " from groups_resources" +
-							" join groups on groups_resources.group_id=groups.id and groups_resources.status=?::group_resource_status" +
+			return jdbc.query("select distinct " + facilityMappingSelectQuery + " from groups_resources_state" +
+							" join groups on groups_resources_state.group_id=groups.id and groups_resources_state.status=?::group_resource_status" +
 							" join groups_members on groups.id=groups_members.group_id" +
 							" join members on groups_members.member_id=members.id " +
-							" join resources on groups_resources.resource_id=resources.id " +
+							" join resources on groups_resources_state.resource_id=resources.id " +
 							" join facilities on resources.facility_id=facilities.id " +
 							" where members.user_id=? and members.status!=? and members.status!=?",
 					FACILITY_MAPPER, GroupResourceStatus.ACTIVE.toString(), user.getId(),
@@ -411,11 +411,11 @@ public class FacilitiesManagerImpl implements FacilitiesManagerImplApi {
 	@Override
 	public List<Facility> getAllowedFacilities(PerunSession sess, Member member) {
 		try  {
-			return jdbc.query("select distinct " + facilityMappingSelectQuery + " from groups_resources" +
-							" join groups on groups_resources.group_id=groups.id and groups_resources.status=?::group_resource_status" +
+			return jdbc.query("select distinct " + facilityMappingSelectQuery + " from groups_resources_state" +
+							" join groups on groups_resources_state.group_id=groups.id and groups_resources_state.status=?::group_resource_status" +
 							" join groups_members on groups.id=groups_members.group_id" +
 							" join members on groups_members.member_id=members.id " +
-							" join resources on groups_resources.resource_id=resources.id " +
+							" join resources on groups_resources_state.resource_id=resources.id " +
 							" join facilities on resources.facility_id=facilities.id " +
 							" where members.id=? and members.status!=? and members.status!=?",
 					FACILITY_MAPPER, GroupResourceStatus.ACTIVE.toString(), member.getId(),
@@ -726,8 +726,8 @@ public class FacilitiesManagerImpl implements FacilitiesManagerImplApi {
 			return jdbc.query("select distinct " + UsersManagerImpl.userMappingSelectQuery + " from users"
 					+ " join members on users.id = members.user_id"
 					+ " join groups_members on members.id = groups_members.member_id"
-					+ " join groups_resources on groups_members.group_id = groups_resources.group_id and groups_resources.status=?::group_resource_status"
-					+ " join resources on resources.id = groups_resources.resource_id and resources.facility_id=?",
+					+ " join groups_resources_state on groups_members.group_id = groups_resources_state.group_id and groups_resources_state.status=?::group_resource_status"
+					+ " join resources on resources.id = groups_resources_state.resource_id and resources.facility_id=?",
 					UsersManagerImpl.USER_MAPPER, GroupResourceStatus.ACTIVE.toString(), facility.getId());
 		} catch (RuntimeException e) {
 			throw new InternalErrorException(e);
@@ -741,8 +741,8 @@ public class FacilitiesManagerImpl implements FacilitiesManagerImplApi {
 			return jdbc.query("select distinct " + UsersManagerImpl.userMappingSelectQuery + " from users"
 					+ " join members on users.id = members.user_id"
 					+ " join groups_members on members.id = groups_members.member_id"
-					+ " join groups_resources on groups_members.group_id = groups_resources.group_id and groups_resources.status=?::group_resource_status"
-					+ " join resources on resources.id = groups_resources.resource_id and resources.facility_id=?"
+					+ " join groups_resources_state on groups_members.group_id = groups_resources_state.group_id and groups_resources_state.status=?::group_resource_status"
+					+ " join resources on resources.id = groups_resources_state.resource_id and resources.facility_id=?"
 					+ " join resource_services on resources.id=resource_services.resource_id and resource_services.service_id=?",
 					UsersManagerImpl.USER_MAPPER, GroupResourceStatus.ACTIVE.toString(), facility.getId(),service.getId());
 		} catch (RuntimeException e) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/MembersManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/MembersManagerImpl.java
@@ -590,9 +590,9 @@ public class MembersManagerImpl implements MembersManagerImplApi {
 
 		try {
 			Member result = jdbc.queryForObject("select distinct " + MembersManagerImpl.groupsMembersMappingSelectQuery +
-							" from groups_resources join groups on groups_resources.group_id=groups.id" +
+							" from groups_resources_state join groups on groups_resources_state.group_id=groups.id" +
 					" join groups_members on groups.id=groups_members.group_id join members on groups_members.member_id=members.id " +
-					" where groups_resources.resource_id=? and groups_resources.status=?::group_resource_status and members.id=?",
+					" where groups_resources_state.resource_id=? and groups_resources_state.status=?::group_resource_status and members.id=?",
 					MembersManagerImpl.MEMBERS_WITH_GROUP_STATUSES_SET_EXTRACTOR, resource.getId(),
 					GroupResourceStatus.ACTIVE.toString(), member.getId());
 			return result.getGroupStatus();
@@ -610,10 +610,10 @@ public class MembersManagerImpl implements MembersManagerImplApi {
 		try {
 
 			List<Member> result = jdbc.query("select distinct " + MembersManagerImpl.groupsMembersMappingSelectQuery +
-							" from groups_resources join groups on groups_resources.group_id=groups.id" +
+							" from groups_resources_state join groups on groups_resources_state.group_id=groups.id" +
 							" join groups_members on groups.id=groups_members.group_id join members on groups_members.member_id=members.id " +
-							" join resources on groups_resources.resource_id=resources.id " +
-							" where groups_resources.status=?::group_resource_status and resources.facility_id=? and members.user_id=?",
+							" join resources on groups_resources_state.resource_id=resources.id " +
+							" where groups_resources_state.status=?::group_resource_status and resources.facility_id=? and members.user_id=?",
 					MembersManagerImpl.MEMBERS_WITH_GROUP_STATUSES_SET_EXTRACTOR, GroupResourceStatus.ACTIVE.toString(),
 					facility.getId(), user.getId());
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/UsersManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/UsersManagerImpl.java
@@ -1348,8 +1348,8 @@ public class UsersManagerImpl implements UsersManagerImplApi {
 	public List<Resource> getAssignedResources(PerunSession sess, User user) {
 		try  {
 			return jdbc.query("select distinct " + resourceMappingSelectQuery + " from resources" +
-					" join groups_resources on resources.id=groups_resources.resource_id and groups_resources.status=?::group_resource_status " +
-					" join groups on groups_resources.group_id=groups.id" +
+					" join groups_resources_state on resources.id=groups_resources_state.resource_id and groups_resources_state.status=?::group_resource_status " +
+					" join groups on groups_resources_state.group_id=groups.id" +
 					" join groups_members on groups.id=groups_members.group_id " +
 					" join members on groups_members.member_id=members.id " +
 					" where members.user_id=?", RESOURCE_MAPPER, GroupResourceStatus.ACTIVE.toString(), user.getId());
@@ -1362,8 +1362,8 @@ public class UsersManagerImpl implements UsersManagerImplApi {
 	public List<Resource> getAllowedResources(PerunSession sess, User user) {
 		try  {
 			return jdbc.query("select distinct " + resourceMappingSelectQuery + " from resources" +
-							" join groups_resources on resources.id=groups_resources.resource_id and groups_resources.status=?::group_resource_status " +
-							" join groups on groups_resources.group_id=groups.id" +
+							" join groups_resources_state on resources.id=groups_resources_state.resource_id and groups_resources_state.status=?::group_resource_status " +
+							" join groups on groups_resources_state.group_id=groups.id" +
 							" join groups_members on groups.id=groups_members.group_id " +
 							" join members on groups_members.member_id=members.id " +
 							" where members.user_id=? and members.status!=? and members.status!=?",
@@ -1377,8 +1377,8 @@ public class UsersManagerImpl implements UsersManagerImplApi {
 	public List<Resource> getAssignedResources(PerunSession sess, Facility facility, User user) {
 		try {
 			return jdbc.query("select distinct " + ResourcesManagerImpl.resourceMappingSelectQuery + " from resources "+
-							" join groups_resources on groups_resources.resource_id=resources.id and groups_resources.status=?::group_resource_status " +
-							" join groups_members on groups_members.group_id=groups_resources.group_id" +
+							" join groups_resources_state on groups_resources_state.resource_id=resources.id and groups_resources_state.status=?::group_resource_status " +
+							" join groups_members on groups_members.group_id=groups_resources_state.group_id" +
 							" join members on members.id=groups_members.member_id" +
 							" where resources.facility_id=? and members.user_id=?",
 					RESOURCE_MAPPER, GroupResourceStatus.ACTIVE.toString(), facility.getId(), user.getId());
@@ -1394,8 +1394,8 @@ public class UsersManagerImpl implements UsersManagerImplApi {
 					FacilitiesManagerImpl.facilityMappingSelectQuery + ", "+resourceTagMappingSelectQuery+" from resources" +
 					" join vos on resources.vo_id=vos.id " +
 					" join facilities on resources.facility_id=facilities.id " +
-					" join groups_resources on resources.id=groups_resources.resource_id and groups_resources.status=?::group_resource_status " +
-					" join groups on groups_resources.group_id=groups.id " +
+					" join groups_resources_state on resources.id=groups_resources_state.resource_id and groups_resources_state.status=?::group_resource_status " +
+					" join groups on groups_resources_state.group_id=groups.id " +
 					" join groups_members on groups.id=groups_members.group_id " +
 					" join members on groups_members.member_id=members.id " +
 					" left outer join tags_resources on resources.id=tags_resources.resource_id" +

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/ResourcesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/ResourcesManagerImplApi.java
@@ -144,12 +144,21 @@ public interface ResourcesManagerImplApi {
 	 * @param perunSession
 	 * @param group
 	 * @param resource
-	 * @param status Status of the group-resource assignment
 
 	 * @throws InternalErrorException
 	 * @throws GroupAlreadyAssignedException
 	 */
-	void assignGroupToResource(PerunSession perunSession, Group group, Resource resource, GroupResourceStatus status) throws GroupAlreadyAssignedException;
+	void assignGroupToResource(PerunSession perunSession, Group group, Resource resource) throws GroupAlreadyAssignedException;
+
+	/**
+	 * Set initial status to group-resource assignment.
+	 *
+	 * @param perunSession
+	 * @param group
+	 * @param resource
+	 * @param status Status of the group-resource assignment
+	 */
+	void assignGroupToResourceState(PerunSession perunSession, Group group, Resource resource, GroupResourceStatus status);
 
 	/**
 	 * Remove group from a resource.

--- a/perun-core/src/main/resources/postgresChangelog.txt
+++ b/perun-core/src/main/resources/postgresChangelog.txt
@@ -6,6 +6,18 @@
 -- Directly under version number should be version commands. They will be executed in the order they are written here.
 -- Comments are prefixed with -- and can be written only between version blocks, that means not in the lines with commands. They have to be at the start of the line.
 
+3.1.85
+create function relation_group_resource_exist(integer, integer) returns integer as 'select count(1) from groups_resources where group_id=$1 and resource_id=$2;' language sql;
+create table groups_resources_state (group_id integer not null, resource_id integer not null, failure_cause varchar default null, status group_resource_status not null default 'PROCESSING', check (relation_group_resource_exist(group_id, resource_id) != 0));
+create function delete_group_resource_status() returns trigger as 'begin delete from groups_resources_state where group_id=OLD.group_id and resource_id=OLD.resource_id; return OLD; end;' language plpgsql;
+create trigger after_deleting_from_groups_resources after delete on groups_resources for each row execute procedure delete_group_resource_status();
+create index idx_fk_grres_s_gr on groups_resources_state(group_id);
+create index idx_fk_grres_s_res on groups_resources_state(resource_id);
+grant all on groups_resources_state to perun;
+insert into groups_resources_state (group_id, resource_id, failure_cause, status) select group_id, resource_id, failure_cause, status from groups_resources;
+alter table groups_resources drop column status, drop column failure_cause;
+UPDATE configurations SET value='3.1.85' WHERE property='DATABASE VERSION';
+
 3.1.84
 ALTER TABLE groups_resources ADD COLUMN failure_cause varchar default null;
 UPDATE configurations SET value='3.1.84' WHERE property='DATABASE VERSION';

--- a/perun-db/postgres.sql
+++ b/perun-db/postgres.sql
@@ -1,4 +1,4 @@
--- database version 3.1.84 (don't forget to update insert statement at the end of file)
+-- database version 3.1.85 (don't forget to update insert statement at the end of file)
 
 -- VOS - virtual organizations
 create table vos (
@@ -752,18 +752,41 @@ create type group_resource_status as enum (
 create table groups_resources (
 	group_id integer not null,     --identifier of group (groups.id)
 	resource_id integer not null,  --identifier of resource (resources.id)
-	status group_resource_status not null default 'PROCESSING',
 	created_at timestamp default statement_timestamp() not null,
 	created_by varchar default user not null,
 	modified_at timestamp default statement_timestamp() not null,
 	modified_by varchar default user not null,
 	created_by_uid integer,
 	modified_by_uid integer,
-	failure_cause varchar default null,
 	constraint grres_grp_res_u unique (group_id,resource_id),
   constraint grres_gr_fk foreign key (group_id) references groups(id),
   constraint grres_res_fk foreign key (resource_id) references resources(id)
 );
+
+create function relation_group_resource_exist(integer, integer) returns integer as
+    'select count(1) from groups_resources where group_id=$1 and resource_id=$2;' language sql;
+
+create table groups_resources_state (
+	group_id integer not null,
+	resource_id integer not null,
+	status group_resource_status not null default 'PROCESSING',
+	failure_cause varchar default null,
+	constraint grres_s_grp_res_u unique (group_id,resource_id),
+	constraint grres_s_gr_fk foreign key (group_id) references groups(id),
+	constraint grres_s_res_fk foreign key (resource_id) references resources(id),
+	check ( relation_group_resource_exist(group_id, resource_id) != 0 )
+);
+
+create function delete_group_resource_status() returns trigger as
+	'
+    begin
+    	delete from groups_resources_state where group_id=OLD.group_id and resource_id=OLD.resource_id;
+		return OLD;
+   	end;
+	' language plpgsql;
+
+create trigger after_deleting_from_groups_resources after delete on groups_resources
+	for each row execute procedure delete_group_resource_status();
 
 -- MEMBER_ATTR_VALUES - values of attributes assigned to members
 create table member_attr_values (
@@ -1585,6 +1608,8 @@ create index idx_fk_authz_sec_team on authz(security_team_id);
 create index idx_fk_authz_sponsu on authz(sponsored_user_id);
 create index idx_fk_grres_gr on groups_resources(group_id);
 create index idx_fk_grres_res on groups_resources(resource_id);
+create index idx_fk_grres_s_gr on groups_resources_state(group_id);
+create index idx_fk_grres_s_res on groups_resources_state(resource_id);
 create index idx_fk_grpmem_gr on groups_members(group_id);
 create index idx_fk_grpmem_mem on groups_members(member_id);
 create index idx_fk_grpmem_memtype on groups_members(membership_type);
@@ -1718,6 +1743,7 @@ grant all on cabinet_thanks to perun;
 grant all on roles to perun;
 grant all on authz to perun;
 grant all on groups_resources to perun;
+grant all on groups_resources_state to perun;
 grant all on groups_members to perun;
 grant all on application_mails to perun;
 grant all on application_mail_texts to perun;
@@ -1753,7 +1779,7 @@ grant all on members_sponsored to perun;
 grant all on groups_to_register to perun;
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.1.84');
+insert into configurations values ('DATABASE VERSION','3.1.85');
 
 -- insert membership types
 insert into membership_types (id, membership_type, description) values (1, 'DIRECT', 'Member is directly added into group');


### PR DESCRIPTION
* columns status and failure_cause moved from groups_resources table to the
new table groups_resources_state to ensure there is only one status record for
group-resource, since there could be multiple group-resource records when we
add assigning of group's tree to resource
* methods using groups-resource status needed to be changed to use the new
table
* new function relation_group_resource_exist checks that there is a record in
groups_resources table, and we can add status to this record into the table
* new function delete_group_resource_status deletes record of status when
deleting record from groups_resources table, this can be later modified to
look into either groups_resources table or new table for indirect relations
* new trigger after_deleting_from_groups_resources triggers aforementioned
function when deleting row from groups_resources table