### PR TITLE
fix(core): modules marked as deprecated

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace_researcher_access_persistent_shadow.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace_researcher_access_persistent_shadow.java
@@ -22,6 +22,7 @@ import java.util.UUID;
  * It is only storage! Use module login researcher-access_persistent for access the value.
  *
  */
+@Deprecated
 public class urn_perun_user_attribute_def_def_login_namespace_researcher_access_persistent_shadow
 	extends urn_perun_user_attribute_def_def_login_namespace {
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_login_namespace_researcher_access_persistent.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_login_namespace_researcher_access_persistent.java
@@ -21,6 +21,7 @@ import java.util.List;
  *
  */
 @SkipValueCheckDuringDependencyCheck
+@Deprecated
 public class urn_perun_user_attribute_def_virt_login_namespace_researcher_access_persistent
 	extends UserVirtualAttributesModuleAbstract {
 


### PR DESCRIPTION
Marked researcher_access_persistent and researcher_access_persistent_shadow
modules as deprecated, because they are not used.