### PR TITLE
perf(core): adjust threads pool for async tasks

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/MembersManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/MembersManagerBl.java
@@ -48,6 +48,7 @@ import cz.metacentrum.perun.core.api.exceptions.UserNotInRoleException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.api.SponsoredUserData;
+import org.springframework.scheduling.annotation.Async;
 
 import java.time.LocalDate;
 import java.util.Date;
@@ -1227,6 +1228,7 @@ public interface MembersManagerBl {
 	 * @return member with original status
 	 *
 	 */
+	@Async
 	Member validateMemberAsync(PerunSession sess, Member member);
 
 	/**

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
@@ -106,6 +106,7 @@ import cz.metacentrum.perun.core.implApi.modules.pwdmgr.PasswordManagerModule;
 import cz.metacentrum.perun.core.api.SponsoredUserData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Async;
 
 import java.beans.IntrospectionException;
 import java.beans.PropertyDescriptor;
@@ -1491,25 +1492,17 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 		return member;
 	}
 
+	@Async
 	@Override
 	public Member validateMemberAsync(final PerunSession sess, final Member member) {
-		new Thread(() -> {
-			try {
-				Thread.sleep(5000);
-			} catch (InterruptedException e) {
-				// TODO Auto-generated catch block
-				e.printStackTrace();
-			}
-			Status oldStatus = Status.getStatus(member.getStatus().getCode());
-
-			try {
-				((PerunSessionImpl) sess).getPerunBl().getMembersManagerBl().validateMember(sess, member);
-			} catch(Exception ex) {
-				log.info("validateMemberAsync failed.", ex);
-				getPerunBl().getAuditer().log(sess, new MemberValidatedFailed(member, oldStatus));
-				log.info("Validation of {} failed. He stays in {} state.", member, oldStatus);
-			}
-		}, "validateMemberAsync").start();
+		Status oldStatus = Status.getStatus(member.getStatus().getCode());
+		try {
+			((PerunSessionImpl) sess).getPerunBl().getMembersManagerBl().validateMember(sess, member);
+		} catch(Exception ex) {
+			log.info("validateMemberAsync failed.", ex);
+			getPerunBl().getAuditer().log(sess, new MemberValidatedFailed(member, oldStatus));
+			log.info("Validation of {} failed. He stays in {} state.", member, oldStatus);
+		}
 		return member;
 	}
 

--- a/perun-core/src/main/resources/perun-core.xml
+++ b/perun-core/src/main/resources/perun-core.xml
@@ -167,7 +167,7 @@ http://www.springframework.org/schema/task http://www.springframework.org/schema
 	</tx:advice>
 
 	<!-- Enabling Spring's @Async execution	-->
-	<task:executor id="asyncExecutor" pool-size="10-1000" queue-capacity="1"/>
+	<task:executor id="asyncExecutor" pool-size="20-20" queue-capacity="5000" keep-alive="120" rejection-policy="DISCARD_OLDEST" />
 	<task:annotation-driven executor="asyncExecutor"/>
 
 	<!--FIXME   a hack which forces Spring to call a static method -->


### PR DESCRIPTION
* The performance of asynchronous tasks was poor for a heavy load, optimized configuration should
restrict the number of simultaneously running threads and rather place tasks in enlarged queue
* Changed async member's validation to use this configuration too