### PR TITLE
chore: use tomcat9 for runing perun locally

### DIFF
--- a/perun-rpc/pom.xml
+++ b/perun-rpc/pom.xml
@@ -33,11 +33,11 @@
 				and to provide http->ajp rewrite so that calls from GUI (browser) are passed to Perun app. -->
 			<plugin>
 				<groupId>org.codehaus.cargo</groupId>
-				<artifactId>cargo-maven2-plugin</artifactId>
-				<version>1.8.2</version>
+				<artifactId>cargo-maven3-plugin</artifactId>
+				<version>1.9.6</version>
 				<configuration>
 					<container>
-						<containerId>tomcat8x</containerId>
+						<containerId>tomcat9x</containerId>
 						<artifactInstaller>
 							<groupId>org.apache.tomcat</groupId>
 							<artifactId>tomcat</artifactId>
@@ -52,7 +52,7 @@
 						 -->
 					</container>
 					<configuration>
-						<home>${basedir}/target/cargo/tomcat8x</home>
+						<home>${basedir}/target/cargo/tomcat9x</home>
 						<files>
 							<copy>
 								<file>${basedir}/tomcat.xml</file>

--- a/perun-rpc/tomcat.xml
+++ b/perun-rpc/tomcat.xml
@@ -22,10 +22,10 @@
 	           address="127.0.0.1"
 	           tomcatAuthentication="false"
 	           URIEncoding="UTF-8"
-	           packetSize="36000"
+	           packetSize="65536"
 	           redirectPort="8080"
 	           secretRequired="false"
-	           allowedRequestAttributesPattern=".*"/>
+	           allowedRequestAttributesPattern=".*" />
 
 	<Engine name="Catalina" defaultHost="localhost" debug="FINE">
 

--- a/pom.xml
+++ b/pom.xml
@@ -60,9 +60,6 @@
 		<!-- by default we run perun in memory -->
 		<spring.profiles.default>default</spring.profiles.default>
 
-		<!-- redefine versions of some libraries defined by Spring Boot Starter Parent -->
-		<tomcat.version>8.5.57</tomcat.version>
-
 		<!-- versions of libraries not defined by the Spring Boot Starter Parent -->
 		<commons-cli.version>1.4</commons-cli.version>
 		<commons-text.version>1.9</commons-text.version>


### PR DESCRIPTION
- Updated dependency to Tomcat 9 version provided by Spring Boot
- Updated cargo plugin
- Increase packetSize=65536 on APJ port