### PR TITLE
fix(core): use correct authorization for getResourceAssignments

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ResourcesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ResourcesManagerEntry.java
@@ -1337,7 +1337,9 @@ public class ResourcesManagerEntry implements ResourcesManager {
 
 		List<AssignedResource> filteredResources = getResourcesManagerBl().getResourceAssignments(sess, group, attrNames).stream()
 			.filter(assignedResource -> AuthzResolver.authorizedInternal(sess,
-				"filter-getResourceAssignments_Group_policy", assignedResource.getEnrichedResource().getResource()))
+				"filter-getResourceAssignments_Group_policy",
+				assignedResource.getEnrichedResource().getResource(),
+				group))
 			.collect(Collectors.toList());
 
 		filteredResources.forEach(assignedResource ->


### PR DESCRIPTION
* The group parameter was not passed to the method which was used to filter returned resources.
Therefore, all policies, that used the Group object, were not evaluated correctly.