### PR TITLE
fix(core): skip running ResourceAssignmentActivator component in read-only mode

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ResourceAssignmentActivator.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ResourceAssignmentActivator.java
@@ -61,6 +61,11 @@ public class ResourceAssignmentActivator implements ApplicationListener<ContextR
 	 * The activations run synchronously in one thread.
 	 */
 	private void activateGroupResourceAssignments() {
+		if (perunBl.isPerunReadOnly()) {
+			log.warn("This instance is just read only so skip activation of group-resource assignments.");
+			return;
+		}
+
 		try {
 			log.debug("ResourceAssignmentActivator starting to activate group-resource assignments in PROCESSING or FAILED state.");
 


### PR DESCRIPTION
* If instance runs in read-only mode, this component shouldn't try to activate group-resource
assignments.