### PR TITLE
fix(core): change regex to forbid using reserved characters

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_adGroupName.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_adGroupName.java
@@ -20,7 +20,7 @@ import java.util.regex.Pattern;
 
 public class urn_perun_group_attribute_def_def_adGroupName extends GroupAttributesModuleAbstract implements GroupAttributesModuleImplApi {
 
-	private static final Pattern pattern = Pattern.compile("[A-Za-z0-9 _-]+");
+	private static final Pattern pattern = Pattern.compile("[A-Za-z0-9_-]|([A-Za-z0-9_-][A-Za-z0-9 _-]*[A-Za-z0-9_-])");
 	private static final String A_R_D_AD_RESOURCE_REPRESENTATION = AttributesManager.NS_RESOURCE_ATTR_DEF + ":adResourceRepresentation";
 	private static final String A_G_D_AD_GROUP_NAME = AttributesManager.NS_GROUP_ATTR_DEF + ":adGroupName";
 

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_adGroupNameTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_adGroupNameTest.java
@@ -66,6 +66,22 @@ public class urn_perun_group_attribute_def_def_adGroupNameTest extends AbstractP
 		classInstance.checkAttributeSyntax(sess, group, attributeToCheck);
 	}
 
+	@Test(expected = WrongAttributeValueException.class)
+	public void testWrongSyntaxWithSpaceAtStart() throws Exception {
+		System.out.println("testWrongSyntaxWithSpaceAtStart()");
+		attributeToCheck.setValue(" badValue");
+
+		classInstance.checkAttributeSyntax(sess, group, attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testWrongSyntaxWithSpaceAtEnd() throws Exception {
+		System.out.println("testWrongSyntaxWithSpaceAtEnd()");
+		attributeToCheck.setValue("badValue ");
+
+		classInstance.checkAttributeSyntax(sess, group, attributeToCheck);
+	}
+
 	@Test
 	public void testCorrectSyntax() {
 		System.out.println("testCorrectSyntax()");
@@ -77,8 +93,26 @@ public class urn_perun_group_attribute_def_def_adGroupNameTest extends AbstractP
 
 	@Test
 	public void testCorrectSyntaxWithDash() {
-		System.out.println("testCorrectSyntax()");
-		attributeToCheck.setValue("correct-Value-with-Dash");
+		System.out.println("testCorrectSyntaxWithDash()");
+		attributeToCheck.setValue("-correct-Value-with-Dash-");
+
+		assertThatNoException().isThrownBy(
+			() -> classInstance.checkAttributeSyntax(sess, group, attributeToCheck));
+	}
+
+	@Test
+	public void testCorrectSyntaxWithUnderscore() {
+		System.out.println("testCorrectSyntaxWithUnderscore()");
+		attributeToCheck.setValue("_correct_Value_with_Dash_");
+
+		assertThatNoException().isThrownBy(
+			() -> classInstance.checkAttributeSyntax(sess, group, attributeToCheck));
+	}
+
+	@Test
+	public void testCorrectSyntaxWithSpace() {
+		System.out.println("testCorrectSyntaxWithSpace()");
+		attributeToCheck.setValue("correct Value with Dash");
 
 		assertThatNoException().isThrownBy(
 			() -> classInstance.checkAttributeSyntax(sess, group, attributeToCheck));


### PR DESCRIPTION
* Regex used for validation forbids using space at the beginning or at the end of attribute value