### PR TITLE
fix(registrar): Fix retrieving VO application while initializing registrar

### DIFF
--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/RegistrarManager.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/RegistrarManager.java
@@ -419,6 +419,14 @@ public interface RegistrarManager {
 	List<Application> getApplicationsForUser(PerunSession sess);
 
 	/**
+	 * Returns open applications submitted by user (in session)
+	 *
+	 * @param sess PerunSession
+	 * @return open applications submitted by user (in session)
+	 */
+	List<Application> getOpenApplicationsForUser(PerunSession sess);
+
+	/**
 	 * Returns applications submitted by member of VO or Group
 	 *
 	 * @param sess PerunSession

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
@@ -2213,6 +2213,19 @@ public class RegistrarManagerImpl implements RegistrarManager {
 	}
 
 	@Override
+	public List<Application> getOpenApplicationsForUser(PerunSession sess) {
+
+		try {
+			List<Application> allApplications = jdbc.query(APP_SELECT + " where state in (?,?) order by a.id desc",
+				APP_MAPPER, AppState.VERIFIED.toString(), AppState.NEW.toString());
+			return filterPrincipalApplications(sess, allApplications);
+		} catch (EmptyResultDataAccessException ex) {
+			return new ArrayList<>();
+		}
+
+	}
+
+	@Override
 	public List<Application> getApplicationsForMember(PerunSession sess, Group group, Member member) throws PerunException {
 		membersManager.checkMemberExists(sess, member);
 
@@ -2469,9 +2482,9 @@ public class RegistrarManagerImpl implements RegistrarManager {
 
 		// pending vo data for current user (if known to Perun) or session principal
 		if (group != null) {
-			Optional<Application> pendingVoApplication = getApplicationsForUser(sess)
+			Optional<Application> pendingVoApplication = getOpenApplicationsForUser(sess)
 				.stream()
-				.filter(voApp -> voApp.getGroup() == null && (voApp.getState().equals(AppState.NEW) || voApp.getState().equals(AppState.VERIFIED)))
+				.filter(voApp -> voApp.getGroup() == null)
 				.findFirst();
 			if (pendingVoApplication.isPresent()) {
 				pendingVoApplicationData = getApplicationDataById(sess, pendingVoApplication.get().getId());


### PR DESCRIPTION
When we were initializing registrar for group applications all
applications were fetched and checked if some of them belong to the
user. This had to be optimized because we do not need all applications,
just the open ones. Therefore, new method was created for that and it is
used in the initialization process instead of the old one.