### PR TITLE
fix(core): added missing return in utils manager method

### DIFF
--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/Api.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/Api.java
@@ -681,6 +681,7 @@ public class Api extends HttpServlet {
 				long systemTimeInMillis = System.currentTimeMillis();
 				ser.write(systemTimeInMillis);
 				out.close();
+				return;
 			}
 
 			// Store identification of the request only if supported by app (it passed unique callbackName)


### PR DESCRIPTION
- Added missing return after processing utils.getPerunSystemTimeInMillis()
  since it return data to output anyway and it caused unnecessary
  exception to be thrown and logged later in the code.