### PR TITLE
feat: address link to new pwd reset app in email message

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Utils.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Utils.java
@@ -88,6 +88,7 @@ import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
 import static cz.metacentrum.perun.core.impl.PerunAppsConfig.getBrandContainingDomain;
+import static cz.metacentrum.perun.core.impl.PerunAppsConfig.getInstance;
 import static cz.metacentrum.perun.core.impl.modules.attributes.urn_perun_entityless_attribute_def_def_identityAlertsTemplates.ALERT_TIME_FORMATTER;
 import static cz.metacentrum.perun.core.impl.modules.attributes.urn_perun_entityless_attribute_def_def_identityAlertsTemplates.DEFAULT_IDENTITY_ADDED_PREF_MAIL;
 import static cz.metacentrum.perun.core.impl.modules.attributes.urn_perun_entityless_attribute_def_def_identityAlertsTemplates.DEFAULT_IDENTITY_ADDED_PREF_MAIL_SUBJECT;
@@ -1137,8 +1138,31 @@ public class Utils {
 	 */
 	public static void sendPasswordResetEmail(User user, String email, String namespace, String url, UUID uuid, String messageTemplate, String subject, LocalDateTime validityTo) {
 		String instanceName = BeansUtils.getCoreConfig().getInstanceName();
+		String linkLocation = "/non/pwd-reset/";
 
-		String validationLink = prepareValidationLinkForPasswordResetAndAccountActivation(url, "/non/pwd-reset/", uuid, user, namespace, false);
+		try {
+			URL urlObject = new URL(url);
+			String domain = urlObject.getProtocol()+"://"+urlObject.getHost();
+			PerunAppsConfig.Brand brand = getBrandContainingDomain(domain);
+
+			if (brand != null) {
+				if (!brand.getOldGuiDomain().equals(domain) && brand.getNewApps().getPwdReset() != null && !brand.getNewApps().getPwdReset().isEmpty()) {
+					// change url to new pwd reset app
+					url = brand.getNewApps().getPwdReset();
+					linkLocation = "";
+				} else {
+					url = brand.getOldGuiDomain();
+				}
+			} else {
+				// if no brand contains specified domain, set default old gui domain
+				brand = getInstance().getBrands().get(0);
+				url = brand.getOldGuiDomain();
+			}
+		} catch (MalformedURLException ex) {
+			throw new InternalErrorException("Not valid URL of running Perun instance.", ex);
+		}
+
+		String validationLink = prepareValidationLinkForPasswordResetAndAccountActivation(url, linkLocation, uuid, user, namespace, false);
 		String validityToString = prepareValidityTo(validityTo);
 
 		String defaultSubject = "[" + instanceName + "] Password reset in namespace: " + namespace;

--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -9609,6 +9609,7 @@ paths:
         - $ref: '#/components/parameters/namespace'
         - { name: emailAttributeURN, schema: { type: string }, in: query, required: true, description: "urn of the attribute with stored mail" }
         - { name: language, schema: { type: string }, in: query, required: true, description: "language of the message" }
+        - { name: baseUrl, schema: { type: string }, in: query, required: false, description: "base url of Perun instance (optional)" }
       responses:
         '200':
           $ref: '#/components/responses/VoidResponse'


### PR DESCRIPTION
* If request comes from new gui (with correct base url in parameter) and new pwd reset app url is defined in configuration for specified brand, then this url will be used in the message.
* If request comes from new gui (with correct base url in parameter) and new pwd reset app url is `NOT` defined in configuration for specified brand, then will be used old pwd reset domain for this brand.
* If request comes from new gui (with `incorrect` base url in parameter), then will be used default old pwd reset url.
* If request comes from old gui and old pwd reset app url is defined for specified brand, than will be used this url.
* If request comes from old gui and old pwd reset app url is `NOT` defined for specified brand, than will be used default old pwd reset url.