### PR TITLE
fix(githubci): fix version update in cli on release

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -7,7 +7,7 @@
 		"prepareCmd": "./update-versions.sh ${nextRelease.version} && mvn -B clean install"
     }],
     ["@semantic-release/git", {
-		"assets": [["**/pom.xml", "!perun-openapi/target/generated-sources/openapi/pom.xml"], "perun-openapi/openapi.yml"],
+		"assets": [["**/pom.xml", "!perun-openapi/target/generated-sources/openapi/pom.xml"], "perun-openapi/openapi.yml", "perun-cli/Perun/Agent.pm"],
 		"message": "chore(release): ${nextRelease.version} \n\n${nextRelease.notes}"
     }],
     ["@semantic-release/github", {


### PR DESCRIPTION
* The `Agent.pm` file was not specified in the semantic-release/git plugin.
Therefore, it was not commited when new release was published.