### PR TITLE
fix(core): fixed audit logging for group-resource assignement without services on resource

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ResourcesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ResourcesManagerBlImpl.java
@@ -1144,7 +1144,10 @@ public class ResourcesManagerBlImpl implements ResourcesManagerBl {
 		getResourcesManagerImpl().setFailedGroupResourceAssignmentCause(sess, group, resource, null);
 
 		// if there are no services, the members are empty and there is nothing more to process
-		if (getAssignedServices(sess, resource).isEmpty()) return;
+		if (getAssignedServices(sess, resource).isEmpty()) {
+			getPerunBl().getAuditer().log(sess, new GroupAssignedToResource(group, resource));
+			return;
+		}
 
 		// get/fill/set all required group and group-resource attributes
 		try {


### PR DESCRIPTION
When assigning group to resource which do not have any service, the
activation process ended up earlier than the audit message was created.
Therefore, the audit message creation was added in case the process is
finished earlier.