### PR TITLE
fix(core): when creating sponsored accounts return correctly duplicat…

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/MembersManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/MembersManager.java
@@ -1217,13 +1217,14 @@ public interface MembersManager {
 	/**
 	 * Creates new sponsored members using input from CSV file.
 	 *
-	 * Since there may be error while creating some of the members and we cannot simply rollback the transaction and
-	 * start over, exceptions during member creation are not thrown and the returned map has this structure:
+	 * Since there may be error while creating some of the members and we cannot simply rollback the transaction and start over,
+	 * exceptions during member creation are not thrown and the returned list has this structure:
 	 *
-	 * name -> {"status" -> "OK" or "Error...", "login" -> login, "password" -> password}
+	 * [{"name" -> name, "status" -> "OK" or "Error...", "login" -> login, "password" -> password}]
 	 *
-	 * Keys are names given to this method and values are maps containing keys "status", "login" and "password".
+	 * Each list element represents member as map containing keys "name", "status", "login" and "password".
 	 * "status" has as its value either "OK" or message of exception which was thrown during creation of the member.
+	 * "name" contains full entry as received (e.g. first name; last name; email),
 	 * "login" contains login (e.g. učo) if status is OK, "password" contains password if status is OK.
 	 *
 	 * @param sess perun session
@@ -1239,10 +1240,10 @@ public interface MembersManager {
 	 *                           to email which was set for him, be careful when using no-reply emails
 	 * @param url base URL of Perun Instance
 	 * @param groups groups, to which will be the created users assigned
-	 * @return map of names to map of status, login and password
+	 * @return list of maps of name, status, login and password
 	 * @throws PrivilegeException insufficient permissions
 	 */
-	Map<String, Map<String, String>> createSponsoredMembersFromCSV(PerunSession sess, Vo vo, String namespace,
+	List<Map<String, String>> createSponsoredMembersFromCSV(PerunSession sess, Vo vo, String namespace,
 	                                                               List<String> data, String header, User sponsor,
 	                                                               LocalDate validityTo, boolean sendActivationLink,
 																   String url, List<Group> groups) throws PrivilegeException;
@@ -1251,12 +1252,13 @@ public interface MembersManager {
 	 * Creates new sponsored Members (with random generated passwords).
 	 *
 	 * Since there may be error while creating some of the members and we cannot simply rollback the transaction and start over,
-	 * exceptions during member creation are not thrown and the returned map has this structure:
+	 * exceptions during member creation are not thrown and the returned list has this structure:
 	 *
-	 * name -> {"status" -> "OK" or "Error...", "login" -> login, "password" -> password}
+	 * [{"name" -> name, "status" -> "OK" or "Error...", "login" -> login, "password" -> password}]
 	 *
-	 * Keys are names given to this method and values are maps containing keys "status", "login" and "password".
+	 * Each list element represents member as map containing keys "name", "status", "login" and "password".
 	 * "status" has as its value either "OK" or message of exception which was thrown during creation of the member.
+	 * "name" contains full entry as received (e.g. first name; last name; email),
 	 * "login" contains login (e.g. učo) if status is OK, "password" contains password if status is OK.
 	 *
 	 * @param session perun session
@@ -1271,10 +1273,10 @@ public interface MembersManager {
 	 * @param sendActivationLink if true link for manual activation of every created sponsored member account will be send
 	 *                           to the email, be careful when using with empty (no-reply) email
 	 * @param url base URL of Perun Instance
-	 * @return map of names to map of status, login and password
+	 * @return list of maps of name, status, login and password
 	 * @throws PrivilegeException
 	 */
-	Map<String, Map<String, String>> createSponsoredMembers(PerunSession session, Vo vo, String namespace, List<String> names, String email, User sponsor, LocalDate validityTo, boolean sendActivationLink, String url) throws PrivilegeException;
+	List<Map<String, String>> createSponsoredMembers(PerunSession session, Vo vo, String namespace, List<String> names, String email, User sponsor, LocalDate validityTo, boolean sendActivationLink, String url) throws PrivilegeException;
 
 	/**
 	 * Transform non-sponsored member to sponsored one with defined sponsor

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/MembersManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/MembersManagerBl.java
@@ -1546,13 +1546,14 @@ public interface MembersManagerBl {
 	/**
 	 * Creates new sponsored members.
 	 *
-	 * Since there may be error while creating some of the members and we cannot simply rollback the transaction and
-	 * start over, exceptions during member creation are not thrown and the returned map has this structure:
+	 * Since there may be error while creating some of the members and we cannot simply rollback the transaction and start over,
+	 * exceptions during member creation are not thrown and the returned list has this structure:
 	 *
-	 * name -> {"status" -> "OK" or "Error...", "login" -> login, "password" -> password}
+	 * [{"name" -> name, "status" -> "OK" or "Error...", "login" -> login, "password" -> password}]
 	 *
-	 * Keys are names given to this method and values are maps containing keys "status", "login" and "password".
+	 * Each list element represents member as map containing keys "name", "status", "login" and "password".
 	 * "status" has as its value either "OK" or message of exception which was thrown during creation of the member.
+	 * "name" contains full entry as received (e.g. first name; last name; email),
 	 * "login" contains login (e.g. učo) if status is OK, "password" contains password if status is OK.
 	 *
 	 * @param sess perun session
@@ -1569,9 +1570,9 @@ public interface MembersManagerBl {
 	 * @param url base URL of Perun Instance
 	 * @param validation Type of members validation, when ASYNC do not call this method in a cycle!
 	 * @param groups groups, to which will be the created users assigned
-	 * @return map of names to map of status, login, password, user and member
+	 * @return list of maps of name, status, login and password
 	 */
-	Map<String, Map<String, String>> createSponsoredMembersFromCSV(PerunSession sess, Vo vo, String namespace,
+	List<Map<String, String>> createSponsoredMembersFromCSV(PerunSession sess, Vo vo, String namespace,
 	                                                               List<String> data, String header, User sponsor,
 	                                                               LocalDate validityTo, boolean sendActivationLink,
 																   String url, Validation validation, List<Group> groups);
@@ -1580,12 +1581,13 @@ public interface MembersManagerBl {
 	 * Creates new sponsored members.
 	 *
 	 * Since there may be error while creating some of the members and we cannot simply rollback the transaction and start over,
-	 * exceptions during member creation are not thrown and the returned map has this structure:
+	 * exceptions during member creation are not thrown and the returned list has this structure:
 	 *
-	 * name -> {"status" -> "OK" or "Error...", "login" -> login, "password" -> password}
+	 * [{"name" -> name, "status" -> "OK" or "Error...", "login" -> login, "password" -> password}]
 	 *
-	 * Keys are names given to this method and values are maps containing keys "status", "login" and "password".
+	 * Each list element represents member as map containing keys "name", "status", "login" and "password".
 	 * "status" has as its value either "OK" or message of exception which was thrown during creation of the member.
+	 * "name" contains full entry as received (e.g. first name; last name; email),
 	 * "login" contains login (e.g. učo) if status is OK, "password" contains password if status is OK.
 	 *
 	 * @param session perun session
@@ -1600,9 +1602,9 @@ public interface MembersManagerBl {
 	 *                           to the email, be careful when using with empty (no-reply) email
 	 * @param url base URL of Perun Instance
 	 * @param validation Type of members validation, when ASYNC do not call this method in a cycle!
-	 * @return map of names to map of status, login, password
+	 * @return list of maps of name, status, login and password
 	 */
-	Map<String, Map<String, String>> createSponsoredMembers(PerunSession session, Vo vo, String namespace, List<String> names, String email, User sponsor, LocalDate validityTo, boolean sendActivationLink, String url, Validation validation);
+	List<Map<String, String>> createSponsoredMembers(PerunSession session, Vo vo, String namespace, List<String> names, String email, User sponsor, LocalDate validityTo, boolean sendActivationLink, String url, Validation validation);
 
 	/**
 	 * Links sponsored member and sponsoring user.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/MembersManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/MembersManagerEntry.java
@@ -1300,7 +1300,7 @@ public class MembersManagerEntry implements MembersManager {
 	}
 
 	@Override
-	public Map<String, Map<String, String>> createSponsoredMembersFromCSV(PerunSession sess, Vo vo, String namespace,
+	public List<Map<String, String>> createSponsoredMembersFromCSV(PerunSession sess, Vo vo, String namespace,
 			List<String> data, String header, User sponsor, LocalDate validityTo, boolean sendActivationLink,
 			String url, List<Group> groups) throws PrivilegeException {
 		Utils.checkPerunSession(sess);
@@ -1331,7 +1331,7 @@ public class MembersManagerEntry implements MembersManager {
 	}
 
 	@Override
-	public Map<String, Map<String, String>> createSponsoredMembers(PerunSession session, Vo vo, String namespace, List<String> names, String email, User sponsor, LocalDate validityTo, boolean sendActivationLink, String url) throws PrivilegeException {
+	public List<Map<String, String>> createSponsoredMembers(PerunSession session, Vo vo, String namespace, List<String> names, String email, User sponsor, LocalDate validityTo, boolean sendActivationLink, String url) throws PrivilegeException {
 		Utils.checkPerunSession(session);
 		Utils.notNull(vo, "vo");
 		Utils.notNull(namespace, "namespace");

--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -1372,6 +1372,17 @@ components:
               additionalProperties:
                 type: string
 
+    ListOfMapStringStringResponse:
+      description: "returns List<Map<String,String>>"
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              type: object
+              additionalProperties:
+                type: string
+
     UserResponse:
       description: returns User
       content:
@@ -9246,7 +9257,7 @@ paths:
       summary: Creates new sponsored members in a given VO and namespace.
       responses:
         '200':
-          $ref: '#/components/responses/MapStringMapStringStringResponse'
+          $ref: '#/components/responses/ListOfMapStringStringResponse'
         default:
           $ref: '#/components/responses/ExceptionResponse'
       requestBody:
@@ -9281,7 +9292,7 @@ paths:
       summary: Creates new sponsored members in a given VO and namespace.
       responses:
         '200':
-          $ref: '#/components/responses/MapStringMapStringStringResponse'
+          $ref: '#/components/responses/ListOfMapStringStringResponse'
         default:
           $ref: '#/components/responses/ExceptionResponse'
       requestBody:

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/MembersManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/MembersManagerMethod.java
@@ -326,12 +326,13 @@ public enum MembersManagerMethod implements ManagerMethod {
 	 * If the sponsor is not specified, the current principal becomes the SPONSOR, if he has such privileges.
 	 *
 	 * Since there may be error while creating some of the members and we cannot simply rollback the transaction and
-	 * start over, exceptions during member creation are not thrown and the returned map has this structure:
+	 * start over, exceptions during member creation are not thrown and the returned list has this structure:
 	 *
-	 * name -> {"status" -> "OK" or "Error...", "login" -> login, "password" -> password}
+	 * [{"name" -> name, "status" -> "OK" or "Error...", "login" -> login, "password" -> password}]
 	 *
-	 * Keys are names given to this method and values are maps containing keys "status", "login" and "password".
+	 * Each list element represents member as map containing keys "name", "status", "login" and "password".
 	 * "status" has as its value either "OK" or message of exception which was thrown during creation of the member.
+	 * "name" contains full entry as received (e.g. first name; last name; email),
 	 * "login" contains login (e.g. učo) if status is OK, "password" contains password if status is OK.
 	 *
 	 * @param data List<String> csv file values separated by semicolon ';' characters
@@ -348,11 +349,11 @@ public enum MembersManagerMethod implements ManagerMethod {
 	 *                           account will be send to the email (can't be used with empty email parameter), default is false
 	 *                           If set to true, a non-empty namespace has to be provided.
 	 * @param groups int[] group ids, to which will be the created users assigned (has to be from the given vo)
-	 * @return Map<String, Map<String, String> newly created sponsored member, their password and status of creation
+	 * @return List<Map<String, String>> newly created sponsored member, their password and status of creation
 	 */
 	createSponsoredMembersFromCSV {
 		@Override
-		public Map<String, Map<String, String>> call(ApiCaller ac, Deserializer params) throws PerunException {
+		public List<Map<String, String>> call(ApiCaller ac, Deserializer params) throws PerunException {
 			params.stateChangingCheck();
 			Vo vo =  ac.getVoById(params.readInt("vo"));
 			String namespace = null;
@@ -404,12 +405,13 @@ public enum MembersManagerMethod implements ManagerMethod {
 	 * or by a user with role REGISTRAR that must specify the sponsoring user using ID.
 	 *
 	 * Since there may be error while creating some of the members and we cannot simply rollback the transaction and start over,
-	 * exceptions during member creation are not thrown and the returned map has this structure:
+	 * exceptions during member creation are not thrown and the returned list has this structure:
 	 *
-	 * name -> {"status" -> "OK" or "Error...", "login" -> login, "password" -> password}
+	 * [{"name" -> name, "status" -> "OK" or "Error...", "login" -> login, "password" -> password}]
 	 *
-	 * Keys are names given to this method and values are maps containing keys "status", "login" and "password".
+	 * Each list element represents member as map containing keys "name", "status", "login" and "password".
 	 * "status" has as its value either "OK" or message of exception which was thrown during creation of the member.
+	 * "name" contains full entry as received (e.g. first name; last name; email),
 	 * "login" contains login (e.g. učo) if status is OK, "password" contains password if status is OK.
 	 *
 	 * @param guestNames List<String> names of members to create, single name should have the format
@@ -422,11 +424,11 @@ public enum MembersManagerMethod implements ManagerMethod {
 	 * @param sendActivationLink (optional) boolean if true link for manual activation of every created sponsored member account will be send
 	 *                           to the email, be careful when using with empty (no-reply) email, default is false
 	 * @param validityTo (Optional) String the last day, when the sponsorship is active, yyyy-mm-dd format.
-	 * @return Map<String, Map<String, String> newly created sponsored member, their password and status of creation
+	 * @return List<Map<String, String>> newly created sponsored member, their password and status of creation
 	 */
 	createSponsoredMembers {
 		@Override
-		public Map<String, Map<String, String>> call(ApiCaller ac, Deserializer params) throws PerunException {
+		public List<Map<String, String>> call(ApiCaller ac, Deserializer params) throws PerunException {
 			params.stateChangingCheck();
 			Vo vo =  ac.getVoById(params.readInt("vo"));
 			String namespace = params.readString("namespace");


### PR DESCRIPTION
…ed entries

* when creating sponsored accounts, unique entries (input lines) were expected and used as key in a map structure
* identical entries (e.g. same names) would create distinct accounts, but would not return both accounts data from method
* changing structure from map to list will fix the problem