### PR TITLE
fix(core): groups and subgroups assignment to resource fixed

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ResourcesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ResourcesManagerBl.java
@@ -368,14 +368,12 @@ public interface ResourcesManagerBl {
 	 * @param sourceGroup source group (containing groupToAssign in hierarchy as a subgroup)
 	 * @param groupToAssign source group's subgroup to be assigned on resource as by automatic assignment
 	 * @param resource resource
-	 * @param assignInactive assign subgroup to inactive state
-	 *
 	 * @throws GroupResourceMismatchException
 	 * @throws GroupAlreadyAssignedException
 	 * @throws WrongReferenceAttributeValueException
 	 * @throws WrongAttributeValueException
 	 */
-	void assignAutomaticGroupToResource(PerunSession perunSession, Group sourceGroup, Group groupToAssign, Resource resource, boolean assignInactive) throws GroupResourceMismatchException, GroupAlreadyAssignedException, WrongReferenceAttributeValueException, WrongAttributeValueException;
+	void assignAutomaticGroupToResource(PerunSession perunSession, Group sourceGroup, Group groupToAssign, Resource resource) throws GroupResourceMismatchException, GroupAlreadyAssignedException, WrongReferenceAttributeValueException, WrongAttributeValueException;
 
 	/**
 	 * Assign group to the resources. Check if attributes for each member from group are valid.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
@@ -263,8 +263,7 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 		for (AssignedResource assignedResource : assignedResources) {
 			try {
 				Group sourceGroup = assignedResource.getSourceGroupId() == null ? parentGroup : getPerunBl().getGroupsManagerBl().getGroupById(sess, assignedResource.getSourceGroupId());
-				boolean asInactive = assignedResource.getStatus().equals(GroupResourceStatus.INACTIVE);
-				getPerunBl().getResourcesManagerBl().assignAutomaticGroupToResource(sess, sourceGroup, group, assignedResource.getEnrichedResource().getResource(), asInactive);
+				getPerunBl().getResourcesManagerBl().assignAutomaticGroupToResource(sess, sourceGroup, group, assignedResource.getEnrichedResource().getResource());
 			} catch (GroupResourceMismatchException | GroupNotExistsException | WrongReferenceAttributeValueException | WrongAttributeValueException e) {
 				// silently skip, assignment will have to be repeated after failure cause is solved
 			} catch (GroupAlreadyAssignedException e) {
@@ -860,8 +859,7 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 
 			for (Group groupToAutoassign : groupsToAutoAssign) {
 				try {
-					perunBl.getResourcesManagerBl().assignAutomaticGroupToResource(sess, sourceGroup, groupToAutoassign, resourceToAutoassign.getEnrichedResource().getResource(),
-						resourceToAutoassign.getStatus().equals(GroupResourceStatus.INACTIVE));
+					perunBl.getResourcesManagerBl().assignAutomaticGroupToResource(sess, sourceGroup, groupToAutoassign, resourceToAutoassign.getEnrichedResource().getResource());
 				} catch (GroupAlreadyAssignedException e) {
 					// skip
 				} catch (GroupResourceMismatchException e) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ResourcesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ResourcesManagerBlImpl.java
@@ -416,7 +416,7 @@ public class ResourcesManagerBlImpl implements ResourcesManagerBl {
 		for(Group g: groups) {
 			getPerunBl().getAttributesManagerBl().checkGroupIsFromTheSameVoLikeResource(perunSession, g, resource);
 
-			//first we must assign group
+			// assign source group
 			try {
 				getResourcesManagerImpl().assignGroupToResource(perunSession, g, resource, autoAssignSubgroups);
 				setAssignedGroupStatusAndActivate(perunSession, resource, async, assignInactive, g);
@@ -439,7 +439,7 @@ public class ResourcesManagerBlImpl implements ResourcesManagerBl {
 				for (Group subgroup : subgroups) {
 
 					try {
-						assignAutomaticGroupToResource(perunSession, g, subgroup, resource, assignInactive);
+						assignAutomaticGroupToResource(perunSession, g, subgroup, resource);
 					} catch (GroupAlreadyAssignedException e) {
 						// silently skip
 					}
@@ -487,11 +487,13 @@ public class ResourcesManagerBlImpl implements ResourcesManagerBl {
 	}
 
 	@Override
-	public void assignAutomaticGroupToResource(PerunSession perunSession, Group sourceGroup, Group groupToAssign, Resource resource, boolean assignInactive) throws GroupResourceMismatchException, GroupAlreadyAssignedException, WrongReferenceAttributeValueException, WrongAttributeValueException {
+	public void assignAutomaticGroupToResource(PerunSession perunSession, Group sourceGroup, Group groupToAssign, Resource resource) throws GroupResourceMismatchException, GroupAlreadyAssignedException, WrongReferenceAttributeValueException, WrongAttributeValueException {
 		getPerunBl().getAttributesManagerBl().checkGroupIsFromTheSameVoLikeResource(perunSession, sourceGroup, resource);
 
 		getResourcesManagerImpl().assignAutomaticGroupToResource(perunSession, groupToAssign, resource, sourceGroup);
-		setAssignedGroupStatusAndActivate(perunSession, resource, true, assignInactive, groupToAssign);
+
+		// subgroups should not be assigned as inactive, thus 'assignInactive' flag is always false
+		setAssignedGroupStatusAndActivate(perunSession, resource, true, false, groupToAssign);
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ResourceAssignmentChecker.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ResourceAssignmentChecker.java
@@ -3,7 +3,6 @@ package cz.metacentrum.perun.core.impl;
 import cz.metacentrum.perun.core.api.AssignedGroup;
 import cz.metacentrum.perun.core.api.ExtSourcesManager;
 import cz.metacentrum.perun.core.api.Group;
-import cz.metacentrum.perun.core.api.GroupResourceStatus;
 import cz.metacentrum.perun.core.api.PerunClient;
 import cz.metacentrum.perun.core.api.PerunPrincipal;
 import cz.metacentrum.perun.core.api.PerunSession;
@@ -107,7 +106,7 @@ public class ResourceAssignmentChecker {
 
 		for (Group subgroup : sourceGroupSubgroups) {
 			try {
-				perunBl.getResourcesManagerBl().assignAutomaticGroupToResource(sess, sourceGroup.getEnrichedGroup().getGroup(), subgroup, resource, sourceGroup.getStatus().equals(GroupResourceStatus.INACTIVE));
+				perunBl.getResourcesManagerBl().assignAutomaticGroupToResource(sess, sourceGroup.getEnrichedGroup().getGroup(), subgroup, resource);
 			} catch (GroupResourceMismatchException e) {
 				log.error("Cannot activate group (id = " + subgroup.getId() + ") assignment on resource " + resource, e);
 			} catch (GroupAlreadyAssignedException | WrongReferenceAttributeValueException | WrongAttributeValueException e) {

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ResourcesManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ResourcesManagerEntryIntegrationTest.java
@@ -2678,8 +2678,8 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 	}
 
 	@Test
-	public void autoAssignSubgroupInactive() throws Exception {
-		System.out.println(CLASS_NAME + "autoAssignSubgroupInactive");
+	public void autoAssignSubgroupWithInactiveSourceGroup() throws Exception {
+		System.out.println(CLASS_NAME + "autoAssignSubgroupWithInactiveSourceGroup");
 
 		vo = setUpVo();
 		member = setUpMember(vo);
@@ -2696,7 +2696,30 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 		List<AssignedGroup> assignedGroups = sess.getPerun().getResourcesManager().getGroupAssignments(sess, inactiveResource, List.of());
 
 		AssignedGroup assignedGroup = new AssignedGroup(new EnrichedGroup(group, List.of()), GroupResourceStatus.INACTIVE, null, null, true);
-		AssignedGroup assignedSubgroup = new AssignedGroup(new EnrichedGroup(subGroup, List.of()), GroupResourceStatus.INACTIVE, group.getId(), null, true);
+		AssignedGroup assignedSubgroup = new AssignedGroup(new EnrichedGroup(subGroup, List.of()), GroupResourceStatus.ACTIVE, group.getId(), null, true);
+
+		assertThat(assignedGroups).containsExactlyInAnyOrder(assignedGroup, assignedSubgroup);
+	}
+
+	@Test
+	public void assignInactiveGroupToResourceActivatesItsSubgroups() throws Exception {
+		System.out.println(CLASS_NAME + "assignInactiveGroupToResourceActivatesItsSubgroups");
+
+		vo = setUpVo();
+		member = setUpMember(vo);
+		facility = setUpFacility();
+		Resource inactiveResource = setUpResource();
+
+		group = setUpGroup(vo, member);
+		subGroup = setUpSubGroup(group);
+
+		sess.getPerun().getResourcesManager().assignGroupToResource(sess, group, inactiveResource, false, true, true);
+
+		List<AssignedGroup> assignedGroups = sess.getPerun().getResourcesManager().getGroupAssignments(sess, inactiveResource, List.of());
+
+		AssignedGroup assignedGroup = new AssignedGroup(new EnrichedGroup(group, List.of()), GroupResourceStatus.INACTIVE, null, null, true);
+
+		AssignedGroup assignedSubgroup = new AssignedGroup(new EnrichedGroup(subGroup, List.of()), GroupResourceStatus.ACTIVE, group.getId(), null, true);
 
 		assertThat(assignedGroups).containsExactlyInAnyOrder(assignedGroup, assignedSubgroup);
 	}


### PR DESCRIPTION
Subgroups are assigned to resource always with ACTIVE status, instead of copying its source group status.