### PR TITLE
feat(cli): add async assignments and status of group-resource assignment

### DIFF
--- a/perun-cli/Perun/Common.pm
+++ b/perun-cli/Perun/Common.pm
@@ -50,6 +50,10 @@ use Perun::beans::ResourceTag;
 use Perun::beans::ApplicationFormItem;
 use Perun::beans::Sponsor;
 use Perun::beans::Application;
+use Perun::beans::EnrichedGroup;
+use Perun::beans::AssignedGroup;
+use Perun::beans::EnrichedResource;
+use Perun::beans::AssignedResource;
 
 sub newEmptyBean
 {

--- a/perun-cli/Perun/ResourcesAgent.pm
+++ b/perun-cli/Perun/ResourcesAgent.pm
@@ -177,4 +177,14 @@ sub deactivateGroupResourceAssignment
 	return Perun::Common::callManagerMethod('deactivateGroupResourceAssignment', '', @_);
 }
 
+sub getGroupAssignments
+{
+	return Perun::Common::callManagerMethod('getGroupAssignments', '[]AssignedGroup', @_);
+}
+
+sub getResourceAssignments
+{
+	return Perun::Common::callManagerMethod('getResourceAssignments', '[]AssignedResource', @_);
+}
+
 1;

--- a/perun-cli/Perun/beans/AssignedGroup.pm
+++ b/perun-cli/Perun/beans/AssignedGroup.pm
@@ -1,0 +1,80 @@
+package Perun::beans::AssignedGroup;
+
+use strict;
+use warnings;
+use 5.010;
+
+use Perun::Common;
+
+sub new
+{
+	bless({});
+}
+
+sub fromHash
+{
+	return Perun::Common::fromHash(@_);
+}
+
+sub TO_JSON
+{
+	my $self = shift;
+
+	return { enrichedGroup => $self->{_enrichedGroup}, status => $self->{_status},
+		sourceGroupId => $self->{_sourceGroupId}, failureCause => $self->{_failureCause},
+		autoAssignSubgroups => $self->{_autoAssignSubgroups} };
+}
+
+sub getGroupId {
+	return shift->{_enrichedGroup}->{group}->{id};
+}
+
+sub getVoId {
+	return shift->{_enrichedGroup}->{group}->{voId};
+}
+
+sub getName {
+	return shift->{_enrichedGroup}->{group}->{name};
+}
+
+sub getStatus {
+	return shift->{_status};
+}
+
+sub getStatusToPrint {
+	my $self = shift;
+	return ($self->{_failureCause}) ? $self->{_status} . " - " . $self->{_failureCause} : $self->{_status};
+}
+
+sub getSourceGroupId {
+	my $self = shift;
+	return ($self->{_sourceGroupId}) ? $self->{_sourceGroupId} : -1;
+}
+
+sub getFailureCause {
+	my $self = shift;
+	return $self->{_failureCause};
+}
+
+sub isAutoAssignSubgroups {
+	my $self = shift;
+	return ($self->{_autoAssignSubgroups}) ? 1 : 0;
+}
+
+sub isAutoAssignSubgroupsToPrint
+{
+	my $self = shift;
+
+	return ($self->{_autoAssignSubgroups}) ? 'true' : 'false';
+}
+
+sub getCommonArrayRepresentation {
+	my $self = shift;
+	return ($self->getGroupId, $self->getVoId, $self->getName, $self->{_enrichedGroup}->{group}->{description},
+		$self->getStatusToPrint, $self->{_sourceGroupId}, $self->isAutoAssignSubgroupsToPrint);
+}
+
+sub getCommonArrayRepresentationHeading {
+	return ('ID', 'VO ID', 'Name', 'Description', 'Status', 'Source group ID', 'Assign subgroups');
+}
+1;

--- a/perun-cli/Perun/beans/AssignedResource.pm
+++ b/perun-cli/Perun/beans/AssignedResource.pm
@@ -1,0 +1,86 @@
+package Perun::beans::AssignedResource;
+
+use strict;
+use warnings;
+use 5.010;
+
+use Perun::Common;
+
+sub new
+{
+	bless({});
+}
+
+sub fromHash
+{
+	return Perun::Common::fromHash(@_);
+}
+
+sub TO_JSON
+{
+	my $self = shift;
+
+	return { enrichedResource => $self->{_enrichedResource}, status => $self->{_status},
+		sourceGroupId => $self->{_sourceGroupId}, failureCause => $self->{_failureCause},
+		facility => $self->{_facility}, resourceTags => $self->{_resourceTags},
+		autoAssignSubgroups => $self->{_autoAssignSubgroups} };
+}
+
+sub getResourceId {
+	return shift->{_enrichedResource}->{resource}->{id};
+}
+
+sub getName {
+	return shift->{_enrichedResource}->{resource}->{name};
+}
+
+sub getStatus {
+	return shift->{_status};
+}
+
+sub getStatusToPrint {
+	my $self = shift;
+	return ($self->{_failureCause}) ? $self->{_status} . " - " . $self->{_failureCause} : $self->{_status};
+}
+
+sub getSourceGroupId {
+	my $self = shift;
+	return ($self->{_sourceGroupId}) ? $self->{_sourceGroupId} : -1;
+}
+
+sub getFailureCause {
+	my $self = shift;
+	return $self->{_failureCause};
+}
+
+sub isAutoAssignSubgroups {
+	my $self = shift;
+	return ($self->{_autoAssignSubgroups}) ? 1 : 0;
+}
+
+sub isAutoAssignSubgroupsToPrint
+{
+	my $self = shift;
+
+	return ($self->{_autoAssignSubgroups}) ? 'true' : 'false';
+}
+
+sub getFacilityId {
+	return shift->{_facility}->{id};
+}
+
+sub getResourceTags {
+	my $self = shift;
+	return @{$self->{_getResourceTags}};
+}
+
+sub getCommonArrayRepresentation {
+	my $self = shift;
+	return ($self->getResourceId, $self->getName, $self->{_enrichedResource}->{resource}->{voId}, $self->getFacilityId,
+		$self->{_enrichedResource}->{resource}->{description}, $self->getStatusToPrint, $self->{_sourceGroupId}, $self->isAutoAssignSubgroupsToPrint);
+}
+
+sub getCommonArrayRepresentationHeading {
+	return ('ID', 'Name', 'VO ID', 'Facility ID', 'Description', 'Status', 'Source group ID', 'Assign subgroups');
+}
+1;

--- a/perun-cli/Perun/beans/EnrichedGroup.pm
+++ b/perun-cli/Perun/beans/EnrichedGroup.pm
@@ -1,0 +1,45 @@
+package Perun::beans::EnrichedGroup;
+
+use strict;
+use warnings;
+use 5.010;
+
+use Perun::Common;
+
+sub new
+{
+	bless({});
+}
+
+sub fromHash
+{
+	return Perun::Common::fromHash(@_);
+}
+
+sub TO_JSON
+{
+	my $self = shift;
+
+	return { group => $self->{_group}, attributes => $self->{_attributes} };
+}
+
+sub getGroupId {
+	return shift->{_group}->{id};
+}
+
+sub getAttributes {
+	my $self = shift;
+	return @{$self->{_attributes}};
+}
+
+sub getCommonArrayRepresentation {
+	my $self = shift;
+	return ($self->{_group}->{id}, $self->{_group}->{voId}, $self->{_group}->{name},
+		$self->{_group}->{description}, $self->{_group}->{parentGroupId});
+}
+
+sub getCommonArrayRepresentationHeading {
+	return ('ID', 'VO ID', 'Name', 'Description', 'Parent Group ID');
+}
+
+1;

--- a/perun-cli/Perun/beans/EnrichedResource.pm
+++ b/perun-cli/Perun/beans/EnrichedResource.pm
@@ -1,0 +1,45 @@
+package Perun::beans::EnrichedResource;
+
+use strict;
+use warnings;
+use 5.010;
+
+use Perun::Common;
+
+sub new
+{
+	bless({});
+}
+
+sub fromHash
+{
+	return Perun::Common::fromHash(@_);
+}
+
+sub TO_JSON
+{
+	my $self = shift;
+
+	return { resource => $self->{_resource}, attributes => $self->{_attributes} };
+}
+
+sub getResourceId {
+	return shift->{_resource}->{id};
+}
+
+sub getAttributes {
+	my $self = shift;
+	return @{$self->{_attributes}};
+}
+
+sub getCommonArrayRepresentation {
+	my $self = shift;
+	return ($self->{_resource}->{id}, $self->{_resource}->{name}, $self->{_resource}->{voId},
+		$self->{_resource}->{facilityId}, $self->{_resource}->{description});
+}
+
+sub getCommonArrayRepresentationHeading {
+	return ('ID', 'Name', 'VO ID', 'Facility ID', 'Description');
+}
+
+1;

--- a/perun-cli/Perun/beans/Resource.pm
+++ b/perun-cli/Perun/beans/Resource.pm
@@ -158,7 +158,7 @@ sub setFacilityId
 
 sub getCommonArrayRepresentation {
 	my $self = shift;
-	return ($self->{_id}, $self->{_voId}, $self->{_name}, $self->{_facilityId}, $self->{_description});
+	return ($self->{_id}, $self->{_name}, $self->{_voId}, $self->{_facilityId}, $self->{_description});
 }
 
 sub getCommonArrayRepresentationHeading {

--- a/perun-cli/assignGroupToResource
+++ b/perun-cli/assignGroupToResource
@@ -16,20 +16,24 @@ sub help {
 	--voId        | -v vo id
 	--voShortName | -V vo short name
 	--resource    | -r resource id
+	--async       | -a assigns group asynchronously
+	--inactive    | -i assigns group as inactive
+	--subgroups   | -s assigns group's subgroups automatically
 	--batch       | -b batch
 	--help        | -h prints this help
 
 	};
 }
 
-my ($groupId, $groupName, $voId, $voShortName, $resourceId, $batch);
+my ($groupId, $groupName, $voId, $voShortName, $resourceId, $async, $inactive, $subgroups, $batch);
 GetOptions ("help|h" => sub {
 		print help();
 		exit 0;
 	}, "batch|b"     => \$batch,
 	"groupId|g=i"    => \$groupId, "groupName|G=s" => \$groupName,
 	"voId|v=i"       => \$voId, "voShortName|V=s" => \$voShortName,
-	"resourceId|r=i" => \$resourceId) || die help();
+	"resourceId|r=i" => \$resourceId, "async|a" => \$async,
+	"inactive|i" => \$inactive, "subgroups|s" => \$subgroups) || die help();
 
 # Check options
 unless (defined($groupId) or ((defined($voShortName) or defined($voId)) and defined($groupName))) {die "ERROR: groupId or groupName and voId or voShortName is required\n";}
@@ -50,6 +54,24 @@ if (!defined($groupId)) {
 	$groupId = $group->getId;
 }
 
-$resourcesAgent->assignGroupToResource( group => $groupId, resource => $resourceId );
+if (defined($async)) {
+	$async = 1;
+} else {
+	$async = 0;
+}
+
+if (defined($inactive)) {
+	$inactive = 1;
+} else {
+	$inactive = 0;
+}
+
+if (defined($subgroups)) {
+	$subgroups = 1;
+} else {
+	$subgroups = 0;
+}
+$resourcesAgent->assignGroupToResource(group => $groupId, resource => $resourceId, async => $async,
+	assignInactive => $inactive, autoAssignSubgroups => $subgroups );
 
 printMessage("Group Id: $groupId successfully assigned to the resource Id:$resourceId", $batch);

--- a/perun-cli/listOfGroupResources
+++ b/perun-cli/listOfGroupResources
@@ -38,7 +38,7 @@ unless (defined $sortingFunction) { $sortingFunction = getSortingFunction("getNa
 unless (defined $groupId) { die "ERROR: Group specification required.\n"; }
 
 my $resourcesAgent = $agent->getResourcesAgent;
-my @resources = $resourcesAgent->getAssignedResources( group => $groupId );
+my @resources = $resourcesAgent->getResourceAssignments( group => $groupId );
 unless (@resources) {
 	printMessage "No Group's Resources found", $batch;
 	exit 0;

--- a/perun-cli/listOfGroupsAssignedToResource
+++ b/perun-cli/listOfGroupsAssignedToResource
@@ -39,11 +39,10 @@ unless (defined $resourceId) { die "ERROR: Resource identifier required.\n"; }
 my $agent = Perun::Agent->new();
 my $resourcesAgent = $agent->getResourcesAgent;
 
-my @groups = $resourcesAgent->getAssignedGroups( resource => $resourceId );
+my @groups = $resourcesAgent->getGroupAssignments( resource => $resourceId );
 unless (@groups) {
 	printMessage "No group found.", $batch;
 	exit 0;
 }
-
 #output
 printTable($sortingFunction, @groups);


### PR DESCRIPTION
- New objects were added to perun-cli: AssignedGroup, AssignedResource,
EnrichedGroup, EnrichedResource.
- Async option was added to tool assignGroupToResource to assign groups
asynchronously.
- Tools listOfGroupResources and listOfGroupsAssignedToResource now
also print status of group-resource assignments, source group id if it
is automatic assignment and whether the group's subgroups are
automatically assign as well.