### PR TITLE
feat: add get allRichGroupsMethod 

### DIFF
--- a/perun-base/src/main/resources/perun-roles.yml
+++ b/perun-base/src/main/resources/perun-roles.yml
@@ -1495,6 +1495,12 @@ perun_policies:
     include_policies:
       - default_policy
 
+  getAllRichGroups_policy:
+    policy_roles:
+      - PERUNOBSERVER:
+    include_policies:
+      - default_policy
+
   getGroupsPage_Vo_GroupsPageQuery_List<String>_policy:
     policy_roles:
       - VOADMIN: Vo

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/GroupsManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/GroupsManager.java
@@ -591,6 +591,26 @@ public interface GroupsManager {
 	List<Group> getAllGroups(PerunSession sess) throws PrivilegeException;
 
 	/**
+	 * Get all groups with their specified attributes. If the {@code attrNames} are null or empty,
+	 * all group attributes are returned.
+	 *
+	 * @param sess session
+	 * @param attrNames list of attribute names to get
+	 * @return list of all groups with specified attributes
+	 * @throws PrivilegeException if the principal has insufficient permission
+	 */
+	List<RichGroup> getAllRichGroups(PerunSession sess, List<String> attrNames) throws PrivilegeException;
+
+	/**
+	 * Get all groups with all attributes.
+	 *
+	 * @param sess session
+	 * @return list of all groups with specified attributes
+	 * @throws PrivilegeException if the principal has insufficient permission
+	 */
+	List<RichGroup> getAllRichGroups(PerunSession sess) throws PrivilegeException;
+
+	/**
 	 * Get page of groups from the given vo.
 	 *
 	 * @param sess session

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/GroupsManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/GroupsManagerEntry.java
@@ -839,6 +839,23 @@ public class GroupsManagerEntry implements GroupsManager {
 	}
 
 	@Override
+	public List<RichGroup> getAllRichGroups(PerunSession sess) throws PrivilegeException {
+		return getAllRichGroups(sess, null);
+	}
+
+	@Override
+	public List<RichGroup> getAllRichGroups(PerunSession sess, List<String> attrNames) throws PrivilegeException {
+		Utils.checkPerunSession(sess);
+
+		if (!AuthzResolver.authorizedInternal(sess, "getAllRichGroups_policy")) {
+			throw new PrivilegeException("getAllRichGroups");
+		}
+
+		return groupsManagerBl
+			.convertGroupsToRichGroupsWithAttributes(sess, groupsManagerBl.getAllGroups(sess), attrNames);
+	}
+
+	@Override
 	public Paginated<RichGroup> getGroupsPage(PerunSession sess, Vo vo, GroupsPageQuery query, List<String> attrNames) throws VoNotExistsException, PrivilegeException {
 		Utils.checkPerunSession(sess);
 		perunBl.getVosManagerBl().checkVoExists(sess, vo);

--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -11480,6 +11480,20 @@ paths:
         default:
           $ref: '#/components/responses/ExceptionResponse'
 
+  /json/groupsManager/getAllRichGroups:
+    get:
+      tags:
+        - GroupsManager
+      operationId: getAllRichGroups
+      summary: Get all groups with their specified attributes. If the attrNames are null or empty, all group attributes are returned.
+      parameters:
+        - $ref: '#/components/parameters/attrNames'
+      responses:
+        '200':
+          $ref: '#/components/responses/ListOfRichGroupsResponse'
+        default:
+          $ref: '#/components/responses/ExceptionResponse'
+
   /json/groupsManager/getAllRichGroupsWithAttributesByNames:
     get:
       tags:

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/GroupsManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/GroupsManagerMethod.java
@@ -19,6 +19,7 @@ import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.Vo;
 import cz.metacentrum.perun.core.api.exceptions.NotGroupMemberException;
 import cz.metacentrum.perun.core.api.exceptions.PerunException;
+import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
 import cz.metacentrum.perun.rpc.ApiCaller;
 import cz.metacentrum.perun.rpc.ManagerMethod;
 import cz.metacentrum.perun.core.api.exceptions.RpcException;
@@ -769,6 +770,24 @@ public enum GroupsManagerMethod implements ManagerMethod {
 				return ac.getGroupsManager().getAllGroups(ac.getSession(), ac.getVoById(parms.readInt("vo")));
 			}
 			return ac.getGroupsManager().getAllGroups(ac.getSession());
+		}
+	},
+
+	/*#
+	 * Get all groups with their specified attributes. If the attrNames are null or empty,
+	 * all group attributes are returned.
+	 *
+	 * @param attrNames List<String> list of attribute names to get
+	 * @return List<RichGroup> list of all groups with specified attributes
+	 */
+	getAllRichGroups {
+		@Override
+		public List<RichGroup> call(ApiCaller ac, Deserializer params) throws PerunException {
+			List<String> attrNames = null;
+			if (params.contains("attrNames")) {
+				attrNames = params.readList("attrNames", String.class);
+			}
+			return ac.getGroupsManager().getAllRichGroups(ac.getSession(), attrNames);
 		}
 	},
 

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/GroupsManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/GroupsManagerMethod.java
@@ -19,7 +19,6 @@ import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.Vo;
 import cz.metacentrum.perun.core.api.exceptions.NotGroupMemberException;
 import cz.metacentrum.perun.core.api.exceptions.PerunException;
-import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
 import cz.metacentrum.perun.rpc.ApiCaller;
 import cz.metacentrum.perun.rpc.ManagerMethod;
 import cz.metacentrum.perun.core.api.exceptions.RpcException;


### PR DESCRIPTION
feat(openapi): add getAllRichGroups
* Added getAllRichGroups method to the OpenAPI specification.

feat(core): add getAllRichGroups method
* Added method which can be used to get all groups with their attributes.
The new method works
only for PERUNADMIN and PERUNOBSERVER.
This was done to improve the performance of the method.
