### PR TITLE
feat(openapi): attribute values now work in generated Python client

### DIFF
--- a/perun-cli-python/get_expirations_by_ext_logins.py
+++ b/perun-cli-python/get_expirations_by_ext_logins.py
@@ -24,8 +24,8 @@ def main(args):
 
 		# Attribute.value can be a JSON object, a string, an integer, a list, but OpenAPI 3.0 does not allow this
 		# see https://stackoverflow.com/questions/48111459/how-to-define-a-property-that-can-be-string-or-null-in-openapi-swagger
-		# attr = attributes_manager.get_member_attribute_by_name(member.id,"urn:perun:member:attribute-def:def:membershipExpiration")
-		# pprint(attr)
+		attr = attributes_manager.get_member_attribute_by_name(member.id,"urn:perun:member:attribute-def:def:membershipExpiration")
+		pprint(attr)
 	f.close()
 
 # calling main when invoked from CLI

--- a/perun-cli-python/test_attribute_values.py
+++ b/perun-cli-python/test_attribute_values.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+# -*- coding: utf8 -*-
+import sys
+from cliutils import PerunRpc,options
+from pprint import pprint
+
+def main(args):
+	"""main function"""
+
+	rpc = PerunRpc(args)
+	user = rpc.users_manager().get_user_by_id(3197)
+	member = rpc.members_manager().get_member_by_user(vo=21, user=user.id)
+
+
+	attr = rpc.attributes_manager().get_member_attribute_by_name(member.id,"urn:perun:member:attribute-def:def:membershipExpiration")
+	print(attr['namespace']+':'+attr['friendly_name'],attr['type'],':',attr['value'])
+
+	for attrName in ["urn:perun:user:attribute-def:def:preferredMail",
+					 "urn:perun:user:attribute-def:def:sshPublicKey",
+					 "urn:perun:user:attribute-def:def:publications",
+					 "urn:perun:user:attribute-def:virt:loa",
+					 "urn:perun:user:attribute-def:def:it4iBlockCollision"]:
+		attr = rpc.attributes_manager().get_user_attribute_by_name(user.id, attrName)
+		print(attr['namespace']+':'+attr['friendly_name'],attr['type'],':',attr['value'])
+
+# calling main when invoked from CLI
+if __name__ == "__main__":
+	options = options("Just test, no options")
+	sys.exit(main(vars(options.parse_args())) or 0)

--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -301,11 +301,11 @@ components:
       allOf:
         - $ref: '#/components/schemas/AttributeDefinition'
         - properties:
-            valueCreatedAt: { type: string }
-            valueCreatedBy: { type: string }
-            valueModifiedAt: { type: string }
-            valueModifiedBy: { type: string }
-            value: { type: object }
+            valueCreatedAt: { type: string, nullable: true }
+            valueCreatedBy: { type: string, nullable: true }
+            valueModifiedAt: { type: string, nullable: true }
+            valueModifiedBy: { type: string, nullable: true }
+            value: {}
       discriminator:
         propertyName: beanName
 


### PR DESCRIPTION
Fixed OpenAPI definition of attribute value type to work correctly both in Java and Python clients.