### PR TITLE
fix(core): use correct scope for idp-cert.e-infra.cz

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/EinfraPasswordManagerModule.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/EinfraPasswordManagerModule.java
@@ -151,7 +151,7 @@ public class EinfraPasswordManagerModule extends GenericPasswordManagerModule {
 
 				// Store E-INFRA CERT IdP UES
 				extSource = ((PerunBl) sess.getPerun()).getExtSourcesManagerBl().getExtSourceByName(sess, "https://idp-cert.e-infra.cz/idp/");
-				ues = new UserExtSource(extSource, userLogin + "@idp.e-infra.cz");
+				ues = new UserExtSource(extSource, userLogin + "@idp-cert.e-infra.cz");
 				ues.setLoa(0);
 
 				try {


### PR DESCRIPTION
Each IdP ExtSource must provide unique scope for logins. We can't use same scop acros IdPs.