### PR TITLE
perf(core): skip setting attributes for service without required attr…

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ResourcesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ResourcesManagerBlImpl.java
@@ -632,6 +632,15 @@ public class ResourcesManagerBlImpl implements ResourcesManagerBl {
 			getResourcesManagerImpl().assignService(sess, resource, service);
 			getPerunBl().getAuditer().log(sess, new ServiceAssignedToResource(service, resource));
 		}
+
+		boolean requiresAttributes = services.stream()
+			.anyMatch(s -> !getPerunBl().getAttributesManagerBl().getRequiredAttributesDefinition(sess, s).isEmpty());
+
+		if (!requiresAttributes) {
+			// there are new no attributes to check or add
+			return;
+		}
+
 		try {
 			fillAndSetRequiredAttributesForGroups(sess, services, resource);
 

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/bl/ResourcesManagerBlImplUnitTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/bl/ResourcesManagerBlImplUnitTest.java
@@ -94,13 +94,6 @@ public class ResourcesManagerBlImplUnitTest {
             verify(auditerMock, times(1))
 	            .log(sessionMock, new ServiceAssignedToResource(service, resource));
         }
-
-        verify(resourcesManagerBlMock)
-	        .fillAndSetRequiredAttributesForGroups(sessionMock, services, resource);
-        verify(resourcesManagerBlMock)
-	        .checkSemanticsOfFacilityAndResourceRequiredAttributes(sessionMock, resource);
-        verify(resourcesManagerBlMock)
-	        .updateAllRequiredAttributesForAllowedMembers(sessionMock, resource, services);
 	}
 
 	@Test


### PR DESCRIPTION
…ibtues

* Assigning service without required attributes to resource now skips attributes checking and setting to speed the processing up