### PR TITLE
fix(openapi): fix getGroupMemberRelations specs

### DIFF
--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -16338,7 +16338,7 @@ paths:
   #                                               #
   #################################################
 
-  /jsonsimple/integrationManager/getGroupMemberRelations:
+  /json/integrationManager/getGroupMemberRelations:
     get:
       tags:
         - IntegrationManager


### PR DESCRIPTION
* Method getGroupMemberRelations was using the `jsonsimple` serializer to improve the performance.
However, the response defined that the method returns objects of type Attribute, which has the
`beanname` property. This property was missing because of the `jsonsimple` serializer. The fix is to
user the `json` serializer so the beanname property is present in the Attribute objects.