### PR TITLE
feat(registrar): added option to disable finding similar users during registrations

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/CoreConfig.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/CoreConfig.java
@@ -84,6 +84,7 @@ public class CoreConfig {
 	private List<String> attributesToSearchUsersAndMembersBy;
 	private List<String> attributesToAnonymize;
 	private List<String> attributesToKeep;
+	private boolean findSimilarUsersDisabled;
 
 	public int getGroupMaxConcurentGroupsToSynchronize() {
 		return groupMaxConcurentGroupsToSynchronize;
@@ -701,5 +702,13 @@ public class CoreConfig {
 
 	public void setSendIdentityAlerts(boolean sendIdentityAlerts) {
 		this.sendIdentityAlert = sendIdentityAlerts;
+	}
+
+	public boolean isFindSimilarUsersDisabled() {
+		return findSimilarUsersDisabled;
+	}
+
+	public void setFindSimilarUsersDisabled(boolean findSimilarUsersDisabled) {
+		this.findSimilarUsersDisabled = findSimilarUsersDisabled;
 	}
 }

--- a/perun-base/src/main/resources/perun-base.xml
+++ b/perun-base/src/main/resources/perun-base.xml
@@ -68,6 +68,7 @@
 		<property name="attributesToAnonymize" value="#{'${perun.attributesToAnonymize}'.split('\s*,\s*')}"/>
 		<property name="attributesToKeep" value="#{'${perun.attributesToKeep}'.split('\s*,\s*')}"/>
 		<property name="sendIdentityAlerts" value="${perun.sendIdentityAlerts}"/>
+		<property name="findSimilarUsersDisabled" value="${perun.findSimilarUsersDisabled}"/>
 	</bean>
 
 
@@ -157,6 +158,7 @@
 
 				<prop key="perun.autocreatedNamespaces"></prop>
 				<prop key="perun.sendIdentityAlerts">false</prop>
+				<prop key="perun.findSimilarUsersDisabled">false</prop>
 
 			</props>
 		</property>

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
@@ -89,6 +89,7 @@ public class RegistrarManagerImpl implements RegistrarManager {
 
 	private final static Logger log = LoggerFactory.getLogger(RegistrarManagerImpl.class);
 	private final static Set<String> extSourcesWithMultipleIdentifiers = BeansUtils.getCoreConfig().getExtSourcesMultipleIdentifiers();
+	private final static boolean isFindSimilarUsersDisabled = BeansUtils.getCoreConfig().isFindSimilarUsersDisabled();
 
 	// identifiers for selected attributes
 	private static final String URN_USER_TITLE_BEFORE = "urn:perun:user:attribute-def:core:titleBefore";
@@ -620,16 +621,18 @@ public class RegistrarManagerImpl implements RegistrarManager {
 
 			}
 
-			// FIND SIMILAR USERS
-			try {
-				List<Identity> similarUsers = getConsolidatorManager().checkForSimilarUsers(sess);
-				if (similarUsers != null && !similarUsers.isEmpty()) {
-					log.debug("Similar users found for {} / {}: {}", sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getExtSourceName(), similarUsers);
+			// FIND SIMILAR USERS IF IT IS NOT DISABLED
+			if (!isFindSimilarUsersDisabled) {
+				try {
+					List<Identity> similarUsers = getConsolidatorManager().checkForSimilarUsers(sess);
+					if (similarUsers != null && !similarUsers.isEmpty()) {
+						log.debug("Similar users found for {} / {}: {}", sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getExtSourceName(), similarUsers);
+					}
+					result.put("similarUsers", similarUsers);
+				} catch (Exception ex) {
+					// not relevant exception in this use-case
+					log.error("[REGISTRAR] Exception when searching for similar users.", ex);
 				}
-				result.put("similarUsers", similarUsers);
-			} catch (Exception ex) {
-				// not relevant exception in this use-case
-				log.error("[REGISTRAR] Exception when searching for similar users.", ex);
 			}
 
 		} catch (Exception ex) {


### PR DESCRIPTION
- findSimilarUsersProperty was added to have the ability to stop finding
  similar users during registrations. Default is false, meaning that the
  process will be executed.