### PR TITLE
fix(core): Fixed getMemberPage method to return member-group attributes

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
@@ -2768,7 +2768,15 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 			}
 		}
 
-		richMembers = convertMembersToRichMembersWithAttributes(sess, richMembers, attrDefs);
+		if (query.getGroupId() == null) {
+			richMembers = convertMembersToRichMembersWithAttributes(sess, richMembers, attrDefs);
+		} else {
+			try {
+				richMembers = convertMembersToRichMembersWithAttributes(sess, perunBl.getGroupsManagerBl().getGroupById(sess, query.getGroupId()), richMembers, attrDefs);
+			} catch (GroupNotExistsException | MemberGroupMismatchException e) {
+				throw new InternalErrorException(e);
+			}
+		}
 
 		return new Paginated<>(richMembers, paginatedMembers.getOffset(), paginatedMembers.getPageSize(),
 				paginatedMembers.getTotalCount());

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/MembersManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/MembersManagerEntryIntegrationTest.java
@@ -89,6 +89,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 	private static final String A_U_NOTE = AttributesManager.NS_USER_ATTR_DEF + ":note";
 	private static final String A_U_ADDRESS = AttributesManager.NS_USER_ATTR_DEF + ":address";
 	private static final String A_M_MAIL = AttributesManager.NS_MEMBER_ATTR_DEF + ":mail";
+	private static final String A_M_G_EXPIRATION = AttributesManager.NS_MEMBER_GROUP_ATTR_DEF + ":groupMembershipExpiration";
 
 	private Vo createdVo = null;
 	private ExtSource extSource = new ExtSource(0, EXT_SOURCE_NAME, ExtSourcesManager.EXTSOURCE_INTERNAL);
@@ -2933,6 +2934,40 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 
 		assertThat(returnedMemberIds).containsExactly(member2.getId());
 		assertThat(result.getData().get(0).getMembershipType()).isEqualTo(MembershipType.DIRECT);
+	}
+
+	@Test
+	public void getGroupMembersPageWithMemberGroupAttribute() throws Exception {
+		System.out.println(CLASS_NAME + "getGroupMembersPageWithMemberGroupAttribute");
+
+		Vo vo = perun.getVosManager().createVo(sess, new Vo(0, "testPagination", "tp"));
+
+		Group group = perun.getGroupsManager().createGroup(sess, vo, new Group("test", "testPaginationInGroup"));
+
+		Member member = setUpMember(vo, "Doe", "John");
+
+		perun.getGroupsManager().addMember(sess, group, member);
+
+		AttributeDefinition expirationDef = perun.getAttributesManagerBl().getAttributeDefinition(sess, A_M_G_EXPIRATION);
+		Attribute expiration = new Attribute(expirationDef);
+		expiration.setValue("2021-11-11");
+
+		perun.getAttributesManagerBl().setAttribute(sess, member, group, expiration);
+
+		MembersPageQuery query = new MembersPageQuery(1, 0, SortingOrder.ASCENDING, MembersOrderColumn.NAME, "doe", List.of(), group.getId(), List.of());
+
+		Paginated<RichMember> result = perun.getMembersManager().getMembersPage(sess, vo, query, List.of(expiration.getName()));
+		List<Integer> returnedMemberIds = result.getData().stream()
+			.map(PerunBean::getId)
+			.collect(toList());
+
+		assertThat(returnedMemberIds)
+			.containsExactly(member.getId());
+		assertThat(result.getData().get(0).getMemberAttributes().size())
+			.isEqualTo(1);
+		assertThat(result.getData().get(0).getMemberAttributes().get(0))
+			.isEqualTo(expiration);
+
 	}
 
 	private Member setUpMember(Vo vo, String lastName, String firstName) throws Exception {


### PR DESCRIPTION
* Fixed issue where member-group attributes were filtered even when
getting members of a group. The method now uses correct version of
convertMembersToRichMembersWithAttributes when groupId is not null.