### PR TITLE
ci(githubci): add alpha and beta releases

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,5 +1,10 @@
 {
-  "branches": [ "production", "+([0-9])?(.{+([0-9]),x}).x"],
+  "branches": [
+    "production",
+    "+([0-9])?(.{+([0-9]),x}).x",
+    { "name": "alpha", "prerelease": true },
+    { "name": "beta", "prerelease": true }
+  ],
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",


### PR DESCRIPTION
* Change configuration so that `alpha` and `beta` branches can release new alpha/beta releases.