### PR TITLE
fix(registrar): fixed sending notifications about group application creation to admins

### DIFF
--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/RegistrarManager.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/RegistrarManager.java
@@ -419,12 +419,22 @@ public interface RegistrarManager {
 	List<Application> getApplicationsForUser(PerunSession sess);
 
 	/**
-	 * Returns open applications submitted by user (in session)
+	 * Returns open applications submitted by user in a specific VO
+	 *
+	 * @param user to get applications for
+	 * @param vo to get applications from
+	 * @return open applications submitted by user
+	 */
+	List<Application> getOpenApplicationsForUserInVo(User user, Vo vo);
+
+	/**
+	 * Returns open applications submitted by user in a specific VO (in session)
 	 *
 	 * @param sess PerunSession
+	 * @param vo to get applications from
 	 * @return open applications submitted by user (in session)
 	 */
-	List<Application> getOpenApplicationsForUser(PerunSession sess);
+	List<Application> getOpenApplicationsForUserInVo(PerunSession sess, Vo vo);
 
 	/**
 	 * Returns applications submitted by member of VO or Group


### PR DESCRIPTION
- Notifications about created group applications were sent immediately
  after the application was created. This was causing issues in cases
  where the user was not member of the VO yet. Administrator received a
  notification but he could not approve the group application yet. This
  was changed so it sends such notification only when the user is already
  member of the VO.