### PR TITLE
feat(openapi): OpenAPI Generator now works for Python CLI

### DIFF
--- a/perun-cli-python/cliutils/__init__.py
+++ b/perun-cli-python/cliutils/__init__.py
@@ -1,4 +1,7 @@
 import perun_openapi
+import perun_openapi.api.users_manager_api
+import perun_openapi.api.members_manager_api
+import perun_openapi.api.attributes_manager_api
 import os
 import sys
 import argparse
@@ -40,13 +43,13 @@ class PerunRpc:
 		self.api_client.user_agent = "Perun OpenAPI Python CLI"
 
 	def users_manager(self):
-		return perun_openapi.api.UsersManagerApi(self.api_client)
+		return perun_openapi.api.users_manager_api.UsersManagerApi(self.api_client)
 
 	def members_manager(self):
-		return perun_openapi.api.MembersManagerApi(self.api_client)
+		return perun_openapi.api.members_manager_api.MembersManagerApi(self.api_client)
 
 	def attributes_manager(self):
-		return perun_openapi.api.AttributesManagerApi(self.api_client)
+		return perun_openapi.api.attributes_manager_api.AttributesManagerApi(self.api_client)
 
 class PerunCliConfiguration(perun_openapi.configuration.Configuration):
 	def auth_settings(self):

--- a/perun-cli-python/generate.sh
+++ b/perun-cli-python/generate.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-GENERATOR_VERSION=5.1.0
+GENERATOR_VERSION=5.3.1
 if [ ! -f  "openapi-generator-cli-$GENERATOR_VERSION.jar" ] ; then
   wget https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/$GENERATOR_VERSION/openapi-generator-cli-$GENERATOR_VERSION.jar
 fi

--- a/perun-cli-python/get_expirations_by_ext_logins.py
+++ b/perun-cli-python/get_expirations_by_ext_logins.py
@@ -15,21 +15,23 @@ def main(args):
 
 	f = open(args['file'], "r")
 	for x in f:
-		x = x.strip(' \n')
+		x = x.strip(' \n') + '@idp.e-infra.cz'
 		user = users_manager.get_user_by_ext_source_name_and_ext_login(ext_login=x,ext_source_name=args['extSourceName'])
 		pprint(user)
-		#TODO Python OpenAPI generator does not support inheritance yest :-(
-		# see https://github.com/OpenAPITools/openapi-generator/pull/4446
+
 		member = members_manager.get_member_by_user(vo=args['voId'], user=user.id)
 		pprint(member)
-		attr = attributes_manager.get_member_attribute_by_name(member.id,"urn:perun:member:attribute-def:def:membershipExpiration")
-		pprint(attr)
+
+		# Attribute.value can be a JSON object, a string, an integer, a list, but OpenAPI 3.0 does not allow this
+		# see https://stackoverflow.com/questions/48111459/how-to-define-a-property-that-can-be-string-or-null-in-openapi-swagger
+		# attr = attributes_manager.get_member_attribute_by_name(member.id,"urn:perun:member:attribute-def:def:membershipExpiration")
+		# pprint(attr)
 	f.close()
 
 # calling main when invoked from CLI
 if __name__ == "__main__":
 	options = options("Outputs member expirations in given VO.")
 	options.add_argument('-f', '--file', help='file with user logins', required=True)
-	options.add_argument('-v', '--voId', help='id of VO', default=20, required=False, type=int)
-	options.add_argument('-E', '--extSourceName', help='name of external source', required=False, default='https://login.cesnet.cz/idp/')
+	options.add_argument('-v', '--voId', help='id of VO', default=21, required=False, type=int)
+	options.add_argument('-E', '--extSourceName', help='name of external source', required=False, default='https://idp.e-infra.cz/idp/')
 	sys.exit(main(vars(options.parse_args())) or 0)

--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -77,12 +77,12 @@ components:
       allOf:
         - $ref: '#/components/schemas/PerunBean'
         - properties:
-            createdAt: { type: string }
-            createdBy: { type: string }
-            modifiedAt: { type: string }
-            modifiedBy: { type: string }
-            createdByUid: { type: integer }
-            modifiedByUid: { type: integer }
+            createdAt: { type: string, nullable: true }
+            createdBy: { type: string, nullable: true }
+            modifiedAt: { type: string, nullable: true }
+            modifiedBy: { type: string, nullable: true }
+            createdByUid: { type: integer, nullable: true }
+            modifiedByUid: { type: integer, nullable: true }
       discriminator:
         propertyName: beanName
 
@@ -90,11 +90,11 @@ components:
       allOf:
         - $ref: '#/components/schemas/Auditable'
         - properties:
-            firstName: { type: string }
-            lastName: { type: string }
-            middleName: { type: string }
-            titleBefore: { type: string }
-            titleAfter: { type: string }
+            firstName: { type: string, nullable: true }
+            lastName: { type: string, nullable: true }
+            middleName: { type: string, nullable: true }
+            titleBefore: { type: string, nullable: true }
+            titleAfter: { type: string, nullable: true }
             serviceUser: { type: boolean }
             sponsoredUser: { type: boolean }
             uuid: { type: string, format: uuid }
@@ -150,7 +150,7 @@ components:
             voId: { type: integer }
             status: { type: string }
             membershipType: { type: string }
-            sourceGroupId: { type: integer }
+            sourceGroupId: { type: integer, nullable: true }
             sponsored: { type: boolean }
             groupStatus: { type: string }
             groupStatuses:


### PR DESCRIPTION
OpenAPI Generator updated to version 5.3.1 which supports object inheritance, fixed definition of
some schemas to allow null values