### PR TITLE
fix(core): update user extSource attributes inside a transaction while getting session

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/PerunBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/PerunBlImpl.java
@@ -212,7 +212,7 @@ public class PerunBlImpl implements PerunBl {
 					}
 
 					log.debug("storing attribute {}='{}' for user {}", attributeWithValue.getFriendlyName(), attrValue, ues.getLogin());
-					attributesManagerBl.setAttribute(session, ues, attributeWithValue);
+					attributesManagerBl.setAttributeInNestedTransaction(session, ues, attributeWithValue);
 				} catch (AttributeNotExistsException | WrongAttributeAssignmentException | WrongAttributeValueException | WrongReferenceAttributeValueException e) {
 					log.error("Attribute " + attr.getName() + " with value '" + attrValue + "' cannot be saved", e);
 				}


### PR DESCRIPTION
- Attributes were not set in a transaction so when an error ocured,
  attribute was set anyway.