### PR TITLE
fix(core): keep original order of groupResourceStatus

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/GroupResourceStatus.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/GroupResourceStatus.java
@@ -8,9 +8,9 @@ package cz.metacentrum.perun.core.api;
 public enum GroupResourceStatus {
 
 	ACTIVE(3),
-	PROCESSING(2),
 	INACTIVE(1),
-	FAILED(0);
+	FAILED(0),
+	PROCESSING(2);
 
 	private Integer level;
 


### PR DESCRIPTION
* in previous commits we changed the order of groupResourceStatus enum values
* this might cause problems for mapping data from database to the status, so the original order is now restored