### PR TITLE
fix(registrar): 28 days period instead of month in isCesnetEligible logs

### DIFF
--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/ExpirationNotifScheduler.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/ExpirationNotifScheduler.java
@@ -961,17 +961,16 @@ public class ExpirationNotifScheduler {
 	private void auditIsCesnetEligibleExpiration(LocalDate today, User user, String isEligibleTimestamp) {
 		LocalDate lastAccess = LocalDate.parse(isEligibleTimestamp, lastAccessFormatter);
 		LocalDate expiration = lastAccess.plusYears(1);
-		Period period = today.until(expiration);
-		if (period.getYears() == 0 && period.getMonths() == 1 && period.getDays() == 0) {
-			// get also actual number of days
-			getPerun().getAuditer().log(sess, new CesnetEligibleExpiration(user, (int) ChronoUnit.DAYS.between(today, expiration), "in a month"));
-		} else if (period.getYears() == 0 && period.getMonths() == 0 && period.getDays() == 14) {
+		if (ChronoUnit.DAYS.between(today, expiration) == 28) {
+			// don't use plusMonth(1) as some days could be skipped or duplicated
+			getPerun().getAuditer().log(sess, new CesnetEligibleExpiration(user, 28));
+		} else if (ChronoUnit.DAYS.between(today, expiration) == 14) {
 			getPerun().getAuditer().log(sess, new CesnetEligibleExpiration(user, 14));
-		} else if (period.getYears() == 0 && period.getMonths() == 0 && period.getDays() == 7) {
+		} else if (ChronoUnit.DAYS.between(today, expiration) == 7) {
 			getPerun().getAuditer().log(sess, new CesnetEligibleExpiration(user, 7));
-		} else if (period.getYears() == 0 && period.getMonths() == 0 && period.getDays() == 1) {
+		} else if (ChronoUnit.DAYS.between(today, expiration) == 1) {
 			getPerun().getAuditer().log(sess, new CesnetEligibleExpiration(user, 1, "tomorrow"));
-		} else if (period.getYears() == 0 && period.getMonths() == 0 && period.getDays() == 0) {
+		} else if (ChronoUnit.DAYS.between(today, expiration) == 0) {
 			getPerun().getAuditer().log(sess, new CesnetEligibleExpiration(user, 0, "today"));
 		}
 	}

--- a/perun-registrar-lib/src/test/java/cz/metacentrum/perun/registrar/ExpirationNotifSchedulerTest.java
+++ b/perun-registrar-lib/src/test/java/cz/metacentrum/perun/registrar/ExpirationNotifSchedulerTest.java
@@ -611,17 +611,22 @@ public class ExpirationNotifSchedulerTest extends RegistrarBaseIntegrationTest {
 	}
 
 	@Test
-	public void isCesnetEligible_month() throws Exception {
-		System.out.println(CLASS_NAME + "isCesnetEligible_month");
+	public void isCesnetEligible_28days() throws Exception {
+		System.out.println(CLASS_NAME + "isCesnetEligible_28days");
 
-		LocalDate today = LocalDate.of(2020, 2, 2);
-		String lastSeen = "2019-03-02 17:18:28";
+		LocalDate today = LocalDate.of(2020, 1, 1);
+		String lastSeen = "2019-01-29 17:18:28";
 		when(spyScheduler.getCurrentLocalDate())
 			.thenReturn(today);
-
 		User user = perun.getUsersManagerBl().getUserByMember(session, setUpMember());
-		int daysLeft = (int) ChronoUnit.DAYS.between(today, today.plusMonths(1));
-		checkDaysIsCesnetEligibleExpiration(lastSeen, daysLeft, user, "in a month");
+		checkDaysIsCesnetEligibleExpiration(lastSeen, 28, user, null);
+
+		today = LocalDate.of(2019, 2, 1);
+		lastSeen = "2018-03-01 17:18:28";
+		when(spyScheduler.getCurrentLocalDate())
+			.thenReturn(today);
+		user = perun.getUsersManagerBl().getUserByMember(session, setUpMember());
+		checkDaysIsCesnetEligibleExpiration(lastSeen, 28, user, null);
 	}
 
 	private void checkDaysIsCesnetEligibleExpiration(String timestamp, int daysToExpiration, User user, String message) throws Exception {


### PR DESCRIPTION
* in isCesnetEligible notifications check a period of one month was used, but it could end up not matching some days at all or logging the same notification more than once, now using 28 days