### PR TITLE
fix(core): Fixed removing user attributes in setAttributes(member)

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -904,7 +904,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 				attributesToSet.add(attribute);
 			}
 		}
-		removeAttributes(sess, member, attributesToRemove);
+		removeAttributes(sess, member, workWithUserAttributes, attributesToRemove);
 		//if checkAttributesSyntax fails it causes rollback so no attribute will be stored
 		checkAttributesSyntax(sess, member, attributesToSet, workWithUserAttributes);
 		// fist we have to store attributes into DB because checkAttributesSemantics can be preformed only on stored attributes.


### PR DESCRIPTION
- When we work with user attributes while setting member attributes,
  we handle all methods for both attribute types. It was not the case
  when value is empty and attributes are about to be removed.
- Now we support also removal of user attributes while working with
  member attributes.