### PR TITLE
fix(core): fix transactions when copying facilityadmins

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/FacilitiesManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/FacilitiesManager.java
@@ -550,7 +550,7 @@ public interface FacilitiesManager {
 	/**
 	 * Copy all managers(admins) of the source facility to the destination facility.
 	 * The admins, that are in the destination facility and aren't in the source facility, are retained.
-	 * The common admins are replaced with admins from source facility.
+	 * The common admins are also retained in destination facility.
 	 */
 	void copyManagers(PerunSession sess, Facility sourceFacility, Facility destinationFacility) throws PrivilegeException, FacilityNotExistsException;
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/FacilitiesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/FacilitiesManagerBl.java
@@ -881,7 +881,7 @@ public interface FacilitiesManagerBl {
 	/**
 	 * Copy all managers(admins) of the source facility to the destination facility.
 	 * The admins, that are in the destination facility and aren't in the source facility, are retained.
-	 * The common admins are replaced with admins from source facility.
+	 * The common admins are also retained in destination facility.
 	 *
 	 * @param sess
 	 * @param sourceFacility

--- a/perun-core/src/main/resources/perun-core.xml
+++ b/perun-core/src/main/resources/perun-core.xml
@@ -56,6 +56,7 @@ http://www.springframework.org/schema/task http://www.springframework.org/schema
 		<aop:advisor advice-ref="txAdviceNestedTransaction" pointcut="execution(* cz.metacentrum.perun.core.impl.AttributesManagerImpl.setAttributeRight(..))"/>
 		<!-- AuthzResolverImpl -->
 		<aop:advisor advice-ref="txAdviceNestedTransaction" pointcut="execution(* cz.metacentrum.perun.core.impl.AuthzResolverImpl.addAdmin(..))"/>
+		<aop:advisor advice-ref="txAdviceNestedTransaction" pointcut="execution(* cz.metacentrum.perun.core.impl.AuthzResolverImpl.setRole(..))"/>
 		<aop:advisor advice-ref="txAdviceNestedTransaction" pointcut="execution(* cz.metacentrum.perun.core.impl.AuthzResolverImpl.addVoRole(..))"/>
 		<aop:advisor advice-ref="txAdviceNestedTransaction" pointcut="execution(* cz.metacentrum.perun.core.impl.AuthzResolverImpl.makeUserPerunAdmin(..))"/>
 		<!-- ExtSourcesManagerImpl -->

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntryIntegrationTest.java
@@ -60,6 +60,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -723,6 +724,27 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		assertNotNull("unable to create Facility", returnedFacility);
 		assertEquals("created and returned facility should be the same", returnedFacility, facility);
 
+	}
+
+	@Test
+	public void copyFacilityAdminAlreadyExists() throws Exception {
+		System.out.println(CLASS_NAME + "copyFacilityAdminAlreadyExists");
+
+		Facility f2 = new Facility();
+		f2.setName("FacilitiesManagerTestSecondFacility");
+		f2.setDescription("TestSecondFacilityDescription");
+		Facility facility2 = perun.getFacilitiesManager().createFacility(sess, f2);
+
+		Member member = setUpMember(vo);
+		User u = perun.getUsersManagerBl().getUserByMember(sess, member);
+		facilitiesManagerEntry.addAdmin(sess, facility, u);
+		facilitiesManagerEntry.addAdmin(sess, facility2, u);
+
+		Group group = setUpGroup(vo, member);
+		facilitiesManagerEntry.addAdmin(sess, facility, group);
+		facilitiesManagerEntry.addAdmin(sess, facility2, group);
+
+		assertThatNoException().isThrownBy(() -> perun.getFacilitiesManager().copyManagers(sess, facility, facility2));
 	}
 
 	@Test (expected=FacilityExistsException.class)


### PR DESCRIPTION
* when copying facilityadmin between facilities, AlreadyAdminException is thrown
* because this exception is thrown in nested transaction that continues with other operations, postgres raises error
* using transaction on setRole method should correctly rollback copying already present admin and continue