### PR TITLE
fix(core): user correct authorization for getGroupAssignments

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ResourcesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ResourcesManagerEntry.java
@@ -1359,7 +1359,9 @@ public class ResourcesManagerEntry implements ResourcesManager {
 
 		List<AssignedGroup> filteredGroups =  getResourcesManagerBl().getGroupAssignments(sess, resource, attrNames).stream()
 			.filter(assignedGroup -> AuthzResolver.authorizedInternal(sess,
-				"filter-getGroupAssignments_Resource_policy", assignedGroup.getEnrichedGroup().getGroup()))
+				"filter-getGroupAssignments_Resource_policy",
+				assignedGroup.getEnrichedGroup().getGroup(),
+				resource))
 			.collect(Collectors.toList());
 
 		filteredGroups.forEach(assignedGroup ->


### PR DESCRIPTION
* The resource parameter was not passed to the method which was used to filter returned groups.
Therefore, all policies, which used the Resource or Facility object, were not evaluated correctly.