### PR TITLE
fix(core): ignore User properties for Candidate object in JsonDeserializer

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/rpc/deserializer/JsonDeserializer.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/rpc/deserializer/JsonDeserializer.java
@@ -52,7 +52,7 @@ public class JsonDeserializer extends Deserializer {
 	@JsonIgnoreProperties({"beanName", "uuid"})
 	private interface PerunBeanMixIn {}
 
-	@JsonIgnoreProperties({"userExtSources", "uuid"})
+	@JsonIgnoreProperties({"userExtSources", "commonName", "displayName", "specificUser", "majorSpecificType", "beanName", "uuid"})
 	private interface CandidateMixIn {}
 
 	@JsonIgnoreProperties({"name"})


### PR DESCRIPTION
- Since Candidate extends User, we must ignore same properties for
  the Candidate in JsonDeserializer.