### PR TITLE
fix(core): filter only authorized groups in paginated method getGroupsPage

### DIFF
--- a/perun-base/src/main/resources/perun-roles.yml
+++ b/perun-base/src/main/resources/perun-roles.yml
@@ -1508,6 +1508,19 @@ perun_policies:
     include_policies:
       - default_policy
 
+  filter-getGroupsPage_Vo_GroupsPageQuery_List<String>_policy:
+    policy_roles:
+      - VOADMIN: Vo
+      - VOOBSERVER: Vo
+      - GROUPADMIN: Group
+      - GROUPOBSERVER: Group
+      - RESOURCEADMIN: Vo
+      - RESOURCEOBSERVER: Vo
+      - TRUSTEDFACILITYADMIN: Vo
+      - PERUNOBSERVER:
+    include_policies:
+      - default_policy
+
   getSubgroupsPage_Group_GroupsPageQuery_List<String>_policy:
     policy_roles:
       - VOADMIN: Vo

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
@@ -1004,6 +1004,18 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 		return false;
 	}
 
+	public static boolean isAuthorizedForGroup(PerunSession sess, String policy, Integer groupId, Integer voId) {
+		Group group = new Group();
+		group.setId(groupId);
+		group.setVoId(voId);
+
+		try {
+			return authorized(sess, policy, Collections.singletonList(group));
+		} catch (PolicyNotExistsException e) {
+			throw new InternalErrorException(e);
+		}
+	}
+
 	/**
 	 * Return map of roles, with allowed actions, which are authorized for doing "action" on "attribute".
 	 *

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/GroupsManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/GroupsManagerImplApi.java
@@ -463,6 +463,16 @@ public interface GroupsManagerImplApi {
 	List<Group> getGroups(PerunSession perunSession, Vo vo);
 
 	/**
+	 * Get all groups ids for given vo.
+	 *
+	 * @param sess perun session
+	 * @param vo vo
+	 *
+	 * @return list of groups ids
+	 */
+	List<Integer> getGroupsIds(PerunSession sess, Vo vo);
+
+	/**
 	 * @param perunSession
 	 * @param vo
 	 *


### PR DESCRIPTION
* In previous PR (#3383) was incorrect authorization.
* Now are filtered only correct groups by authorization rules.