### PR TITLE
fix(core): check member-group attributes in getMembersPage

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/MembersManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/MembersManagerEntry.java
@@ -1579,7 +1579,13 @@ public class MembersManagerEntry implements MembersManager {
 		}
 
 		Paginated<RichMember> result = membersManagerBl.getMembersPage(sess, vo, query, attrNames);
-		result.setData(getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, result.getData()));
+
+		if (query.getGroupId() == null) {
+			result.setData(getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, result.getData()));
+		} else {
+			Group group = getPerunBl().getGroupsManagerBl().getGroupById(sess, query.getGroupId());
+			result.setData(getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, result.getData(), group, true));
+		}
 
 		return result;
 	}


### PR DESCRIPTION
* Exception was thrown if user with role groupadmin called this method, filtering needs to happen separately if group is defined in query