### PR TITLE
feat: add methods for enabling/disabling member VOs for a VO

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/Vo.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/Vo.java
@@ -8,6 +8,7 @@ import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 public class Vo extends Auditable implements Comparable<PerunBean> {
 	private String name;
 	private String shortName;
+	private boolean memberVosEnabled = false; // can other VOs be member organizations of this VO?
 
 	public Vo() {
 	}
@@ -19,6 +20,11 @@ public class Vo extends Auditable implements Comparable<PerunBean> {
 		this.name = name;
 		this.shortName = shortName;
 
+	}
+
+	public Vo(int id, String name, String shortName, boolean memberVosEnabled) {
+		this(id, name, shortName);
+		this.memberVosEnabled = memberVosEnabled;
 	}
 
 	@Deprecated
@@ -36,6 +42,11 @@ public class Vo extends Auditable implements Comparable<PerunBean> {
 		if (shortName == null)  throw new InternalErrorException(new NullPointerException("shortName is null"));
 		this.name = name;
 		this.shortName = shortName;
+	}
+
+	public Vo(int id, String name, String shortName, boolean memberVosEnabled, String createdAt, String createdBy, String modifiedAt, String modifiedBy, Integer createdByUid, Integer modifiedByUid) {
+		this(id, name, shortName, createdAt, createdBy, modifiedAt, modifiedBy, createdByUid, modifiedByUid);
+		this.memberVosEnabled = memberVosEnabled;
 	}
 
 	public String getName() {
@@ -56,6 +67,14 @@ public class Vo extends Auditable implements Comparable<PerunBean> {
 		this.shortName = shortName;
 	}
 
+	public boolean isMemberVosEnabled() {
+		return memberVosEnabled;
+	}
+
+	public void setMemberVosEnabled(boolean memberVosEnabled) {
+		this.memberVosEnabled = memberVosEnabled;
+	}
+
 	@Override
 	public String serializeToString() {
 		StringBuilder str = new StringBuilder();
@@ -64,6 +83,7 @@ public class Vo extends Auditable implements Comparable<PerunBean> {
 			"id=<").append(getId()).append(">").append(
 			", name=<").append(getName() == null ? "\\0" : BeansUtils.createEscaping(getName())).append(">").append(
 			", shortName=<").append(getShortName() == null ? "\\0" : BeansUtils.createEscaping(getShortName())).append(">").append(
+			", memberVosEnabled=<").append(isMemberVosEnabled()).append(">").append(
 			']').toString();
 	}
 
@@ -75,6 +95,7 @@ public class Vo extends Auditable implements Comparable<PerunBean> {
 			"id='").append(this.getId()).append('\'').append(
 			", name='").append(name).append('\'').append(
 			", shortName='").append(shortName).append('\'').append(
+			", memberVosEnabled='").append(memberVosEnabled).append('\'').append(
 			']').toString();
 	}
 

--- a/perun-base/src/main/resources/perun-roles.yml
+++ b/perun-base/src/main/resources/perun-roles.yml
@@ -5667,6 +5667,16 @@ perun_policies:
     include_policies:
       - default_policy
 
+  enableMemberVos_Vo_policy:
+    policy_roles: []
+    include_policies:
+      - default_policy
+
+  disableMemberVos_Vo_policy:
+    policy_roles: []
+    include_policies:
+      - default_policy
+
   getVoByShortName_String_policy:
     policy_roles:
       - RESOURCESELFSERVICE: Vo

--- a/perun-base/src/test/resources/test-schema.sql
+++ b/perun-base/src/test/resources/test-schema.sql
@@ -1,4 +1,4 @@
--- database version 3.1.89 (don't forget to update insert statement at the end of file)
+-- database version 3.1.90 (don't forget to update insert statement at the end of file)
 CREATE EXTENSION IF NOT EXISTS "unaccent";
 CREATE EXTENSION IF NOT EXISTS "pgcrypto";
 
@@ -7,6 +7,7 @@ create table vos (
 					  id integer not null,
 					  name varchar not null,   -- full name of VO
 					  short_name varchar not null, -- commonly used name
+					  member_vos_enabled boolean default false not null, -- can other VOs be member organizations of this VO?
 					  created_at timestamp default statement_timestamp() not null,
 					  created_by varchar default user not null,
 					  modified_at timestamp default statement_timestamp() not null,
@@ -1748,7 +1749,7 @@ CREATE INDEX ufauv_idx ON user_facility_attr_u_values (user_id, facility_id, att
 CREATE INDEX vauv_idx ON vo_attr_u_values (vo_id, attr_id);
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.1.89');
+insert into configurations values ('DATABASE VERSION','3.1.90');
 -- insert membership types
 insert into membership_types (id, membership_type, description) values (1, 'DIRECT', 'Member is directly added into group');
 insert into membership_types (id, membership_type, description) values (2, 'INDIRECT', 'Member is added indirectly through UNION relation');

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/VosManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/VosManager.java
@@ -112,6 +112,28 @@ public interface VosManager {
 	Vo updateVo(PerunSession perunSession, Vo vo) throws VoNotExistsException, PrivilegeException;
 
 	/**
+	 * Enables the given VO to contain member organizations.
+	 *
+	 * @param perunSession
+	 * @param vo the VO
+	 * @return updated VO
+	 * @throws VoNotExistsException
+	 * @throws PrivilegeException
+	 */
+	Vo enableMemberVos(PerunSession perunSession, Vo vo) throws VoNotExistsException, PrivilegeException;
+
+	/**
+	 * Disables the given VO to contain member organizations.
+	 *
+	 * @param perunSession
+	 * @param vo the VO
+	 * @return updated VO
+	 * @throws VoNotExistsException
+	 * @throws PrivilegeException
+	 */
+	Vo disableMemberVos(PerunSession perunSession, Vo vo) throws VoNotExistsException, PrivilegeException;
+
+	/**
 	 * Find existing VO by short name (short name is unique).
 	 *
 	 * @param perunSession

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/VosManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/VosManagerBl.java
@@ -14,17 +14,13 @@ import cz.metacentrum.perun.core.api.RichUser;
 import cz.metacentrum.perun.core.api.Status;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.Vo;
-import cz.metacentrum.perun.core.api.exceptions.AlreadyAdminException;
 import cz.metacentrum.perun.core.api.exceptions.BanNotExistsException;
-import cz.metacentrum.perun.core.api.exceptions.GroupNotAdminException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.MemberNotExistsException;
-import cz.metacentrum.perun.core.api.exceptions.UserNotAdminException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.VoExistsException;
 import cz.metacentrum.perun.core.api.exceptions.VoNotExistsException;
 
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -94,6 +90,24 @@ public interface VosManagerBl {
 	 * @throws InternalErrorException
 	 */
 	Vo updateVo(PerunSession perunSession, Vo vo);
+
+	/**
+	 * Enables the given VO to contain member organizations.
+	 *
+	 * @param perunSession
+	 * @param vo the VO
+	 * @return updated VO
+	 */
+	Vo enableMemberVos(PerunSession perunSession, Vo vo);
+
+	/**
+	 * Disables the given VO to contain member organizations.
+	 *
+	 * @param perunSession
+	 * @param vo the VO
+	 * @return updated VO
+	 */
+	Vo disableMemberVos(PerunSession perunSession, Vo vo);
 
 	/**
 	 * Find existing VO by short name (short name is unique).

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/VosManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/VosManagerBlImpl.java
@@ -36,21 +36,18 @@ import cz.metacentrum.perun.core.api.exceptions.GroupNotAdminException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.LoginNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.MemberNotExistsException;
-import cz.metacentrum.perun.core.api.exceptions.MemberNotSponsoredException;
 import cz.metacentrum.perun.core.api.exceptions.NotGroupMemberException;
 import cz.metacentrum.perun.core.api.exceptions.PerunException;
 import cz.metacentrum.perun.core.api.exceptions.RelationExistsException;
 import cz.metacentrum.perun.core.api.exceptions.RoleCannotBeManagedException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotAdminException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
-import cz.metacentrum.perun.core.api.exceptions.UserNotInRoleException;
 import cz.metacentrum.perun.core.api.exceptions.VoExistsException;
 import cz.metacentrum.perun.core.api.exceptions.VoNotExistsException;
 import cz.metacentrum.perun.core.bl.MembersManagerBl;
 import cz.metacentrum.perun.core.bl.PerunBl;
 import cz.metacentrum.perun.core.bl.UsersManagerBl;
 import cz.metacentrum.perun.core.bl.VosManagerBl;
-import cz.metacentrum.perun.core.impl.Auditer;
 import cz.metacentrum.perun.core.impl.Utils;
 import cz.metacentrum.perun.core.implApi.ExtSourceApi;
 import cz.metacentrum.perun.core.implApi.ExtSourceSimpleApi;
@@ -259,6 +256,17 @@ public class VosManagerBlImpl implements VosManagerBl {
 	public Vo updateVo(PerunSession sess, Vo vo) {
 		getPerunBl().getAuditer().log(sess, new VoUpdated(vo));
 		return getVosManagerImpl().updateVo(sess, vo);
+	}
+
+	@Override
+	public Vo enableMemberVos(PerunSession sess, Vo vo) {
+		return getVosManagerImpl().enableMemberVos(sess, vo);
+	}
+
+	@Override
+	public Vo disableMemberVos(PerunSession sess, Vo vo) {
+		//TODO remove all member VOs from this VO
+		return getVosManagerImpl().disableMemberVos(sess, vo);
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/VosManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/VosManagerEntry.java
@@ -31,13 +31,11 @@ import cz.metacentrum.perun.core.api.exceptions.VoExistsException;
 import cz.metacentrum.perun.core.api.exceptions.VoNotExistsException;
 import cz.metacentrum.perun.core.bl.PerunBl;
 import cz.metacentrum.perun.core.bl.VosManagerBl;
-import cz.metacentrum.perun.core.blImpl.AuthzResolverBlImpl;
 import cz.metacentrum.perun.core.impl.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -167,6 +165,32 @@ public class VosManagerEntry implements VosManager {
 		}
 
 		return vosManagerBl.updateVo(sess, vo);
+	}
+
+	@Override
+	public Vo enableMemberVos(PerunSession sess, Vo vo) throws VoNotExistsException, PrivilegeException {
+		Utils.notNull(sess, "sess");
+		vosManagerBl.checkVoExists(sess, vo);
+
+		// Authorization
+		if (!AuthzResolver.authorizedInternal(sess, "enableMemberVos_Vo_policy", vo)) {
+			throw new PrivilegeException(sess, "enableMemberVos");
+		}
+
+		return vosManagerBl.enableMemberVos(sess, vo);
+	}
+
+	@Override
+	public Vo disableMemberVos(PerunSession sess, Vo vo) throws VoNotExistsException, PrivilegeException {
+		Utils.notNull(sess, "sess");
+		vosManagerBl.checkVoExists(sess, vo);
+
+		// Authorization
+		if (!AuthzResolver.authorizedInternal(sess, "disableMemberVos_Vo_policy", vo)) {
+			throw new PrivilegeException(sess, "disableMemberVos");
+		}
+
+		return vosManagerBl.disableMemberVos(sess, vo);
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/VosManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/VosManagerImplApi.java
@@ -3,7 +3,6 @@ package cz.metacentrum.perun.core.implApi;
 import cz.metacentrum.perun.core.api.BanOnVo;
 import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.Pair;
-import cz.metacentrum.perun.core.api.Perun;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.Vo;
@@ -102,6 +101,24 @@ public interface VosManagerImplApi {
 	 * @throws InternalErrorException
 	 */
 	List<Vo> getVosByIds(PerunSession perunSession, List<Integer> ids);
+
+	/**
+	 * Enables the given VO to contain member organizations.
+	 *
+	 * @param perunSession
+	 * @param vo the VO
+	 * @return updated VO
+	 */
+	Vo enableMemberVos(PerunSession perunSession, Vo vo);
+
+	/**
+	 * Disables the given VO to contain member organizations.
+	 *
+	 * @param perunSession
+	 * @param vo the VO
+	 * @return updated VO
+	 */
+	Vo disableMemberVos(PerunSession perunSession, Vo vo);
 
 	/**
 	 * Get list of user administrators of specific vo for specific role.

--- a/perun-core/src/main/resources/postgresChangelog.txt
+++ b/perun-core/src/main/resources/postgresChangelog.txt
@@ -6,6 +6,10 @@
 -- Directly under version number should be version commands. They will be executed in the order they are written here.
 -- Comments are prefixed with -- and can be written only between version blocks, that means not in the lines with commands. They have to be at the start of the line.
 
+3.1.90
+ALTER TABLE vos ADD COLUMN member_vos_enabled boolean default false not null;
+UPDATE configurations SET value='3.1.90' WHERE property='DATABASE VERSION';
+
 3.1.89
 create type attribute_action as enum ('READ', 'WRITE');
 create table attribute_policy_collections (id integer not null, attr_id integer not null, action attribute_action not null, constraint attrpolcol_pk primary key (id), constraint attrpolcol_attr_fk foreign key (attr_id) references attr_names (id) on delete cascade);

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/VosManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/VosManagerEntryIntegrationTest.java
@@ -34,6 +34,7 @@ import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -189,6 +190,43 @@ public class VosManagerEntryIntegrationTest extends AbstractPerunIntegrationTest
 		System.out.println(CLASS_NAME + "updateVoWhichNotExists");
 
 		vosManagerEntry.updateVo(sess, new Vo());
+	}
+
+	@Test
+	public void enableMemberVos() throws Exception {
+		System.out.println(CLASS_NAME + "enableMemberVos");
+
+		Vo vo = vosManagerEntry.createVo(sess, myVo);
+		vosManagerEntry.enableMemberVos(sess, vo);
+
+		assertTrue(vosManagerEntry.getVoById(sess, vo.getId()).isMemberVosEnabled());
+	}
+
+	@Test
+	public void enableMemberVosWhichNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "enableMemberVosWhichNotExists");
+
+		assertThatThrownBy(() -> vosManagerEntry.enableMemberVos(sess, new Vo()))
+			.isInstanceOf(VoNotExistsException.class);
+	}
+
+	@Test
+	public void disableMemberVos() throws Exception {
+		System.out.println(CLASS_NAME + "disableMemberVos");
+
+		Vo vo = vosManagerEntry.createVo(sess, myVo);
+		vosManagerEntry.enableMemberVos(sess, vo);
+		vosManagerEntry.disableMemberVos(sess, vo);
+
+		assertFalse(vosManagerEntry.getVoById(sess, vo.getId()).isMemberVosEnabled());
+	}
+
+	@Test
+	public void disableMemberVosWhichNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "disableMemberVosWhichNotExists");
+
+		assertThatThrownBy(() -> vosManagerEntry.disableMemberVos(sess, new Vo()))
+			.isInstanceOf(VoNotExistsException.class);
 	}
 
 	@Test

--- a/perun-db/postgres.sql
+++ b/perun-db/postgres.sql
@@ -1,10 +1,11 @@
--- database version 3.1.89 (don't forget to update insert statement at the end of file)
+-- database version 3.1.90 (don't forget to update insert statement at the end of file)
 
 -- VOS - virtual organizations
 create table vos (
 	id integer not null,
 	name varchar not null,   -- full name of VO
 	short_name varchar not null, -- commonly used name
+	member_vos_enabled boolean default false not null, -- can other VOs be member organizations of this VO?
 	created_at timestamp default statement_timestamp() not null,
 	created_by varchar default user not null,
 	modified_at timestamp default statement_timestamp() not null,
@@ -1849,7 +1850,7 @@ grant all on members_sponsored to perun;
 grant all on groups_to_register to perun;
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.1.89');
+insert into configurations values ('DATABASE VERSION','3.1.90');
 
 -- insert membership types
 insert into membership_types (id, membership_type, description) values (1, 'DIRECT', 'Member is directly added into group');

--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -782,6 +782,7 @@ components:
         - properties:
             name: { type: string }
             shortName: { type: string }
+            memberVosEnabled: { type: boolean }
       discriminator:
         propertyName: beanName
 
@@ -13776,6 +13777,34 @@ paths:
                 - vo
               properties:
                 vo: { $ref: '#/components/schemas/Vo' }
+
+  /urlinjsonout/vosManager/enableMemberVos:
+    post:
+      tags:
+        - VosManager
+      operationId: enableMemberVos
+      summary: Enables the given VO to contain member organizations.
+      parameters:
+        - $ref: '#/components/parameters/voId'
+      responses:
+        '200':
+          $ref: '#/components/responses/VoResponse'
+        default:
+          $ref: '#/components/responses/ExceptionResponse'
+
+  /urlinjsonout/vosManager/disableMemberVos:
+    post:
+      tags:
+        - VosManager
+      operationId: disableMemberVos
+      summary: Disables the given VO to contain member organizations.
+      parameters:
+        - $ref: '#/components/parameters/voId'
+      responses:
+        '200':
+          $ref: '#/components/responses/VoResponse'
+        default:
+          $ref: '#/components/responses/ExceptionResponse'
 
   /json/vosManager/getVoByShortName:
     get:

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/VosManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/VosManagerMethod.java
@@ -129,6 +129,38 @@ public enum VosManagerMethod implements ManagerMethod {
 	},
 
 	/*#
+	 * Enables the given VO to contain member organizations.
+	 *
+	 * @param vo int <code>id</code> of the VO
+	 * @throw VoNotExistsException When VO specified by <code>id</code> doesn't exists.
+	 * @return Vo Updated VO
+	 */
+	enableMemberVos {
+		@Override
+		public Vo call(ApiCaller ac, Deserializer parms) throws PerunException {
+			parms.stateChangingCheck();
+
+			return ac.getVosManager().enableMemberVos(ac.getSession(), ac.getVoById(parms.readInt("vo")));
+		}
+	},
+
+	/*#
+	 * Disables the given VO to contain member organizations.
+	 *
+	 * @param vo int <code>id</code> of the VO
+	 * @throw VoNotExistsException When VO specified by <code>id</code> doesn't exist.
+	 * @return Vo Updated VO
+	 */
+	disableMemberVos {
+		@Override
+		public Vo call(ApiCaller ac, Deserializer parms) throws PerunException {
+			parms.stateChangingCheck();
+
+			return ac.getVosManager().disableMemberVos(ac.getSession(), ac.getVoById(parms.readInt("vo")));
+		}
+	},
+
+	/*#
 	 * Returns a VO by its short name.
 	 *
 	 * @param shortName String VO shortName

--- a/perun-utils/rpc-methods-javadoc-generator/parseRpcMethods.pl
+++ b/perun-utils/rpc-methods-javadoc-generator/parseRpcMethods.pl
@@ -57,7 +57,7 @@ $objectExamples{"List<Attribute>"} = $objectExamples{"List&lt;Attribute&gt;"};
 $objectExamples{"Map<String,Attribute>"} = "{ \"key\" : " . $objectExamples{"Attribute"} . " , \"key2\" : {...} }";
 $objectExamples{"Map&lt;String,Attribute&lt;"} = $objectExamples{"Map<String,Attribute>"};
 
-$objectExamples{"Vo"} = "{ \"id\" : 123 , \"name\" : \"My testing VO\" , \"shortName\" : \"test_vo\" , \"beanName\" : \"Vo\" }";
+$objectExamples{"Vo"} = "{ \"id\" : 123 , \"name\" : \"My testing VO\" , \"shortName\" : \"test_vo\" , \"memberVosEnabled\" : false , \"beanName\" : \"Vo\" }";
 $objectExamples{"List&lt;Vo&gt;"} = $listPrepend . $objectExamples{"Vo"} . $listAppend;
 $objectExamples{"List<Vo>"} = $objectExamples{"List&lt;Vo&gt;"};
 


### PR DESCRIPTION
feat(core): add methods for enabling/disabling member VOs for a VO
- New field isTenant was added to Vo class along with getter and
setter method.
- New column is_tenant was added to vos table.
- New method enableMemberVos() was added to all layers and RPC. It
enables the given VO to contain member organizations.
- New method disableMemberVos() was added to all layers and RPC. It
disables the given VO to contain member organizations.

BREAKING CHANGE: update DB version

feat(openapi): add methods for enabling/disabling member VOs for a VO
- Added memberVosEnabled property to Vo object schema.
- New method vosManager/enableMemberVos was added. It enables the given
VO to contain member organizations.
- New method vosManager/disableMemberVos was added. It disables the
given VO to contain member organizations.