### PR TITLE
fix(gui): Fixed unresponsive tabs for form item editing

### DIFF
--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/registrarManager/GetFormItems.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/registrarManager/GetFormItems.java
@@ -424,7 +424,11 @@ public class GetFormItems implements JsonCallback {
 			CustomButton editButton = new CustomButton(ButtonTranslation.INSTANCE.editFormItemButton(), ButtonTranslation.INSTANCE.editFormItem(), SmallIcons.INSTANCE.applicationFormEditIcon());
 			editButton.addClickHandler(new ClickHandler() {
 				public void onClick(ClickEvent event) {
-					session.getTabManager().addTabToCurrentTab(new EditFormItemTabItem(item, group != null, applFormItems, refreshEvents));
+					if (group == null) {
+						session.getTabManager().addTabToCurrentTab(new EditFormItemTabItem(id, 0, item, applFormItems, refreshEvents));
+					} else {
+						session.getTabManager().addTabToCurrentTab(new EditFormItemTabItem(group.getVoId(), group.getId(), item, applFormItems, refreshEvents));
+					}
 				}
 			});
 			editTable.setWidget(0, 2, editButton);

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/GroupApplicationFormSettingsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/GroupApplicationFormSettingsTabItem.java
@@ -185,7 +185,7 @@ public class GroupApplicationFormSettingsTabItem implements TabItem, TabItemWith
 		// add button
 		addButton.addClickHandler(new ClickHandler() {
 			public void onClick(ClickEvent event) {
-				session.getTabManager().addTabToCurrentTab(new CreateFormItemTabItem(currentTemporaryId, sourceList, true, refreshEvents));
+				session.getTabManager().addTabToCurrentTab(new CreateFormItemTabItem(group.getVoId(), group.getId(), currentTemporaryId, sourceList, refreshEvents));
 				currentTemporaryId--;
 			}
 		});

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/CreateFormItemTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/CreateFormItemTabItem.java
@@ -57,7 +57,9 @@ public class CreateFormItemTabItem implements TabItem {
 
 	private int itemId = 0;
 	private JsonCallbackEvents events;
-	private boolean forGroup = false;
+
+	private int voId = 0;
+	private int groupId = 0;
 
 	public static final Map<String, String> inputTypes;
 	static {
@@ -87,20 +89,18 @@ public class CreateFormItemTabItem implements TabItem {
 
 	/**
 	 * Creates a tab instance
+	 *
+	 * @param voId
+	 * @param groupId
+	 * @param itemId
+	 * @param sourceList
+	 * @param events
 	 */
-	public CreateFormItemTabItem(int itemId, ArrayList<ApplicationFormItem> sourceList, JsonCallbackEvents events) {
+	public CreateFormItemTabItem(int voId, int groupId, int itemId, ArrayList<ApplicationFormItem> sourceList, JsonCallbackEvents events) {
+		this.voId = voId;
+		this.groupId = groupId;
 		this.itemId = itemId;
 		this.sourceList = sourceList;
-		this.events = events;
-	}
-
-	/**
-	 * Creates a tab instance
-	 */
-	public CreateFormItemTabItem(int itemId, ArrayList<ApplicationFormItem> sourceList, boolean forGroup, JsonCallbackEvents events) {
-		this.itemId = itemId;
-		this.sourceList = sourceList;
-		this.forGroup = forGroup;
 		this.events = events;
 	}
 
@@ -286,7 +286,7 @@ public class CreateFormItemTabItem implements TabItem {
 		item.setOrdnum(positionToAdd);
 		sourceList.add(positionToAdd, item);
 
-		session.getTabManager().addTabToCurrentTab(new EditFormItemTabItem(item, forGroup, sourceList, events));
+		session.getTabManager().addTabToCurrentTab(new EditFormItemTabItem(voId, groupId, item, sourceList, events));
 
 		events.onFinished(item);
 
@@ -309,7 +309,7 @@ public class CreateFormItemTabItem implements TabItem {
 	public int hashCode() {
 		final int prime = 983;
 		int result = 1;
-		result = prime * result + 672;
+		result = prime * result + 672 + voId + groupId;
 		return result;
 	}
 
@@ -320,6 +320,9 @@ public class CreateFormItemTabItem implements TabItem {
 		if (obj == null)
 			return false;
 		if (getClass() != obj.getClass())
+			return false;
+		CreateFormItemTabItem other = (CreateFormItemTabItem) obj;
+		if (voId != other.voId || groupId != other.groupId)
 			return false;
 
 		return true;

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/EditFormItemTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/EditFormItemTabItem.java
@@ -65,7 +65,6 @@ public class EditFormItemTabItem implements TabItem {
 	 * Item object
 	 */
 	private ApplicationFormItem item;
-	private boolean forGroup = false;
 	private ArrayList<ApplicationFormItem> otherItems;
 	private JsonCallbackEvents events;
 
@@ -100,19 +99,24 @@ public class EditFormItemTabItem implements TabItem {
 	private Map<String, Map<TextBox, TextBox>> optionsBoxes = new HashMap<String, Map<TextBox, TextBox>>();
 
 	private TabItem tab;
+	private int voId = 0;
+	private int groupId = 0;
 
 	/**
 	 * Creates a tab instance
 	 *
+	 * @param voId
+	 * @param groupId
 	 * @param item
-	 * @param forGroup
+	 * @param otherItems
 	 * @param events
 	 */
-	public EditFormItemTabItem(ApplicationFormItem item, boolean forGroup, ArrayList<ApplicationFormItem> otherItems, JsonCallbackEvents events) {
+	public EditFormItemTabItem(int voId, int groupId, ApplicationFormItem item, ArrayList<ApplicationFormItem> otherItems, JsonCallbackEvents events) {
 		this.item = item;
-		this.forGroup = forGroup;
 		this.otherItems = otherItems;
 		this.events = events;
+		this.voId = voId;
+		this.groupId = groupId;
 	}
 
 	public boolean isPrepared() {
@@ -534,7 +538,7 @@ public class EditFormItemTabItem implements TabItem {
 						} else if (def.getEntity().equalsIgnoreCase("vo")) {
 							// source attributes can be VO too
 							perunSourceAttributeListBox.addItem(def.getFriendlyName() + " (" + def.getEntity() + " / " + def.getDefinition() + ")", def.getName());
-						} else if (def.getEntity().equalsIgnoreCase("group") && forGroup) {
+						} else if (def.getEntity().equalsIgnoreCase("group") && groupId != 0) {
 							// source attributes can be Group too if form is for group
 							perunSourceAttributeListBox.addItem(def.getFriendlyName() + " (" + def.getEntity() + " / " + def.getDefinition() + ")", def.getName());
 						}
@@ -756,7 +760,7 @@ public class EditFormItemTabItem implements TabItem {
 			ftf.setColSpan(row, 1, 2);
 
 			row++;
-			ft.setHTML(row, 1, "Select attribute, which will be used to pre-fill form value. You can select also VO "+(forGroup ? "and grou p" : "")+"attributes.");
+			ft.setHTML(row, 1, "Select attribute, which will be used to pre-fill form value. You can select also VO "+(groupId != 0 ? "and group " : "")+"attributes.");
 			ftf.setStyleName(row, 1, "inputFormInlineComment");
 			ftf.setColSpan(row, 1, 2);
 
@@ -1112,25 +1116,21 @@ public class EditFormItemTabItem implements TabItem {
 		return SmallIcons.INSTANCE.addIcon();
 	}
 
-
 	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		EditFormItemTabItem other = (EditFormItemTabItem) o;
+		if (voId != other.voId || groupId != other.groupId)
+			return false;
+		return true;
+	}
+
 	public int hashCode() {
 		final int prime = 991;
 		int result = 1;
-		result = prime * result + 672;
+		result = prime * result + 672 + voId + groupId;
 		return result;
-	}
-
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj)
-			return true;
-		if (obj == null)
-			return false;
-		if (getClass() != obj.getClass())
-			return false;
-
-		return true;
 	}
 
 	public boolean multipleInstancesEnabled() {
@@ -1142,7 +1142,7 @@ public class EditFormItemTabItem implements TabItem {
 
 	public boolean isAuthorized() {
 
-		if (session.isVoAdmin() || session.isGroupAdmin()) {
+		if (session.isVoAdmin(voId) || session.isGroupAdmin(groupId)) {
 			return true;
 		} else {
 			return false;

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/vostabs/VoApplicationFormSettingsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/vostabs/VoApplicationFormSettingsTabItem.java
@@ -187,7 +187,7 @@ public class VoApplicationFormSettingsTabItem implements TabItem, TabItemWithUrl
 		// add button
 		addButton.addClickHandler(new ClickHandler() {
 			public void onClick(ClickEvent event) {
-				session.getTabManager().addTabToCurrentTab(new CreateFormItemTabItem(currentTemporaryId, sourceList, refreshEvents));
+				session.getTabManager().addTabToCurrentTab(new CreateFormItemTabItem(voId, 0, currentTemporaryId, sourceList, refreshEvents));
 				currentTemporaryId--;
 			}
 		});


### PR DESCRIPTION
- Multiple overlay tabs were considered as same, hence
  closing the first one caused others to be non-responding.
- Fixed for both creating and editing form items.