### PR TITLE
feat(registrar): add new delayed group application notification

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/registrar/model/ApplicationMail.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/registrar/model/ApplicationMail.java
@@ -48,6 +48,12 @@ public class ApplicationMail {
 		APP_CREATED_USER,
 
 		/**
+		 * Notification for user when group application is created and it can be approved
+		 * (when the user becomes member in VO).
+		 */
+		APPROVABLE_GROUP_APP_USER,
+
+		/**
 		 * Notification to VO administrator when application is created
 		 */
 		APP_CREATED_VO_ADMIN,

--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -908,6 +908,7 @@ components:
       type: string
       enum:
         - APP_CREATED_USER
+        - APPROVABLE_GROUP_APP_USER
         - APP_CREATED_VO_ADMIN
         - MAIL_VALIDATION
         - APP_APPROVED_USER

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/MailManagerImpl.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/MailManagerImpl.java
@@ -32,7 +32,6 @@ import cz.metacentrum.perun.core.bl.GroupsManagerBl;
 import cz.metacentrum.perun.core.bl.MembersManagerBl;
 import cz.metacentrum.perun.core.bl.UsersManagerBl;
 import cz.metacentrum.perun.core.blImpl.AuthzResolverBlImpl;
-import cz.metacentrum.perun.core.impl.Compatibility;
 import cz.metacentrum.perun.registrar.exceptions.ApplicationMailAlreadyRemovedException;
 import cz.metacentrum.perun.registrar.exceptions.ApplicationMailExistsException;
 import cz.metacentrum.perun.registrar.exceptions.ApplicationMailNotExistsException;
@@ -414,6 +413,9 @@ public class MailManagerImpl implements MailManager {
 				case APP_CREATED_USER:
 					sendUserMessage(app, mail, data, reason, exceptions, MailType.APP_CREATED_USER);
 					break;
+				case APPROVABLE_GROUP_APP_USER:
+					sendUserMessage(app, mail, data, reason, exceptions, MailType.APPROVABLE_GROUP_APP_USER);
+					break;
 				case APP_CREATED_VO_ADMIN:
 					appCreatedVoAdmin(app, mail, data, reason, exceptions);
 					break;
@@ -471,6 +473,7 @@ public class MailManagerImpl implements MailManager {
 
 			switch (mailType) {
 				case APP_CREATED_USER:
+				case APPROVABLE_GROUP_APP_USER:
 				case APP_CREATED_VO_ADMIN: {
 					if (app.getState().equals(Application.AppState.NEW) || app.getState().equals(Application.AppState.VERIFIED)) {
 						sendMessage(app, mailType, null, null);

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
@@ -4393,6 +4393,7 @@ public class RegistrarManagerImpl implements RegistrarManager {
 
 		if (member.getStatus().equals(Status.VALID) || member.getStatus().equals(Status.INVALID)) {
 			getMailManager().sendMessage(application, MailType.APP_CREATED_VO_ADMIN, null, null);
+			getMailManager().sendMessage(application, MailType.APPROVABLE_GROUP_APP_USER, null, null);
 		}
 	}
 
@@ -4406,6 +4407,18 @@ public class RegistrarManagerImpl implements RegistrarManager {
 	 */
 	private void processNotificationsAfterCreation(PerunSession session, Application application, List<Exception> exceptions) {
 		getMailManager().sendMessage(application, MailType.APP_CREATED_USER, null, null);
+
+		// Send APPROVABLE_GROUP_APP_USER notifications if possible (if user is already VO member)
+		if (application.getUser() != null && application.getGroup() != null) {
+			try {
+				Member member = perun.getMembersManagerBl().getMemberByUser(session, application.getVo(), application.getUser());
+				if (member.getStatus().equals(Status.VALID) || member.getStatus().equals(Status.INVALID)) {
+					getMailManager().sendMessage(application, MailType.APPROVABLE_GROUP_APP_USER, null, null);
+				}
+			} catch (MemberNotExistsException e) {
+				// Means that we do not send notification to user yet
+			}
+		}
 
 		if (!exceptions.isEmpty()) {
 			// If there were errors, send the notification immediately to admins


### PR DESCRIPTION
- Added new notification for users when their group application is
created and it can be approved (after the user becomes member in VO).
- When the notification is to be manually resend, it's not checked if
the user is member in VO.