### PR TITLE
feat(core): get associated objects for attribute rights 

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/ResourcesManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/ResourcesManager.java
@@ -377,7 +377,7 @@ public interface ResourcesManager {
 	List<Group> getAssignedGroups(PerunSession perunSession, Resource resource, Member member) throws PrivilegeException, ResourceNotExistsException, MemberNotExistsException;
 
 	/**
-	 * List all resources associated with the group.
+	 * List all resources to which the group is assigned.
 	 *
 	 * @param perunSession
 	 * @param group

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/FacilitiesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/FacilitiesManagerBl.java
@@ -263,6 +263,16 @@ public interface FacilitiesManagerBl {
 	List<User> getAllowedUsers(PerunSession sess, Facility facility);
 
 	/**
+	 * Return all users, which are associated with facility through any member/resource.
+	 * Does not require ACTIVE group-resource status.
+	 *
+	 * @param sess
+	 * @param facility
+	 * @return list of associated users
+	 */
+	List<User> getAssociatedUsers(PerunSession sess, Facility facility);
+
+	/**
 	 * Return all users who can use this facility
 	 * You can specify VO or Service you are interested in to filter resulting users (they must be members of VO and from Resource with assigned Service).
 	 * if specificVo, specificService or both are null, they do not specific (all possible results are returned)
@@ -301,6 +311,20 @@ public interface FacilitiesManagerBl {
 	 * @throws InternalErrorException
 	 */
 	List<Member> getAllowedMembers(PerunSession sess, Facility facility);
+
+	/**
+	 * Return all members, which are associated with the facility and belong to given user.
+	 * Does not require ACTIVE group-resource status or any specific member status.
+	 *
+	 * @param sess
+	 * @param facility
+	 * @param user
+	 *
+	 * @return list of associated members
+	 *
+	 * @throws InternalErrorException
+	 */
+	List<Member> getAssociatedMembers(PerunSession sess, Facility facility, User user);
 
 	/**
 	 * Returns all resources assigned to the facility.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/GroupsManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/GroupsManagerBl.java
@@ -351,6 +351,33 @@ public interface GroupsManagerBl {
 	 */
 	List<Group> getAssignedGroupsToResource(PerunSession perunSession, Resource resource, Member member);
 
+	/**
+	 * Return list of groups associated with the resource with specified member.
+	 * Does not require ACTIVE group-resource status.
+	 *
+	 * @param perunSession
+	 * @param resource
+	 * @param member
+	 *
+	 * @return list of groups, which are associated with the resource with specified member
+	 *
+	 * @throws InternalErrorException
+	 */
+	List<Group> getAssociatedGroupsToResource(PerunSession perunSession, Resource resource, Member member);
+
+	/**
+	 * Return list of assigned groups on the resource.
+	 * Similar to assigned groups, but does not require ACTIVE group-resource status.
+	 *
+	 * @param perunSession
+	 * @param resource
+	 *
+	 * @return list of groups, which are associated with the resource
+	 *
+	 * @throws InternalErrorException
+	 */
+	List<Group> getAssociatedGroupsToResource(PerunSession perunSession, Resource resource);
+
 	/** Return list of assigned groups on the resource.
 	 *
 	 * @param perunSession
@@ -373,6 +400,19 @@ public interface GroupsManagerBl {
 	 * @throws InternalErrorException
 	 */
 	List<Group> getAssignedGroupsToFacility(PerunSession perunSession, Facility facility);
+
+
+	/**
+	 * Return list of all associated groups from all facility resources (does not require ACTIVE group-resource status)
+	 *
+	 * @param perunSession
+	 * @param facility
+	 *
+	 * @return list of groups, which are associated with all facility resources
+	 *
+	 * @throws InternalErrorException
+	 */
+	List<Group> getAssociatedGroupsToFacility(PerunSession perunSession, Facility facility);
 
 	/**
 	 * Removes member form the group. But not from members or administrators group.
@@ -571,6 +611,18 @@ public interface GroupsManagerBl {
 	 * @return list users sorted or empty list if there are no users on specified page
 	 */
 	List<User> getGroupUsers(PerunSession perunSession, Group group);
+
+	/**
+	 * Return groups where user is member.
+	 *
+	 * @param sess
+	 * @param user
+	 *
+	 * @return list of groups
+	 *
+	 * @throws InternalErrorException
+	 */
+	List<Group> getUserGroups(PerunSession sess, User user);
 
 	/**
 	 * Returns group members in the RichMember object, which contains Member+User data.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ResourcesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ResourcesManagerBl.java
@@ -261,6 +261,17 @@ public interface ResourcesManagerBl {
 	List<Member> getAllowedMembers(PerunSession perunSession, Resource resource);
 
 	/**
+	 * Returns all members who are associated with the resource.
+	 * Does not require ACTIVE group-resource status or any specific member status.
+	 *
+	 * @param sess
+	 * @param resource
+	 * @return list of members
+	 * @throws InternalErrorException
+	 */
+	List<Member> getAssociatedMembers(PerunSession sess, Resource resource);
+
+	/**
 	 * Returns all members who can access the resource and who are also valid in at least one group associated to the resource.
 	 *
 	 * @param perunSession
@@ -310,6 +321,17 @@ public interface ResourcesManagerBl {
 	 * @throws InternalErrorException
 	 */
 	List<User> getAllowedUsers(PerunSession sess, Resource resource);
+
+	/**
+	 * Returns all users who are associated with the defined resource.
+	 * Does not require ACTIVE group-resource status.
+	 *
+	 * @param sess
+	 * @param resource
+	 * @return list of users
+	 * @throws InternalErrorException
+	 */
+	List<User> getAssociatedUsers(PerunSession sess, Resource resource);
 
 	/**
 	 * Get all users, who can assess the resource and who are not expired in at least one group associated to the resource.
@@ -493,7 +515,21 @@ public interface ResourcesManagerBl {
 	List<Group> getAssignedGroups(PerunSession perunSession, Resource resource, Member member);
 
 	/**
-	 * List all resources associated with the group.
+	 * Return list of groups associated with the resource with specified member.
+	 * Does not require ACTIVE group-resource status.
+	 *
+	 * @param perunSession
+	 * @param resource
+	 * @param member
+	 *
+	 * @return list of groups, which are associated with the resource with specified member
+	 *
+	 * @throws InternalErrorException
+	 */
+	List<Group> getAssociatedGroups(PerunSession perunSession, Resource resource, Member member);
+
+	/**
+	 * List all resources to which the group is assigned.
 	 *
 	 * @param perunSession
 	 * @param group
@@ -503,6 +539,18 @@ public interface ResourcesManagerBl {
 	 * @throws InternalErrorException
 	 */
 	List<Resource> getAssignedResources(PerunSession perunSession, Group group);
+
+	/**
+	 * List all resources associated with the group.
+	 * Does not require ACTIVE group-resource status.
+	 *
+	 * @param perunSession
+	 * @param group
+	 *
+	 * @throws InternalErrorException
+	 * @return list of associated resources
+	 */
+	List<Resource> getAssociatedResources(PerunSession perunSession, Group group);
 
 	/**
 	 * List all rich resources associated with the group with facility property filled.
@@ -690,6 +738,17 @@ public interface ResourcesManagerBl {
 	 * @throws InternalErrorException
 	 */
 	List<Resource> getAssignedResources(PerunSession sess, Member member);
+
+	/**
+	 * Returns all resources with which the member is associated through the groups.
+	 * Does not require ACTIVE group-resource status.
+	 *
+	 * @param sess
+	 * @param member
+	 * @return list of resources
+	 * @throws InternalErrorException
+	 */
+	List<Resource> getAssociatedResources(PerunSession sess, Member member);
 
 	/**
 	 * Returns all assigned resources where member is assigned through the groups.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
@@ -727,6 +727,17 @@ public interface UsersManagerBl {
 	List<Resource> getAssignedResources(PerunSession sess, Facility facility, User user);
 
 	/**
+	 * Return all resources of specified facility with which user is associated through all his members.
+	 * Does not require ACTIVE group-resource assignment.
+	 *
+	 * @param sess
+	 * @param facility
+	 * @param user
+	 * @return All resources with which user is associated
+	 */
+	List<Resource> getAssociatedResources(PerunSession sess, Facility facility, User user);
+
+	/**
 	 * Get all resources which have the user access on.
 	 *
 	 * @param sess
@@ -752,6 +763,16 @@ public interface UsersManagerBl {
 	 * @return list of rich resources which have the user access on
 	 */
 	List<RichResource> getAssignedRichResources(PerunSession sess, User user);
+
+	/**
+	 * Get all resources with which user can be associated (similar to assigned resources,
+	 * but does not require ACTIVE group-resource assignment).
+	 *
+	 * @param sess
+	 * @param user
+	 * @return list of resources with which the user is associated
+	 */
+	List<Resource> getAssociatedResources(PerunSession sess, User user);
 
 	/**
 	 * Returns all users who have set the attribute with the value. Searching only def and opt attributes.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/FacilitiesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/FacilitiesManagerBlImpl.java
@@ -223,6 +223,11 @@ public class FacilitiesManagerBlImpl implements FacilitiesManagerBl {
 	}
 
 	@Override
+	public List<User> getAssociatedUsers(PerunSession sess, Facility facility) {
+		return getFacilitiesManagerImpl().getAssociatedUsers(sess, facility);
+	}
+
+	@Override
 	public List<User> getAllowedUsers(PerunSession sess, Facility facility, Vo specificVo, Service specificService) {
 
 		//Get all facilities resources
@@ -253,6 +258,11 @@ public class FacilitiesManagerBlImpl implements FacilitiesManagerBl {
 	@Override
 	public List<Member> getAllowedMembers(PerunSession sess, Facility facility) {
 		return getFacilitiesManagerImpl().getAllowedMembers(sess, facility);
+	}
+
+	@Override
+	public List<Member> getAssociatedMembers(PerunSession sess, Facility facility, User user) {
+		return getFacilitiesManagerImpl().getAssociatedMembers(sess, facility, user);
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
@@ -1352,6 +1352,11 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 	}
 
 	@Override
+	public List<Group> getUserGroups(PerunSession perunSession, User user) {
+		return new ArrayList<>(new HashSet<>(getGroupsManagerImpl().getUserGroups(perunSession, user)));
+	}
+
+	@Override
 	public List<Member> getGroupMembersExceptInvalid(PerunSession sess, Group group) {
 		return this.filterMembersByMembershipTypeInGroup(getGroupsManagerImpl().getGroupMembers(sess, group, Collections.singletonList(Status.INVALID), true));
 	}
@@ -1540,6 +1545,16 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 	}
 
 	@Override
+	public List<Group> getAssociatedGroupsToResource(PerunSession sess, Resource resource, Member member) {
+		return getGroupsManagerImpl().getAssociatedGroupsToResource(sess, resource, member);
+	}
+
+	@Override
+	public List<Group> getAssociatedGroupsToResource(PerunSession sess, Resource resource) {
+		return getGroupsManagerImpl().getAssociatedGroupsToResource(sess, resource);
+	}
+
+	@Override
 	public List<Group> getAssignedGroupsToResource(PerunSession sess, Resource resource, boolean withSubGroups) {
 		List<Group> assignedGroups = getGroupsManagerImpl().getAssignedGroupsToResource(sess, resource);
 		if(!withSubGroups) return assignedGroups;
@@ -1571,6 +1586,11 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 		// Sort
 		Collections.sort(assignedGroups);
 		return assignedGroups;
+	}
+
+	@Override
+	public List<Group> getAssociatedGroupsToFacility(PerunSession sess, Facility facility) {
+		return getGroupsManagerImpl().getAssociatedGroupsToFacility(sess, facility);
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ResourcesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ResourcesManagerBlImpl.java
@@ -338,6 +338,11 @@ public class ResourcesManagerBlImpl implements ResourcesManagerBl {
 	}
 
 	@Override
+	public List<User> getAssociatedUsers(PerunSession sess, Resource resource) {
+		return getResourcesManagerImpl().getAssociatedUsers(sess, resource);
+	}
+
+	@Override
 	public List<User> getAllowedUsersNotExpiredInGroups(PerunSession sess, Resource resource) {
 		return getResourcesManagerImpl().getAllowedUsersNotExpiredInGroup(sess, resource);
 	}
@@ -370,6 +375,11 @@ public class ResourcesManagerBlImpl implements ResourcesManagerBl {
 	@Override
 	public List<Member> getAllowedMembers(PerunSession sess, Resource resource) {
 		return getResourcesManagerImpl().getAllowedMembers(sess, resource);
+	}
+
+	@Override
+	public List<Member> getAssociatedMembers(PerunSession sess, Resource resource) {
+		return getResourcesManagerImpl().getAssociatedMembers(sess, resource);
 	}
 
 	@Override
@@ -612,8 +622,18 @@ public class ResourcesManagerBlImpl implements ResourcesManagerBl {
 	}
 
 	@Override
+	public List<Group> getAssociatedGroups(PerunSession sess, Resource resource, Member member) {
+		return getPerunBl().getGroupsManagerBl().getAssociatedGroupsToResource(sess, resource, member);
+	}
+
+	@Override
 	public List<Resource> getAssignedResources(PerunSession sess, Group group) {
 		return getResourcesManagerImpl().getAssignedResources(sess, group);
+	}
+
+	@Override
+	public List<Resource> getAssociatedResources(PerunSession sess, Group group) {
+		return getResourcesManagerImpl().getAssociatedResources(sess, group);
 	}
 
 	@Override
@@ -806,6 +826,11 @@ public class ResourcesManagerBlImpl implements ResourcesManagerBl {
 	@Override
 	public List<Resource> getAssignedResources(PerunSession sess, Member member) {
 		return getResourcesManagerImpl().getAssignedResources(sess, member);
+	}
+
+	@Override
+	public List<Resource> getAssociatedResources(PerunSession sess, Member member) {
+		return getResourcesManagerImpl().getAssociatedResources(sess, member);
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
@@ -932,6 +932,11 @@ public class UsersManagerBlImpl implements UsersManagerBl {
 	}
 
 	@Override
+	public List<Resource> getAssociatedResources(PerunSession sess, Facility facility, User user) {
+		return getUsersManagerImpl().getAssociatedResources(sess, facility, user);
+	}
+
+	@Override
 	public List<Resource> getAllowedResources(PerunSession sess, User user) {
 		return getUsersManagerImpl().getAllowedResources(sess, user);
 	}
@@ -944,6 +949,11 @@ public class UsersManagerBlImpl implements UsersManagerBl {
 	@Override
 	public List<RichResource> getAssignedRichResources(PerunSession sess, User user) {
 		return getUsersManagerImpl().getAssignedRichResources(sess, user);
+	}
+
+	@Override
+	public List<Resource> getAssociatedResources(PerunSession sess, User user) {
+		return getUsersManagerImpl().getAssociatedResources(sess, user);
 	}
 
 	private List<User> getUsersByVirtualAttribute(PerunSession sess, AttributeDefinition attributeDef, String attributeValue) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ResourcesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ResourcesManagerImpl.java
@@ -418,6 +418,23 @@ public class ResourcesManagerImpl implements ResourcesManagerImplApi {
 	}
 
 	@Override
+	public List<User> getAssociatedUsers(PerunSession sess, Resource resource) {
+		try  {
+			return jdbc.query("select distinct " + UsersManagerImpl.userMappingSelectQuery + " from groups_resources_state" +
+					" join groups on groups_resources_state.group_id=groups.id" +
+					" join groups_members on groups.id=groups_members.group_id" +
+					" join members on groups_members.member_id=members.id" +
+					" join users on users.id=members.user_id" +
+					" where groups_resources_state.resource_id=?",
+				UsersManagerImpl.USER_MAPPER, resource.getId());
+		} catch (EmptyResultDataAccessException e) {
+			return new ArrayList<>();
+		} catch (RuntimeException e) {
+			throw new InternalErrorException(e);
+		}
+	}
+
+	@Override
 	public List<User> getAllowedUsersNotExpiredInGroup(PerunSession sess, Resource resource) {
 		try  {
 			return jdbc.query("select distinct " + UsersManagerImpl.userMappingSelectQuery + " from groups_resources_state" +
@@ -517,6 +534,23 @@ public class ResourcesManagerImpl implements ResourcesManagerImplApi {
 					" where groups_resources_state.resource_id=?",
 				MembersManagerImpl.ASSIGNED_MEMBERS_WITH_GROUP_STATUSES_SET_EXTRACTOR, resource.getId());
 
+		} catch (EmptyResultDataAccessException e) {
+			return new ArrayList<>();
+		} catch (RuntimeException e) {
+			throw new InternalErrorException(e);
+		}
+	}
+
+	@Override
+	public List<Member> getAssociatedMembers(PerunSession sess, Resource resource) {
+		try  {
+			// we do include all group statuses for such members
+			return jdbc.query("select distinct " + MembersManagerImpl.groupsMembersMappingSelectQuery + " from groups_resources_state" +
+					" join groups on groups_resources_state.group_id=groups.id" +
+					" join groups_members on groups.id=groups_members.group_id" +
+					" join members on groups_members.member_id=members.id " +
+					" where groups_resources_state.resource_id=?",
+				MembersManagerImpl.MEMBERS_WITH_GROUP_STATUSES_SET_EXTRACTOR, resource.getId());
 		} catch (EmptyResultDataAccessException e) {
 			return new ArrayList<>();
 		} catch (RuntimeException e) {
@@ -635,6 +669,20 @@ public class ResourcesManagerImpl implements ResourcesManagerImplApi {
 	}
 
 	@Override
+	public List<Resource> getAssociatedResources(PerunSession sess, Group group) {
+		try {
+			return jdbc.query("select " + resourceMappingSelectQuery + " from resources" +
+					" join groups_resources_state on resources.id=groups_resources_state.resource_id" +
+					" where groups_resources_state.group_id=?",
+				RESOURCE_MAPPER, group.getId());
+		} catch (EmptyResultDataAccessException e) {
+			return new ArrayList<>();
+		} catch (RuntimeException e) {
+			throw new InternalErrorException(e);
+		}
+	}
+
+	@Override
 	public List<Resource> getAssignedResources(PerunSession sess, Member member) {
 		try  {
 			return jdbc.query("select distinct " + resourceMappingSelectQuery + " from resources" +
@@ -643,6 +691,22 @@ public class ResourcesManagerImpl implements ResourcesManagerImplApi {
 					" join groups_members on groups.id=groups_members.group_id " +
 					" where groups_members.member_id=?",
 				RESOURCE_MAPPER, GroupResourceStatus.ACTIVE.toString(), member.getId());
+		} catch (EmptyResultDataAccessException e) {
+			return new ArrayList<>();
+		} catch (RuntimeException e) {
+			throw new InternalErrorException(e);
+		}
+	}
+
+	@Override
+	public List<Resource> getAssociatedResources(PerunSession sess, Member member) {
+		try  {
+			return jdbc.query("select distinct " + resourceMappingSelectQuery + " from resources" +
+					" join groups_resources_state on resources.id=groups_resources_state.resource_id" +
+					" join groups on groups_resources_state.group_id=groups.id" +
+					" join groups_members on groups.id=groups_members.group_id" +
+					" where groups_members.member_id=?",
+				RESOURCE_MAPPER, member.getId());
 		} catch (EmptyResultDataAccessException e) {
 			return new ArrayList<>();
 		} catch (RuntimeException e) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/UsersManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/UsersManagerImpl.java
@@ -1433,6 +1433,22 @@ public class UsersManagerImpl implements UsersManagerImplApi {
 	}
 
 	@Override
+	public List<Resource> getAssociatedResources(PerunSession sess, User user) {
+		try  {
+			return jdbc.query("select distinct " + resourceMappingSelectQuery + " from resources" +
+				" join groups_resources_state on resources.id=groups_resources_state.resource_id" +
+				" join groups on groups_resources_state.group_id=groups.id" +
+				" join groups_members on groups.id=groups_members.group_id" +
+				" join members on groups_members.member_id=members.id" +
+				" where members.user_id=?", RESOURCE_MAPPER, user.getId());
+		} catch (EmptyResultDataAccessException e) {
+			return new ArrayList<>();
+		} catch (RuntimeException e) {
+			throw new InternalErrorException(e);
+		}
+	}
+
+	@Override
 	public List<Resource> getAllowedResources(PerunSession sess, User user) {
 		try  {
 			return jdbc.query("select distinct " + resourceMappingSelectQuery + " from resources" +
@@ -1457,6 +1473,22 @@ public class UsersManagerImpl implements UsersManagerImplApi {
 							" where resources.facility_id=? and members.user_id=?",
 					RESOURCE_MAPPER, GroupResourceStatus.ACTIVE.toString(), facility.getId(), user.getId());
 		} catch (RuntimeException e) {
+			throw new InternalErrorException(e);
+		}
+	}
+
+	@Override
+	public List<Resource> getAssociatedResources(PerunSession sess, Facility facility, User user) {
+		try {
+			return jdbc.query("select distinct " + ResourcesManagerImpl.resourceMappingSelectQuery + " from resources "+
+					" join groups_resources_state on groups_resources_state.resource_id=resources.id" +
+					" join groups_members on groups_members.group_id=groups_resources_state.group_id" +
+					" join members on members.id=groups_members.member_id" +
+					" where resources.facility_id=? and members.user_id=?",
+				RESOURCE_MAPPER, facility.getId(), user.getId());
+		} catch (EmptyResultDataAccessException e) {
+			return new ArrayList<>();
+		}catch (RuntimeException e) {
 			throw new InternalErrorException(e);
 		}
 	}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/FacilitiesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/FacilitiesManagerImplApi.java
@@ -189,6 +189,20 @@ public interface FacilitiesManagerImplApi {
 	List<Member> getAllowedMembers(PerunSession sess, Facility facility);
 
 	/**
+	 * Return all members, which are associated with the facility and belong to given user.
+	 * Does not require ACTIVE group-resource status or any specific member status.
+	 *
+	 * @param sess
+	 * @param facility
+	 * @param user
+	 *
+	 * @return list of associated members
+	 *
+	 * @throws InternalErrorException
+	 */
+	List<Member> getAssociatedMembers(PerunSession sess, Facility facility, User user);
+
+	/**
 	 * Return all users, which are "allowed" on facility through any member/resource.
 	 *
 	 * @param sess
@@ -196,6 +210,16 @@ public interface FacilitiesManagerImplApi {
 	 * @return list of allowed users
 	 */
 	List<User> getAllowedUsers(PerunSession sess, Facility facility);
+
+	/**
+	 * Return all users, which are associated with facility through any member/resource.
+	 * Does not require ACTIVE group-resource status.
+	 *
+	 * @param sess
+	 * @param facility
+	 * @return list of allowed users
+	 */
+	List<User> getAssociatedUsers(PerunSession sess, Facility facility);
 
 	/**
 	 * Return all allowed facilities of the user.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/GroupsManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/GroupsManagerImplApi.java
@@ -213,6 +213,19 @@ public interface GroupsManagerImplApi {
 	List<Group> getAssignedGroupsToResource(PerunSession perunSession, Resource resource);
 
 	/**
+	 * Return list of assigned groups on the resource.
+	 * Similar to assigned groups, but does not require ACTIVE group-resource status.
+	 *
+	 * @param perunSession
+	 * @param resource
+	 *
+	 * @return list of groups, which are assigned on the resource
+	 *
+	 * @throws InternalErrorException
+	 */
+	List<Group> getAssociatedGroupsToResource(PerunSession perunSession, Resource resource);
+
+	/**
 	 * Return list of assigned groups on the resource with specified member.
 	 *
 	 * @param perunSession
@@ -224,6 +237,20 @@ public interface GroupsManagerImplApi {
 	 * @throws InternalErrorException
 	 */
 	List<Group> getAssignedGroupsToResource(PerunSession perunSession, Resource resource, Member member);
+
+	/**
+	 * Return list of groups associated with the resource with specified member.
+	 * Does not require ACTIVE group-resource status.
+	 *
+	 * @param perunSession
+	 * @param resource
+	 * @param member
+	 *
+	 * @return list of groups, which are assigned on the resource with specified member
+	 *
+	 * @throws InternalErrorException
+	 */
+	List<Group> getAssociatedGroupsToResource(PerunSession perunSession, Resource resource, Member member);
 
 	/**
 	 * Return list of assigned groups from all facility resources
@@ -238,6 +265,18 @@ public interface GroupsManagerImplApi {
 	List<Group> getAssignedGroupsToFacility(PerunSession perunSession, Facility facility);
 
 	/**
+	 * Return list of all associated groups from all facility resources (does not require ACTIVE group-resource status)
+	 *
+	 * @param perunSession
+	 * @param facility
+	 *
+	 * @return list of groups, which are associated with all facility resources
+	 *
+	 * @throws InternalErrorException
+	 */
+	List<Group> getAssociatedGroupsToFacility(PerunSession perunSession, Facility facility);
+
+	/**
 	 * Return group users sorted by name.
 	 *
 	 * @param sess
@@ -248,6 +287,18 @@ public interface GroupsManagerImplApi {
 	 * @throws InternalErrorException
 	 */
 	List<User> getGroupUsers(PerunSession sess, Group group);
+
+	/**
+	 * Return groups where user is member.
+	 *
+	 * @param sess
+	 * @param user
+	 *
+	 * @return list of groups
+	 *
+	 * @throws InternalErrorException
+	 */
+	List<Group> getUserGroups(PerunSession sess, User user);
 
 	/**
 	 * Checks whether the user is member of the group.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/ResourcesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/ResourcesManagerImplApi.java
@@ -221,7 +221,7 @@ public interface ResourcesManagerImplApi {
 	boolean isUserAllowed(PerunSession sess, User user, Resource resource);
 
 	/**
-	 * List all resources associated with the group.
+	 * List all resources to which the group is assigned.
 	 *
 	 * @param perunSession
 	 * @param group
@@ -230,6 +230,18 @@ public interface ResourcesManagerImplApi {
 	 * @return list of assigned resources
 	 */
 	List<Resource> getAssignedResources(PerunSession perunSession, Group group);
+
+	/**
+	 * List all resources associated with the group.
+	 * Does not require ACTIVE group-resource status.
+	 *
+	 * @param perunSession
+	 * @param group
+	 *
+	 * @throws InternalErrorException
+	 * @return list of associated resources
+	 */
+	List<Resource> getAssociatedResources(PerunSession perunSession, Group group);
 
 	/**
 	 * List of all rich resources associated with the group.
@@ -404,6 +416,17 @@ public interface ResourcesManagerImplApi {
 	List<User> getAllowedUsers(PerunSession sess, Resource resource);
 
 	/**
+	 * Returns all users who are associated with the defined resource.
+	 * Does not require ACTIVE group-resource status.
+	 *
+	 * @param sess
+	 * @param resource
+	 * @return list of users
+	 * @throws InternalErrorException
+	 */
+	List<User> getAssociatedUsers(PerunSession sess, Resource resource);
+
+	/**
 	 * Returns all users which are allowed on the resource and are not expired within their assigned groups.
 	 * It means if user is allowed on the resource, but only through expired groups, it is filtered out.
 	 *
@@ -457,6 +480,17 @@ public interface ResourcesManagerImplApi {
 	List<Member> getAllowedMembers(PerunSession sess, Resource resource);
 
 	/**
+	 * Returns all members who are associated with the resource.
+	 * Does not require ACTIVE group-resource status or any specific member status.
+	 *
+	 * @param sess
+	 * @param resource
+	 * @return list of members
+	 * @throws InternalErrorException
+	 */
+	List<Member> getAssociatedMembers(PerunSession sess, Resource resource);
+
+	/**
 	 * Returns all members which are allowed on the resource and are not expired within their assigned groups.
 	 * It means if member is allowed on the resource, but only through expired groups, it is filtered out.
 	 *
@@ -476,6 +510,17 @@ public interface ResourcesManagerImplApi {
 	 * @throws InternalErrorException
 	 */
 	List<Resource> getAssignedResources(PerunSession sess, Member member);
+
+	/**
+	 * Returns all resources with which the member is associated through the groups.
+	 * Does not require ACTIVE group-resource status.
+	 *
+	 * @param sess
+	 * @param member
+	 * @return list of resources
+	 * @throws InternalErrorException
+	 */
+	List<Resource> getAssociatedResources(PerunSession sess, Member member);
 
 	/**
 	 * Returns all assigned resources where member is assigned through the groups.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/UsersManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/UsersManagerImplApi.java
@@ -857,6 +857,17 @@ public interface UsersManagerImplApi {
 	List<Resource> getAssignedResources(PerunSession sess, Facility facility, User user);
 
 	/**
+	 * Return all resources of specified facility with which user is associated through all his members.
+	 * Does not require ACTIVE group-resource assignment.
+	 *
+	 * @param sess
+	 * @param facility
+	 * @param user
+	 * @return All resources with which user is associated
+	 */
+	List<Resource> getAssociatedResources(PerunSession sess, Facility facility, User user);
+
+	/**
 	 * Return all rich resources, where user is assigned through all his members.
 	 *
 	 * @param sess
@@ -864,5 +875,15 @@ public interface UsersManagerImplApi {
 	 * @return All resources where user is assigned
 	 */
 	List<RichResource> getAssignedRichResources(PerunSession sess, User user);
+
+	/**
+	 * Get all resources with which user can be associated (similar to assigned resources,
+	 * but does not require ACTIVE group-resource assignment).
+	 *
+	 * @param sess
+	 * @param user
+	 * @return list of resources with which user is associated
+	 */
+	List<Resource> getAssociatedResources(PerunSession sess, User user);
 
 }

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntryIntegrationTest.java
@@ -1992,6 +1992,35 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 	}
 
 	@Test
+	public void getAssociatedMembersForUserAndFacility() throws Exception {
+		System.out.println(CLASS_NAME + "getAssociatedMembersForUserAndFacility");
+
+		Vo vo2 = new Vo(0, "TestVO2", "TestVO2");
+		vo2 = perun.getVosManagerBl().createVo(sess, vo2);
+
+		Member member1 = setUpMember(vo);
+		User user = perun.getUsersManagerBl().getUserByMember(sess, member1);
+		Member member2 = perun.getMembersManagerBl().createMember(sess, vo2, user);
+
+		Resource resource1 = setUpResource(vo);
+		Resource resource2 = setUpResource(vo2);
+
+		Group group1 = setUpGroup(vo, member1);
+		Group group2 = setUpGroup(vo2, member2);
+
+		perun.getMembersManager().setStatus(sess, member1, Status.INVALID);
+		perun.getMembersManager().setStatus(sess, member2, Status.EXPIRED);
+
+		perun.getResourcesManager().assignGroupToResource(sess, group1, resource1, false, false, false);
+		perun.getResourcesManager().assignGroupToResource(sess, group2, resource2, false, true, false);
+
+		List<Member> members = perun.getFacilitiesManagerBl().getAssociatedMembers(sess, facility, user);
+
+		assertTrue( members.size() == 2);
+		assertTrue("Our members are not part of result list.", members.containsAll(List.of(member1, member2)));
+	}
+
+	@Test
 	public void getAssignedResourcesWithVoOrServiceFilter() throws Exception {
 		System.out.println(CLASS_NAME + "getAssignedResourcesWithVoOrServiceFilter");
 

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntryIntegrationTest.java
@@ -442,6 +442,41 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 	}
 
 	@Test
+	public void getAssociatedUsersForFacility() throws Exception {
+		System.out.println(CLASS_NAME + "getAssociatedUsersForFacility");
+
+		Vo vo2 = new Vo(1, "TestVO2", "TestVO2");
+		vo2 = perun.getVosManagerBl().createVo(sess, vo2);
+
+		Resource resource1 = setUpResource(vo);
+		Resource resource2 = setUpResource(vo2);
+
+		Member member1 = setUpMember(vo);
+		Member member2 = setUpMember(vo2);
+		Member member3 = setUpMember(vo2);
+
+		User user1 = perun.getUsersManagerBl().getUserByMember(sess, member1);
+		User user2 = perun.getUsersManagerBl().getUserByMember(sess, member2);
+		User user3 = perun.getUsersManagerBl().getUserByMember(sess, member3);
+
+		Group group1 = setUpGroup(vo, member1);
+		Group group2 = setUpGroup(vo2, member2);
+		Group group3 = setUpGroup2(vo2, member3);
+
+		perun.getMembersManager().setStatus(sess, member1, Status.INVALID);
+		perun.getMembersManager().setStatus(sess, member2, Status.EXPIRED);
+		perun.getGroupsManagerBl().expireMemberInGroup(sess, member2, group2);
+
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group1, resource1, false, true, false);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group2, resource2, false, false, false);
+
+		List<User> users = perun.getFacilitiesManagerBl().getAssociatedUsers(sess, facility);
+		assertTrue("our facility should have 2 associated user", users.size() == 2);
+		assertTrue("user not associated with resource should not be returned", !users.contains(user3));
+		assertTrue("our users should be associated with facility", users.containsAll(List.of(user1, user2)));
+	}
+
+	@Test
 	public void getAllowedUsersCheckUniqueness() throws Exception {
 		System.out.println(CLASS_NAME + "getAllowedUsersCheckUniqueness");
 

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/GroupsManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/GroupsManagerEntryIntegrationTest.java
@@ -2648,6 +2648,73 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 	}
 
 	@Test
+	public void getAssociatedGroupsToFacility() throws Exception {
+		System.out.println(CLASS_NAME + "getAssociatedGroupsToFacility");
+
+		Vo vo = setUpVo();
+		Group group = setUpGroup(vo);
+		Group subgroup = setUpSubgroup(group);
+		List<Group> assignedGroups = List.of(group, subgroup);
+		List<Group> notAssignedGroups = setUpGroups(vo);
+
+		Facility facility = setUpFacility();
+		Resource resource = setUpResource(vo, facility);
+
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource, false, true, true);
+
+		List<Group> groupsList = groupsManagerBl.getAssociatedGroupsToFacility(sess, facility);
+		assertThat(groupsList).containsAll(assignedGroups);
+		assertThat(groupsList).doesNotContainAnyElementsOf(notAssignedGroups);
+	}
+
+	@Test
+	public void getAssociatedGroupsToResource() throws Exception {
+		System.out.println(CLASS_NAME + "getAssociatedGroupsToResource");
+
+		Vo vo = setUpVo();
+		Group group = setUpGroup(vo);
+		Group subgroup = setUpSubgroup(group);
+		List<Group> assignedGroups = List.of(group, subgroup);
+		List<Group> notAssignedGroups = setUpGroups(vo);
+
+		Facility facility = setUpFacility();
+		Resource resource = setUpResource(vo, facility);
+
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource, false, true, true);
+
+		List<Group> groupsList = groupsManagerBl.getAssociatedGroupsToResource(sess, resource);
+		assertThat(groupsList).containsAll(assignedGroups);
+		assertThat(groupsList).doesNotContainAnyElementsOf(notAssignedGroups);
+	}
+
+	@Test
+	public void getAssociatedGroupsToResourceForMember() throws Exception {
+		System.out.println(CLASS_NAME + "getAssociatedGroupsToResourceForMember");
+
+		Vo vo = setUpVo();
+		Group group = setUpGroup(vo);
+		List<Group> notAssignedGroups = setUpGroups(vo);
+
+		Facility facility = setUpFacility();
+		Resource resource = setUpResource(vo, facility);
+
+		Member member = setUpMember(vo);
+		Member member2 = setUpMember(vo);
+
+		perun.getGroupsManagerBl().addMember(sess, group, member);
+		perun.getGroupsManagerBl().expireMemberInGroup(sess, member, group);
+		perun.getGroupsManagerBl().addMember(sess, notAssignedGroups.get(0), member2);
+
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource, false, true, false);
+
+		List<Group> groupsList = groupsManagerBl.getAssociatedGroupsToResource(sess, resource, member);
+		assertThat(groupsList).containsExactly(group);
+
+		groupsList = groupsManagerBl.getAssociatedGroupsToResource(sess, resource, member2);
+		assertThat(groupsList).isEmpty();
+	}
+
+	@Test
 	public void getMemberGroupsByAttribute() throws Exception {
 		System.out.println(CLASS_NAME + "getMemberGroupsByAttribute");
 		Vo createdVo = perun.getVosManager().createVo(sess, new Vo(0, "testik123456", "testik123456"));
@@ -6060,12 +6127,17 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 
 	}
 
-	private void setUpGroup(Vo vo) throws Exception {
+	private Group setUpGroup(Vo vo) throws Exception {
 
 		Group returnedGroup = groupsManager.createGroup(sess, vo, group);
 		assertNotNull("unable to create a group",returnedGroup);
 		assertEquals("created group should be same as returned group",group,returnedGroup);
+		return returnedGroup;
+	}
 
+	private Group setUpSubgroup(Group group) throws Exception {
+		Group subgroup = new Group("Subgroup", "Subgroup");
+		return this.groupsManagerBl.createGroup(sess, group, subgroup);
 	}
 
 	private List<Group> setUpGroups(Vo vo) throws Exception {

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/GroupsManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/GroupsManagerEntryIntegrationTest.java
@@ -1900,6 +1900,24 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 	}
 
 	@Test
+	public void getUserGroups() throws Exception {
+		System.out.println(CLASS_NAME + "getUserGroups");
+
+		vo = setUpVo();
+		setUpGroup(vo);
+		List<Group> groups = setUpGroups(vo);
+
+		Member member = setUpMember(vo);
+		groupsManagerBl.addMember(sess, group, member);
+		User u = perun.getUsersManager().getUserByMember(sess, member);
+
+		List<Group> resultGroups = groupsManagerBl.getUserGroups(sess, u);
+		assertTrue("User should be member of two groups.", resultGroups.size() == 2);
+		assertTrue("Returned groups should contain expected group.", resultGroups.contains(group));
+		assertTrue("Returned groups should contain VO's members group", resultGroups.stream().anyMatch(g -> g.getName().equals("members")));
+	}
+
+	@Test
 	public void testGroupNameLength() throws Exception {
 		System.out.println(CLASS_NAME + "testGroupNameLength");
 

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/UsersManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/UsersManagerEntryIntegrationTest.java
@@ -1059,6 +1059,42 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 	}
 
 	@Test
+	public void getAssociatedResources() throws Exception {
+		System.out.println(CLASS_NAME + "getAssociatedResources");
+
+		Member member = setUpMember(vo);
+		User user = usersManager.getUserByMember(sess, member);
+		Group group = setUpGroup(vo, member);
+
+		Facility facility = setUpFacility();
+		Resource resource = setUpResource(facility, vo);
+
+		perun.getResourcesManager().assignGroupToResource(sess, group, resource, false, true, false);
+
+		List<Resource> resources = perun.getUsersManagerBl().getAssociatedResources(sess, user);
+		assertThat(resources).containsExactly(resource);
+
+	}
+
+	@Test
+	public void getAssociatedResourcesForFacility() throws Exception {
+		System.out.println(CLASS_NAME + "getAssociatedResourcesForFacility");
+
+		Member member = setUpMember(vo);
+		User user = usersManager.getUserByMember(sess, member);
+		Group group = setUpGroup(vo, member);
+
+		Facility facility = setUpFacility();
+		Resource resource = setUpResource(facility, vo);
+
+		perun.getResourcesManager().assignGroupToResource(sess, group, resource, false, true, false);
+
+		List<Resource> resources = perun.getUsersManagerBl().getAssociatedResources(sess, facility, user);
+		assertThat(resources).containsExactly(resource);
+
+	}
+
+	@Test
 	public void findUsers() throws Exception {
 		System.out.println(CLASS_NAME + "findUsers");
 
@@ -2468,5 +2504,18 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 		attrLogin.setFriendlyName("login-namespace:dummy");
 		attrLogin.setType(String.class.getName());
 		perun.getAttributesManager().createAttribute(sess, attrLogin);
+	}
+
+	private Facility setUpFacility() throws Exception {
+		Facility facility = new Facility();
+		facility.setName("UsersManagerTestFacility");
+		return perun.getFacilitiesManager().createFacility(sess, facility);
+	}
+
+	private Resource setUpResource(Facility facility, Vo vo) throws Exception {
+		Resource resource = new Resource();
+		resource.setName("UsersManagerTestResource");
+		resource.setDescription("Testovaci");
+		return perun.getResourcesManager().createResource(sess, resource, vo, facility);
 	}
 }

--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -12462,7 +12462,7 @@ paths:
       tags:
         - ResourcesManager
       operationId: getAssignedResourcesWithGroup
-      summary: List all resources associated with a group.
+      summary: List all resources to which the group is assigned.
       parameters:
         - $ref: '#/components/parameters/groupId'
       responses:


### PR DESCRIPTION
* Return associated objects for entities and their combinations used in attributes
* For combination of entities the intersection is taken where it makes sense (e.g. user-facility attribute returns associated groups as intersection of groups where user is member and groups which are assigned to facility)
* Associated objects should include all statuses of relations (not just ACTIVE or VALID statuses)