### PR TITLE
feat(core): allow ssh keys with command prefixes

### DIFF
--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_sshPublicKeyTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_sshPublicKeyTest.java
@@ -98,11 +98,44 @@ public class urn_perun_user_attribute_def_def_sshPublicKeyTest {
 		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
 	}
 
+	@Test
+	public void testCheckCorrectSshRSAWithPrefixAttributeSyntax() throws Exception {
+		System.out.println("testCheckCorrectSshRSAWithPrefixAttributeSyntax()");
+		List<String> value = new ArrayList<>();
+		value.add("command=\"cat - > ~/VO_cesnet_neant-tape_tape/sb/l-`date +%12s`.bumbrleetschek\" ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC7FPq20sXf+83P/mvfEBntaGUkVJu36X2gLIi5TioYPSqGVIPV+ztnhNUuJHQZ3HYRDhGw/5c32mIYKQvsAB0T/WT6hgs9zVHU1s5ieJSduxx9DqbEkHaZUirmukd8uF97QJm6Ve/cvS3YUb3yxWXcRiJX5jy1aRazoJgm/Vocgz/1PHInq46IQUN6I62ge7u5YrpSxym6Ehw8ZGCr7QyIyg5TdNVbK4flkf6LM/uKh0JuODfm+/R/3TjzbR/7oDzfkQR4TZE3sCHXpSEwaHbb4SM6if1di2PKefhlx9m7w0oMwaE6Epoq/US1FHxR0up+PQYqqwE+/fi9C88byT1Kjz7xpC3IV0bOdeP6nDcLDYsKssgotqU0YIrBCTes/an1efe1jrYZQvr54XvKNFWUnJsMJLosT2ZCWkNCyyrnL9V+KEJ07Qb4NAXfgcrVakP/6647FAXCgyY8Len9c/0aTn7SVd1aC3aTGRvLtvPNPzhbDJGKzjPs90So0GZ+q7s= martin@martin-ThinkPad-T480");
+		value.add("principals=\"oskar\" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJhGU1cLG0UldPhYxbEjKcZmFSZsGznmAYvra2QPls7a martin@martin-ThinkPad-T480");
+		value.add("environment=\"GIT_AUTHOR_NAME=John Doe\",environment=\"GIT_AUTHOR_EMAIL=john.doe@email.cz\" ecdsa-sha2-nistp521 AAAAE2VjZHNhLXNoYTItbmlzdHA1MjEAAAAIbmlzdHA1MjEAAACFBAFtrrFATKkxbaAKKBvl/X8SIbpJZffbCS0v2v9KLEE+6VEHqQFIDreZEXKbvk5/3JZ9Foh6+SJLE8fSyZKJE/0zcgEhhHfsYMdQASwshLSKpoaBNApo5gIqHD8a0WFIed86MOFIuB/Ux90X3an23bPSyM7Ri4mko3BXc8iAvvLQwf10HA== martin@martin-ThinkPad-T480");
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+	}
+
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckSshED25519AttributeSyntaxWithWrongPrefix() throws Exception {
+		System.out.println("testCheckSshED25519AttributeSyntaxWithWrongPrefix()");
+		List<String> value = new ArrayList<>();
+		value.add("ssh-rsa environment=\"GIT_AUTHOR_NAME=John Doe\",environment=\"GIT_AUTHOR_EMAIL=john.doe@email.cz\" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJhGU1cLG0UldPhYxbEjKcZmFSZsGznmAYvra2QPls7a martin@martin-ThinkPad-T480");
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+	}
+
 	@Test(expected = WrongAttributeValueException.class)
 	public void testCheckAttributeSyntaxWithWrongValue() throws Exception {
 		System.out.println("testCheckAttributeSyntaxWithWrongValue()");
 		List<String> value = new ArrayList<>();
 		value.add("bad_example\n");
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckAttributeSyntaxWithEmptyKey() throws Exception {
+		System.out.println("testCheckAttributeSyntaxWithEmptyKey()");
+		List<String> value = new ArrayList<>();
+		value.add("");
 		attributeToCheck.setValue(value);
 
 		classInstance.checkAttributeSyntax(session, user, attributeToCheck);


### PR DESCRIPTION
* added new method removeSSHKeyCommandPrefix which checks for and removes the command prefix, then the validation proceeds as before.