### PR TITLE
feat: add groups pagination

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/GroupsOrderColumn.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/GroupsOrderColumn.java
@@ -1,0 +1,44 @@
+package cz.metacentrum.perun.core.api;
+
+import java.util.function.Function;
+
+/**
+ * Class representing columns, that can be used to sort paginated groups.
+ *
+ * For each such column, this instances also contain sql parts that are specific for them.
+ * This class can be extended, in the future, if for example, we would like to sort by some attributes.
+ *
+ * @author Jakub Hejda <Jakub.Hejda@cesnet.cz>
+ */
+public enum GroupsOrderColumn {
+	ID("", "", query -> "groups_id " + query.getOrder().getSqlValue()),
+	NAME("", "", query -> "groups_name " + query.getOrder().getSqlValue()),
+	DESCRIPTION("", "", query -> "groups_dsc " + query.getOrder().getSqlValue());
+
+	private final Function<GroupsPageQuery, String> orderBySqlFunction;
+	private final String selectSql;
+	private final String joinSql;
+
+	GroupsOrderColumn(String selectSql, String joinSql, Function<GroupsPageQuery, String> sqlFunction) {
+		this.selectSql = selectSql;
+		this.joinSql = joinSql;
+		this.orderBySqlFunction = sqlFunction;
+	}
+
+	public String getSqlOrderBy(GroupsPageQuery query) {
+		return this.orderBySqlFunction.apply(query);
+	}
+
+	public String getSqlSelect() {
+		return this.selectSql;
+	}
+
+	public String getSqlJoin() {
+		return this.joinSql;
+	}
+
+	private static String getLangSql(GroupsPageQuery query) {
+		return "";
+		// TODO add support for other languages
+	}
+}

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/GroupsPageQuery.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/GroupsPageQuery.java
@@ -1,0 +1,93 @@
+package cz.metacentrum.perun.core.api;
+
+/**
+ * Class representing a query requesting a specific page of groups.
+ *
+ * @author Jakub Hejda <Jakub.Hejda@cesnet.cz>
+ */
+public class GroupsPageQuery {
+	private int pageSize;
+	private int offset;
+	private SortingOrder order;
+	private GroupsOrderColumn sortColumn;
+	private String searchString = "";
+
+	public GroupsPageQuery() {}
+
+	public GroupsPageQuery(int pageSize, int offset, SortingOrder order, GroupsOrderColumn sortColumn) {
+		this.pageSize = pageSize;
+		this.offset = offset;
+		this.order = order;
+		this.sortColumn = sortColumn;
+	}
+
+	public GroupsPageQuery(int pageSize, int offset, SortingOrder order, GroupsOrderColumn sortColumn, String searchString) {
+		this.pageSize = pageSize;
+		this.offset = offset;
+		this.order = order;
+		this.sortColumn = sortColumn;
+		this.searchString = searchString;
+	}
+
+	public int getPageSize() {
+		return pageSize;
+	}
+
+	public void setPageSize(int pageSize) {
+		this.pageSize = pageSize;
+	}
+
+	public int getOffset() {
+		return offset;
+	}
+
+	public void setOffset(int offset) {
+		this.offset = offset;
+	}
+
+	public SortingOrder getOrder() { return order; }
+
+	public void setOrder(SortingOrder order) {
+		this.order = order;
+	}
+
+	public GroupsOrderColumn getSortColumn() {
+		return sortColumn;
+	}
+
+	public void setSortColumn(GroupsOrderColumn sortColumn) {
+		this.sortColumn = sortColumn;
+	}
+
+	public String getSearchString() {
+		return searchString;
+	}
+
+	public void setSearchString(String searchString) {
+		this.searchString = searchString;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (!(o instanceof GroupsPageQuery)) return false;
+
+		GroupsPageQuery that = (GroupsPageQuery) o;
+
+		if (getPageSize() != that.getPageSize()) return false;
+		if (getOffset() != that.getOffset()) return false;
+		if (getOrder() != that.getOrder()) return false;
+		if (getSortColumn() != that.getSortColumn()) return false;
+		return getSearchString().equals(that.getSearchString());
+	}
+
+	@Override
+	public int hashCode() {
+		int result = getPageSize();
+		result = 31 * result + getOffset();
+		result = 31 * result + (getOrder() != null ? getOrder().hashCode() : 0);
+		result = 31 * result + (getSortColumn() != null ? getSortColumn().hashCode() : 0);
+		result = 31 * result + (getSearchString() != null ? getSearchString().hashCode() : 0);
+		return result;
+	}
+}

--- a/perun-base/src/main/resources/perun-roles.yml
+++ b/perun-base/src/main/resources/perun-roles.yml
@@ -1495,6 +1495,32 @@ perun_policies:
     include_policies:
       - default_policy
 
+  getGroupsPage_Vo_GroupsPageQuery_List<String>_policy:
+    policy_roles:
+      - VOADMIN: Vo
+      - VOOBSERVER: Vo
+      - GROUPADMIN: Vo
+      - GROUPOBSERVER: Vo
+      - RESOURCEADMIN: Vo
+      - RESOURCEOBSERVER: Vo
+      - TRUSTEDFACILITYADMIN: Vo
+      - PERUNOBSERVER:
+    include_policies:
+      - default_policy
+
+  getSubgroupsPage_Group_GroupsPageQuery_List<String>_policy:
+    policy_roles:
+      - VOADMIN: Vo
+      - VOOBSERVER: Vo
+      - GROUPADMIN: Group
+      - GROUPOBSERVER: Group
+      - RESOURCEADMIN: Vo
+      - RESOURCEOBSERVER: Vo
+      - TRUSTEDFACILITYADMIN: Vo
+      - PERUNOBSERVER:
+    include_policies:
+      - default_policy
+
   getAllGroups_Vo_policy:
     policy_roles:
       - RESOURCEADMIN: Vo

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/GroupsManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/GroupsManager.java
@@ -10,7 +10,6 @@ import cz.metacentrum.perun.core.api.exceptions.GroupAlreadyRemovedFromResourceE
 import cz.metacentrum.perun.core.api.exceptions.GroupExistsException;
 import cz.metacentrum.perun.core.api.exceptions.GroupMoveNotAllowedException;
 import cz.metacentrum.perun.core.api.exceptions.GroupNotAdminException;
-import cz.metacentrum.perun.core.api.exceptions.GroupNotAllowedToAutoRegistrationException;
 import cz.metacentrum.perun.core.api.exceptions.GroupNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.GroupRelationAlreadyExists;
 import cz.metacentrum.perun.core.api.exceptions.GroupRelationCannotBeRemoved;
@@ -590,6 +589,30 @@ public interface GroupsManager {
 	 * @throws PrivilegeException if the principal has insufficient permission
 	 */
 	List<Group> getAllGroups(PerunSession sess) throws PrivilegeException;
+
+	/**
+	 * Get page of groups from the given vo.
+	 *
+	 * @param sess session
+	 * @param vo vo
+	 * @param query query with page information
+	 * @param attrNames attribute names
+	 *
+	 * @return page of requested rich groups
+	 */
+	Paginated<RichGroup> getGroupsPage(PerunSession sess, Vo vo, GroupsPageQuery query, List<String> attrNames) throws VoNotExistsException, PrivilegeException;
+
+	/**
+	 * Get page of subgroups from the given parent group.
+	 *
+	 * @param sess session
+	 * @param group parent group
+	 * @param query query with page information
+	 * @param attrNames attribute names
+	 *
+	 * @return page of requested rich groups
+	 */
+	Paginated<RichGroup> getSubgroupsPage(PerunSession sess, Group group, GroupsPageQuery query, List<String> attrNames) throws GroupNotExistsException, PrivilegeException;
 
 	/**
 	 * Get groups of Vo by ACCESS RIGHTS:

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/GroupsManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/GroupsManagerBl.java
@@ -5,9 +5,11 @@ import cz.metacentrum.perun.core.api.EnrichedGroup;
 import cz.metacentrum.perun.core.api.ExtSource;
 import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.GroupsPageQuery;
 import cz.metacentrum.perun.core.api.Host;
 import cz.metacentrum.perun.core.api.Member;
 import cz.metacentrum.perun.core.api.MemberGroupStatus;
+import cz.metacentrum.perun.core.api.Paginated;
 import cz.metacentrum.perun.core.api.Pair;
 import cz.metacentrum.perun.core.api.Perun;
 import cz.metacentrum.perun.core.api.PerunSession;
@@ -904,6 +906,30 @@ public interface GroupsManagerBl {
 	 * @return list of groups
 	 */
 	List<Group> getGroups(PerunSession sess, Vo vo);
+
+	/**
+	 * Get page of groups from the given vo.
+	 *
+	 * @param sess session
+	 * @param vo vo
+	 * @param query query with page information
+	 * @param attrNames attribute names
+	 *
+	 * @return page of requested rich groups
+	 */
+	Paginated<RichGroup> getGroupsPage(PerunSession sess, Vo vo, GroupsPageQuery query, List<String> attrNames);
+
+	/**
+	 * Get page of subgroups from the given parent group.
+	 *
+	 * @param sess session
+	 * @param group parent group
+	 * @param query query with page information
+	 * @param attrNames attribute names
+	 *
+	 * @return page of requested rich groups
+	 */
+	Paginated<RichGroup> getSubgroupsPage(PerunSession sess, Group group, GroupsPageQuery query, List<String> attrNames);
 
 	/**
 	 * @param sess

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
@@ -35,10 +35,12 @@ import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.GroupResourceStatus;
 import cz.metacentrum.perun.core.api.GroupsManager;
+import cz.metacentrum.perun.core.api.GroupsPageQuery;
 import cz.metacentrum.perun.core.api.Host;
 import cz.metacentrum.perun.core.api.Member;
 import cz.metacentrum.perun.core.api.MemberGroupStatus;
 import cz.metacentrum.perun.core.api.MembershipType;
+import cz.metacentrum.perun.core.api.Paginated;
 import cz.metacentrum.perun.core.api.Pair;
 import cz.metacentrum.perun.core.api.PerunClient;
 import cz.metacentrum.perun.core.api.PerunPrincipal;
@@ -1669,6 +1671,26 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 		Collections.sort(groups);
 
 		return groups;
+	}
+
+	@Override
+	public Paginated<RichGroup> getGroupsPage(PerunSession sess, Vo vo, GroupsPageQuery query, List<String> attrNames) {
+		Paginated<Group> paginatedGroups = groupsManagerImpl.getGroupsPage(sess, vo, query);
+
+		List<RichGroup> richGroups = convertGroupsToRichGroupsWithAttributes(sess, paginatedGroups.getData(), attrNames);
+
+		return new Paginated<>(richGroups, paginatedGroups.getOffset(), paginatedGroups.getPageSize(),
+		paginatedGroups.getTotalCount());
+	}
+
+	@Override
+	public Paginated<RichGroup> getSubgroupsPage(PerunSession sess, Group group, GroupsPageQuery query, List<String> attrNames) {
+		Paginated<Group> paginatedGroups = groupsManagerImpl.getSubgroupsPage(sess, group, query);
+
+		List<RichGroup> richGroups = convertGroupsToRichGroupsWithAttributes(sess, paginatedGroups.getData(), attrNames);
+
+		return new Paginated<>(richGroups, paginatedGroups.getOffset(), paginatedGroups.getPageSize(),
+			paginatedGroups.getTotalCount());
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/GroupsManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/GroupsManagerImpl.java
@@ -9,10 +9,12 @@ import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.GroupResourceStatus;
 import cz.metacentrum.perun.core.api.GroupsManager;
+import cz.metacentrum.perun.core.api.GroupsPageQuery;
 import cz.metacentrum.perun.core.api.Member;
 import cz.metacentrum.perun.core.api.MemberGroupStatus;
 import cz.metacentrum.perun.core.api.MembershipType;
 import cz.metacentrum.perun.core.api.Pair;
+import cz.metacentrum.perun.core.api.Paginated;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.SecurityTeam;
@@ -53,6 +55,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+
+import static org.apache.commons.lang3.ObjectUtils.isEmpty;
 
 /**
  * Implementation of GroupsManager
@@ -102,6 +106,27 @@ public class GroupsManagerImpl implements GroupsManagerImplApi {
 		else g.setCreatedByUid(resultSet.getInt("groups_created_by_uid"));
 		return g;
 	};
+
+	/**
+	 * Returns ResultSetExtractor that can be used to extract returned paginated groups
+	 * from db.
+	 *
+	 * @param query query data
+	 * @return extractor, that can be used to extract returned paginated groups from db
+	 */
+	private static ResultSetExtractor<Paginated<Group>> getPaginatedGroupsExtractor(GroupsPageQuery query) {
+		return resultSet -> {
+			List<Group> groups = new ArrayList<>();
+			int total_count = 0;
+			int row = 0;
+			while (resultSet.next()) {
+				total_count = resultSet.getInt("total_count");
+				groups.add(GROUP_MAPPER.mapRow(resultSet, row));
+				row++;
+			}
+			return new Paginated<>(groups, query.getOffset(), query.getPageSize(), total_count);
+		};
+	}
 
 	protected static final RowMapper<AssignedGroup> ASSIGNED_GROUP_MAPPER = (resultSet, i) -> {
 		Group group = GROUP_MAPPER.mapRow(resultSet, i);
@@ -526,6 +551,59 @@ public class GroupsManagerImpl implements GroupsManagerImplApi {
 			throw new InternalErrorException(ex);
 		}
 
+	}
+
+	@Override
+	public Paginated<Group> getGroupsPage(PerunSession sess, Vo vo, GroupsPageQuery query) {
+		MapSqlParameterSource namedParams = new MapSqlParameterSource();
+
+		namedParams.addValue("voId", vo.getId());
+		namedParams.addValue("offset", query.getOffset());
+		namedParams.addValue("limit", query.getPageSize());
+
+		String searchQuery = getSQLWhereForGroupsPage(query, namedParams);
+
+		return namedParameterJdbcTemplate.query(
+			"SELECT " + groupMappingSelectQuery +
+			", count(*) OVER() AS total_count" +
+			" FROM groups" +
+			" WHERE groups.vo_id=(:voId)" +
+			searchQuery +
+			" ORDER BY " + query.getSortColumn().getSqlOrderBy(query) +
+			" OFFSET (:offset)" +
+			" LIMIT (:limit);",
+			namedParams,
+			getPaginatedGroupsExtractor(query));
+	}
+
+	@Override
+	public Paginated<Group> getSubgroupsPage(PerunSession sess, Group group, GroupsPageQuery query) {
+		MapSqlParameterSource namedParams = new MapSqlParameterSource();
+
+		namedParams.addValue("parentGroupId", group.getId());
+		namedParams.addValue("offset", query.getOffset());
+		namedParams.addValue("limit", query.getPageSize());
+
+		String searchQuery = getSQLWhereForGroupsPageParentGroup(query, namedParams);
+
+		return namedParameterJdbcTemplate.query(
+			"WITH RECURSIVE subgroups AS (" +
+					" SELECT " + groupMappingSelectQuery +
+					" FROM groups" +
+					" WHERE groups.parent_group_id=(:parentGroupId)" +
+					" UNION" +
+						" SELECT " + groupMappingSelectQuery +
+						" FROM groups" +
+						" INNER JOIN subgroups s ON s.groups_id = groups.parent_group_id" +
+				") SELECT *" +
+				", count(*) OVER() AS total_count" +
+				" FROM subgroups" +
+				searchQuery +
+				" ORDER BY " + query.getSortColumn().getSqlOrderBy(query) +
+				" OFFSET (:offset)" +
+				" LIMIT (:limit);",
+				namedParams,
+				getPaginatedGroupsExtractor(query));
 	}
 
 	@Override
@@ -1135,4 +1213,19 @@ public class GroupsManagerImpl implements GroupsManagerImplApi {
 			throw new InternalErrorException(err);
 		}
 	}
+
+	private String getSQLWhereForGroupsPage(GroupsPageQuery query, MapSqlParameterSource namedParams) {
+		if (isEmpty(query.getSearchString())) {
+			return "";
+		}
+		return " AND " + Utils.prepareSqlWhereForGroupSearch(query.getSearchString(), namedParams, false);
+	}
+
+	private String getSQLWhereForGroupsPageParentGroup(GroupsPageQuery query, MapSqlParameterSource namedParams) {
+		if (isEmpty(query.getSearchString())) {
+			return "";
+		}
+		return " WHERE " + Utils.prepareSqlWhereForGroupSearch(query.getSearchString(), namedParams, true);
+	}
+
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/GroupsManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/GroupsManagerImplApi.java
@@ -4,10 +4,12 @@ import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.ExtSource;
 import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.GroupsPageQuery;
 import cz.metacentrum.perun.core.api.Member;
 import cz.metacentrum.perun.core.api.MemberGroupStatus;
 import cz.metacentrum.perun.core.api.MembershipType;
 import cz.metacentrum.perun.core.api.Pair;
+import cz.metacentrum.perun.core.api.Paginated;
 import cz.metacentrum.perun.core.api.Perun;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.Resource;
@@ -343,6 +345,29 @@ public interface GroupsManagerImplApi {
 	 * @throws InternalErrorException
 	 */
 	List<Group> getAllGroups(PerunSession perunSession, Vo vo);
+
+
+	/**
+	 * Get page of groups from the given vo.
+	 *
+	 * @param sess session
+	 * @param vo vo
+	 * @param query query with page information
+	 *
+	 * @return page of requested groups
+	 */
+	Paginated<Group> getGroupsPage(PerunSession sess, Vo vo, GroupsPageQuery query);
+
+	/**
+	 * Get page of subgroups from the given parent group.
+	 *
+	 * @param sess session
+	 * @param group parent group
+	 * @param query query with page information
+	 *
+	 * @return page of requested groups
+	 */
+	Paginated<Group> getSubgroupsPage(PerunSession sess, Group group, GroupsPageQuery query);
 
 	/**
 	 * Get parent group.

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/GroupsManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/GroupsManagerEntryIntegrationTest.java
@@ -11,12 +11,16 @@ import cz.metacentrum.perun.core.api.ExtSourcesManager;
 import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.GroupsManager;
+import cz.metacentrum.perun.core.api.GroupsOrderColumn;
+import cz.metacentrum.perun.core.api.GroupsPageQuery;
 import cz.metacentrum.perun.core.api.Member;
 import cz.metacentrum.perun.core.api.MemberGroupStatus;
 import cz.metacentrum.perun.core.api.MembershipType;
+import cz.metacentrum.perun.core.api.Paginated;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.RichGroup;
 import cz.metacentrum.perun.core.api.RichMember;
+import cz.metacentrum.perun.core.api.SortingOrder;
 import cz.metacentrum.perun.core.api.Status;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.UserExtSource;
@@ -5500,6 +5504,320 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 		List<Group> groups = groupsManager.getAllGroups(sess);
 
 		assertThat(groups).contains(group1, group2);
+	}
+
+	@Test
+	public void getGroupsPage_Vo_all () throws Exception {
+		System.out.println(CLASS_NAME + "getGroupsPage_Vo_all");
+
+		vo = setUpVo();
+
+		perun.getGroupsManager().createGroup(sess, vo, group);
+		perun.getGroupsManager().createGroup(sess, vo, group2);
+		perun.getGroupsManager().createGroup(sess, group2, group21);
+		perun.getGroupsManager().createGroup(sess, group21, group3);
+
+		GroupsPageQuery query = new GroupsPageQuery(10, 0, SortingOrder.ASCENDING, GroupsOrderColumn.ID);
+		Paginated<RichGroup> groups = groupsManager.getGroupsPage(sess, vo, query, List.of());
+
+		assertNotNull(groups);
+		assertEquals(groups.getData().size(), 5);
+		assertTrue(groups.getData().containsAll(groupsManager.getAllRichGroupsWithAttributesByNames(sess, vo, List.of())));
+	}
+
+	@Test
+	public void getGroupsPage_Vo_all_totalCount_5 () throws Exception {
+		System.out.println(CLASS_NAME + "getGroupsPage_Vo_all");
+
+		vo = setUpVo();
+
+		perun.getGroupsManager().createGroup(sess, vo, group);
+		perun.getGroupsManager().createGroup(sess, vo, group2);
+		perun.getGroupsManager().createGroup(sess, group2, group21);
+		perun.getGroupsManager().createGroup(sess, group21, group3);
+		perun.getGroupsManager().createGroup(sess, group21, group4);
+		perun.getGroupsManager().createGroup(sess, group21, group5);
+		perun.getGroupsManager().createGroup(sess, group21, group6);
+
+		GroupsPageQuery query = new GroupsPageQuery(5, 0, SortingOrder.ASCENDING, GroupsOrderColumn.ID);
+		Paginated<RichGroup> groups = groupsManager.getGroupsPage(sess, vo, query, List.of());
+
+		assertNotNull(groups);
+		assertEquals(groups.getData().size(), 5);
+		assertEquals(groups.getTotalCount(), 8);
+	}
+
+	@Test
+	public void getGroupsPage_Vo_OrderByNameASC () throws Exception {
+		System.out.println(CLASS_NAME + "getGroupsPage_Vo_OrderByNameASC");
+
+		vo = setUpVo();
+
+		perun.getGroupsManager().createGroup(sess, vo, group);
+		Group groupA = new Group("A_group","testovaci_A");
+		perun.getGroupsManager().createGroup(sess, vo, groupA);
+		Group groupZ = new Group("Z_group","testovaci_Z");
+		perun.getGroupsManager().createGroup(sess, vo, groupZ);
+
+		GroupsPageQuery query = new GroupsPageQuery(10, 0, SortingOrder.ASCENDING, GroupsOrderColumn.NAME);
+		Paginated<RichGroup> groups = groupsManager.getGroupsPage(sess, vo, query, List.of());
+
+		assertNotNull(groups);
+		assertEquals(groups.getData().size(), 4);
+		assertEquals(groups.getData().get(0), groupsManagerBl.convertGroupToRichGroupWithAttributesByName(sess, groupA, List.of()));
+		assertEquals(groups.getData().get(3), groupsManagerBl.convertGroupToRichGroupWithAttributesByName(sess, groupZ, List.of()));
+	}
+
+	@Test
+	public void getGroupsPage_Vo_OrderByDescriptionDSC () throws Exception {
+		System.out.println(CLASS_NAME + "getGroupsPage_Vo_OrderByDescriptionDSC");
+
+		vo = setUpVo();
+
+		perun.getGroupsManager().createGroup(sess, vo, group);
+		Group groupA = new Group("A_group","A_testovaci");
+		perun.getGroupsManager().createGroup(sess, vo, groupA);
+		Group groupZ = new Group("Z_group","Z_testovaci");
+		perun.getGroupsManager().createGroup(sess, vo, groupZ);
+
+		GroupsPageQuery query = new GroupsPageQuery(10, 0, SortingOrder.DESCENDING, GroupsOrderColumn.DESCRIPTION);
+		Paginated<RichGroup> groups = groupsManager.getGroupsPage(sess, vo, query, List.of());
+
+		assertNotNull(groups);
+		assertEquals(groups.getData().size(), 4);
+		assertEquals(groups.getData().get(0), groupsManagerBl.convertGroupToRichGroupWithAttributesByName(sess, groupZ, List.of()));
+		assertEquals(groups.getData().get(3), groupsManagerBl.convertGroupToRichGroupWithAttributesByName(sess, groupA, List.of()));
+	}
+
+	@Test
+	public void getGroupsPage_Vo_searchStringName () throws Exception {
+		System.out.println(CLASS_NAME + "getGroupsPage_Vo_searchStringName");
+
+		vo = setUpVo();
+
+		perun.getGroupsManager().createGroup(sess, vo, group);
+		perun.getGroupsManager().createGroup(sess, vo, group2);
+		perun.getGroupsManager().createGroup(sess, group2, group21);
+		perun.getGroupsManager().createGroup(sess, group21, group3);
+
+		GroupsPageQuery query = new GroupsPageQuery(10, 0, SortingOrder.ASCENDING, GroupsOrderColumn.ID, "GroupsManagerTestGroup");
+		Paginated<RichGroup> groups = groupsManager.getGroupsPage(sess, vo, query, List.of());
+
+		assertNotNull(groups);
+		assertEquals(groups.getData().size(), 4);
+	}
+
+	@Test
+	public void getGroupsPage_Vo_searchStringDescription () throws Exception {
+		System.out.println(CLASS_NAME + "getGroupsPage_Vo_searchStringDescription");
+
+		vo = setUpVo();
+
+		perun.getGroupsManager().createGroup(sess, vo, group);
+		perun.getGroupsManager().createGroup(sess, vo, group2);
+		perun.getGroupsManager().createGroup(sess, group2, group21);
+		perun.getGroupsManager().createGroup(sess, group21, group3);
+
+		GroupsPageQuery query = new GroupsPageQuery(10, 0, SortingOrder.ASCENDING, GroupsOrderColumn.ID, "testovaci2");
+		Paginated<RichGroup> groups = groupsManager.getGroupsPage(sess, vo, query, List.of());
+
+		assertNotNull(groups);
+		assertEquals(groups.getData().size(), 2);
+		assertTrue(groups.getData().contains(groupsManagerBl.convertGroupToRichGroupWithAttributesByName(sess, group2, List.of())));
+		assertTrue(groups.getData().contains(groupsManagerBl.convertGroupToRichGroupWithAttributesByName(sess, group21, List.of())));
+	}
+
+	@Test
+	public void getGroupsPage_Vo_ReturnsAttributes () throws Exception {
+		System.out.println(CLASS_NAME + "getGroupsPage_Vo_ReturnsAttributes");
+
+		vo = setUpVo();
+
+		perun.getGroupsManager().createGroup(sess, vo, group);
+
+		// set membershipExpirationRules attribute
+		HashMap<String, String> extendMembershipRules = new LinkedHashMap<>();
+		extendMembershipRules.put(AbstractMembershipExpirationRulesModule.membershipPeriodKeyName, "+10d");
+
+		Attribute extendMembershipRulesAttribute = new Attribute(attributesManager.getAttributeDefinition(sess, AttributesManager.NS_GROUP_ATTR_DEF+":groupMembershipExpirationRules"));
+		extendMembershipRulesAttribute.setValue(extendMembershipRules);
+
+		attributesManager.setAttribute(sess, group, extendMembershipRulesAttribute);
+
+		GroupsPageQuery query = new GroupsPageQuery(10, 0, SortingOrder.ASCENDING, GroupsOrderColumn.ID);
+		Paginated<RichGroup> groups = groupsManager.getGroupsPage(sess, vo, query, List.of(extendMembershipRulesAttribute.getName()));
+
+		assertNotNull(groups);
+		assertEquals(groups.getData().size(), 2);
+		assertEquals(groups.getData().get(1), groupsManagerBl.convertGroupToRichGroupWithAttributesByName(sess, group, List.of(extendMembershipRulesAttribute.getName())));
+		assertThat(groups.getData().get(1).getAttributes()).containsOnly(extendMembershipRulesAttribute);
+	}
+
+	@Test
+	public void getGroupsPage_ParentGroup_all () throws Exception {
+		System.out.println(CLASS_NAME + "getGroupsPage_ParentGroup_all");
+
+		vo = setUpVo();
+
+		perun.getGroupsManager().createGroup(sess, vo, group);
+		perun.getGroupsManager().createGroup(sess, group, group2);
+		perun.getGroupsManager().createGroup(sess, group2, group21);
+		perun.getGroupsManager().createGroup(sess, group21, group3);
+		perun.getGroupsManager().createGroup(sess, group, group4);
+		perun.getGroupsManager().createGroup(sess, group, group5);
+
+		GroupsPageQuery query = new GroupsPageQuery(10, 0, SortingOrder.ASCENDING, GroupsOrderColumn.ID);
+		Paginated<RichGroup> subgroups = groupsManager.getSubgroupsPage(sess, group, query, List.of());
+		Paginated<RichGroup> subgroups2 = groupsManager.getSubgroupsPage(sess, group2, query, List.of());
+
+		assertNotNull(subgroups);
+		assertEquals(subgroups.getData().size(), 5);
+
+		assertNotNull(subgroups2);
+		assertEquals(subgroups2.getData().size(), 2);
+	}
+
+	@Test
+	public void getGroupsPage_ParentGroup_all_totalCount_5 () throws Exception {
+		System.out.println(CLASS_NAME + "getGroupsPage_ParentGroup_all");
+
+		vo = setUpVo();
+
+		perun.getGroupsManager().createGroup(sess, vo, group);
+		perun.getGroupsManager().createGroup(sess, group, group2);
+		perun.getGroupsManager().createGroup(sess, group2, group21);
+		perun.getGroupsManager().createGroup(sess, group21, group3);
+		perun.getGroupsManager().createGroup(sess, group, group4);
+		perun.getGroupsManager().createGroup(sess, group, group5);
+		perun.getGroupsManager().createGroup(sess, group, group6);
+		perun.getGroupsManager().createGroup(sess, group, group7);
+
+		GroupsPageQuery query = new GroupsPageQuery(5, 0, SortingOrder.ASCENDING, GroupsOrderColumn.ID);
+		Paginated<RichGroup> subgroups = groupsManager.getSubgroupsPage(sess, group, query, List.of());
+
+		assertNotNull(subgroups);
+		assertEquals(subgroups.getData().size(), 5);
+		assertEquals(subgroups.getTotalCount(), 7);
+	}
+
+	@Test
+	public void getGroupsPage_ParentGroup_OrderByNameASC () throws Exception {
+		System.out.println(CLASS_NAME + "getGroupsPage_ParentGroup_OrderByNameASC");
+
+		vo = setUpVo();
+
+		perun.getGroupsManager().createGroup(sess, vo, group);
+		perun.getGroupsManager().createGroup(sess, group, group2);
+		perun.getGroupsManager().createGroup(sess, group2, group21);
+		Group groupA = new Group("A_group","testovaci_A");
+		perun.getGroupsManager().createGroup(sess, group, groupA);
+		Group groupZ = new Group("Z_group","testovaci_Z");
+		perun.getGroupsManager().createGroup(sess, group, groupZ);
+
+		GroupsPageQuery query = new GroupsPageQuery(10, 0, SortingOrder.ASCENDING, GroupsOrderColumn.NAME);
+		Paginated<RichGroup> subgroups = groupsManager.getSubgroupsPage(sess, group, query, List.of());
+
+		assertNotNull(subgroups);
+		assertEquals(subgroups.getData().size(), 4);
+		assertEquals(subgroups.getData().get(0), groupsManagerBl.convertGroupToRichGroupWithAttributesByName(sess, groupA, List.of()));
+		assertEquals(subgroups.getData().get(3), groupsManagerBl.convertGroupToRichGroupWithAttributesByName(sess, groupZ, List.of()));
+	}
+
+	@Test
+	public void getGroupsPage_ParentGroup_OrderByDescriptionDSC () throws Exception {
+		System.out.println(CLASS_NAME + "getGroupsPage_ParentGroup_OrderByDescriptionDSC");
+
+		vo = setUpVo();
+
+		perun.getGroupsManager().createGroup(sess, vo, group);
+		perun.getGroupsManager().createGroup(sess, group, group2);
+		perun.getGroupsManager().createGroup(sess, group2, group21);
+		Group groupA = new Group("A_group","A_testovaci");
+		perun.getGroupsManager().createGroup(sess, group, groupA);
+		Group groupZ = new Group("Z_group","Z_testovaci");
+		perun.getGroupsManager().createGroup(sess, group, groupZ);
+
+		GroupsPageQuery query = new GroupsPageQuery(10, 0, SortingOrder.DESCENDING, GroupsOrderColumn.DESCRIPTION);
+		Paginated<RichGroup> subgroups = groupsManager.getSubgroupsPage(sess, group, query, List.of());
+
+		assertNotNull(subgroups);
+		assertEquals(subgroups.getData().size(), 4);
+		assertEquals(subgroups.getData().get(0), groupsManagerBl.convertGroupToRichGroupWithAttributesByName(sess, groupZ, List.of()));
+		assertEquals(subgroups.getData().get(3), groupsManagerBl.convertGroupToRichGroupWithAttributesByName(sess, groupA, List.of()));
+	}
+
+	@Test
+	public void getGroupsPage_ParentGroup_searchStringName () throws Exception {
+		System.out.println(CLASS_NAME + "getGroupsPage_ParentGroup_searchStringName");
+
+		vo = setUpVo();
+
+		perun.getGroupsManager().createGroup(sess, vo, group);
+		perun.getGroupsManager().createGroup(sess, group, group2);
+		perun.getGroupsManager().createGroup(sess, group2, group21);
+		perun.getGroupsManager().createGroup(sess, group2, group3);
+		perun.getGroupsManager().createGroup(sess, group21, group4);
+		perun.getGroupsManager().createGroup(sess, group3, group5);
+
+		GroupsPageQuery query = new GroupsPageQuery(10, 0, SortingOrder.ASCENDING, GroupsOrderColumn.ID, "GroupsManagerTestGroup");
+		Paginated<RichGroup> subgroups = groupsManager.getSubgroupsPage(sess, group, query, List.of());
+		Paginated<RichGroup> subgroups2 = groupsManager.getSubgroupsPage(sess, group21, query, List.of());
+
+		assertNotNull(subgroups);
+		assertEquals(subgroups.getData().size(), 5);
+
+		assertNotNull(subgroups2);
+		assertEquals(subgroups2.getData().size(), 1);
+	}
+
+	@Test
+	public void getGroupsPage_ParentGroup_searchStringDescription () throws Exception {
+		System.out.println(CLASS_NAME + "getGroupsPage_ParentGroup_searchStringName");
+
+		vo = setUpVo();
+
+		perun.getGroupsManager().createGroup(sess, vo, group);
+		perun.getGroupsManager().createGroup(sess, group, group2);
+		perun.getGroupsManager().createGroup(sess, group2, group21);
+		perun.getGroupsManager().createGroup(sess, group2, group3);
+		perun.getGroupsManager().createGroup(sess, group21, group4);
+		perun.getGroupsManager().createGroup(sess, group3, group5);
+
+		GroupsPageQuery query = new GroupsPageQuery(10, 0, SortingOrder.ASCENDING, GroupsOrderColumn.ID, "testovaci2");
+		Paginated<RichGroup> subgroups = groupsManager.getSubgroupsPage(sess, group, query, List.of());
+		Paginated<RichGroup> subgroups2 = groupsManager.getSubgroupsPage(sess, group21, query, List.of());
+
+		assertNotNull(subgroups);
+		assertEquals(subgroups.getData().size(), 2);
+
+		assertEquals(subgroups2.getData().size(), 0);
+	}
+
+	@Test
+	public void getGroupsPage_ParentGroup_ReturnsAttributes () throws Exception {
+		System.out.println(CLASS_NAME + "getGroupsPage_Vo_ReturnsAttributes");
+
+		vo = setUpVo();
+
+		perun.getGroupsManager().createGroup(sess, vo, group);
+		perun.getGroupsManager().createGroup(sess, group, group2);
+
+		// set membershipExpirationRules attribute
+		HashMap<String, String> extendMembershipRules = new LinkedHashMap<>();
+		extendMembershipRules.put(AbstractMembershipExpirationRulesModule.membershipPeriodKeyName, "+10d");
+
+		Attribute extendMembershipRulesAttribute = new Attribute(attributesManager.getAttributeDefinition(sess, AttributesManager.NS_GROUP_ATTR_DEF+":groupMembershipExpirationRules"));
+		extendMembershipRulesAttribute.setValue(extendMembershipRules);
+
+		attributesManager.setAttribute(sess, group2, extendMembershipRulesAttribute);
+
+		GroupsPageQuery query = new GroupsPageQuery(10, 0, SortingOrder.ASCENDING, GroupsOrderColumn.ID);
+		Paginated<RichGroup> groups = groupsManager.getSubgroupsPage(sess, group, query, List.of(extendMembershipRulesAttribute.getName()));
+
+		assertNotNull(groups);
+		assertEquals(groups.getData().size(), 1);
+		assertEquals(groups.getData().get(0), groupsManagerBl.convertGroupToRichGroupWithAttributesByName(sess, group2, List.of(extendMembershipRulesAttribute.getName())));
+		assertThat(groups.getData().get(0).getAttributes()).containsOnly(extendMembershipRulesAttribute);
 	}
 
 	// PRIVATE METHODS -------------------------------------------------------------

--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -652,6 +652,38 @@ components:
       discriminator:
         propertyName: beanName
 
+    PaginatedRichGroups:
+      properties:
+        offset: { type: integer }
+        pageSize: { type: integer }
+        totalCount: { type: integer }
+        data: { type: array, items: { $ref: '#/components/schemas/RichGroup' } }
+      required:
+        - offset
+        - pageSize
+        - totalCount
+        - data
+
+    GroupsOrderColumn:
+      type: string
+      enum:
+        - ID
+        - NAME
+        - DESCRIPTION
+
+    GroupsPageQuery:
+      properties:
+        pageSize: { type: integer }
+        offset: { type: integer }
+        order: { $ref: '#/components/schemas/SortingOrder' }
+        sortColumn: { $ref: '#/components/schemas/GroupsOrderColumn' }
+        searchString: { type: string }
+      required:
+        - pageSize
+        - offset
+        - order
+        - sortColumn
+
     Resource:
       allOf:
         - $ref: '#/components/schemas/Auditable'
@@ -1677,6 +1709,13 @@ components:
             type: array
             items:
               $ref: "#/components/schemas/RichGroup"
+
+    PaginatedRichGroupsResponse:
+      description: "returns Paginated<RichGroup>"
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/PaginatedRichGroups"
 
     PaginatedRichMembersResponse:
       description: "returns Paginated<RichMember>"
@@ -11899,6 +11938,62 @@ paths:
           $ref: '#/components/responses/ListOfRichMembersResponse'
         default:
           $ref: '#/components/responses/ExceptionResponse'
+
+  /json/groupsManager/getGroupsPage:
+    post:
+      tags:
+        - GroupsManager
+      operationId: getGroupsPage
+      summary: Get page of groups from the given vo.
+      responses:
+        '200':
+          $ref: '#/components/responses/PaginatedRichGroupsResponse'
+        default:
+          $ref: '#/components/responses/ExceptionResponse'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              title: InputGetPaginatedGroups
+              description: "input to getPaginatedGroups"
+              type: object
+              required:
+                - vo
+                - query
+                - attrNames
+              properties:
+                vo: { type: integer }
+                attrNames: { type: array, items: { type: string } }
+                query: { $ref: '#/components/schemas/GroupsPageQuery' }
+
+  /json/groupsManager/getSubgroupsPage:
+    post:
+      tags:
+        - GroupsManager
+      operationId: getSubgroupsPage
+      summary: Get page of subgroups from the given parent group.
+      responses:
+        '200':
+          $ref: '#/components/responses/PaginatedRichGroupsResponse'
+        default:
+          $ref: '#/components/responses/ExceptionResponse'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              title: InputGetPaginatedGroups
+              description: "input to getPaginatedGroups"
+              type: object
+              required:
+                - group
+                - query
+                - attrNames
+              properties:
+                group: { type: integer }
+                attrNames: { type: array, items: { type: string } }
+                query: { $ref: '#/components/schemas/GroupsPageQuery' }
 
   #################################################
   #                                               #

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/GroupsManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/GroupsManagerMethod.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.GroupsPageQuery;
 import cz.metacentrum.perun.core.api.Member;
 import cz.metacentrum.perun.core.api.MemberGroupStatus;
 import cz.metacentrum.perun.core.api.MembershipType;
@@ -768,6 +769,52 @@ public enum GroupsManagerMethod implements ManagerMethod {
 				return ac.getGroupsManager().getAllGroups(ac.getSession(), ac.getVoById(parms.readInt("vo")));
 			}
 			return ac.getGroupsManager().getAllGroups(ac.getSession());
+		}
+	},
+
+	/*#
+	 * Get page of groups from the given vo.
+	 * Query parameter specifies offset, page size, sorting order, sorting column and string to search groups by
+	 * (by default it searches in names, ids, uuids and descriptions), last parameter is optional and by default it
+	 * finds all groups in vo.
+	 *
+	 * @param vo int Vo <code>id</code>
+	 * @param query GroupsPageQuery Query with page information
+	 * @param attrNames List<String> List of attribute names
+	 *
+	 * @return Paginated<RichGroup> page of requested rich groups
+	 * @throw VoNotExistsException if there is no such vo
+	 */
+	getGroupsPage {
+		@Override
+		public Object call(ApiCaller ac, Deserializer parms) throws PerunException {
+			return ac.getGroupsManager().getGroupsPage(ac.getSession(),
+				ac.getVoById(parms.readInt("vo")),
+				parms.read("query", GroupsPageQuery.class),
+				parms.readList("attrNames", String.class));
+		}
+	},
+
+	/*#
+	 * Get page of subgroups from the parent group.
+	 * Query parameter specifies offset, page size, sorting order, sorting column and string to search groups by
+	 * (by default it searches in names, ids, uuids and descriptions), last parameter is optional and by default it
+	 * finds all subgroups for the given parent group.
+	 *
+	 * @param group int Group <code>id</code>
+	 * @param query GroupsPageQuery Query with page information
+	 * @param attrNames List<String> List of attribute names
+	 *
+	 * @return Paginated<RichGroup> page of requested rich groups
+	 * @throw GroupNotExistsException if there is no such query group
+	 */
+	getSubgroupsPage {
+		@Override
+		public Object call(ApiCaller ac, Deserializer parms) throws PerunException {
+			return ac.getGroupsManager().getSubgroupsPage(ac.getSession(),
+				ac.getGroupById(parms.readInt("group")),
+				parms.read("query", GroupsPageQuery.class),
+				parms.readList("attrNames", String.class));
 		}
 	},
 

--- a/perun-utils/rpc-methods-javadoc-generator/parseRpcMethods.pl
+++ b/perun-utils/rpc-methods-javadoc-generator/parseRpcMethods.pl
@@ -227,6 +227,13 @@ $objectExamples{"List<UsersPageQuery>"} = $objectExamples{"List&lt;UsersPageQuer
 $objectExamples{"Paginated&lt;RichUser&gt;"} = "{ \"offset\" : 0 , \"pageSize\" : 3 , \"totalCount\" : 1 , \"data\" : " . $objectExamples{"List&lt;RichUser&gt;"} . "  }";
 $objectExamples{"Paginated<RichUser>"} = @objectExamples{"Paginated&lt;RichUser&gt;"};
 
+$objectExamples{"GroupsPageQuery"} = "{ \"pageSize\" : 3 , \"offset\" : 0 , \"order\" : \"ASCENDING\" , \"sortColumn\" : \"ID\" , \"searchString\" : \"My group\" }";
+$objectExamples{"List&lt;GroupsPageQuery&gt;"} = $listPrepend . $objectExamples{"GroupsPageQuery"} . $listAppend;
+$objectExamples{"List<GroupsPageQuery>"} = $objectExamples{"List&lt;GroupsPageQuery&gt;"};
+
+$objectExamples{"Paginated&lt;RichGroup&gt;"} = "{ \"offset\" : 0 , \"pageSize\" : 3 , \"totalCount\" : 1 , \"data\" : " . $objectExamples{"List&lt;RichGroup&gt;"} . "  }";
+$objectExamples{"Paginated<RichGroup>"} = @objectExamples{"Paginated&lt;RichGroup&gt;"};
+
 # SUB HELP
 # help info
 sub help {


### PR DESCRIPTION
* Added two new methods getGroupsPage and getSubgroupsPage. Method getGroupsPage returns paginated groups for the given Vo and method getSubgroupsPage returns paginated subgroups for the given parent group. Both these methods return paginated groups based on GroupsPageQuery.
* GroupsPageQuery consist of page size, offset, sorting order, sort column and optionally search string, which filters groups by uuid, id, name and description.