### PR TITLE
fix(core): rename richGroup attributes set/getters back

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/RichGroup.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/RichGroup.java
@@ -10,7 +10,7 @@ import java.util.Objects;
  */
 public class RichGroup extends Group {
 
-	private List<Attribute> groupAttributes;
+	private List<Attribute> attributes;
 
 	public RichGroup() {
 	}
@@ -23,15 +23,15 @@ public class RichGroup extends Group {
 				group.getModifiedByUid());
 		this.setVoId(group.getVoId());
 		this.setUuid(group.getUuid());
-		this.groupAttributes = attrs;
+		this.attributes = attrs;
 	}
 
-	public List<Attribute> getGroupAttributes() {
-		return this.groupAttributes;
+	public List<Attribute> getAttributes() {
+		return this.attributes;
 	}
 
-	public void setGroupAttributes(List<Attribute> groupAttributes) {
-		this.groupAttributes = groupAttributes;
+	public void setAttributes(List<Attribute> attributes) {
+		this.attributes = attributes;
 	}
 
 	@Override
@@ -54,7 +54,7 @@ public class RichGroup extends Group {
 		ret.append("', voId='");
 		ret.append(this.getVoId());
 		ret.append("', groupAttributes='");
-		ret.append(this.getGroupAttributes());
+		ret.append(this.getAttributes());
 		ret.append("']");
 		return ret.toString();
 	}
@@ -67,7 +67,7 @@ public class RichGroup extends Group {
 		List<String> nAttrs = new ArrayList<>();
 
 		// serialize group attributes
-		List<Attribute> oAttrs = this.getGroupAttributes();
+		List<Attribute> oAttrs = this.getAttributes();
 		if (oAttrs == null) {
 			sGroupAttrs = "\\0";
 		} else {
@@ -92,7 +92,7 @@ public class RichGroup extends Group {
 	@Override
 	public int hashCode() {
 		int hash = 5;
-		hash = 53 * hash + Objects.hashCode(this.groupAttributes);
+		hash = 53 * hash + Objects.hashCode(this.attributes);
 		return hash;
 	}
 
@@ -111,11 +111,11 @@ public class RichGroup extends Group {
 		if (getId() != other.getId()) {
 			return false;
 		}
-		if (groupAttributes == null) {
-			if (other.getGroupAttributes() != null) {
+		if (attributes == null) {
+			if (other.getAttributes() != null) {
 				return false;
 			}
-		} else if (!this.getGroupAttributes().equals(other.getGroupAttributes())) {
+		} else if (!this.getAttributes().equals(other.getAttributes())) {
 			return false;
 		}
 		return true;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
@@ -2674,8 +2674,8 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 		if(richGroup == null) throw new InternalErrorException("RichGroup can't be null.");
 
 		//Filtering richGroup attributes
-		if(richGroup.getGroupAttributes() != null) {
-			List<Attribute> groupAttributes = richGroup.getGroupAttributes();
+		if(richGroup.getAttributes() != null) {
+			List<Attribute> groupAttributes = richGroup.getAttributes();
 			List<Attribute> allowedGroupAttributes = new ArrayList<>();
 			for(Attribute groupAttr : groupAttributes) {
 				if(AuthzResolver.isAuthorizedForAttribute(sess, ActionType.READ, groupAttr, richGroup)) {
@@ -2684,7 +2684,7 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 				}
 			}
 
-			richGroup.setGroupAttributes(allowedGroupAttributes);
+			richGroup.setAttributes(allowedGroupAttributes);
 		}
 		return richGroup;
 	}
@@ -2733,8 +2733,8 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 			}
 
 			//Filtering group attributes
-			if(richGroup.getGroupAttributes() != null) {
-				List<Attribute> groupAttributes = richGroup.getGroupAttributes();
+			if(richGroup.getAttributes() != null) {
+				List<Attribute> groupAttributes = richGroup.getAttributes();
 				List<Attribute> allowedGroupAttributes = new ArrayList<>();
 				for(Attribute groupAttr: groupAttributes) {
 					//if there is record in contextMap, use it
@@ -2772,7 +2772,7 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 						}
 					}
 				}
-				richGroup.setGroupAttributes(allowedGroupAttributes);
+				richGroup.setAttributes(allowedGroupAttributes);
 			}
 			filteredRichGroups.add(richGroup);
 		}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/GroupsManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/GroupsManagerEntryIntegrationTest.java
@@ -45,7 +45,6 @@ import cz.metacentrum.perun.core.api.exceptions.IllegalArgumentException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.MemberNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.NotGroupMemberException;
-import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
 import cz.metacentrum.perun.core.api.exceptions.RelationExistsException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotAdminException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
@@ -4849,11 +4848,11 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 		//get rich group with all possible attributes (not-null)
 		List<RichGroup> richGroups = groupsManagerBl.getMemberRichGroupsWithAttributesByNames(sess, member, null);
 		assertEquals(group.getId(), richGroups.get(0).getId());
-		assertTrue(richGroups.get(0).getGroupAttributes().containsAll(allAttributes));
+		assertTrue(richGroups.get(0).getAttributes().containsAll(allAttributes));
 		//get rich groups with selected attributes (not-null)
 		richGroups = groupsManagerBl.getMemberRichGroupsWithAttributesByNames(sess, member, allAttributes.stream().map(Attribute::getName).collect(Collectors.toList()));
 		assertEquals(group.getId(), richGroups.get(0).getId());
-		assertEquals(allAttributes, richGroups.get(0).getGroupAttributes());
+		assertEquals(allAttributes, richGroups.get(0).getAttributes());
 	}
 
 	@Test(expected=MemberNotExistsException.class)
@@ -5550,7 +5549,7 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 			.findAny()
 			.orElseThrow();
 
-		assertThat(foundRichGroup.getGroupAttributes())
+		assertThat(foundRichGroup.getAttributes())
 			.anyMatch(attr -> attrName.equals(attr.getFriendlyName()) &&
 		                      attrValue.equals(attr.getValue()));
 	}
@@ -5699,7 +5698,7 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 		assertNotNull(groups);
 		assertEquals(groups.getData().size(), 2);
 		assertEquals(groups.getData().get(1), groupsManagerBl.convertGroupToRichGroupWithAttributesByName(sess, group, List.of(extendMembershipRulesAttribute.getName())));
-		assertThat(groups.getData().get(1).getGroupAttributes()).containsOnly(extendMembershipRulesAttribute);
+		assertThat(groups.getData().get(1).getAttributes()).containsOnly(extendMembershipRulesAttribute);
 	}
 
 	@Test
@@ -5899,7 +5898,7 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 		assertNotNull(groups);
 		assertEquals(groups.getData().size(), 1);
 		assertEquals(groups.getData().get(0), groupsManagerBl.convertGroupToRichGroupWithAttributesByName(sess, group2, List.of(extendMembershipRulesAttribute.getName())));
-		assertThat(groups.getData().get(0).getGroupAttributes()).containsOnly(extendMembershipRulesAttribute);
+		assertThat(groups.getData().get(0).getAttributes()).containsOnly(extendMembershipRulesAttribute);
 	}
 
 	@Test
@@ -5946,7 +5945,7 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 		assertEquals(groups.getData().size(), 2);
 
 		for (RichGroup g : groups.getData()) {
-			assertTrue(g.getGroupAttributes().containsAll(memberGroupAttributes.get(g.getUuid())));
+			assertTrue(g.getAttributes().containsAll(memberGroupAttributes.get(g.getUuid())));
 		}
 	}
 
@@ -5982,7 +5981,7 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 		assertEquals(groups.getData().size(), 2);
 
 		for (RichGroup g : groups.getData()) {
-			assertEquals(new HashSet<>(g.getGroupAttributes()), new HashSet<>(attributes.get(g.getUuid())));
+			assertEquals(new HashSet<>(g.getAttributes()), new HashSet<>(attributes.get(g.getUuid())));
 		}
 	}
 


### PR DESCRIPTION
* renaming richGroup attributes to groupAttributes caused errors in GUI, so we want to keep the original naming