### PR TITLE
fix(core): use correct bean name

### DIFF
--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/ApiCaller.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/ApiCaller.java
@@ -443,7 +443,7 @@ public class ApiCaller {
 		// Initialize Notifications
 		this.notificationManager = WebApplicationContextUtils.getWebApplicationContext(context).getBean("perunNotifNotificationManager", PerunNotifNotificationManager.class);
 
-		this.integrationManagerApi = WebApplicationContextUtils.getWebApplicationContext(context).getBean("integrationManager", IntegrationManagerApi.class);
+		this.integrationManagerApi = WebApplicationContextUtils.getWebApplicationContext(context).getBean("integrationManagerApi", IntegrationManagerApi.class);
 		// Initialize SCIM Manager
 		this.scimManager = new SCIM();
 


### PR DESCRIPTION
* The bean name for integrationManagerApi was changed but in the ApiCaller, it wasn't updated.
Therefore, the RPC failed to start.