### PR TITLE
fix(core): fix database dump problem caused by unqualified table name…

### DIFF
--- a/perun-base/src/test/resources/test-schema.sql
+++ b/perun-base/src/test/resources/test-schema.sql
@@ -1,4 +1,4 @@
--- database version 3.1.87 (don't forget to update insert statement at the end of file)
+-- database version 3.1.88 (don't forget to update insert statement at the end of file)
 CREATE EXTENSION IF NOT EXISTS "unaccent";
 CREATE EXTENSION IF NOT EXISTS "pgcrypto";
 
@@ -1708,7 +1708,7 @@ CREATE INDEX ufauv_idx ON user_facility_attr_u_values (user_id, facility_id, att
 CREATE INDEX vauv_idx ON vo_attr_u_values (vo_id, attr_id);
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.1.87');
+insert into configurations values ('DATABASE VERSION','3.1.88');
 -- insert membership types
 insert into membership_types (id, membership_type, description) values (1, 'DIRECT', 'Member is directly added into group');
 insert into membership_types (id, membership_type, description) values (2, 'INDIRECT', 'Member is added indirectly through UNION relation');

--- a/perun-core/src/main/resources/postgresChangelog.txt
+++ b/perun-core/src/main/resources/postgresChangelog.txt
@@ -6,6 +6,10 @@
 -- Directly under version number should be version commands. They will be executed in the order they are written here.
 -- Comments are prefixed with -- and can be written only between version blocks, that means not in the lines with commands. They have to be at the start of the line.
 
+3.1.88
+create or replace function relation_group_resource_exist(integer, integer) returns integer as 'select count(1)::integer from (SELECT group_id, resource_id FROM perun.groups_resources UNION SELECT group_id, resource_id FROM perun.groups_resources_automatic) gr_res where group_id=$1 and resource_id=$2;' language sql;
+UPDATE configurations SET value='3.1.88' WHERE property='DATABASE VERSION';
+
 3.1.87
 ALTER TABLE groups_resources ADD COLUMN auto_assign_subgroups boolean default false not null;
 UPDATE configurations SET value='3.1.87' WHERE property='DATABASE VERSION';

--- a/perun-db/postgres.sql
+++ b/perun-db/postgres.sql
@@ -1,4 +1,4 @@
--- database version 3.1.87 (don't forget to update insert statement at the end of file)
+-- database version 3.1.88 (don't forget to update insert statement at the end of file)
 
 -- VOS - virtual organizations
 create table vos (
@@ -782,7 +782,7 @@ create table groups_resources_automatic (
 );
 
 create function relation_group_resource_exist(integer, integer) returns integer as
-    'select count(1)::integer from (SELECT group_id, resource_id FROM groups_resources UNION SELECT group_id, resource_id FROM groups_resources_automatic) gr_res where group_id=$1 and resource_id=$2;' language sql;
+    'select count(1)::integer from (SELECT group_id, resource_id FROM perun.groups_resources UNION SELECT group_id, resource_id FROM perun.groups_resources_automatic) gr_res where group_id=$1 and resource_id=$2;' language sql;
 
 create table groups_resources_state (
 	group_id integer not null,
@@ -1806,7 +1806,7 @@ grant all on members_sponsored to perun;
 grant all on groups_to_register to perun;
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.1.87');
+insert into configurations values ('DATABASE VERSION','3.1.88');
 
 -- insert membership types
 insert into membership_types (id, membership_type, description) values (1, 'DIRECT', 'Member is directly added into group');


### PR DESCRIPTION
… in SQL function

The SQL function relation_group_resource_exist contained table name without schema which caused
problem with dumps when loaded.

BREAKING CHANGE: New database version