### PR TITLE
feat(core): load membership role to session with authorization refresh

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/GroupsManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/GroupsManagerBl.java
@@ -625,6 +625,19 @@ public interface GroupsManagerBl {
 	List<Group> getUserGroups(PerunSession sess, User user);
 
 	/**
+	 * Return groups where user is member with allowed statuses in vo and group.
+	 * If statuses are empty or null, all statuses are used.
+	 *
+	 * @param sess
+	 * @param user
+	 * @param memberStatuses allowed statuses of member in VO
+	 * @param memberGroupStatuses allowed statuses of member in group
+	 * @return list of groups
+	 * @throws InternalErrorException
+	 */
+	List<Group> getUserGroups(PerunSession sess, User user, List<Status> memberStatuses, List<MemberGroupStatus> memberGroupStatuses);
+
+	/**
 	 * Returns group members in the RichMember object, which contains Member+User data.
 	 *
 	 * @param sess

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ResourcesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ResourcesManagerBl.java
@@ -11,6 +11,7 @@ import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.GroupResourceAssignment;
 import cz.metacentrum.perun.core.api.GroupResourceStatus;
 import cz.metacentrum.perun.core.api.Member;
+import cz.metacentrum.perun.core.api.MemberGroupStatus;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.ResourceTag;
@@ -19,6 +20,7 @@ import cz.metacentrum.perun.core.api.RichResource;
 import cz.metacentrum.perun.core.api.RichUser;
 import cz.metacentrum.perun.core.api.Service;
 import cz.metacentrum.perun.core.api.ServicesPackage;
+import cz.metacentrum.perun.core.api.Status;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.Vo;
 import cz.metacentrum.perun.core.api.exceptions.AlreadyAdminException;
@@ -725,6 +727,23 @@ public interface ResourcesManagerBl {
 	 * @throws InternalErrorException
 	 */
 	List<Resource> getAllowedResources(PerunSession sess, Facility facility, User user);
+
+	/**
+	 * Return all resources where user is assigned.
+	 * Checks member's status in VO and group and status of group-resource assignment.
+	 * If statuses are null or empty all statuses are used.
+	 *
+	 * @param sess
+	 * @param user
+	 * @param memberStatuses allowed member's statuses in VO
+	 * @param memberGroupStatuses allowed member's statuses in group
+	 * @param groupResourceStatuses allowed statuses of group-resource assignment
+	 *
+	 * @return List of allowed resources for the user
+	 * @throws InternalErrorException
+	 */
+	List<Resource> getResources(PerunSession sess, User user, List<Status> memberStatuses, List<MemberGroupStatus> memberGroupStatuses, List<GroupResourceStatus> groupResourceStatuses);
+
 
 	/**
 	 * Get all resources where the member is assigned.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
@@ -16,8 +16,10 @@ import cz.metacentrum.perun.core.api.BanOnVo;
 import cz.metacentrum.perun.core.api.BeansUtils;
 import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.GroupResourceStatus;
 import cz.metacentrum.perun.core.api.Host;
 import cz.metacentrum.perun.core.api.Member;
+import cz.metacentrum.perun.core.api.MemberGroupStatus;
 import cz.metacentrum.perun.core.api.PerunBean;
 import cz.metacentrum.perun.core.api.PerunClient;
 import cz.metacentrum.perun.core.api.PerunPolicy;
@@ -1028,11 +1030,8 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 
 		List<AttributePolicyCollection> policyCollections = getAttributePolicyCollections(sess, actionType, attrDef);
 
-		// If the user has no roles and this attribute does not have any rule for MEMBERSHIP, deny access
-		if ((sess.getPerunPrincipal().getRoles() == null || sess.getPerunPrincipal().getRoles().isEmpty())
-			&& policyCollections.stream()
-			.flatMap(c -> c.getPolicies().stream())
-			.noneMatch(p -> p.getRole().equals(Role.MEMBERSHIP))) {
+		// If the user has no roles deny access
+		if (sess.getPerunPrincipal().getRoles() == null || sess.getPerunPrincipal().getRoles().isEmpty()) {
 			return false;
 		}
 
@@ -1071,11 +1070,8 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 
 		List<AttributePolicyCollection> policyCollections = getAttributePolicyCollections(sess, actionType, attrDef);
 
-		// If the user has no roles and this attribute does not have any rule for MEMBERSHIP, deny access
-		if ((sess.getPerunPrincipal().getRoles() == null || sess.getPerunPrincipal().getRoles().isEmpty())
-			&& policyCollections.stream()
-			.flatMap(c -> c.getPolicies().stream())
-			.noneMatch(p -> p.getRole().equals(Role.MEMBERSHIP))) {
+		// If the user has no roles deny access
+		if (sess.getPerunPrincipal().getRoles() == null || sess.getPerunPrincipal().getRoles().isEmpty()) {
 			return false;
 		}
 
@@ -1114,11 +1110,8 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 
 		List<AttributePolicyCollection> policyCollections = getAttributePolicyCollections(sess, actionType, attrDef);
 
-		// If the user has no roles and this attribute does not have any rule for MEMBERSHIP, deny access
-		if ((sess.getPerunPrincipal().getRoles() == null || sess.getPerunPrincipal().getRoles().isEmpty())
-			&& policyCollections.stream()
-			.flatMap(c -> c.getPolicies().stream())
-			.noneMatch(p -> p.getRole().equals(Role.MEMBERSHIP))) {
+		// If the user has no roles deny access
+		if (sess.getPerunPrincipal().getRoles() == null || sess.getPerunPrincipal().getRoles().isEmpty()) {
 			return false;
 		}
 
@@ -1157,11 +1150,8 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 
 		List<AttributePolicyCollection> policyCollections = getAttributePolicyCollections(sess, actionType, attrDef);
 
-		// If the user has no roles and this attribute does not have any rule for MEMBERSHIP, deny access
-		if ((sess.getPerunPrincipal().getRoles() == null || sess.getPerunPrincipal().getRoles().isEmpty())
-			&& policyCollections.stream()
-			.flatMap(c -> c.getPolicies().stream())
-			.noneMatch(p -> p.getRole().equals(Role.MEMBERSHIP))) {
+		// If the user has no roles deny access
+		if (sess.getPerunPrincipal().getRoles() == null || sess.getPerunPrincipal().getRoles().isEmpty()) {
 			return false;
 		}
 
@@ -1193,11 +1183,8 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 
 		List<AttributePolicyCollection> policyCollections = getAttributePolicyCollections(sess, actionType, attrDef);
 
-		// If the user has no roles and this attribute does not have any rule for MEMBERSHIP, deny access
-		if ((sess.getPerunPrincipal().getRoles() == null || sess.getPerunPrincipal().getRoles().isEmpty())
-			&& policyCollections.stream()
-			.flatMap(c -> c.getPolicies().stream())
-			.noneMatch(p -> p.getRole().equals(Role.MEMBERSHIP))) {
+		// If the user has no roles deny access
+		if (sess.getPerunPrincipal().getRoles() == null || sess.getPerunPrincipal().getRoles().isEmpty()) {
 			return false;
 		}
 
@@ -1229,11 +1216,8 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 
 		List<AttributePolicyCollection> policyCollections = getAttributePolicyCollections(sess, actionType, attrDef);
 
-		// If the user has no roles and this attribute does not have any rule for MEMBERSHIP, deny access
-		if ((sess.getPerunPrincipal().getRoles() == null || sess.getPerunPrincipal().getRoles().isEmpty())
-			&& policyCollections.stream()
-			.flatMap(c -> c.getPolicies().stream())
-			.noneMatch(p -> p.getRole().equals(Role.MEMBERSHIP))) {
+		// If the user has no roles deny access
+		if (sess.getPerunPrincipal().getRoles() == null || sess.getPerunPrincipal().getRoles().isEmpty()) {
 			return false;
 		}
 
@@ -1265,11 +1249,8 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 
 		List<AttributePolicyCollection> policyCollections = getAttributePolicyCollections(sess, actionType, attrDef);
 
-		// If the user has no roles and this attribute does not have any rule for MEMBERSHIP, deny access
-		if ((sess.getPerunPrincipal().getRoles() == null || sess.getPerunPrincipal().getRoles().isEmpty())
-			&& policyCollections.stream()
-			.flatMap(c -> c.getPolicies().stream())
-			.noneMatch(p -> p.getRole().equals(Role.MEMBERSHIP))) {
+		// If the user has no roles deny access
+		if (sess.getPerunPrincipal().getRoles() == null || sess.getPerunPrincipal().getRoles().isEmpty()) {
 			return false;
 		}
 
@@ -1301,11 +1282,8 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 
 		List<AttributePolicyCollection> policyCollections = getAttributePolicyCollections(sess, actionType, attrDef);
 
-		// If the user has no roles and this attribute does not have any rule for MEMBERSHIP, deny access
-		if ((sess.getPerunPrincipal().getRoles() == null || sess.getPerunPrincipal().getRoles().isEmpty())
-			&& policyCollections.stream()
-			.flatMap(c -> c.getPolicies().stream())
-			.noneMatch(p -> p.getRole().equals(Role.MEMBERSHIP))) {
+		// If the user has no roles deny access
+		if (sess.getPerunPrincipal().getRoles() == null || sess.getPerunPrincipal().getRoles().isEmpty()) {
 			return false;
 		}
 
@@ -1337,11 +1315,8 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 
 		List<AttributePolicyCollection> policyCollections = getAttributePolicyCollections(sess, actionType, attrDef);
 
-		// If the user has no roles and this attribute does not have any rule for MEMBERSHIP, deny access
-		if ((sess.getPerunPrincipal().getRoles() == null || sess.getPerunPrincipal().getRoles().isEmpty())
-			&& policyCollections.stream()
-			.flatMap(c -> c.getPolicies().stream())
-			.noneMatch(p -> p.getRole().equals(Role.MEMBERSHIP))) {
+		// If the user has no roles deny access
+		if (sess.getPerunPrincipal().getRoles() == null || sess.getPerunPrincipal().getRoles().isEmpty()) {
 			return false;
 		}
 
@@ -1373,11 +1348,8 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 
 		List<AttributePolicyCollection> policyCollections = getAttributePolicyCollections(sess, actionType, attrDef);
 
-		// If the user has no roles and this attribute does not have any rule for MEMBERSHIP, deny access
-		if ((sess.getPerunPrincipal().getRoles() == null || sess.getPerunPrincipal().getRoles().isEmpty())
-			&& policyCollections.stream()
-			.flatMap(c -> c.getPolicies().stream())
-			.noneMatch(p -> p.getRole().equals(Role.MEMBERSHIP))) {
+		// If the user has no roles deny access
+		if (sess.getPerunPrincipal().getRoles() == null || sess.getPerunPrincipal().getRoles().isEmpty()) {
 			return false;
 		}
 
@@ -1409,11 +1381,8 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 
 		List<AttributePolicyCollection> policyCollections = getAttributePolicyCollections(sess, actionType, attrDef);
 
-		// If the user has no roles and this attribute does not have any rule for MEMBERSHIP, deny access
-		if ((sess.getPerunPrincipal().getRoles() == null || sess.getPerunPrincipal().getRoles().isEmpty())
-			&& policyCollections.stream()
-			.flatMap(c -> c.getPolicies().stream())
-			.noneMatch(p -> p.getRole().equals(Role.MEMBERSHIP))) {
+		// If the user has no roles deny access
+		if (sess.getPerunPrincipal().getRoles() == null || sess.getPerunPrincipal().getRoles().isEmpty()) {
 			return false;
 		}
 
@@ -1445,11 +1414,8 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 
 		List<AttributePolicyCollection> policyCollections = getAttributePolicyCollections(sess, actionType, attrDef);
 
-		// If the user has no roles and this attribute does not have any rule for MEMBERSHIP, deny access
-		if ((sess.getPerunPrincipal().getRoles() == null || sess.getPerunPrincipal().getRoles().isEmpty())
-			&& policyCollections.stream()
-			.flatMap(c -> c.getPolicies().stream())
-			.noneMatch(p -> p.getRole().equals(Role.MEMBERSHIP))) {
+		// If the user has no roles deny access
+		if (sess.getPerunPrincipal().getRoles() == null || sess.getPerunPrincipal().getRoles().isEmpty()) {
 			return false;
 		}
 
@@ -1481,11 +1447,8 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 
 		List<AttributePolicyCollection> policyCollections = getAttributePolicyCollections(sess, actionType, attrDef);
 
-		// If the user has no roles and this attribute does not have any rule for MEMBERSHIP, deny access
-		if ((sess.getPerunPrincipal().getRoles() == null || sess.getPerunPrincipal().getRoles().isEmpty())
-			&& policyCollections.stream()
-			.flatMap(c -> c.getPolicies().stream())
-			.noneMatch(p -> p.getRole().equals(Role.MEMBERSHIP))) {
+		// If the user has no roles deny access
+		if (sess.getPerunPrincipal().getRoles() == null || sess.getPerunPrincipal().getRoles().isEmpty()) {
 			return false;
 		}
 
@@ -1544,7 +1507,7 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 			}
 
 			for (AttributePolicy policy : policyCollection.getPolicies()) {
-				if (!resolvePolicyPrivileges(sess, associatedObjects, policy, policyCollection.getAction()) && !resolveMembershipPrivileges(sess, policy, associatedObjects)) {
+				if (!resolvePolicyPrivileges(sess, associatedObjects, policy, policyCollection.getAction())) {
 					collectionSatisfied = false;
 					break;
 				}
@@ -1607,21 +1570,6 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 			throw new InternalErrorException("Objects of type " + policy.getObject().name() + " were not retrieved for attribute policy check.");
 		}
 
-		return false;
-	}
-
-	/**
-	 * Resolve membership privileges of single policy for the principal
-	 *
-	 * @param sess from which will be principal fetched
-	 * @param policy policy which may contain MEMBERSHIP role
-	 * @param associatedObjects map of object types with actual associated objects to which will be membership checked
-	 * @return true if roles contains MEMBERSHIP role and the principal satisfies that, false otherwise.
-	 */
-	private static boolean resolveMembershipPrivileges(PerunSession sess, AttributePolicy policy, Map<RoleObject, Set<Integer>> associatedObjects) {
-		if (policy.getRole().equals(Role.MEMBERSHIP)) {
-			return MembershipPrivilegesResolver.getValue(policy.getObject().name()).apply(sess, associatedObjects.get(policy.getObject()));
-		}
 		return false;
 	}
 
@@ -2285,6 +2233,7 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 				if (user.isServiceUser()) {
 					roles.putAuthzRole(Role.SERVICEUSER);
 				}
+				addMembershipRole(sess, roles, user);
 			}
 
 			setAdditionalRoles(sess, roles);
@@ -2387,6 +2336,29 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 		}
 		groupRoles.put("Group", newGroupsIds);
 		authzRoles.put(role, groupRoles);
+
+		return authzRoles;
+	}
+
+	/**
+	 * Adds valid membership roles in VOs, groups, facilities and resources to roles.
+	 *
+	 * @param authzRoles authzRoles for the user to append membership role to
+	 * @param user       user
+	 * @return the same object authzRoles, which is given in the parameter, with loaded membership roles
+	 */
+	private static AuthzRoles addMembershipRole(PerunSession sess, AuthzRoles authzRoles, User user) {
+		perunBl.getMembersManagerBl().getMembersByUserWithStatus(sess, user, Status.VALID)
+				.forEach(member -> authzRoles.putAuthzRole(Role.MEMBERSHIP, Vo.class, member.getVoId()));
+
+		perunBl.getResourcesManagerBl().getResources(sess, user, List.of(Status.VALID), List.of(MemberGroupStatus.VALID), List.of(GroupResourceStatus.ACTIVE))
+				.forEach(resource -> {
+					authzRoles.putAuthzRole(Role.MEMBERSHIP, Resource.class, resource.getId());
+					authzRoles.putAuthzRole(Role.MEMBERSHIP, Facility.class, resource.getFacilityId());
+				});
+
+		perunBl.getGroupsManagerBl().getUserGroups(sess, user, List.of(Status.VALID), List.of(MemberGroupStatus.VALID))
+				.forEach(group -> authzRoles.putAuthzRole(Role.MEMBERSHIP, Group.class, group.getId()));
 
 		return authzRoles;
 	}
@@ -3746,76 +3718,6 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 		public Set<Integer> apply(PerunSession sess, String key) {
 			return function.apply(sess, key);
 		}
-	}
-
-	/**
-	 * Enum defines PerunBean's name and action. The action checks if the principal is a valid member of at least one related object of that name from the given ids.
-	 */
-	private enum MembershipPrivilegesResolver implements BiFunction<PerunSession, Set<Integer>, Boolean> {
-		Vo((sess, objectIds) -> {
-			if (sess.getPerunPrincipal().getUser() == null) return false;
-			List<Member> principalUserMembers = getPerunBl().getMembersManagerBl().getMembersByUser(sess, sess.getPerunPrincipal().getUser());
-			for (Integer objectId: objectIds) {
-				for (Member userMember : principalUserMembers) {
-					if (userMember.getVoId() == objectId && userMember.getStatus() == Status.VALID) {
-						return true;
-					}
-				}
-			}
-			return false;
-		}),
-		Facility((sess, objectIds) -> {
-			if (sess.getPerunPrincipal().getUser() == null) return false;
-			HashSet<Resource> resourcesFromUser = new HashSet<>();
-			List<Member> principalUserMembers = getPerunBl().getMembersManagerBl().getMembersByUser(sess, sess.getPerunPrincipal().getUser());
-			for (Member member : principalUserMembers) {
-				if (member.getStatus() != Status.VALID) continue;
-				resourcesFromUser.addAll(getPerunBl().getResourcesManagerBl().getAssignedResources(sess, member));
-			}
-			for (Resource resource: resourcesFromUser) {
-				if (objectIds.contains(resource.getFacilityId())) return true;
-			}
-			return false;
-		}),
-		Group((sess, objectIds) -> {
-			if (sess.getPerunPrincipal().getUser() == null) return false;
-			List<Member> principalUserMembers = getPerunBl().getMembersManagerBl().getMembersByUser(sess, sess.getPerunPrincipal().getUser());
-			for (Member member : principalUserMembers) {
-				if (member.getStatus() != Status.VALID) continue;
-				List<Group> memberGroups = getPerunBl().getGroupsManagerBl().getGroupsByPerunBean(sess, member);
-				for (Group group : memberGroups) {
-					if (objectIds.contains(group.getId())) return true;
-				}
-			}
-			return false;
-		}),
-		Default((sess, objectIds) -> false);
-
-		private BiFunction<PerunSession, Set<Integer>, Boolean> function;
-
-		MembershipPrivilegesResolver(final BiFunction<PerunSession, Set<Integer>, Boolean> function) {
-			this.function = function;
-		}
-
-		/**
-		 * Get MembershipPrivilegesResolver value by the given name or default value if the name does not exist.
-		 *
-		 * @param name of the value which will be retrieved if exists.
-		 * @return MembershipPrivilegesResolver value.
-		 */
-		public static MembershipPrivilegesResolver getValue(String name) {
-			try {
-				return MembershipPrivilegesResolver.valueOf(name);
-			} catch (IllegalArgumentException ex) {
-				return MembershipPrivilegesResolver.Default;
-			}
-		}
-
-		@Override
-		public Boolean apply(PerunSession sess, Set<Integer> objectIds) {
-			return function.apply(sess, objectIds);
-		}
-
 	}
 
 	/**

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
@@ -1355,6 +1355,11 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 	}
 
 	@Override
+	public List<Group> getUserGroups(PerunSession perunSession, User user, List<Status> memberStatuses, List<MemberGroupStatus> memberGroupStatuses) {
+		return new ArrayList<>(new HashSet<>(getGroupsManagerImpl().getUserGroups(perunSession, user, memberStatuses, memberGroupStatuses)));
+	}
+
+	@Override
 	public List<Member> getGroupMembersExceptInvalid(PerunSession sess, Group group) {
 		return this.filterMembersByMembershipTypeInGroup(getGroupsManagerImpl().getGroupMembers(sess, group, Collections.singletonList(Status.INVALID), true));
 	}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ResourcesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ResourcesManagerBlImpl.java
@@ -25,6 +25,7 @@ import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.GroupResourceAssignment;
 import cz.metacentrum.perun.core.api.GroupResourceStatus;
 import cz.metacentrum.perun.core.api.Member;
+import cz.metacentrum.perun.core.api.MemberGroupStatus;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.ResourceTag;
@@ -818,6 +819,11 @@ public class ResourcesManagerBlImpl implements ResourcesManagerBl {
 	@Override
 	public List<Resource> getAllowedResources(PerunSession sess, Facility facility, User user) {
 		return getResourcesManagerImpl().getAllowedResources(sess, facility, user);
+	}
+
+	@Override
+	public List<Resource> getResources(PerunSession sess, User user, List<Status> memberStatuses, List<MemberGroupStatus> memberGroupStatuses, List<GroupResourceStatus> groupResourceStatuses) {
+		return getResourcesManagerImpl().getResources(sess, user, memberStatuses, memberGroupStatuses, groupResourceStatuses);
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/GroupsManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/GroupsManagerImpl.java
@@ -395,6 +395,33 @@ public class GroupsManagerImpl implements GroupsManagerImplApi {
 	}
 
 	@Override
+	public List<Group> getUserGroups(PerunSession sess, User user, List<Status> memberStatuses, List<MemberGroupStatus> memberGroupStatuses) {
+		if (memberStatuses == null || memberStatuses.isEmpty()) {
+			memberStatuses = List.of(Status.values());
+		}
+		if (memberGroupStatuses == null || memberGroupStatuses.isEmpty()) {
+			memberGroupStatuses = List.of(MemberGroupStatus.values());
+		}
+
+		try {
+			MapSqlParameterSource parameters = new MapSqlParameterSource();
+			List<Integer> memberStatusesCodes = memberStatuses.stream().map(Status::getCode).toList();
+			List<Integer> memberGroupStatusesCodes = memberGroupStatuses.stream().map(MemberGroupStatus::getCode).toList();
+			parameters.addValue("voStatuses", memberStatusesCodes);
+			parameters.addValue("groupStatuses", memberGroupStatusesCodes);
+			parameters.addValue("uid", user.getId());
+
+			return namedParameterJdbcTemplate.query("select " + groupMappingSelectQuery + "from groups" +
+				" join groups_members on groups.id=groups_members.group_id and groups_members.source_group_status in (:groupStatuses)" +
+				" join members on members.id=groups_members.member_id where members.user_id=:uid and members.status in (:voStatuses)", parameters, GROUP_MAPPER);
+		} catch (EmptyResultDataAccessException e) {
+			return new ArrayList<>();
+		} catch(RuntimeException ex) {
+			throw new InternalErrorException(ex);
+		}
+	}
+
+	@Override
 	public boolean isUserMemberOfGroup(PerunSession sess, User user, Group group) {
 		try {
 			return 1 <= jdbc.queryForInt("select count(1) from groups_members join members on members.id = member_id where members.user_id=? and groups_members.group_id=?", user.getId(), group.getId());

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/GroupsManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/GroupsManagerImplApi.java
@@ -301,6 +301,19 @@ public interface GroupsManagerImplApi {
 	List<Group> getUserGroups(PerunSession sess, User user);
 
 	/**
+	 * Return groups where user is member with allowed statuses in vo and group.
+	 * If statuses are empty or null, all statuses are used.
+	 *
+	 * @param sess
+	 * @param user
+	 * @param memberStatuses allowed statuses of member in VO
+	 * @mparam emberGroupStatuses allowed statuses of member in group
+	 * @return list of groups
+	 * @throws InternalErrorException
+	 */
+	List<Group> getUserGroups(PerunSession sess, User user, List<Status> memberStatuses, List<MemberGroupStatus> memberGroupStatuses);
+
+	/**
 	 * Checks whether the user is member of the group.
 	 *
 	 * @param sess

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/ResourcesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/ResourcesManagerImplApi.java
@@ -10,11 +10,13 @@ import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.GroupResourceAssignment;
 import cz.metacentrum.perun.core.api.GroupResourceStatus;
 import cz.metacentrum.perun.core.api.Member;
+import cz.metacentrum.perun.core.api.MemberGroupStatus;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.ResourceTag;
 import cz.metacentrum.perun.core.api.RichResource;
 import cz.metacentrum.perun.core.api.Service;
+import cz.metacentrum.perun.core.api.Status;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.Vo;
 import cz.metacentrum.perun.core.api.exceptions.BanNotExistsException;
@@ -448,6 +450,22 @@ public interface ResourcesManagerImplApi {
 	 * @throws InternalErrorException
 	 */
 	List<Resource> getAllowedResources(PerunSession sess, Facility facility, User user);
+
+	/**
+	 * Return all resources where user is assigned.
+	 * Checks member's status in VO and group and status of group-resource assignment.
+	 * If statuses are null or empty all statuses are used.
+	 *
+	 * @param sess
+	 * @param user
+	 * @param memberStatuses allowed member's statuses in VO
+	 * @param memberGroupStatuses allowed member's statuses in group
+	 * @param groupResourceStatuses allowed statuses of group-resource assignment
+	 *
+	 * @return List of allowed resources for the user
+	 * @throws InternalErrorException
+	 */
+	List<Resource> getResources(PerunSession sess, User user, List<Status> memberStatuses, List<MemberGroupStatus> memberGroupStatuses, List<GroupResourceStatus> groupResourceStatuses);
 
 	/**
 	 * Returns all members who are assigned on the defined resource.

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/api/AuthzResolverIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/api/AuthzResolverIntegrationTest.java
@@ -546,6 +546,80 @@ public class AuthzResolverIntegrationTest extends AbstractPerunIntegrationTest {
 	}
 
 	@Test
+	public void groupMembershipIsAuthorized() throws Exception {
+		System.out.println(CLASS_NAME + "groupMembershipIsAuthorized");
+		final Vo createdVo = perun.getVosManager().createVo(sess, new Vo(0,"test123test123","test123test123"));
+		final Member createdMember = createSomeMember(createdVo);
+		final Group createdGroup = setUpGroup(createdVo, createdMember);
+
+		AttributeDefinition attrDef = setUpGroupAttributeDefinition();
+		perun.getAttributesManagerBl().setAttribute(sess, createdGroup, new Attribute(attrDef));
+
+		List<AttributePolicy> policies = List.of(new AttributePolicy(1, Role.MEMBERSHIP, RoleObject.Group, 1));
+		List<AttributePolicyCollection> policyCollections = List.of(new AttributePolicyCollection(1, attrDef.getId(), AttributeAction.READ, new ArrayList<>(policies)));
+
+		perun.getAttributesManager().setAttributePolicyCollections(sess, policyCollections);
+
+		PerunSession session = getHisSession(createdMember);
+		AuthzResolver.refreshAuthz(session);
+
+		assertTrue(AuthzResolver.isAuthorizedForAttribute(session, AttributeAction.READ, attrDef, createdGroup));
+		assertFalse(AuthzResolver.isAuthorizedForAttribute(session, AttributeAction.WRITE, attrDef, createdGroup));
+	}
+
+	@Test
+	public void facilityMembershipIsAuthorized() throws Exception {
+		System.out.println(CLASS_NAME + "facilityMembershipIsAuthorized");
+		final Vo createdVo = perun.getVosManager().createVo(sess, new Vo(0,"test123test123","test123test123"));
+		final Member createdMember = createSomeMember(createdVo);
+		final Group createdGroup = setUpGroup(createdVo, createdMember);
+		final Facility createdFacility = setUpFacility();
+		final Resource createdResource = setUpResource(createdVo, createdFacility);
+
+		AttributeDefinition attrDef = setUpFacilityAttributeDefinition();
+		perun.getAttributesManagerBl().setAttribute(sess, createdFacility, new Attribute(attrDef));
+
+		List<AttributePolicy> policies = List.of(new AttributePolicy(1, Role.MEMBERSHIP, RoleObject.Facility, 1));
+		List<AttributePolicyCollection> policyCollections = List.of(new AttributePolicyCollection(1, attrDef.getId(), AttributeAction.READ, new ArrayList<>(policies)));
+
+		perun.getAttributesManager().setAttributePolicyCollections(sess, policyCollections);
+
+		PerunSession session = getHisSession(createdMember);
+		AuthzResolver.refreshAuthz(session);
+
+		// group is not assigned to resource yet
+		assertFalse(AuthzResolver.isAuthorizedForAttribute(session, AttributeAction.READ, attrDef, createdFacility));
+
+		perun.getResourcesManagerBl().assignGroupToResource(sess, createdGroup, createdResource, false, false, false);
+		AuthzResolver.refreshAuthz(session);
+
+		assertTrue(AuthzResolver.isAuthorizedForAttribute(session, AttributeAction.READ, attrDef, createdFacility));
+		assertFalse(AuthzResolver.isAuthorizedForAttribute(session, AttributeAction.WRITE, attrDef, createdFacility));
+	}
+
+	@Test
+	public void voMembershipIsAuthorized() throws Exception {
+		System.out.println(CLASS_NAME + "voMembershipIsAuthorized");
+		final Vo createdVo = perun.getVosManager().createVo(sess, new Vo(0,"test123test123","test123test123"));
+		final Member createdMember = createSomeMember(createdVo);
+		final Group createdGroup = perun.getGroupsManagerBl().createGroup(sess, createdVo, new Group("Test group", "test group"));
+
+		AttributeDefinition attrDef = setUpGroupAttributeDefinition();
+		perun.getAttributesManagerBl().setAttribute(sess, createdGroup, new Attribute(attrDef));
+
+		List<AttributePolicy> policies = List.of(new AttributePolicy(1, Role.MEMBERSHIP, RoleObject.Vo, 1));
+		List<AttributePolicyCollection> policyCollections = List.of(new AttributePolicyCollection(1, attrDef.getId(), AttributeAction.READ, new ArrayList<>(policies)));
+
+		perun.getAttributesManager().setAttributePolicyCollections(sess, policyCollections);
+
+		PerunSession session = getHisSession(createdMember);
+		AuthzResolver.refreshAuthz(session);
+
+		assertTrue(AuthzResolver.isAuthorizedForAttribute(session, AttributeAction.READ, attrDef, createdGroup));
+		assertFalse(AuthzResolver.isAuthorizedForAttribute(session, AttributeAction.WRITE, attrDef, createdGroup));
+	}
+
+	@Test
 	public void setRoleResourceSelfServiceForUser() throws Exception {
 		System.out.println(CLASS_NAME + "setRoleResourceSelfServiceForUser");
 		final Vo createdVo = perun.getVosManager().createVo(sess, new Vo(0,"test123test123","test123test123"));
@@ -1550,6 +1624,17 @@ public class AuthzResolverIntegrationTest extends AbstractPerunIntegrationTest {
 		attrDef.setType(Integer.class.getName());
 		attrDef.setFriendlyName("testGroupAttr");
 		attrDef.setDisplayName("test group attr");
+
+		attrDef = perun.getAttributesManagerBl().createAttribute(sess, attrDef);
+		return attrDef;
+	}
+
+	private AttributeDefinition setUpFacilityAttributeDefinition() throws Exception {
+		AttributeDefinition attrDef = new AttributeDefinition();
+		attrDef.setNamespace(AttributesManager.NS_FACILITY_ATTR_DEF);
+		attrDef.setType(Integer.class.getName());
+		attrDef.setFriendlyName("testFacilityAttribute");
+		attrDef.setDisplayName("test facility attr");
 
 		attrDef = perun.getAttributesManagerBl().createAttribute(sess, attrDef);
 		return attrDef;

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/GroupsManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/GroupsManagerEntryIntegrationTest.java
@@ -1918,6 +1918,61 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 	}
 
 	@Test
+	public void getUserGroupsWithAllStatuses() throws Exception {
+		System.out.println(CLASS_NAME + "getUserGroupsWithAllStatuses");
+
+		vo = setUpVo();
+		setUpGroup(vo);
+		List<Group> groups = setUpGroups(vo);
+
+		Member member = setUpMember(vo);
+		groupsManagerBl.addMember(sess, group, member);
+		User u = perun.getUsersManager().getUserByMember(sess, member);
+
+		List<Group> resultGroups = groupsManagerBl.getUserGroups(sess, u, List.of(Status.VALID), null);
+		assertThat(resultGroups).contains(group);
+
+		resultGroups = groupsManagerBl.getUserGroups(sess, u, List.of(Status.VALID), List.of());
+		assertThat(resultGroups).contains(group);
+
+		resultGroups = groupsManagerBl.getUserGroups(sess, u, List.of(), null);
+		assertThat(resultGroups).contains(group);
+	}
+
+	@Test
+	public void getUserGroupsWithAllowedStatuses() throws Exception {
+		System.out.println(CLASS_NAME + "getUserGroupsWithAllowedStatuses");
+
+		vo = setUpVo();
+		setUpGroup(vo);
+		List<Group> groups = setUpGroups(vo);
+
+		Member member = setUpMember(vo);
+		groupsManagerBl.addMember(sess, group, member);
+		User u = perun.getUsersManager().getUserByMember(sess, member);
+
+		List<Group> resultGroups = groupsManagerBl.getUserGroups(sess, u, List.of(Status.VALID), List.of(MemberGroupStatus.VALID));
+		assertThat(resultGroups).contains(group);
+
+		groupsManagerBl.expireMemberInGroup(sess, member, group);
+
+		resultGroups = groupsManagerBl.getUserGroups(sess, u, List.of(Status.VALID), null);
+		assertThat(resultGroups).contains(group);
+		resultGroups = groupsManagerBl.getUserGroups(sess, u, null, List.of(MemberGroupStatus.EXPIRED));
+		assertThat(resultGroups).contains(group);
+		resultGroups = groupsManagerBl.getUserGroups(sess, u, null, List.of(MemberGroupStatus.VALID));
+		assertThat(resultGroups).doesNotContain(group);
+
+		groupsManagerBl.validateMemberInGroup(sess, member, group);
+		perun.getMembersManagerBl().expireMember(sess, member);
+
+		resultGroups = groupsManagerBl.getUserGroups(sess, u, List.of(Status.VALID), null);
+		assertThat(resultGroups).doesNotContain(group);
+		resultGroups = groupsManagerBl.getUserGroups(sess, u, List.of(Status.EXPIRED), null);
+		assertThat(resultGroups).contains(group);
+	}
+
+	@Test
 	public void testGroupNameLength() throws Exception {
 		System.out.println(CLASS_NAME + "testGroupNameLength");
 


### PR DESCRIPTION
* membership will now be loaded into perun session's principal's roles
* this would speed up the search for entities where user is member
* applies to group, vo, facility and resource