### PR TITLE
fix(core): added uniqueness check to adGroupName

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_adGroupName.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_adGroupName.java
@@ -4,16 +4,25 @@ import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.ConsistencyErrorException;
+import cz.metacentrum.perun.core.api.exceptions.ParentGroupNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.GroupAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.GroupAttributesModuleImplApi;
 
+import java.util.List;
 import java.util.regex.Pattern;
 
 public class urn_perun_group_attribute_def_def_adGroupName extends GroupAttributesModuleAbstract implements GroupAttributesModuleImplApi {
 
 	private static final Pattern pattern = Pattern.compile("[A-Za-z0-9 _-]+");
+	private static final String A_R_D_AD_RESOURCE_REPRESENTATION = AttributesManager.NS_RESOURCE_ATTR_DEF + ":adResourceRepresentation";
+	private static final String A_G_D_AD_GROUP_NAME = AttributesManager.NS_GROUP_ATTR_DEF + ":adGroupName";
 
 	@Override
 	public void checkAttributeSyntax(PerunSessionImpl sess, Group group, Attribute attribute) throws WrongAttributeValueException {
@@ -23,6 +32,65 @@ public class urn_perun_group_attribute_def_def_adGroupName extends GroupAttribut
 		if (!pattern.matcher(attribute.valueAsString()).matches()) {
 			throw new WrongAttributeValueException(attribute, "Invalid attribute adGroupName value. It should contain only letters, digits, underscores, dashes or spaces.");
 		}
+	}
+
+	@Override
+	public void checkAttributeSemantics(PerunSessionImpl sess, Group group, Attribute attribute) throws WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
+		//Attribute can be null
+		if(attribute.getValue() == null) {
+			return;
+		}
+
+		List<Resource> assignedResources = sess.getPerunBl().getResourcesManagerBl().getAssignedResources(sess, group);
+
+		for (Resource assignedResource : assignedResources) {
+			try {
+				Attribute resourceAdRepresentation = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, assignedResource, A_R_D_AD_RESOURCE_REPRESENTATION);
+
+				if ("tree".equals(resourceAdRepresentation.valueAsString())) {
+					if (!groupHasUniqueName(sess, group, attribute)) {
+						throw new WrongReferenceAttributeValueException(attribute, "There already exists a group with the same name and same hierarchy!");
+					}
+
+					return;
+				}
+			} catch (AttributeNotExistsException e) {
+				//We can skip this case
+			}
+		}
+	}
+
+	/**
+	 * Checks uniqueness of adGroupName by comparing it to all adGroupNames of subgroups of parent group.
+	 *
+	 * @param sess perun session
+	 * @param group group
+	 * @param attribute attribute
+	 * @return true if the name is unique, false otherwise
+	 * @throws AttributeNotExistsException
+	 * @throws WrongAttributeAssignmentException
+	 */
+	private boolean groupHasUniqueName(PerunSessionImpl sess, Group group, Attribute attribute) throws AttributeNotExistsException, WrongAttributeAssignmentException {
+		if (group.getParentGroupId() != null) {
+			try {
+				Group parentGroup = sess.getPerunBl().getGroupsManagerBl().getParentGroup(sess, group);
+
+				List<Group> subGroups = sess.getPerunBl().getGroupsManagerBl().getSubGroups(sess, parentGroup);
+				subGroups.remove(group);
+
+				for (Group subGroup : subGroups) {
+					Attribute nameAttribute = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, subGroup, A_G_D_AD_GROUP_NAME);
+					String name = nameAttribute.valueAsString();
+					if (attribute.valueAsString().equals(name)) {
+						return false;
+					}
+				}
+			} catch (ParentGroupNotExistsException e) {
+				throw new ConsistencyErrorException(e);
+			}
+		}
+
+		return true;
 	}
 
 	@Override

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_adGroupNameTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_adGroupNameTest.java
@@ -2,26 +2,60 @@ package cz.metacentrum.perun.core.impl.modules.attributes;
 
 import cz.metacentrum.perun.core.AbstractPerunIntegrationTest;
 import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class urn_perun_group_attribute_def_def_adGroupNameTest extends AbstractPerunIntegrationTest {
 
+	private PerunSessionImpl sess;
 	private urn_perun_group_attribute_def_def_adGroupName classInstance;
 	private Attribute attributeToCheck;
+	private Attribute requiredAttribute;
+	private Attribute requiredAttribute2;
 	private Group group;
+	private Group parentGroup;
+	private Group subGroup;
+	private Resource resource;
+
+	private static final String A_R_D_AD_RESOURCE_REPRESENTATION = AttributesManager.NS_RESOURCE_ATTR_DEF + ":adResourceRepresentation";
+	private static final String A_G_D_AD_GROUP_NAME = AttributesManager.NS_GROUP_ATTR_DEF + ":adGroupName";
 
 	@Before
 	public void setUp() throws Exception {
 		classInstance = new urn_perun_group_attribute_def_def_adGroupName();
 		attributeToCheck = new Attribute();
-		group = new Group();
+		requiredAttribute = new Attribute();
+		requiredAttribute2 = new Attribute();
+		parentGroup = new Group("parentGroupTest", "parentGroupTest");
+		group = new Group(0,"groupTest", "groupTest");
+		subGroup = new Group(0, "subgroupTest", "subgroupTest");
+		resource = new Resource();
 
+		sess = mock(PerunSessionImpl.class, RETURNS_DEEP_STUBS);
+
+		List<Group> subgroups = new ArrayList<>();
+		subgroups.add(group);
+		subgroups.add(subGroup);
+
+		when(sess.getPerunBl().getResourcesManagerBl().getAssignedResources(sess, group)).thenReturn(List.of(resource));
+		when(sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, resource, A_R_D_AD_RESOURCE_REPRESENTATION)).thenReturn(requiredAttribute);
+		when(sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, subGroup, A_G_D_AD_GROUP_NAME)).thenReturn(requiredAttribute2);
+		when(sess.getPerunBl().getGroupsManagerBl().getSubGroups(sess, parentGroup)).thenReturn(subgroups);
+		when(sess.getPerunBl().getGroupsManagerBl().getParentGroup(sess, group)).thenReturn(parentGroup);
 	}
 
 	@Test(expected = WrongAttributeValueException.class)
@@ -29,7 +63,7 @@ public class urn_perun_group_attribute_def_def_adGroupNameTest extends AbstractP
 		System.out.println("testWrongSyntax()");
 		attributeToCheck.setValue("bad@value");
 
-		classInstance.checkAttributeSyntax((PerunSessionImpl) sess, group, attributeToCheck);
+		classInstance.checkAttributeSyntax(sess, group, attributeToCheck);
 	}
 
 	@Test
@@ -38,7 +72,7 @@ public class urn_perun_group_attribute_def_def_adGroupNameTest extends AbstractP
 		attributeToCheck.setValue("correctValue");
 
 		assertThatNoException().isThrownBy(
-			() -> classInstance.checkAttributeSyntax((PerunSessionImpl) sess, group, attributeToCheck));
+			() -> classInstance.checkAttributeSyntax(sess, group, attributeToCheck));
 	}
 
 	@Test
@@ -47,6 +81,38 @@ public class urn_perun_group_attribute_def_def_adGroupNameTest extends AbstractP
 		attributeToCheck.setValue("correct-Value-with-Dash");
 
 		assertThatNoException().isThrownBy(
-			() -> classInstance.checkAttributeSyntax((PerunSessionImpl) sess, group, attributeToCheck));
+			() -> classInstance.checkAttributeSyntax(sess, group, attributeToCheck));
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testSemanticsNameAlreadyTaken() throws Exception {
+		System.out.println("testSemanticsNameAlreadyTaken()");
+		attributeToCheck.setValue("name");
+		requiredAttribute.setValue("tree");
+		requiredAttribute2.setValue("name");
+
+		classInstance.checkAttributeSemantics(sess, group, attributeToCheck);
+	}
+
+	@Test
+	public void testSemanticsResourceAttrNotTree() throws Exception {
+		System.out.println("testSemanticsResourceAttrNotTree()");
+		attributeToCheck.setValue("name");
+		requiredAttribute.setValue("");
+		requiredAttribute2.setValue("name");
+
+		assertThatNoException().isThrownBy(
+			() -> classInstance.checkAttributeSemantics(sess, group, attributeToCheck));
+	}
+
+	@Test
+	public void testSemanticsCorrect() throws Exception {
+		System.out.println("testSemanticsCorrect()");
+		attributeToCheck.setValue("name");
+		requiredAttribute.setValue("tree");
+		requiredAttribute2.setValue("name2");
+
+		assertThatNoException().isThrownBy(
+			() -> classInstance.checkAttributeSemantics(sess, group, attributeToCheck));
 	}
 }


### PR DESCRIPTION
* added checkAttributeSemantics to adGroupName module that prevents
using already used adGroupName on the same level in group hierarchy