### PR TITLE
fix(cli): escape pipe character in batch mode

### DIFF
--- a/perun-cli/addVoMember
+++ b/perun-cli/addVoMember
@@ -6,7 +6,7 @@ use Getopt::Long qw(:config no_ignore_case);
 use Text::ASCIITable;
 use Perun::Agent;
 use Term::ReadKey;
-use Perun::Common qw(printMessage tableToPrint);
+use Perun::Common qw(printMessage tableContentToPrint);
 
 sub help {
 	return qq{
@@ -63,8 +63,7 @@ if ((scalar(@candidates) > 1) && $batch) {
 # We are not in the batch mode, so there can be more then one matching user for the searchString, let the user select
 my $candidate;
 if (!$batch) {
-	my $table = Text::ASCIITable->new( { reportErrors => 0, utf8 => 0 } );
-	$table->setCols( "Candidate\nnumber", 'name', 'login in the external source', 'external source' );
+	my @rows = ();
 
 	my $i = 0;
 	foreach my $tmpCandidate (@candidates) {
@@ -82,9 +81,11 @@ if (!$batch) {
 			bless($auesExtSource, 'Perun::beans::ExtSource');
 			$userExtSourceNames .= "\n".$auesExtSource->getName;
 		}
-		$table->addRow( $i, $candidateName, $userExtSourceLogins, $userExtSourceNames );
+		my @row = ($i, $candidateName, $userExtSourceLogins, $userExtSourceNames);
+		push(@rows, \@row);
 	}
-	print tableToPrint($table, $batch);
+	my @columnsNames = ("Candidate\nnumber", 'name', 'login in the external source', 'external source');
+	print tableContentToPrint(\@columnsNames, \@rows, $batch);
 
 	print "\nEnter the candidate number (empty string to exit): ";
 	my $candidateNumber = <>;

--- a/perun-cli/exportGroupMembers
+++ b/perun-cli/exportGroupMembers
@@ -5,7 +5,7 @@ use warnings;
 use Getopt::Long qw(:config no_ignore_case);
 use Text::ASCIITable;
 use Perun::Agent;
-use Perun::Common qw(printMessage getSortingFunction tableToPrint);
+use Perun::Common qw(printMessage getSortingFunction tableContentToPrint);
 
 
 # je potreba udelat obecne tak, aby uzivatel mohl zadavat atributy, ktere chce videt, formou u:d:Organization atp.
@@ -107,11 +107,7 @@ unless (@richMembers) {
 }
 
 #output
-my $table = Text::ASCIITable->new( { utf8 => 0 } );
-#my $table = Text::ASCIITable->new({reportErrors => 0, utf8 => 0});
-
-$table->setCols( 'Name', 'Status', sort keys(%attrShort) );
-
+my @rows = ();
 foreach my $richMember (sort $sortingFunction @richMembers) {
 	my @uattributes = $richMember->getUserAttributes;
 	my @mattributes = $richMember->getMemberAttributes;
@@ -129,8 +125,10 @@ foreach my $richMember (sort $sortingFunction @richMembers) {
 			}
 		}
 	}
-	$table->addRow( $richMember->getDisplayName, $richMember->getStatus, @dispAtt );
+	my @row = ($richMember->getDisplayName, $richMember->getStatus, @dispAtt);
+	push( @rows, \@row );
 }
 
-print tableToPrint($table, $batch);
+my @columnsNames = ( 'Name', 'Status', sort keys(%attrShort) );
+print tableContentToPrint( \@columnsNames, \@rows, $batch );
 

--- a/perun-cli/exportVoMembers
+++ b/perun-cli/exportVoMembers
@@ -5,7 +5,7 @@ use warnings;
 use Getopt::Long qw(:config no_ignore_case);
 use Text::ASCIITable;
 use Perun::Agent;
-use Perun::Common qw(printMessage getSortingFunction tableToPrint);
+use Perun::Common qw(printMessage getSortingFunction tableContentToPrint);
 
 sub help {
 	return qq{
@@ -94,11 +94,7 @@ unless (@richMembers) {
 }
 
 #output
-my $table = Text::ASCIITable->new( { utf8 => 0 } );
-#my $table = Text::ASCIITable->new({reportErrors => 0, utf8 => 0});
-
-$table->setCols( 'Name', 'Status', sort keys(%attrShort) );
-
+my @rows = ();
 foreach my $richMember (sort $sortingFunction @richMembers) {
 	my @uattributes = $richMember->getUserAttributes;
 	my @mattributes = $richMember->getMemberAttributes;
@@ -116,8 +112,10 @@ foreach my $richMember (sort $sortingFunction @richMembers) {
 			}
 		}
 	}
-	$table->addRow( $richMember->getDisplayName, $richMember->getStatus, @dispAtt );
+	my @row = ($richMember->getDisplayName, $richMember->getStatus, @dispAtt);
+	push( @rows, \@row );
 }
 
-print tableToPrint($table, $batch);
+my @columnsNames = ( 'Name', 'Status', sort keys(%attrShort) );
+print tableContentToPrint( \@columnsNames, \@rows, $batch );
 

--- a/perun-cli/getAttribute
+++ b/perun-cli/getAttribute
@@ -5,7 +5,7 @@ use warnings;
 use Getopt::Long qw(:config no_ignore_case);
 use Text::ASCIITable;
 use Perun::Agent;
-use Perun::Common qw(printMessage tableToPrint getSortingFunction);
+use Perun::Common qw(printMessage getSortingFunction tableContentToPrint);
 
 sub help {
 	return qq{
@@ -163,18 +163,19 @@ unless (@attributes) {
 }
 
 #output
-my $table = Text::ASCIITable->new( { reportErrors => 0, utf8 => 0 } );
-$table->setCols( 'ID', 'Name', 'Type','isUnique', 'Value' );
 
 my $aa=0;
+my @rows = ();
 foreach my $attribute (sort $sortingFunction @attributes) {
-        if ($attribute->getId == $attributeId) {
-		$table->addRow( $attribute->getId, $attribute->getName, $attribute->getType, $attribute->isUniqueToPrint, $attribute->getValueAsScalar );
+	if ($attribute->getId == $attributeId) {
+		my @row = ($attribute->getId, $attribute->getName, $attribute->getType, $attribute->isUniqueToPrint, $attribute->getValueAsScalar);
+		push( @rows, \@row );
 		$aa++;
 	}
 }
 if ($aa>0) { 
-	print tableToPrint($table, $batch);
+	my @columnsNames = ('ID', 'Name', 'Type','isUnique', 'Value');
+	print tableContentToPrint(\@columnsNames, \@rows, $batch);
 } else {
 	printMessage "Attribute not set", $batch;
 }

--- a/perun-cli/getAttributeRights
+++ b/perun-cli/getAttributeRights
@@ -5,7 +5,7 @@ use warnings;
 use Getopt::Long qw(:config no_ignore_case);
 use Text::ASCIITable;
 use Perun::Agent;
-use Perun::Common qw(printMessage tableToPrint getSortingFunction);
+use Perun::Common qw(printMessage getSortingFunction tableContentToPrint);
 #use Data::Dumper;
 
 sub help {
@@ -44,8 +44,7 @@ my @rights;
 @rights = $attributesAgent->getAttributeRights(attributeId => $attributeId);
 #output
 printMessage "\n.-----------------------------.\n| Attribute : ".$attributeId."\t      |", $batch;
-my $table = Text::ASCIITable->new({ reportErrors => 0, utf8 => 0 });
-$table->setCols('Role','Rights' );
+my @rows = ();
 foreach my $right (@rights) {
 	#print Dumper($right);
 	my @actions=$right->getRights;
@@ -60,7 +59,9 @@ foreach my $right (@rights) {
 	} else {
 		$out=$out."      ";
 	}
-	$table->addRow($right->getRole,$out);
+	my @row = ($right->getRole, $out);
+	push(@rows, \@row);
 } 
-print tableToPrint($table, $batch);
+my @columnsNames = ('Role', 'Rights');
+print tableContentToPrint(\@columnsNames, \@rows, $batch);
 

--- a/perun-cli/getFacilityBlackList
+++ b/perun-cli/getFacilityBlackList
@@ -5,7 +5,7 @@ use warnings;
 use Getopt::Long qw(:config no_ignore_case);
 use Text::ASCIITable;
 use Perun::Agent;
-use Perun::Common qw(printMessage tableToPrint getSortingFunction);
+use Perun::Common qw(printMessage getSortingFunction tableContentToPrint);
 
 sub help {
 	return qq{
@@ -51,10 +51,10 @@ unless (@users) {
 }
 
 #output
-my $table = Text::ASCIITable->new( { reportErrors => 0, utf8 => 0 } );
-
-$table->setCols( 'User Id', 'User Name' );
+my @rows = ();
 foreach my $user (sort $sortingFunction @users) {
-	$table->addRow( $user->getId, $user->getCommonName );
+	my @row = ($user->getId, $user->getCommonName);
+	push(@rows, \@row);
 }
-print tableToPrint($table, $batch);
+my @columnsNames = ('User Id', 'User Name');
+print tableContentToPrint(\@columnsNames, \@rows, $batch);

--- a/perun-cli/getGroupUnions
+++ b/perun-cli/getGroupUnions
@@ -5,7 +5,7 @@ use warnings;
 use Getopt::Long qw(:config no_ignore_case);
 use Text::ASCIITable;
 use Perun::Agent;
-use Perun::Common qw(printMessage tableToPrint getSortingFunction);
+use Perun::Common qw(printMessage getSortingFunction tableContentToPrint);
 
 sub help {
 	return qq{
@@ -59,16 +59,16 @@ my @groups = $groupsAgent->getGroupUnions( group => $groupId, reverseDirection =
 
 $sortingFunction = getSortingFunction("getId") unless defined $sortingFunction;
 
-my $table = Text::ASCIITable->new( { reportErrors => 0, utf8 => 0 } );
-if ($reverse == 0) {
-	$table->setCols( 'operand group Id', 'operand group Name' );
-} else {
-	$table->setCols( 'result group Id', 'result group Name' );
-}
-
+my @rows = ();
 foreach my $grp (sort $sortingFunction @groups) {
-	$table->addRow( $grp->getId, $grp->getName );
+	my @row = ($grp->getId, $grp->getName);
+	push(@rows, \@row);
 }
 
-print tableToPrint($table, $batch);
-
+my @columnsNames;
+if ($reverse == 0) {
+	@columnsNames = ('operand group Id', 'operand group Name');
+} else {
+	@columnsNames = ('result group Id', 'result group Name');
+}
+print tableContentToPrint(\@columnsNames, \@rows, $batch);

--- a/perun-cli/getHostNumCores
+++ b/perun-cli/getHostNumCores
@@ -5,7 +5,7 @@ use warnings;
 use Getopt::Long qw(:config no_ignore_case);
 use Text::ASCIITable;
 use Perun::Agent;
-use Perun::Common qw(printMessage tableToPrint getSortingFunction);
+use Perun::Common qw(printMessage getSortingFunction tableContentToPrint);
 
 sub help {
 	return qq{
@@ -36,10 +36,8 @@ my $agent = Perun::Agent->new();
 my $attributesAgent = $agent->getAttributesAgent;
 my $facilitiesAgent = $agent->getFacilitiesAgent;
 
-my $table = Text::ASCIITable->new();
-$table->setCols( 'Id', 'Host name', 'Number of cores', 'Facility name' );
-
 my @hosts = $facilitiesAgent->getHostsByHostname( hostname => $hostName );
+my @rows = ();
 while (@hosts) {
 	my $host = shift(@hosts);
 	my $hostId = $host->getId;
@@ -53,7 +51,9 @@ while (@hosts) {
 	unless ($facility) {$facilityName = " ";}
 	$facilityName = $facility->getName;
 
-	$table->addRow( $hostId, $hostName, $numCores, $facilityName );
+	my @row = ($hostId, $hostName, $numCores, $facilityName);
+	push(@rows, \@row);
 }
 
-print tableToPrint($table, $batch);
+my @columnsNames = ('Id', 'Host name', 'Number of cores', 'Facility name');
+print tableContentToPrint(\@columnsNames, \@rows, $batch);

--- a/perun-cli/getMemberByUser
+++ b/perun-cli/getMemberByUser
@@ -5,7 +5,7 @@ use warnings;
 use Getopt::Long qw(:config no_ignore_case);
 use Text::ASCIITable;
 use Perun::Agent;
-use Perun::Common qw(printMessage tableToPrint);
+use Perun::Common qw(printMessage tableContentToPrint);
 
 sub help {
 	return qq{
@@ -47,8 +47,9 @@ unless (defined $voId) {
 my $member = $membersAgent->getMemberByUser( user => $userId, vo => $voId );
 
 #output
-my $table = Text::ASCIITable->new( { reportErrors => 0, utf8 => 0 } );
-$table->setCols( 'ID', 'VO' );
-$table->addRow( $member->getId, $voId );
-print tableToPrint($table, $batch);
+my @rows = ();
+my @row = ($member->getId, $voId);
+push(@rows, \@row);
+my @columnsNames = ('ID', 'VO');
+print tableContentToPrint(\@columnsNames, \@rows, $batch);
 

--- a/perun-cli/getSecurityTeamBlackList
+++ b/perun-cli/getSecurityTeamBlackList
@@ -5,7 +5,7 @@ use warnings;
 use Getopt::Long qw(:config no_ignore_case);
 use Text::ASCIITable;
 use Perun::Agent;
-use Perun::Common qw(printMessage tableToPrint getSortingFunction);
+use Perun::Common qw(printMessage getSortingFunction tableContentToPrint);
 
 sub help {
 	return qq{
@@ -46,11 +46,12 @@ unless (@users) {
 }
 
 #output
-my $table = Text::ASCIITable->new( { reportErrors => 0, utf8 => 0 } );
 printMessage "\nSecurityTeamId: ".$securityTeamId.", SecurityTeamName: ".$securityTeam->getName, $batch;
 
-$table->setCols( 'User Id', 'User Name' );
+my @rows = ();
 foreach my $user (sort $sortingFunction @users) {
-	$table->addRow( $user->getId, $user->getCommonName );
+	my @row = ($user->getId, $user->getCommonName);
+	push(@rows, \@row);
 }
-print tableToPrint($table, $batch);
+my @columnsNames = ('User Id', 'User Name');
+print tableContentToPrint(\@columnsNames, \@rows, $batch);

--- a/perun-cli/getSecurityTeamDetails
+++ b/perun-cli/getSecurityTeamDetails
@@ -5,7 +5,7 @@ use warnings;
 use Getopt::Long qw(:config no_ignore_case);
 use Text::ASCIITable;
 use Perun::Agent;
-use Perun::Common qw(printMessage tableToPrint getSortingFunction);
+use Perun::Common qw(printMessage getSortingFunction tableContentToPrint);
 
 sub help {
 	return qq{
@@ -45,24 +45,28 @@ my @users = $securityTeamsAgent->getBlacklist( securityTeam => $securityTeamId )
 unless (@users) { printMessage "No blacklisted users found", $batch; }
 
 #output
-my $table = Text::ASCIITable->new( { reportErrors => 0, utf8 => 0 } );
-$table->setCols( 'Id:'.$securityTeamId.','.$securityTeam->getName, 'User Id', 'User Name' );
 $ii = 0;
+my @rows = ();
 foreach my $admin (sort $sortingFunction @admins) {
+	my @row;
 	if ($ii == 0) {
-		$table->addRow( 'ADMINS', $admin->getId, $admin->getCommonName );
+		@row = ('ADMINS', $admin->getId, $admin->getCommonName);
 	} else {
-		$table->addRow( '', $admin->getId, $admin->getCommonName );
+		@row = ('', $admin->getId, $admin->getCommonName);
 	}
 	$ii++;
+	push(@rows, \@row);
 }
 $ii = 0;
 foreach my $user (sort $sortingFunction @users) {
+	my @row;
 	if ($ii == 0) {
-		$table->addRow( 'BLACKLISTED USERS', $user->getId, $user->getCommonName );
+		@row = ('BLACKLISTED USERS', $user->getId, $user->getCommonName);
 	} else {
-		$table->addRow( '', $user->getId, $user->getCommonName );
+		@row = ('', $user->getId, $user->getCommonName);
 	}
 	$ii++;
+	push(@rows, \@row);
 }
-print tableToPrint($table, $batch);
+my @columnsNames = ('Id:'.$securityTeamId.','.$securityTeam->getName, 'User Id', 'User Name');
+print tableContentToPrint(\@columnsNames, \@rows, $batch);

--- a/perun-cli/getSecurityTeamsOfFacility
+++ b/perun-cli/getSecurityTeamsOfFacility
@@ -5,7 +5,7 @@ use warnings;
 use Getopt::Long qw(:config no_ignore_case);
 use Text::ASCIITable;
 use Perun::Agent;
-use Perun::Common qw(printMessage tableToPrint getSortingFunction);
+use Perun::Common qw(printMessage getSortingFunction tableContentToPrint);
 #use Data::Dumper;
 
 sub help {
@@ -59,12 +59,10 @@ unless (@securityTeams) {
 }
 
 #output
-my $table = Text::ASCIITable->new( { reportErrors => 0, utf8 => 0 } );
-
-$table->setCols( 'Id', 'Name' );
-
+my @rows = ();
 foreach my $securityTeam (sort $sortingFunction @securityTeams) {
-	$table->addRow( $securityTeam->getId(), $securityTeam->getName() );
+	my @row = ($securityTeam->getId(), $securityTeam->getName());
+	push(@rows, \@row);
 }
-print tableToPrint($table, $batch);
-
+my @columnsNames = ('Id', 'Name');
+print tableContentToPrint(\@columnsNames, \@rows, $batch);

--- a/perun-cli/getUserByMember
+++ b/perun-cli/getUserByMember
@@ -5,7 +5,7 @@ use warnings;
 use Getopt::Long qw(:config no_ignore_case);
 use Text::ASCIITable;
 use Perun::Agent;
-use Perun::Common qw(printMessage tableToPrint);
+use Perun::Common qw(printMessage tableContentToPrint);
 
 sub help {
 	return qq{
@@ -35,9 +35,10 @@ my $usersAgent = $agent->getUsersAgent;
 my $user = $usersAgent->getUserByMember( member => $memberId );
 
 #output
-my $table = Text::ASCIITable->new( { reportErrors => 0, utf8 => 0 } );
-$table->setCols( 'ID', 'Name' );
 my $name = $user->getFirstName." ".($user->getMiddleName ? $user->getMiddleName." " : "" ).$user->getLastName;
-$table->addRow( $user->getId, $name );
-print tableToPrint($table, $batch);
+my @rows = ();
+my @row = ($user->getId, $name);
+push(@rows, \@row);
+my @columnsNames = ('ID', 'Name');
+print tableContentToPrint(\@columnsNames, \@rows, $batch);
 

--- a/perun-cli/getUsersByAttribute
+++ b/perun-cli/getUsersByAttribute
@@ -5,7 +5,7 @@ use warnings;
 use Getopt::Long qw(:config no_ignore_case);
 use Text::ASCIITable;
 use Perun::Agent;
-use Perun::Common qw(printMessage tableToPrint getSortingFunction);
+use Perun::Common qw(printMessage getSortingFunction tableContentToPrint);
 
 sub help {
 	return qq{
@@ -47,12 +47,12 @@ $attribute->setValueFromArray( @attributeValue );
 my @users = $usersAgent->getUsersByAttribute( attributeName => $attributeName, attributeValue => $attribute->getValue );
 
 #output
-my $table = Text::ASCIITable->new( { reportErrors => 0, utf8 => 0 } );
-$table->setCols( 'ID', 'Name' );
-
+my @rows = ();
 foreach my $user (sort $sortingFunction @users) {
 	my $name = $user->getFirstName." ".($user->getMiddleName ? $user->getMiddleName." " : "" ).$user->getLastName;
-	$table->addRow( $user->getId, $name );
+	my @row = ($user->getId, $name);
+	push(@rows, \@row);
 }
 
-print tableToPrint($table, $batch);
+my @columnsNames = ('ID', 'Name');
+print tableContentToPrint(\@columnsNames, \@rows, $batch);

--- a/perun-cli/listOfBans
+++ b/perun-cli/listOfBans
@@ -6,7 +6,7 @@ use Time::Local;
 use Getopt::Long qw(:config no_ignore_case);
 use Text::ASCIITable;
 use Perun::Agent;
-use Perun::Common qw(printMessage getSortingFunction tableToPrint);
+use Perun::Common qw(printMessage getSortingFunction tableContentToPrint);
 use Switch;
 
 sub help {
@@ -45,7 +45,8 @@ if (defined($resourceId) and defined($memberId)) { die "ERROR: only one of resou
 if (defined($facilityId) and defined($userId)) { die "ERROR: only one of facility or use can be entered \n";}
 
 my $agent = Perun::Agent->new();
-my $table = Text::ASCIITable->new( { reportErrors => 0, utf8 => 0 } );
+my @rows = ();
+my @columnsNames;
 
 unless (defined $sortingFunction) {$sortingFunction = getSortingFunction('getValidityTo');}
 
@@ -57,11 +58,11 @@ if (defined($resourceId) or defined($memberId)) {
 
 	if (defined($resourceId)) {
 		@bans = $banOnResourceAgent->getBansForResource( resourceId => $resourceId );
-		$table->setCols( 'BanId', 'MemberId', 'BannedTo', 'Description' );
+		@columnsNames = ('BanId', 'MemberId', 'BannedTo', 'Description');
 	}
 	if (defined($memberId)) {
 		@bans = $banOnResourceAgent->getBansForMember( memberId => $memberId );
-		$table->setCols( 'BanId', 'ResourceId', 'BannedTo', 'Description' );
+		@columnsNames = ('BanId', 'ResourceId', 'BannedTo', 'Description');
 	}
 	unless (@bans) {
 		printMessage "No Bans found\n", $batch;
@@ -75,9 +76,10 @@ if (defined($resourceId) or defined($memberId)) {
 		my $entityId;
 		$entityId = $ban->getMemberId if defined $resourceId;
 		$entityId = $ban->getResourceId if defined $memberId;
-		$table->addRow( $ban->getId, $entityId, $valTo, $ban->getDescription );
+		my @row = ($ban->getId, $entityId, $valTo, $ban->getDescription);
+		push(@rows, \@row);
 	}
-	print tableToPrint($table, $batch);
+	print tableContentToPrint(\@columnsNames, \@rows, $batch);
 }
 
 if (defined($facilityId) or defined($userId)) {
@@ -88,11 +90,11 @@ if (defined($facilityId) or defined($userId)) {
 
 	if (defined($facilityId)) {
 		@bans = $banOnFacilityAgent->getBansForFacility( facilityId => $facilityId );
-		$table->setCols( 'BanId', 'UserId', 'BannedTo', 'Description' );
+		@columnsNames = ('BanId', 'UserId', 'BannedTo', 'Description');
 	}
 	if (defined($userId)) {
 		@bans = $banOnFacilityAgent->getBansForUser( userId => $userId );
-		$table->setCols( 'BanId', 'FacilityId', 'BannedTo', 'Description' );
+		@columnsNames = ('BanId', 'FacilityId', 'BannedTo', 'Description');
 	}
 	unless (@bans) {
 		printMessage "No Bans found\n", $batch;
@@ -106,8 +108,9 @@ if (defined($facilityId) or defined($userId)) {
 		my $entityId;
 		$entityId = $ban->getUserId if defined $facilityId;
 		$entityId = $ban->getFacilityId if defined $userId;
-		$table->addRow( $ban->getId, $entityId, $valTo, $ban->getDescription );
+		my @row = ($ban->getId, $entityId, $valTo, $ban->getDescription);
+		push(@rows, \@row);
 	}
-	print tableToPrint($table, $batch);
+	print tableContentToPrint(\@columnsNames, \@rows, $batch);
 }
 

--- a/perun-cli/listOfExpiredGroupMembers
+++ b/perun-cli/listOfExpiredGroupMembers
@@ -5,7 +5,7 @@ use warnings;
 use Getopt::Long qw(:config no_ignore_case);
 use Text::ASCIITable;
 use Perun::Agent;
-use Perun::Common qw(printMessage getSortingFunction tableToPrint);
+use Perun::Common qw(printMessage getSortingFunction tableContentToPrint);
 
 sub help {
 	return qq{
@@ -73,18 +73,18 @@ unless (@richMembers) {
 }
 
 # output
-my $table = Text::ASCIITable->new( { reportErrors => 0, utf8 => 0 } );
-$table->setCols( 'MemberId', 'Name', 'VO status','Group status','Expiration' );
-
+my @rows = ();
 foreach my $member (sort $sortingFunction @richMembers) {
 	my @mattributes = $member->getMemberAttributes;
 	my $val = $mattributes[0]->getValue;
 	my $stat = $member->getGroupStatus;
 	if ($stat eq 'EXPIRED' ) {
 		if (not defined $val) { $val="UNSET";} 
-		$table->addRow( $member->getMemberId, $member->getCommonName, $member->getStatus, $stat, $val );
+		my @row = ($member->getMemberId, $member->getCommonName, $member->getStatus, $stat, $val);
+		push(@rows, \@row);
 	}
 }
 
 #output
-print tableToPrint($table, $batch) unless defined $unsetDate;
+my @columnsNames = ('MemberId', 'Name', 'VO status','Group status', 'Expiration');
+print tableContentToPrint(\@columnsNames, \@rows, $batch) unless defined $unsetDate;

--- a/perun-cli/listOfExpiredMembers
+++ b/perun-cli/listOfExpiredMembers
@@ -5,7 +5,7 @@ use warnings;
 use Getopt::Long qw(:config no_ignore_case);
 use Text::ASCIITable;
 use Perun::Agent;
-use Perun::Common qw(printMessage getSortingFunction tableToPrint);
+use Perun::Common qw(printMessage getSortingFunction tableContentToPrint);
 
 sub help {
 	return qq{
@@ -79,10 +79,9 @@ unless (@richMembers) {
 }
 
 # output
-my $table = Text::ASCIITable->new( { reportErrors => 0, utf8 => 0 } );
-$table->setCols( 'MemberId','Logname', 'Name', 'Expiration' );
 my @lognames;
 
+my @rows = ();
 foreach my $member (sort $sortingFunction @richMembers) {
 	my @mattributes = $member->getMemberAttributes;
 	my $val = $mattributes[0]->getValue;
@@ -91,14 +90,16 @@ foreach my $member (sort $sortingFunction @richMembers) {
 	unless (defined $login) {$login = ' ';}
 	my $eyear = substr($val, 0, 4);
 	if ($actualyear - $eyear >= $years) {
-		$table->addRow( $member->getMemberId, $login, $member->getCommonName, $val );
+		my @row = ($member->getMemberId, $login, $member->getCommonName, $val);
+		push(@rows, \@row);
 		push (@lognames, $login);
 	}
 }
 
 #output
 unless (defined $lo) {
-	print tableToPrint($table, $batch);
+	my @columnsNames = ('MemberId','Logname', 'Name', 'Expiration');
+	print tableContentToPrint(\@columnsNames, \@rows, $batch);
 } else {
 	while (@lognames) {
 		printMessage(shift(@lognames), $batch);

--- a/perun-cli/listOfFacilityManagers
+++ b/perun-cli/listOfFacilityManagers
@@ -5,7 +5,7 @@ use warnings;
 use Getopt::Long qw(:config no_ignore_case);
 use Text::ASCIITable;
 use Perun::Agent;
-use Perun::Common qw(printMessage getSortingFunction printTable tableToPrint);
+use Perun::Common qw(printMessage getSortingFunction tableContentToPrint);
 
 sub help {
 	return qq{
@@ -33,7 +33,6 @@ GetOptions("help|h"    => sub {
 my $agent = Perun::Agent->new();
 my $facilitiesAgent = $agent->getFacilitiesAgent;
 my $groupsAgent = $agent->getGroupsAgent;
-my $table = Text::ASCIITable->new( { reportErrors => 0, utf8 => 0 } );
 
 #options check
 if (defined $byName) {
@@ -59,30 +58,37 @@ unless (@richUsers or @groups ) {
 	printMessage "No Managers found", $batch;
 }
 
-$table->setCols('Managers group', 'User Id', 'Name');
-
 # direct managers
 my $ii=0;
+my @rows = ();
 foreach my $richUser (sort $sortingFunction @richUsers) {
 	if ($ii++ == 0) {
-		$table->addRow ('Direct Managers',$richUser->getId, $richUser->getDisplayName);
+		my @row = ('Direct Managers',$richUser->getId, $richUser->getDisplayName);
+		push(@rows, \@row);
 	} else {
-		$table->addRow ('',$richUser->getId, $richUser->getDisplayName);
+		my @row = ('',$richUser->getId, $richUser->getDisplayName);
+		push(@rows, \@row);
 	}
 }
 
 # groups of managers
 while (@groups) {
-	$table->addRow (' ',' ',' ') if $ii;
+	if ($ii) {
+		my @row = (' ',' ',' ');
+		push(@rows, \@row);
+	}
 	my $group=shift (@groups);
 	my @members = $groupsAgent->getGroupRichMembers ( group => $group->getId);
 	$ii=0;
 	foreach my $member (sort $sortingFunction2 @members) {
 		if ($ii++ == 0) {
-			$table->addRow ($group->getName,$member->getUserId, $member->getDisplayName);
+			my @row = ($group->getName,$member->getUserId, $member->getDisplayName);
+			push(@rows, \@row);
 		} else {
-			$table->addRow ('',$member->getUserId, $member->getDisplayName);
+			my @row = ('',$member->getUserId, $member->getDisplayName);
+			push(@rows, \@row);
 		}
 	}
 }
-print tableToPrint($table, $batch);
+my @columnsNames = ('Managers group', 'User Id', 'Name');
+print tableContentToPrint(\@columnsNames, \@rows, $batch);

--- a/perun-cli/listOfGroupManagers
+++ b/perun-cli/listOfGroupManagers
@@ -5,7 +5,7 @@ use warnings;
 use Getopt::Long qw(:config no_ignore_case);
 use Text::ASCIITable;
 use Perun::Agent;
-use Perun::Common qw(printMessage getSortingFunction printTable tableToPrint);
+use Perun::Common qw(printMessage getSortingFunction tableContentToPrint);
 
 sub help {
 	return qq{
@@ -38,7 +38,6 @@ GetOptions("help|h"   => sub {
 
 my $agent = Perun::Agent->new();
 my $groupsAgent = $agent->getGroupsAgent;
-my $table = Text::ASCIITable->new( { reportErrors => 0, utf8 => 0 } );
 
 #options check
 if (defined $byName) {
@@ -68,30 +67,37 @@ unless (@richUsers or @groups ) {
 	printMessage "No Managers found", $batch;
 }
 
-$table->setCols('Managers group', 'User Id', 'Name');
-
 # direct managers
 my $ii=0;
+my @rows = ();
 foreach my $richUser (sort $sortingFunction @richUsers) {
 	if ($ii++ == 0) {
-		$table->addRow ('Direct Managers',$richUser->getId, $richUser->getDisplayName);
+		my @row = ('Direct Managers',$richUser->getId, $richUser->getDisplayName);
+		push(@rows, \@row);
 	} else {
-		$table->addRow ('',$richUser->getId, $richUser->getDisplayName);
+		my @row = ('',$richUser->getId, $richUser->getDisplayName);
+		push(@rows, \@row);
 	}
 }
 
 # groups of managers
 while (@groups) {
-	$table->addRow (' ',' ',' ') if $ii;
+	if ($ii) {
+		my @row = (' ',' ',' ');
+		push(@rows, \@row);
+	}
 	my $group=shift (@groups);
 	my @members = $groupsAgent->getGroupRichMembers ( group => $group->getId);
 	$ii=0;
 	foreach my $member (sort $sortingFunction2 @members) {
 		if ($ii++ == 0) {
-			$table->addRow ($group->getName,$member->getUserId, $member->getDisplayName);
+			my @row = ($group->getName,$member->getUserId, $member->getDisplayName);
+			push(@rows, \@row);
 		} else {
-			$table->addRow ('',$member->getUserId, $member->getDisplayName);
+			my @row = ('',$member->getUserId, $member->getDisplayName);
+			push(@rows, \@row);
 		}
 	}
 }
-print tableToPrint($table, $batch);
+my @columnsNames = ('Managers group', 'User Id', 'Name');
+print tableContentToPrint(\@columnsNames, \@rows, $batch);

--- a/perun-cli/listOfGroupRoles
+++ b/perun-cli/listOfGroupRoles
@@ -4,7 +4,7 @@ use strict;
 use Getopt::Long qw(:config no_ignore_case);
 use Text::ASCIITable;
 use Perun::Agent;
-use Perun::Common qw(printMessage tableToPrint getSortingFunction);
+use Perun::Common qw(printMessage getSortingFunction tableContentToPrint);
 
 sub help {
 	return qq{
@@ -56,12 +56,13 @@ unless ($role) {
 }
 
 #output
-my $table = Text::ASCIITable->new({ reportErrors => 0, utf8 => 0 });
-$table->setCols('Role Name');
 
 my @roles = @$role;
+my @rows = ();
 foreach my $rol (@roles) {
-	$table->addRow($rol);
+	my @row = ($rol);
+	push(@rows, \@row);
 }
 
-print tableToPrint($table, $batch);
+my @columnsNames = ('Role Name');
+print tableContentToPrint(\@columnsNames, \@rows, $batch);

--- a/perun-cli/listOfHostNumCores
+++ b/perun-cli/listOfHostNumCores
@@ -5,7 +5,7 @@ use warnings;
 use Getopt::Long qw(:config no_ignore_case);
 use Text::ASCIITable;
 use Perun::Agent;
-use Perun::Common qw(printMessage tableToPrint getSortingFunction);
+use Perun::Common qw(printMessage getSortingFunction tableContentToPrint);
 
 sub help {
 	return qq{
@@ -46,9 +46,6 @@ my $agent = Perun::Agent->new();
 my $attributesAgent = $agent->getAttributesAgent;
 my $facilitiesAgent = $agent->getFacilitiesAgent;
 
-my $table = Text::ASCIITable->new();
-$table->setCols( 'Facility name', 'Host name', 'Number of cores' );
-
 if ($all > 0) {
 	@facilities = $facilitiesAgent->getFacilities;
 	unless (@facilities) {
@@ -66,6 +63,7 @@ if ($all > 0) {
 	$facilities[0] = $facility;
 }
 
+my @rows = ();
 foreach my $facility (sort $sortingFunction2 @facilities) {
 	my $facilityId = $facility->getId;
 	my $facilityName = $facility->getName;
@@ -83,8 +81,10 @@ foreach my $facility (sort $sortingFunction2 @facilities) {
 		$numCores = $attribute->getValueAsScalar;
 		unless (defined $numCores) { $numCores = "undefined";}
 
-		$table->addRow( $facilityName, $hostName, $numCores );
+		my @row = ($facilityName, $hostName, $numCores);
+		push(@rows, \@row);
 	}
 }
 
-print tableToPrint($table, $batch);
+my @columnsNames = ('Facility name', 'Host name', 'Number of cores');
+print tableContentToPrint(\@columnsNames, \@rows, $batch);

--- a/perun-cli/listOfMembersSponsoredByUserInVo
+++ b/perun-cli/listOfMembersSponsoredByUserInVo
@@ -5,7 +5,7 @@ use warnings;
 use Getopt::Long qw(:config no_ignore_case);
 use Text::ASCIITable;
 use Perun::Agent;
-use Perun::Common qw(printMessage tableToPrint getSortingFunction);
+use Perun::Common qw(printMessage getSortingFunction tableContentToPrint);
 
 sub help {
 	return qq{
@@ -42,12 +42,13 @@ unless (@members) {
 
 #output
 my $sortingFunction = getSortingFunction("getDisplayName", 1);
-my $table = Text::ASCIITable->new( { reportErrors => 0, utf8 => 0 } );
-$table->setCols( 'ID', 'Name' );
 
+my @rows = ();
 foreach my $member (sort $sortingFunction @members) {
-	$table->addRow( $member->getMemberId, $member->getDisplayName );
+	my @row = ($member->getMemberId, $member->getDisplayName);
+	push(@rows, \@row);
 }
 
-print tableToPrint($table, $batch);
+my @columnsNames = ('ID', 'Name');
+print tableContentToPrint(\@columnsNames, \@rows, $batch);
 

--- a/perun-cli/listOfNotExpiringGroupMembers
+++ b/perun-cli/listOfNotExpiringGroupMembers
@@ -5,7 +5,7 @@ use warnings;
 use Getopt::Long qw(:config no_ignore_case);
 use Text::ASCIITable;
 use Perun::Agent;
-use Perun::Common qw(printMessage getSortingFunction tableToPrint);
+use Perun::Common qw(printMessage getSortingFunction tableContentToPrint);
 
 sub help {
 	return qq{
@@ -73,17 +73,18 @@ unless (@richMembers) {
 }
 
 # output
-my $table = Text::ASCIITable->new( { reportErrors => 0, utf8 => 0 } );
-$table->setCols( 'MemberId', 'Name', 'VO status','Group status' );
 
+my @rows = ();
 foreach my $member (sort $sortingFunction @richMembers) {
 	my @mattributes = $member->getMemberAttributes;
 	my $val = $mattributes[0]->getValue;
 	my $stat = $member->getGroupStatus;
 	if (not defined $val) {  
-		$table->addRow( $member->getMemberId, $member->getCommonName, $member->getStatus, $stat );
+		my @row = ($member->getMemberId, $member->getCommonName, $member->getStatus, $stat);
+		push(@rows, \@row);
 	}
 }
 
 #output
-print tableToPrint($table, $batch) unless defined $unsetDate;
+my @columnsNames = ('MemberId', 'Name', 'VO status','Group status');
+print tableContentToPrint(\@columnsNames, \@rows, $batch) unless defined $unsetDate;

--- a/perun-cli/listOfPrincipalRoles
+++ b/perun-cli/listOfPrincipalRoles
@@ -4,7 +4,7 @@ use strict;
 use Getopt::Long qw(:config no_ignore_case);
 use Text::ASCIITable;
 use Perun::Agent;
-use Perun::Common qw(printMessage tableToPrint getSortingFunction);
+use Perun::Common qw(printMessage getSortingFunction tableContentToPrint);
 
 sub help {
 	return qq{
@@ -33,12 +33,12 @@ unless ($role) {
 }
 
 #output
-my $table = Text::ASCIITable->new({ reportErrors => 0, utf8 => 0 });
-$table->setCols('Role Name');
-
+my @rows = ();
 my @roles = @$role;
 foreach my $rol (@roles) {
-	$table->addRow($rol);
+	my @row = ($rol);
+	push(@rows, \@row);
 }
 
-print tableToPrint($table, $batch);
+my @columnsNames = ('Role Name');
+print tableContentToPrint(\@columnsNames, \@rows, $batch);

--- a/perun-cli/listOfResourceManagers
+++ b/perun-cli/listOfResourceManagers
@@ -5,7 +5,7 @@ use warnings;
 use Getopt::Long qw(:config no_ignore_case);
 use Text::ASCIITable;
 use Perun::Agent;
-use Perun::Common qw(printMessage getSortingFunction printTable tableToPrint);
+use Perun::Common qw(printMessage getSortingFunction printTable tableContentToPrint);
 
 sub help {
 	return qq{
@@ -31,7 +31,6 @@ GetOptions("help|h"    => sub {
 my $agent = Perun::Agent->new();
 my $resourcesAgent = $agent->getResourcesAgent;
 my $groupsAgent = $agent->getGroupsAgent;
-my $table = Text::ASCIITable->new( { reportErrors => 0, utf8 => 0 } );
 
 #options check
 if (defined $byName) {
@@ -52,30 +51,37 @@ unless (@richUsers or @groups ) {
 	printMessage "No Managers found", $batch;
 }
 
-$table->setCols('Managers group', 'User Id', 'Name');
-
+my @rows = ();
 # direct managers
 my $ii=0;
 foreach my $richUser (sort $sortingFunction @richUsers) {
 	if ($ii++ == 0) {
-		$table->addRow ('Direct Managers',$richUser->getId, $richUser->getDisplayName);
+		my @row = ('Direct Managers',$richUser->getId, $richUser->getDisplayName);
+		push(@rows, \@row);
 	} else {
-		$table->addRow ('',$richUser->getId, $richUser->getDisplayName);
+		my @row = ('',$richUser->getId, $richUser->getDisplayName);
+		push(@rows, \@row);
 	}
 }
 
 # groups of managers
 while (@groups) {
-	$table->addRow (' ',' ',' ') if $ii;
+	if ($ii) {
+		my @row = (' ',' ',' ');
+		push(@rows, \@row);
+	}
 	my $group=shift (@groups);
 	my @members = $groupsAgent->getGroupRichMembers ( group => $group->getId);
 	$ii=0;
 	foreach my $member (sort $sortingFunction2 @members) {
 		if ($ii++ == 0) {
-			$table->addRow ($group->getName,$member->getUserId, $member->getDisplayName);
+			my @row = ($group->getName,$member->getUserId, $member->getDisplayName);
+			push(@rows, \@row);
 		} else {
-			$table->addRow ('',$member->getUserId, $member->getDisplayName);
+			my @row = ('',$member->getUserId, $member->getDisplayName);
+			push(@rows, \@row);
 		}
 	}
 }
-print tableToPrint($table, $batch);
+my @columnsNames = ('Managers group', 'User Id', 'Name');
+print tableContentToPrint(\@columnsNames, \@rows, $batch);

--- a/perun-cli/listOfResourceMembers
+++ b/perun-cli/listOfResourceMembers
@@ -5,7 +5,7 @@ use warnings;
 use Getopt::Long qw(:config no_ignore_case);
 use Text::ASCIITable;
 use Perun::Agent;
-use Perun::Common qw(printMessage tableToPrint getSortingFunction);
+use Perun::Common qw(printMessage getSortingFunction tableContentToPrint);
 
 sub help {
 	return qq{
@@ -43,13 +43,14 @@ unless (@members) {
 }
 
 #output
-my $table = Text::ASCIITable->new( { reportErrors => 0, utf8 => 0 } );
-$table->setCols( 'Id', 'Name' );
 
+my @rows = ();
 foreach my $member (sort $sortingFunction @members) {
 	my $user = $agent->getUsersAgent->getUserByMember( member => $member->getId );
 	my $name = $user->getFirstName." ".($user->getMiddleName ? $user->getMiddleName." " : "" ).$user->getLastName;
-	$table->addRow( $member->getId, $name );
+	my @row = ($member->getId, $name);
+	push(@rows, \@row);
 }
 
-print tableToPrint($table, $batch);
+my @columnsNames = ('Id', 'Name');
+print tableContentToPrint(\@columnsNames, \@rows, $batch);

--- a/perun-cli/listOfSecurityTeamManagers
+++ b/perun-cli/listOfSecurityTeamManagers
@@ -5,7 +5,7 @@ use warnings;
 use Getopt::Long qw(:config no_ignore_case);
 use Text::ASCIITable;
 use Perun::Agent;
-use Perun::Common qw(printMessage tableToPrint getSortingFunction);
+use Perun::Common qw(printMessage getSortingFunction tableContentToPrint);
 
 sub help {
 	return qq{
@@ -41,7 +41,6 @@ unless (defined($securityTeamId)) {die "ERROR: securityTeamId is required\n";}
 my $agent = Perun::Agent->new();
 my $securityTeamsAgent = $agent->getSecurityTeamsAgent;
 my $groupsAgent = $agent->getGroupsAgent;
-my $table = Text::ASCIITable->new( { reportErrors => 0, utf8 => 0 } );
 
 my $securityTeam = $securityTeamsAgent->getSecurityTeamById( 'id', $securityTeamId );
 
@@ -53,30 +52,38 @@ unless (@richUsers or @groups ) {
 	printMessage "No Managers found", $batch;
 }
 
-$table->setCols('Managers group', 'User Id', 'Name');
+my @rows = ();
 
 # direct managers
 my $ii=0;
 foreach my $richUser (sort $sortingFunction @richUsers) {
 	if ($ii++ == 0) {
-		$table->addRow ('Direct Managers',$richUser->getId, $richUser->getDisplayName);
+		my @row = ('Direct Managers',$richUser->getId, $richUser->getDisplayName);
+		push(@rows, \@row);
 	} else {
-		$table->addRow ('',$richUser->getId, $richUser->getDisplayName);
+		my @row = ('',$richUser->getId, $richUser->getDisplayName);
+		push(@rows, \@row);
 	}
 }
 
 # groups of managers
 while (@groups) {
-	$table->addRow (' ',' ',' ') if $ii;
+	if ($ii) {
+		my @row = (' ',' ',' ');
+		push(@rows, \@row);
+	}
 	my $group=shift (@groups);
 	my @members = $groupsAgent->getGroupRichMembers ( group => $group->getId);
 	$ii=0;
 	foreach my $member (sort $sortingFunction2 @members) {
 		if ($ii++ == 0) {
-			$table->addRow ($group->getName,$member->getUserId, $member->getDisplayName);
+			my @row = ($group->getName,$member->getUserId, $member->getDisplayName);
+			push(@rows, \@row);
 		} else {
-			$table->addRow ('',$member->getUserId, $member->getDisplayName);
+			my @row = ('',$member->getUserId, $member->getDisplayName);
+			push(@rows, \@row);
 		}
 	}
 }
-print tableToPrint($table, $batch);
+my @columnsNames = ('Managers group', 'User Id', 'Name');
+print tableContentToPrint(\@columnsNames, \@rows, $batch);

--- a/perun-cli/listOfServicesAssignedToDestination
+++ b/perun-cli/listOfServicesAssignedToDestination
@@ -5,7 +5,7 @@ use warnings;
 use Getopt::Long qw(:config no_ignore_case);
 use Text::ASCIITable;
 use Perun::Agent;
-use Perun::Common qw(printMessage tableToPrint);
+use Perun::Common qw(printMessage tableContentToPrint);
 use Perun::beans::Destination;
 use Perun::beans::Facility;
 
@@ -67,11 +67,11 @@ while (@facilities) {
 
 #output
 
-my $table = Text::ASCIITable->new( { reportErrors => 0, utf8 => 0 } );
-$table->setCols( 'Service for '.$destination );
-
+my @rows = ();
 foreach my $service (sort keys (%services)) {
-	$table->addRow( $service );
+	my @row = ($service);
+	push(@rows, \@row);
 }
 
-print tableToPrint($table, $batch);
+my @columnsNames = ('Service for '.$destination);
+print tableContentToPrint(\@columnsNames, \@rows, $batch);

--- a/perun-cli/listOfSponsorsForMember
+++ b/perun-cli/listOfSponsorsForMember
@@ -5,7 +5,7 @@ use warnings;
 use Getopt::Long qw(:config no_ignore_case);
 use Text::ASCIITable;
 use Perun::Agent;
-use Perun::Common qw(printMessage tableToPrint getSortingFunction);
+use Perun::Common qw(printMessage getSortingFunction tableContentToPrint);
 
 sub help {
 	return qq{
@@ -38,12 +38,11 @@ unless (@sponsors) {
 }
 
 #output
-my $table = Text::ASCIITable->new( { reportErrors => 0, utf8 => 0 } );
-$table->setCols( 'ID', 'Name' );
-
+my @rows = ();
 foreach my $sponsor (@sponsors) {
-	$table->addRow( $sponsor->getUserId, $sponsor->getUserFirstName.' '.$sponsor->getUserLastName );
+	my @row = ($sponsor->getUserId, $sponsor->getUserFirstName.' '.$sponsor->getUserLastName);
+	push(@rows, \@row);
 }
 
-print tableToPrint($table, $batch);
-
+my @columnsNames = ('ID', 'Name' );
+print tableContentToPrint(\@columnsNames, \@rows, $batch);

--- a/perun-cli/listOfUserRoles
+++ b/perun-cli/listOfUserRoles
@@ -4,7 +4,7 @@ use strict;
 use Getopt::Long qw(:config no_ignore_case);
 use Text::ASCIITable;
 use Perun::Agent;
-use Perun::Common qw(printMessage tableToPrint getSortingFunction);
+use Perun::Common qw(printMessage getSortingFunction tableContentToPrint);
 
 sub help {
 	return qq{
@@ -36,12 +36,12 @@ unless ($role) {
 }
 
 #output
-my $table = Text::ASCIITable->new({ reportErrors => 0, utf8 => 0 });
-$table->setCols('Role Name');
-
+my @rows = ();
 my @roles = @$role;
 foreach my $rol (@roles) {
-	$table->addRow($rol);
+	my @row = ($rol);
+	push(@rows, \@row);
 }
 
-print tableToPrint($table, $batch);
+my @columnsNames = ('Role Name');
+print tableContentToPrint(\@columnsNames, \@rows, $batch);

--- a/perun-cli/listOfVoManagers
+++ b/perun-cli/listOfVoManagers
@@ -5,7 +5,7 @@ use warnings;
 use Getopt::Long qw(:config no_ignore_case);
 use Text::ASCIITable;
 use Perun::Agent;
-use Perun::Common qw(printMessage getSortingFunction printTable tableToPrint);
+use Perun::Common qw(printMessage getSortingFunction tableContentToPrint);
 
 sub help {
 	return qq{
@@ -35,7 +35,6 @@ $role = "VOADMIN";
 my $agent = Perun::Agent->new();
 my $vosAgent = $agent->getVosAgent;
 my $groupsAgent = $agent->getGroupsAgent; 
-my $table = Text::ASCIITable->new( { reportErrors => 0, utf8 => 0 } );
 
 #options check
 if (defined $byName) { 
@@ -59,30 +58,38 @@ unless (@richUsers or @groups ) {
 	printMessage "No Managers found", $batch;
 }
 
-$table->setCols('Managers group', 'User Id', 'Name');
+my @rows = ();
 
 # direct managers
 my $ii=0;
 foreach my $richUser (sort $sortingFunction @richUsers) {
 	if ($ii++ == 0) {
-		$table->addRow ('Direct Managers',$richUser->getId, $richUser->getDisplayName);
+		my @row = ('Direct Managers',$richUser->getId, $richUser->getDisplayName);
+		push(@rows, \@row);
 	} else {
-		$table->addRow ('',$richUser->getId, $richUser->getDisplayName);
+		my @row = ('',$richUser->getId, $richUser->getDisplayName);
+		push(@rows, \@row);
 	}
 }
 
 # groups of managers
 while (@groups) {
-	$table->addRow (' ',' ',' ') if $ii;
+	if ($ii) {
+		my @row = (' ',' ',' ');
+		push(@rows, \@row);
+	}
 	my $group=shift (@groups);
 	my @members = $groupsAgent->getGroupRichMembers ( group => $group->getId);
 	$ii=0;
 	foreach my $member (sort $sortingFunction2 @members) {
 		if ($ii++ == 0) {
-			$table->addRow ($group->getName,$member->getUserId, $member->getDisplayName);
+			my @row = ($group->getName,$member->getUserId, $member->getDisplayName);
+			push(@rows, \@row);
 		} else {
-			$table->addRow ('',$member->getUserId, $member->getDisplayName);
+			my @row = ('',$member->getUserId, $member->getDisplayName);
+			push(@rows, \@row);
 		}
 	} 
 }
-print tableToPrint($table, $batch);
+my @columnsNames = ('Managers group', 'User Id', 'Name');
+print tableContentToPrint(\@columnsNames, \@rows, $batch);

--- a/perun-cli/setAllFacilityHostAttribute
+++ b/perun-cli/setAllFacilityHostAttribute
@@ -5,7 +5,7 @@ use warnings;
 use Getopt::Long qw(:config no_ignore_case);
 use Text::ASCIITable;
 use Perun::Agent;
-use Perun::Common qw(printMessage tableToPrint getSortingFunction);
+use Perun::Common qw(printMessage getSortingFunction);
 
 sub help {
 	return qq{

--- a/perun-cli/setHostNumCores
+++ b/perun-cli/setHostNumCores
@@ -5,7 +5,7 @@ use warnings;
 use Getopt::Long qw(:config no_ignore_case);
 use Text::ASCIITable;
 use Perun::Agent;
-use Perun::Common qw(printMessage tableToPrint getSortingFunction);
+use Perun::Common qw(printMessage getSortingFunction);
 
 sub help {
 	return qq{


### PR DESCRIPTION
- Pipe character is now escaped when printing a table in batch mode -
backslash character is added before pipe character in all the table's
cells.