### PR TITLE
fix(registrar): add new exception for the application form item

### DIFF
--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/exceptions/NoPrefilledUneditableRequiredDataException.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/exceptions/NoPrefilledUneditableRequiredDataException.java
@@ -1,0 +1,35 @@
+package cz.metacentrum.perun.registrar.exceptions;
+
+import cz.metacentrum.perun.core.api.exceptions.PerunException;
+import cz.metacentrum.perun.registrar.model.ApplicationFormItemWithPrefilledValue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Exception thrown during application form retrieval for user when
+ * any required application form item has no pre-filled value from
+ * federation and currently this item is hidden or disabled.
+ *
+ * @author Jakub Hejda <Jakub.Hejda@cesnet.cz>
+ */
+public class NoPrefilledUneditableRequiredDataException extends PerunException {
+
+	private static final long serialVersionUID = 1L;
+
+	private List<ApplicationFormItemWithPrefilledValue> formItems = new ArrayList<>();
+
+	public NoPrefilledUneditableRequiredDataException(String message) {
+		super(message);
+	}
+
+	public NoPrefilledUneditableRequiredDataException(String message, List<ApplicationFormItemWithPrefilledValue> items) {
+		super(message);
+		this.formItems = items;
+	}
+
+	public List<ApplicationFormItemWithPrefilledValue> getFormItems() {
+		return formItems;
+	}
+
+}

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
@@ -527,6 +527,9 @@ public class RegistrarManagerImpl implements RegistrarManager {
 			} catch (ExtendMembershipException ex) {
 				// can't become member of VO
 				result.put("voFormInitialException", ex);
+			} catch (NoPrefilledUneditableRequiredDataException ex) {
+				// can't display form
+				result.put("voFormInitialException", ex);
 			} catch (MissingRequiredDataException ex) {
 				// can't display form
 				result.put("voFormInitialException", ex);
@@ -551,6 +554,9 @@ public class RegistrarManagerImpl implements RegistrarManager {
 					result.put("voFormExtensionException", ex);
 				} catch (MemberNotExistsException ex) {
 					// is not member -> can't extend
+					result.put("voFormExtensionException", ex);
+				} catch (NoPrefilledUneditableRequiredDataException ex) {
+					// can't display form
 					result.put("voFormExtensionException", ex);
 				} catch (MissingRequiredDataException ex) {
 					// can't display form
@@ -583,6 +589,9 @@ public class RegistrarManagerImpl implements RegistrarManager {
 				} catch (ExtendMembershipException ex) {
 					// can't become member of VO -> then can't be member of group either
 					result.put("groupFormInitialException", ex);
+				} catch (NoPrefilledUneditableRequiredDataException ex) {
+					// can't display form
+					result.put("groupFormInitialException", ex);
 				}  catch (MissingRequiredDataException ex) {
 					// can't display form
 					result.put("groupFormInitialException", ex);
@@ -612,6 +621,9 @@ public class RegistrarManagerImpl implements RegistrarManager {
 					result.put("groupFormExtensionException", ex);
 				} catch (NotGroupMemberException ex) {
 					// is not member of Group -> can't extend
+					result.put("groupFormExtensionException", ex);
+				} catch (NoPrefilledUneditableRequiredDataException ex) {
+					// can't display form
 					result.put("groupFormExtensionException", ex);
 				} catch (MissingRequiredDataException ex) {
 					// can't display form
@@ -2656,6 +2668,8 @@ public class RegistrarManagerImpl implements RegistrarManager {
 		Map<Integer, ApplicationFormItemWithPrefilledValue> allItemsByIds = itemsWithValues.stream()
 				.collect(toMap(item -> item.getFormItem().getId(), Function.identity()));
 
+		List<ApplicationFormItemWithPrefilledValue> noPrefilledUneditableRequiredItems = new ArrayList<>();
+
 		for (ApplicationFormItemWithPrefilledValue itemW : itemsWithValues) {
 			// We do require value from IDP (federation) if attribute is supposed to be pre-filled and item is required and not editable to users
 			if (isEmpty(itemW.getPrefilledValue()) &&
@@ -2664,7 +2678,12 @@ public class RegistrarManagerImpl implements RegistrarManager {
 				if (URN_USER_DISPLAY_NAME.equals(itemW.getFormItem().getPerunDestinationAttribute())) {
 					log.error("Couldn't resolve displayName from: {}, parsedNames were: {}", federValues, parsedName);
 				}
-				itemsWithMissingData.add(itemW);
+				// Required uneditable items with no source or federation attribute
+				if (isEmpty(itemW.getFormItem().getFederationAttribute()) && isEmpty(itemW.getFormItem().getPerunSourceAttribute())) {
+					noPrefilledUneditableRequiredItems.add(itemW);
+				} else {
+					itemsWithMissingData.add(itemW);
+				}
 			}
 		}
 
@@ -2672,11 +2691,16 @@ public class RegistrarManagerImpl implements RegistrarManager {
 			module.processFormItemsWithData(sess, appType, form, itemsWithValues);
 		}
 
+		if (!noPrefilledUneditableRequiredItems.isEmpty()) {
+			log.error("[REGISTRAR] Uneditable (hidden or disabled) required items with no prefilled data: {}", noPrefilledUneditableRequiredItems);
+			throw new NoPrefilledUneditableRequiredDataException("The administrator sets these required items as hidden or disabled without any prefilled data.", noPrefilledUneditableRequiredItems);
+		}
+
 		if (!itemsWithMissingData.isEmpty() && extSourceType.equals(ExtSourcesManager.EXTSOURCE_IDP)) {
 			// throw exception only if user is logged-in by Federation IDP
 			String IDP = federValues.get("originIdentityProvider");
-			log.error("[REGISTRAR] IDP {} doesn't provide data for following form items: {}", IDP, itemsWithMissingData);
-			throw new MissingRequiredDataException("Your IDP doesn't provide data required by this application form.", itemsWithMissingData);
+			log.error("[REGISTRAR] Wrongly configured form OR user doesn't match any conditions for the following form items OR IDP {} doesn't provide data for following form items: {}", IDP, itemsWithMissingData);
+			throw new MissingRequiredDataException("The administrator set up this form wrongly OR you don't match any conditions OR your IDP doesn't provide data required by this application form.", itemsWithMissingData);
 		}
 
 		itemsWithValues.stream()


### PR DESCRIPTION
* This new exception is thrown if the item is required, uneditable (hidden or disabled) and it has no possible prefilled data (item doesn't have source attribute nor federation attribute).
* The message of the MissingRequiredDataException was extended by other possible reasons, which can bring on this error.