### PR TITLE
fix(core): pass all application's information to richApplication

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/registrar/model/RichApplication.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/registrar/model/RichApplication.java
@@ -18,6 +18,10 @@ public class RichApplication extends Application {
 		super(application.getId(), application.getVo(), application.getGroup(), application.getType(),
 			application.getFedInfo(), application.getState(), application.getExtSourceName(),
 			application.getExtSourceType(), application.getExtSourceLoa(), application.getUser());
+		this.setCreatedBy(application.getCreatedBy());
+		this.setCreatedAt(application.getCreatedAt());
+		this.setModifiedAt(application.getModifiedAt());
+		this.setModifiedBy(application.getModifiedBy());
 	}
 
 	public RichApplication(Application application, List<ApplicationFormItemData> formData) {


### PR DESCRIPTION
* created by/at and modified by/at parameters were not passed to new rich application object because they are not part of application's constructor
* these would be missing in gui applications table