### PR TITLE
fix(core): pass attribute to exception in ssh public key

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_sshPublicKey.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_sshPublicKey.java
@@ -98,7 +98,7 @@ public class urn_perun_user_attribute_def_def_sshPublicKey extends UserAttribute
 					sshKey = removeSSHKeyCommandPrefix(sshKey);
 					validateSSH(sshKey);
 				} catch (Exception e) {
-					throw new WrongAttributeValueException("Invalid SSH key format: " + e.getMessage());
+					throw new WrongAttributeValueException(attribute, user, "Invalid SSH key format: " + e.getMessage());
 				}
 			}
 		}


### PR DESCRIPTION
- In order to let user know the problem pass affected
  attribute and user to the thrown Exception.