### PR TITLE
make getRichGroupByIdWithAttributesByNames parameter attrNames optional

### DIFF
--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -11055,7 +11055,7 @@ paths:
       description: Throws GroupNotExistsException when the group doesn't exist.
       parameters:
         - { name: groupId, description: "id of Group", schema: { type: integer }, in: query, required: true }
-        - $ref: '#/components/parameters/attrNames'
+        - $ref: '#/components/parameters/attrNamesOptional'
       responses:
         '200':
           $ref: '#/components/responses/RichGroupResponse'

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/GroupsManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/GroupsManagerMethod.java
@@ -1623,7 +1623,7 @@ public enum GroupsManagerMethod implements ManagerMethod {
 
 			return ac.getGroupsManager().getRichGroupByIdWithAttributesByNames(ac.getSession(),
 					parms.readInt("groupId"),
-					parms.readList("attrNames", String.class));
+					parms.contains("attrNames") ? parms.readList("attrNames", String.class) : null);
 		}
 	},
 


### PR DESCRIPTION
For method GroupManager::getRichGroupByIdWithAttributesByNames
- mark the parameter attrNames in openapi as optional
- modify the GroupManagerMethod to pass null if the parameter is not present

Fixes the RPC method code so that it corresponds with documentation and core implementation.