### PR TITLE
feat: add method for getting attribute policy collections 

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/AttributeAction.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/AttributeAction.java
@@ -1,0 +1,11 @@
+package cz.metacentrum.perun.core.api;
+
+/**
+ * Represents types of actions that users can perform upon attributes.
+ *
+ * @author Radoslav Čerhák <r.cerhak@gmail.com>
+ */
+public enum AttributeAction {
+	READ,
+	WRITE
+}

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/AttributePolicy.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/AttributePolicy.java
@@ -1,0 +1,82 @@
+package cz.metacentrum.perun.core.api;
+
+import java.util.Objects;
+
+/**
+ * Represents a policy of an attribute.
+ * It specifies the role, that users need to have, and the object, upon which the role is set.
+ *
+ * @author Radoslav Čerhák <r.cerhak@gmail.com>
+ */
+public class AttributePolicy {
+	private int id;
+	private String role;
+	private RoleObject object;
+	private int policyCollectionId;
+
+	public AttributePolicy() {
+	}
+
+	public AttributePolicy(int id, String role, RoleObject object, int policyCollectionId) {
+		this.id = id;
+		this.role = role;
+		this.object = object;
+		this.policyCollectionId = policyCollectionId;
+	}
+
+	public int getId() {
+		return id;
+	}
+
+	public void setId(int id) {
+		this.id = id;
+	}
+
+	public String getRole() {
+		return role;
+	}
+
+	public void setRole(String role) {
+		this.role = role;
+	}
+
+	public RoleObject getObject() {
+		return object;
+	}
+
+	public void setObject(RoleObject object) {
+		this.object = object;
+	}
+
+	public int getPolicyCollectionId() {
+		return policyCollectionId;
+	}
+
+	public void setPolicyCollectionId(int policyCollectionId) {
+		this.policyCollectionId = policyCollectionId;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		AttributePolicy that = (AttributePolicy) o;
+		return getId() == that.getId() && getPolicyCollectionId() == that.getPolicyCollectionId()
+					&& Objects.equals(getRole(), that.getRole()) && getObject() == that.getObject();
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(getId(), getRole(), getObject(), getPolicyCollectionId());
+	}
+
+	@Override
+	public String toString() {
+		return "AttributePolicy{" +
+			"id=" + id +
+			", role='" + role + '\'' +
+			", object=" + object +
+			", policyCollectionId=" + policyCollectionId +
+			'}';
+	}
+}

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/AttributePolicyCollection.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/AttributePolicyCollection.java
@@ -1,0 +1,90 @@
+package cz.metacentrum.perun.core.api;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Represents a policy collection of an attribute.
+ *
+ * User has rights to perform an action (READ/WRITE) on the attribute,
+ * if he satisfies all policies in at least one of the attribute policy
+ * collections with given action.
+ *
+ * @author Radoslav Čerhák <r.cerhak@gmail.com>
+ */
+public class AttributePolicyCollection {
+	private int id;
+	private int attributeId;
+	private AttributeAction action;
+	private List<AttributePolicy> policies;
+
+	public AttributePolicyCollection() {
+	}
+
+	public AttributePolicyCollection(int id, int attributeId, AttributeAction action, List<AttributePolicy> policies) {
+		this.id = id;
+		this.attributeId = attributeId;
+		this.action = action;
+		this.policies = policies;
+	}
+
+	public int getId() {
+		return id;
+	}
+
+	public void setId(int id) {
+		this.id = id;
+	}
+
+	public int getAttributeId() {
+		return attributeId;
+	}
+
+	public void setAttributeId(int attributeId) {
+		this.attributeId = attributeId;
+	}
+
+	public AttributeAction getAction() {
+		return action;
+	}
+
+	public void setAction(AttributeAction action) {
+		this.action = action;
+	}
+
+	public List<AttributePolicy> getPolicies() {
+		return policies;
+	}
+
+	public void setPolicies(List<AttributePolicy> policies) {
+		this.policies = policies;
+	}
+
+	public void addPolicy(AttributePolicy policy) {
+		policies.add(policy);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		AttributePolicyCollection that = (AttributePolicyCollection) o;
+		return getId() == that.getId() && getAttributeId() == that.getAttributeId()
+				&& getAction() == that.getAction() && Objects.equals(getPolicies(), that.getPolicies());
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(getId(), getAttributeId(), getAction(), getPolicies());
+	}
+
+	@Override
+	public String toString() {
+		return "AttributePolicyCollection{" +
+			"id=" + id +
+			", attributeId=" + attributeId +
+			", action=" + action +
+			", policies=" + policies +
+			'}';
+	}
+}

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/RoleObject.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/RoleObject.java
@@ -1,0 +1,17 @@
+package cz.metacentrum.perun.core.api;
+
+/**
+ * Represents objects, upon which Perun roles can be set, e.g. role RESOURCEADMIN
+ * can be set upon Resource, Vo, Facility or no object (None).
+ *
+ * @author Radoslav Čerhák <r.cerhak@gmail.com>
+ */
+public enum RoleObject {
+	None,
+	Group,
+	Vo,
+	Facility,
+	Resource,
+	User,
+	Member
+}

--- a/perun-base/src/main/resources/perun-roles.yml
+++ b/perun-base/src/main/resources/perun-roles.yml
@@ -258,6 +258,12 @@ perun_policies:
     include_policies:
       - default_policy
 
+  getAttributePolicyCollections_int_policy:
+    policy_roles:
+      - PERUNOBSERVER:
+    include_policies:
+      - default_policy
+
   convertAttributeToUnique_int_policy:
     policy_roles: []
     include_policies:

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/AttributesManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/AttributesManager.java
@@ -4044,6 +4044,16 @@ public interface AttributesManager {
 	void setAttributeRights(PerunSession sess, List<AttributeRights> rights) throws PrivilegeException, AttributeNotExistsException, RoleNotSupportedException;
 
 	/**
+	 * Gets attribute policy collections for an attribute definition with given id.
+	 *
+	 * @param sess perun session
+	 * @param attributeId id of the attribute definition
+	 * @return all policy collections of the attribute definition
+	 * @throws AttributeNotExistsException when there is no attribute definition with such id
+	 */
+	List<AttributePolicyCollection> getAttributePolicyCollections(PerunSession sess, int attributeId) throws PrivilegeException, AttributeNotExistsException;
+
+	/**
 	 * Converts attribute to unique.
 	 * Marks the attribute definition as unique, and copies all values to a special table with unique constraint
 	 * that ensures that all values remain unique. Values of type ArrayList and LinkedHashMap are splitted into

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
@@ -3,6 +3,7 @@ package cz.metacentrum.perun.core.bl;
 import cz.metacentrum.perun.core.api.ActionType;
 import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.AttributePolicyCollection;
 import cz.metacentrum.perun.core.api.AttributeRights;
 import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.Group;
@@ -4619,6 +4620,16 @@ public interface AttributesManagerBl {
 	 * @throws InternalErrorException
 	 */
 	void setAttributeRights(PerunSession sess, List<AttributeRights> rights);
+
+	/**
+	 * Gets attribute policy collections for an attribute definition with given id.
+	 *
+	 * @param sess perun session
+	 * @param attributeId id of the attribute definition
+	 * @return all policy collections of the attribute definition
+	 * @throws InternalErrorException
+	 */
+	List<AttributePolicyCollection> getAttributePolicyCollections(PerunSession sess, int attributeId);
 
 	/**
 	 * Get user virtual attribute module by the attribute.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -50,6 +50,7 @@ import cz.metacentrum.perun.audit.events.AttributesManagerEvents.FacilityAllAttr
 import cz.metacentrum.perun.core.api.ActionType;
 import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.AttributePolicyCollection;
 import cz.metacentrum.perun.core.api.AttributeRights;
 import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.AuthzResolver;
@@ -8253,6 +8254,11 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 				getPerunBl().getAuditer().log(sess, new AttributeRightsSet(right));
 			}
 		}
+	}
+
+	@Override
+	public List<AttributePolicyCollection> getAttributePolicyCollections(PerunSession sess, int attributeId) {
+		return getAttributesManagerImpl().getAttributePolicyCollections(sess, attributeId);
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/AttributesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/AttributesManagerEntry.java
@@ -3,6 +3,7 @@ package cz.metacentrum.perun.core.entry;
 import cz.metacentrum.perun.core.api.ActionType;
 import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.AttributePolicyCollection;
 import cz.metacentrum.perun.core.api.AttributeRights;
 import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.AuthzResolver;
@@ -4509,6 +4510,19 @@ public class AttributesManagerEntry implements AttributesManager {
 		}
 
 		getAttributesManagerBl().setAttributeRights(sess, rights);
+	}
+
+	@Override
+	public List<AttributePolicyCollection> getAttributePolicyCollections(PerunSession sess, int attributeId) throws PrivilegeException, AttributeNotExistsException {
+		Utils.checkPerunSession(sess);
+		getAttributeDefinitionById(sess, attributeId);
+
+		// Authorization
+		if (!AuthzResolver.authorizedInternal(sess, "getAttributePolicyCollections_int_policy")) {
+			throw new PrivilegeException("getAttributePolicyCollections");
+		}
+
+		return getAttributesManagerBl().getAttributePolicyCollections(sess, attributeId);
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
@@ -6,6 +6,7 @@ package cz.metacentrum.perun.core.implApi;
 import cz.metacentrum.perun.core.api.ActionType;
 import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.AttributePolicyCollection;
 import cz.metacentrum.perun.core.api.AttributeRights;
 import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.Group;
@@ -2706,4 +2707,14 @@ public interface AttributesManagerImplApi {
 	 * e.g. 'domain/?vo=vo name' => 'domain/?vo=vo+name'
 	 */
 	String escapeQueryParameters(String value);
+
+	/**
+	 * Gets attribute policy collections for an attribute definition with given id.
+	 *
+	 * @param sess perun session
+	 * @param attributeId id of the attribute definition
+	 * @return all policy collections of the attribute definition
+	 * @throws InternalErrorException
+	 */
+	List<AttributePolicyCollection> getAttributePolicyCollections(PerunSession sess, int attributeId);
 }

--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -371,6 +371,54 @@ components:
           items:
             $ref: '#/components/schemas/ActionType'
 
+    AttributeAction:
+      type: string
+      description: "Represents types of actions that users can perform upon attributes."
+      enum:
+        - "WRITE"
+        - "READ"
+
+    RoleObject:
+      type: string
+      description: "Represents objects, upon which Perun roles can be set, e.g. role RESOURCEADMIN can be set upon Resource, Vo, Facility or no object (None)."
+      enum:
+        - "None"
+        - "Group"
+        - "Vo"
+        - "Facility"
+        - "Resource"
+        - "User"
+        - "Member"
+
+    AttributePolicy:
+      type: object
+      required:
+        - id
+        - role
+        - object
+        - policyCollectionId
+      properties:
+        id: { type: integer }
+        role: { type: string }
+        object: { $ref: '#/components/schemas/RoleObject' }
+        policyCollectionId: { type: integer }
+
+    AttributePolicyCollection:
+      type: object
+      required:
+        - id
+        - attributeId
+        - action
+        - policies
+      properties:
+        id: { type: integer }
+        attributeId: { type: integer }
+        action: { $ref: '#/components/schemas/AttributeAction' }
+        policies:
+          type: array
+          items:
+            $ref: '#/components/schemas/AttributePolicy'
+
     Facility:
       allOf:
         - $ref: '#/components/schemas/Auditable'
@@ -1667,6 +1715,15 @@ components:
             type: array
             items:
               $ref: "#/components/schemas/AttributeRights"
+
+    ListOfAttributePolicyCollectionResponse:
+      description: "returns List<AttributePolicyCollection>"
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/AttributePolicyCollection"
 
     AttributeResponse:
       description: "returns Attribute"
@@ -6804,6 +6861,19 @@ paths:
         default:
           $ref: '#/components/responses/ExceptionResponse'
 
+  /json/attributesManager/getAttributePolicyCollections:
+    get:
+      tags:
+        - AttributesManager
+      operationId: getAttributePolicyCollections
+      summary: "Gets attribute policy collections for an attribute definition with given id."
+      parameters:
+        - $ref: '#/components/parameters/attributeId'
+      responses:
+        '200':
+          $ref: '#/components/responses/ListOfAttributePolicyCollectionResponse'
+        default:
+          $ref: '#/components/responses/ExceptionResponse'
 
   /urlinjsonout/attributesManager/convertAttributeToUnique:
     post:

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/AttributesManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/AttributesManagerMethod.java
@@ -3958,6 +3958,21 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	},
 
 	/*#
+	 * Gets attribute policy collections for an attribute definition with given id.
+	 *
+	 * @param attributeId int AttributeDefinition <code>id</code>
+	 * @return List<AttributePolicyCollection> all policy collections of attribute definition
+	 * @throw AttributeNotExistsException When AttributeDefinition with <code>id</code> doesn't exist.
+	 */
+	getAttributePolicyCollections {
+		@Override
+		public List<AttributePolicyCollection> call(ApiCaller ac, Deserializer parms) throws PerunException {
+			return ac.getAttributesManager().getAttributePolicyCollections(ac.getSession(),
+				parms.readInt("attributeId"));
+		}
+	},
+
+	/*#
 	 * Converts attribute to unique - marks its definition as unique and ensures that all its values are unique.
 	 * Entityless attributes cannot be converted to unique, only attributes attached to PerunBeans or pairs of PerunBeans.
 	 *

--- a/perun-utils/rpc-methods-javadoc-generator/parseRpcMethods.pl
+++ b/perun-utils/rpc-methods-javadoc-generator/parseRpcMethods.pl
@@ -237,6 +237,14 @@ $objectExamples{"Paginated<RichGroup>"} = @objectExamples{"Paginated&lt;RichGrou
 $objectExamples{"GroupMemberRelation"} = "{\"groupId\" : 69, \"memberId\" : 55, \"sourceGroupId\", \"sourceGroupStatus\" : \"EXPIRED\", \"membershipType\" : \"DIRECT\" }";
 $objectExamples{"GroupMemberData"} = "{\"relations\" : " . $listPrepend . $objectExamples{"GroupMemberRelation"} . $listAppend . ", \"groupMemberAttributes\": { \"69\": { \"55\": ".$listPrepend . $objectExamples{"Attribute"} . $listAppend. " } } }";
 
+$objectExamples{"AttributePolicy"} = "{ \"id\" : 290 , \"role\" : \"RESOURCEADMIN\" , \"object\" : \"Resource\" , \"policyCollectionId\" : 10 }";
+$objectExamples{"List&lt;AttributePolicy&gt;"} = $listPrepend . $objectExamples{"AttributePolicy"} . $listAppend;
+$objectExamples{"List<AttributePolicy>"} = $objectExamples{"List&lt;AttributePolicy&gt;"};
+
+$objectExamples{"AttributePolicyCollection"} = "{ \"id\" : 10 , \"attributeId\" : 2220 , \"action\" : \"READ\" , \"policies\" : " . $objectExamples{"List&lt;AttributePolicyCollection&gt;"} . " }";
+$objectExamples{"List&lt;AttributePolicyCollection&gt;"} = $listPrepend . $objectExamples{"AttributePolicyCollection"} . $listAppend;
+$objectExamples{"List<AttributePolicyCollection>"} = $objectExamples{"List&lt;AttributePolicyCollection&gt;"};
+
 # SUB HELP
 # help info
 sub help {


### PR DESCRIPTION
- Added new objects AttributePolicy and AttributePolicyCollection. They
will be used for evaluating users' rights on attributes. User has
rights to perform an action (READ/WRITE) on the attribute, if he
satisfies all policies in at least one of the attribute policy
collections with given action.
- Added new method getAttributePolicyCollections, it gets attribute
policy collections for given attribute.