### PR TITLE
fix(core): use u:d:titleBeforeDc2 instead of u:d:titleBeforeVema at VŠUP

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_titleBeforeDc2.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_titleBeforeDc2.java
@@ -16,10 +16,10 @@ import cz.metacentrum.perun.core.implApi.modules.attributes.UserAttributesModule
  *
  * @author Pavel Zlámal <zlamal@cesnet.cz>
  */
-public class urn_perun_user_attribute_def_def_titleBeforeVema extends UserAttributesModuleAbstract implements UserAttributesModuleImplApi {
+public class urn_perun_user_attribute_def_def_titleBeforeDc2 extends UserAttributesModuleAbstract implements UserAttributesModuleImplApi {
 
 	/**
-	 * When title before name from VEMA changes, update User.
+	 * When title before name from DC2 changes, update User.
 	 *
 	 * @param session
 	 * @param user
@@ -42,10 +42,10 @@ public class urn_perun_user_attribute_def_def_titleBeforeVema extends UserAttrib
 	public AttributeDefinition getAttributeDefinition() {
 		AttributeDefinition attr = new AttributeDefinition();
 		attr.setNamespace(AttributesManager.NS_USER_ATTR_DEF);
-		attr.setFriendlyName("titleBeforeVema");
-		attr.setDisplayName("Title before (VEMA)");
+		attr.setFriendlyName("titleBeforeDc2");
+		attr.setDisplayName("Title before (DC2)");
 		attr.setType(Integer.class.getName());
-		attr.setDescription("Title before name from VEMA.");
+		attr.setDescription("Title before name from DC2.");
 		return attr;
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_titleBeforeKos.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_titleBeforeKos.java
@@ -22,7 +22,7 @@ import static cz.metacentrum.perun.core.api.AttributesManager.NS_USER_ATTR_DEF;
 public class urn_perun_user_attribute_def_def_titleBeforeKos extends UserAttributesModuleAbstract implements UserAttributesModuleImplApi {
 
 	/**
-	 * When KOS title before name is set, check if there is title from VEMA (personal system).
+	 * When KOS title before name is set, check if there is title from DC2 (personal system).
 	 * If not, update title in User.
 	 *
 	 * @param session
@@ -34,11 +34,11 @@ public class urn_perun_user_attribute_def_def_titleBeforeKos extends UserAttribu
 	public void changedAttributeHook(PerunSessionImpl session, User user, Attribute attribute) {
 
 		if (attribute.getValue() != null) {
-			Attribute titleBeforeVema;
+			Attribute titleBeforeDc2;
 			try {
-				titleBeforeVema = session.getPerunBl().getAttributesManagerBl().getAttribute(session, user, NS_USER_ATTR_DEF + ":titleBeforeVema");
-				if (titleBeforeVema.getValue() == null) {
-					// no title from VEMA - update from KOS
+				titleBeforeDc2 = session.getPerunBl().getAttributesManagerBl().getAttribute(session, user, NS_USER_ATTR_DEF + ":titleBeforeDc2");
+				if (titleBeforeDc2.getValue() == null) {
+					// no title from DC2 - update from KOS
 					user.setTitleBefore((String)attribute.getValue());
 					session.getPerunBl().getUsersManagerBl().updateNameTitles(session, user);
 				}


### PR DESCRIPTION
We no longer use VEMA as personel system, hence attribute modules must be switched to use new
attribute.