### PR TITLE
fix(cli): fixed reading of statuses from input in export tools

### DIFF
--- a/perun-cli/exportGroupMembers
+++ b/perun-cli/exportGroupMembers
@@ -49,7 +49,7 @@ GetOptions("help|h"       => sub {
 	"voId|v=i"            => \$voId,
 	"voShortName|V=s"     => \$voShortName,
 	'attrList|am=s@{1,}'  => \@attributes,
-	'statusList|s=s@{0,}' => \@statuses,
+	'statuses|s=s@{0,}'   => \@statuses,
 	"orderByName|n"       => sub { $sortingFunction = getSortingFunction("getLastName", 1) },
 	"batch|b"             => \$batch) || die help;
 

--- a/perun-cli/exportVoMembers
+++ b/perun-cli/exportVoMembers
@@ -42,7 +42,7 @@ GetOptions("help|h"       => sub {
 	"voId|v=i"            => \$voId,
 	"voShortName|V=s"     => \$voShortName,
 	'attrList|a=s@{1,}'   => \@attributes,
-	'statusList|s=s@{0,}' => \@statuses,
+	'statuses|s=s@{0,}'   => \@statuses,
 	"orderByName|n"       => sub { $sortingFunction = getSortingFunction("getLastName", 1) },
 	"batch|b"             => \$batch) || die help;
 


### PR DESCRIPTION
- There was a wrong name of input param (statuses vs. statusList)
  in exportVoMembers and exportGroupMembers CLI tools.