### PR TITLE
fix(core): allow duplicates in user identities for the same user

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace_einfraid_persistent_shadow.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace_einfraid_persistent_shadow.java
@@ -1,6 +1,16 @@
 package cz.metacentrum.perun.core.impl.modules.attributes;
 
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.ExtSource;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.UserExtSource;
+import cz.metacentrum.perun.core.api.exceptions.ExtSourceNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.UserExtSourceExistsException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.UserPersistentShadowAttribute;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Class for checking logins uniqueness in the namespace and filling einfraid-persistent id.
@@ -8,10 +18,12 @@ import cz.metacentrum.perun.core.implApi.modules.attributes.UserPersistentShadow
  *
  * @author Pavel Zlámal <zlamal@cesnet.cz>
  */
-public class urn_perun_user_attribute_def_def_login_namespace_einfraid_persistent_shadow
-		extends UserPersistentShadowAttribute {
+public class urn_perun_user_attribute_def_def_login_namespace_einfraid_persistent_shadow extends UserPersistentShadowAttribute {
+
+	private final static Logger log = LoggerFactory.getLogger(urn_perun_user_attribute_def_def_login_namespace_einfraid_persistent_shadow.class);
 
 	private final static String extSourceNameEinfraid = "https://login.cesnet.cz/idp/";
+	private final static String extSourceNameEinfraCZ = "https://login.e-infra.cz/idp/";
 	private final static String domainNameEinfraid = "einfra.cesnet.cz";
 	private final static String attrNameEinfraid = "login-namespace:einfraid-persistent-shadow";
 
@@ -44,4 +56,38 @@ public class urn_perun_user_attribute_def_def_login_namespace_einfraid_persisten
 	public String getFriendlyNameParameter() {
 		return "einfraid-persistent-shadow";
 	}
+
+	/**
+	 * ChangedAttributeHook() sets UserExtSource with following properties:
+	 *  - extSourceType is IdP
+	 *  - extSourceName is {getExtSourceName()}
+	 *  - user's extSource login is the same as his persistent attribute
+	 */
+	@Override
+	public void changedAttributeHook(PerunSessionImpl session, User user, Attribute attribute) {
+		try {
+
+			// create default identity based on module configuration
+			super.changedAttributeHook(session, user, attribute);
+
+			// duplicate logic for e-INFRA CZ proxy identity
+			String userNamespace = attribute.getFriendlyNameParameter();
+
+			if(userNamespace.equals(getFriendlyNameParameter()) && attribute.getValue() != null){
+				ExtSource extSource = session.getPerunBl()
+						.getExtSourcesManagerBl()
+						.getExtSourceByName(session, extSourceNameEinfraCZ);
+				UserExtSource userExtSource = new UserExtSource(extSource, 0, attribute.getValue().toString());
+
+				session.getPerunBl().getUsersManagerBl().addUserExtSource(session, user, userExtSource);
+			}
+
+		} catch (UserExtSourceExistsException ex) {
+			log.warn("Attribute: {}, External source already exists for the user.", getFriendlyNameParameter(), ex);
+		} catch (ExtSourceNotExistsException ex) {
+			throw new InternalErrorException("Attribute: " + getFriendlyNameParameter() +
+					", IdP external source doesn't exist.", ex);
+		}
+	}
+
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_eduPersonPrincipalNames.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_eduPersonPrincipalNames.java
@@ -6,14 +6,15 @@ import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.ExtSourcesManager;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.UserExtSource;
-import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.SkipValueCheckDuringDependencyCheck;
 import cz.metacentrum.perun.core.implApi.modules.attributes.UserVirtualAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.UserVirtualAttributesModuleImplApi;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -29,7 +30,9 @@ public class urn_perun_user_attribute_def_virt_eduPersonPrincipalNames extends U
 
 	@Override
 	public Attribute getAttributeValue(PerunSessionImpl sess, User user, AttributeDefinition attributeDefinition) {
-		List<String> idpLogins = new ArrayList<>();
+
+		// prevent duplicate entries in EPPN
+		Set<String> idpLogins = new HashSet<>();
 		List<UserExtSource> userExtSources = sess.getPerunBl().getUsersManagerBl().getUserExtSources(sess, user);
 
 		for(UserExtSource uES: userExtSources) {
@@ -48,7 +51,7 @@ public class urn_perun_user_attribute_def_virt_eduPersonPrincipalNames extends U
 		}
 
 		Attribute attribute = new Attribute(attributeDefinition);
-		attribute.setValue(idpLogins);
+		attribute.setValue(new ArrayList<>(idpLogins));
 		return attribute;
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_login_namespace_einfraid_persistent.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_login_namespace_einfraid_persistent.java
@@ -28,23 +28,23 @@ public class urn_perun_user_attribute_def_virt_login_namespace_einfraid_persiste
 
 	@Override
 	public Attribute getAttributeValue(PerunSessionImpl sess, User user, AttributeDefinition attributeDefinition) {
-		Attribute elixirPersistent = new Attribute(attributeDefinition);
+		Attribute einfraPersistent = new Attribute(attributeDefinition);
 
 		try {
-			Attribute elixirPersistentShadow = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, user, SHADOW);
+			Attribute einfraPersistentShadow = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, user, SHADOW);
 
-			if (elixirPersistentShadow.getValue() == null) {
+			if (einfraPersistentShadow.getValue() == null) {
 
-				elixirPersistentShadow = sess.getPerunBl().getAttributesManagerBl().fillAttribute(sess, user, elixirPersistentShadow);
+				einfraPersistentShadow = sess.getPerunBl().getAttributesManagerBl().fillAttribute(sess, user, einfraPersistentShadow);
 
-				if (elixirPersistentShadow.getValue() == null) {
+				if (einfraPersistentShadow.getValue() == null) {
 					throw new InternalErrorException("Einfra ID couldn't be set automatically");
 				}
-				sess.getPerunBl().getAttributesManagerBl().setAttribute(sess, user, elixirPersistentShadow);
+				sess.getPerunBl().getAttributesManagerBl().setAttribute(sess, user, einfraPersistentShadow);
 			}
 
-			elixirPersistent.setValue(elixirPersistentShadow.getValue());
-			return elixirPersistent;
+			einfraPersistent.setValue(einfraPersistentShadow.getValue());
+			return einfraPersistent;
 
 		} catch (WrongAttributeAssignmentException | WrongAttributeValueException | WrongReferenceAttributeValueException | AttributeNotExistsException e) {
 			throw new InternalErrorException(e);

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/UsersManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/UsersManagerEntryIntegrationTest.java
@@ -470,7 +470,7 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 		}
 	}
 
-	@Test (expected=InternalErrorException.class)
+	@Test
 	public void addIDPExtSourcesWithSameLogin() throws Exception {
 		System.out.println(CLASS_NAME + "addIDPExtSourcesWithSameLogin");
 
@@ -483,9 +483,52 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 		UserExtSource ues1 = new UserExtSource(ext1, 1, "testExtLogin@test");
 		UserExtSource ues2 = new UserExtSource(ext2, 1, "testExtLogin@test");
 
-
+		// should be allowed since user is the same
 		usersManager.addUserExtSource(sess, user, ues1);
 		usersManager.addUserExtSource(sess, user, ues2);
+
+	}
+
+	@Test
+	public void addIDPExtSourcesWithSameLoginFailing() throws Exception {
+		System.out.println(CLASS_NAME + "addIDPExtSourcesWithSameLoginFailing");
+
+		ExtSource ext1 = new ExtSource("test1", ExtSourcesManagerEntry.EXTSOURCE_IDP);
+		ExtSource ext2 = new ExtSource("test2", ExtSourcesManagerEntry.EXTSOURCE_IDP);
+		ExtSource ext3 = new ExtSource("test3", ExtSourcesManagerEntry.EXTSOURCE_IDP);
+
+		ext1 = perun.getExtSourcesManagerBl().createExtSource(sess, ext1, null);
+		ext2 = perun.getExtSourcesManagerBl().createExtSource(sess, ext2, null);
+		ext3 = perun.getExtSourcesManagerBl().createExtSource(sess, ext3, null);
+
+		UserExtSource ues1 = new UserExtSource(ext1, 1, "testExtLogin@test");
+		UserExtSource ues2 = new UserExtSource(ext2, 1, "testExtLogin@test");
+		UserExtSource ues3 = new UserExtSource(ext3, 1, "testExtLogin@test");
+
+		// should fail since we allow only 2 duplicates for same user
+		usersManager.addUserExtSource(sess, user, ues1);
+		usersManager.addUserExtSource(sess, user, ues2);
+		usersManager.addUserExtSource(sess, user, ues3);
+
+	}
+
+	@Test (expected=InternalErrorException.class)
+	public void addIDPExtSourcesWithSameLoginDifferentUser() throws Exception {
+		System.out.println(CLASS_NAME + "addIDPExtSourcesWithSameLoginDifferentUser");
+
+		ExtSource ext1 = new ExtSource("test1", ExtSourcesManagerEntry.EXTSOURCE_IDP);
+		ExtSource ext2 = new ExtSource("test2", ExtSourcesManagerEntry.EXTSOURCE_IDP);
+
+		ext1 = perun.getExtSourcesManagerBl().createExtSource(sess, ext1, null);
+		ext2 = perun.getExtSourcesManagerBl().createExtSource(sess, ext2, null);
+
+		UserExtSource ues1 = new UserExtSource(ext1, 1, "testExtLogin@test");
+		UserExtSource ues2 = new UserExtSource(ext2, 1, "testExtLogin@test");
+
+		// should fail since there are different users
+		usersManager.addUserExtSource(sess, user, ues1);
+		usersManager.addUserExtSource(sess, sponsoredUser, ues2);
+
 	}
 
 	@Test


### PR DESCRIPTION
- We need to support two identities with same login (eppn) from IdP
  (identity for proxy). As we don't want to allow duplicates globally,
  only 2 duplicates and for the same user are allowed.
- Updated module for einfraid persistent shadow login, we will generate identity
  for both proxies using the same attribute (login) value.
- Ensure uniqueness when returning value of user:virt:eduPersonPrincipalNames.
- Fixed variable naming in module user:virt:login-namespace:einfraif_persistent
  from elixir to einfra.
- Added tests for updated IdP identities logic.