### PR TITLE
fix(openapi): fix null values detection in JsonDeserializer

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/rpc/deserializer/JsonDeserializer.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/rpc/deserializer/JsonDeserializer.java
@@ -167,7 +167,7 @@ public class JsonDeserializer extends Deserializer {
 
 	@Override
 	public boolean contains(String name) {
-		return root.get(name) != null;
+		return root.hasNonNull(name);
 	}
 
 	@Override


### PR DESCRIPTION
Parameters to API calls that contain null value should be treated as not provided.