### PR TITLE
feat: added systemd service units to manage perun app processes

### DIFF
--- a/perun-utils/systemd/perun-auditlogger.service.debian
+++ b/perun-utils/systemd/perun-auditlogger.service.debian
@@ -1,0 +1,45 @@
+[Unit]
+Description=Perun-AuditLogger
+After=postgresql.service
+
+[Service]
+Type=simple
+WorkingDirectory=/home/perun/perun-auditlogger/
+User=perun
+Group=perun
+ProtectSystem=strict
+ReadOnlyPaths=/etc/perun/
+ReadWritePaths=/var/log/perun/
+
+# Default settings
+Environment="PERUN_CONF_DIR=/etc/perun/"
+Environment="PERUN_LOG_CONF=/etc/perun/logback-auditlogger.xml"
+Environment="JAR=/home/perun/perun-auditlogger/perun-auditlogger.jar"
+Environment="SYSLOG_HOST=localhost"
+Environment="SYSLOG_FACILITY=LOCAL0"
+
+# Override default systemd unit environment using our config file
+# "-" at start means "don't fail if not present/readable"
+#
+# File content example:
+#
+# SYSLOG_HOST=localhost
+# SYSLOG_FACILITY=LOCAL7
+#
+EnvironmentFile=-/etc/perun/perun-auditlogger
+
+# Start Engine
+ExecStart=/usr/bin/java \
+  -Dperun.conf.custom=${PERUN_CONF_DIR} \
+  -Dlogback.configurationFile=${PERUN_LOG_CONF} \
+  -Dauditlogger.syslog.host=${SYSLOG_HOST} \
+  -Dauditlogger.syslog.facility=${SYSLOG_FACILITY} \
+  -Dspring.profiles.default=production \
+  -DApplicationName=AuditLogger \
+  -jar $JAR
+
+# If no ExecStop is specified, systemd uses SIGTERM and SIGKILL to stop java process, hence: 143 = 128 + 15 (SIGTERM).
+SuccessExitStatus=143
+
+[Install]
+WantedBy=multi-user.target

--- a/perun-utils/systemd/perun-engine.service.debian
+++ b/perun-utils/systemd/perun-engine.service.debian
@@ -1,0 +1,48 @@
+[Unit]
+Description=Perun-Engine
+After=tomcat9.service
+
+[Service]
+Type=simple
+WorkingDirectory=/home/perun/perun-engine/
+User=perun
+Group=perun
+ProtectSystem=strict
+ReadOnlyPaths=/etc/perun/
+ReadWritePaths=/var/log/perun/
+
+# Default settings
+Environment="PERUN_CONF_DIR=/etc/perun/"
+Environment="PERUN_LOG_CONF=/etc/perun/logback-engine.xml"
+Environment="JAR=/home/perun/perun-engine/perun-engine.jar"
+# Default PERL lib paths for gen scripts
+Environment="PERL5LIB='/opt/perun-cli/lib/:.'"
+# Disable Kerberos if someone under the same user creates the ticket
+Environment="KRB5CCNAME='/dev/null'"
+
+# Override default systemd unit environment using our config file
+# "-" at start means "don't fail if not present/readable"
+#
+# File content example:
+#
+# PERUN_USER=perun-engine/password
+# PERUN_URL=https://perundomain.com/ba/rpc/
+# PERL5LIB='/opt/perun-cli/lib/:.'
+# PERL_LWP_SSL_VERIFY_HOSTNAME=0
+# KRB5CCNAME='/path/to/ticket_or_dev_null'
+#
+EnvironmentFile=-/etc/perun/perun-engine
+
+# Start Engine
+ExecStart=/usr/bin/java \
+  -Dperun.conf.custom=${PERUN_CONF_DIR} \
+  -Dlogback.configurationFile=${PERUN_LOG_CONF} \
+  -Dspring.profiles.default=production \
+  -DApplicationName=Engine \
+  -jar $JAR
+
+# If no ExecStop is specified, systemd uses SIGTERM and SIGKILL to stop java process, hence: 143 = 128 + 15 (SIGTERM).
+SuccessExitStatus=143
+
+[Install]
+WantedBy=multi-user.target

--- a/perun-utils/systemd/perun-ldapc.service.debian
+++ b/perun-utils/systemd/perun-ldapc.service.debian
@@ -1,0 +1,37 @@
+[Unit]
+Description=Perun-LDAPc
+After=slapd.service
+After=postgresql.service
+
+[Service]
+Type=simple
+WorkingDirectory=/home/perun/perun-ldapc/
+User=perun
+Group=perun
+ProtectSystem=strict
+ReadOnlyPaths=/etc/perun/
+ReadWritePaths=/var/log/perun/
+
+# Default settings
+Environment="PERUN_CONF_DIR=/etc/perun/"
+Environment="PERUN_LOG_CONF=/etc/perun/logback-ldapc.xml"
+Environment="JAR=/home/perun/perun-ldapc/perun-ldapc.jar"
+Environment="LAST_PROCESSED_ID='--sync'"
+
+# Override default systemd unit environment using our config file
+# "-" at start means "don't fail if not present/readable"
+EnvironmentFile=-/etc/perun/perun-ldapc
+
+# Start LDAPC
+ExecStart=/usr/bin/java \
+  -Dperun.conf.custom=${PERUN_CONF_DIR} \
+  -Dlogback.configurationFile=${PERUN_LOG_CONF} \
+  -Dspring.profiles.default=production \
+  -DApplicationName=LDAPc \
+  -jar $JAR $LAST_PROCESSED_ID
+
+# If no ExecStop is specified, systemd uses SIGTERM and SIGKILL to stop java process, hence: 143 = 128 + 15 (SIGTERM).
+SuccessExitStatus=143
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
- We used to depend on legacy init.d scripts to start/stop processes for perun-ldapc, perun-engine
and perun-auditlogger. This no longer reliably works in Debian 11, so new systemd units were added
between the old templates (those used on RHEL), which are compatible with Debian do not require
external start/stop scripts.