### PR TITLE
feat: add support for consent

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/ConsentDefinition.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/ConsentDefinition.java
@@ -1,0 +1,137 @@
+package cz.metacentrum.perun.core.api;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Represents consent definition for facilities, services and attributes
+ */
+public class ConsentDefinition extends Auditable {
+	private String name;
+	private String text;
+	private List<Facility> facilities;
+	private List<Service> services;
+	private List<Attribute> attributes;
+
+	public ConsentDefinition() {
+	}
+
+	public ConsentDefinition(int id, String name, List<Facility> facilities, List<Service> services, List<Attribute> attributes) {
+		super(id);
+		this.name = name;
+		this.facilities = facilities;
+		this.services = services;
+		this.attributes = attributes;
+	}
+
+	public ConsentDefinition(int id, String name, String text, List<Facility> facilities, List<Service> services, List<Attribute> attributes) {
+		this(id, name, facilities, services, attributes);
+		this.text = text;
+	}
+
+	public ConsentDefinition(int id, String name, List<Facility> facilities, List<Service> services, List<Attribute> attributes, String createdAt, String createdBy, String modifiedAt, String modifiedBy, Integer createdByUid, Integer modifiedByUid) {
+		super(id, createdAt, createdBy, modifiedAt, modifiedBy, createdByUid, modifiedByUid);
+		this.name = name;
+		this.facilities = facilities;
+		this.services = services;
+		this.attributes = attributes;
+	}
+
+	public ConsentDefinition(int id, String name, String text, List<Facility> facilities, List<Service> services, List<Attribute> attributes, String createdAt, String createdBy, String modifiedAt, String modifiedBy, Integer createdByUid, Integer modifiedByUid) {
+		this(id, name, facilities, services, attributes, createdAt, createdBy, modifiedAt, modifiedBy, createdByUid, modifiedByUid);
+		this.text = text;
+	}
+
+	public String getName() { return name; }
+
+	public void setName(String name) { this.name = name; }
+
+	public String getText() { return text; }
+
+	public void setText(String text) { this.text = text; }
+
+	public List<Facility> getFacilities() { return facilities; }
+
+	public void setFacilities(List<Facility> facilities) { this.facilities = facilities; }
+
+	public List<Service> getServices() { return services; }
+
+	public void setServices(List<Service> services) { this.services = services; }
+
+	public List<Attribute> getAttributes() { return attributes; }
+
+	public void setAttributes(List<Attribute> attributes) { this.attributes = attributes; }
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		ConsentDefinition that = (ConsentDefinition) o;
+		return Objects.equals(getName(), that.getName()) && Objects.equals(getText(), that.getText());
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(getName(), getText());
+	}
+
+	@Override
+	public String serializeToString() {
+		List<Facility> facilities = getFacilities();
+		List<Service> services = getServices();
+		List<Attribute> attributes = getAttributes();
+		List<String> entityStringArray = new ArrayList<>();
+		String facilitiesString;
+		String servicesString;
+		String attributesString;
+
+
+		if (getFacilities() == null) facilitiesString = "\\0";
+		else {
+			for(Facility f: facilities) {
+				entityStringArray.add(f.serializeToString());
+			}
+			facilitiesString = entityStringArray.toString();
+			entityStringArray.clear();
+		}
+
+		if (getServices() == null) servicesString = "\\0";
+		else {
+			for(Service s: services) {
+				entityStringArray.add(s.serializeToString());
+			}
+			servicesString = entityStringArray.toString();
+			entityStringArray.clear();
+		}
+
+		if (getAttributes() == null) attributesString = "\\0";
+		else {
+			for(Attribute a: attributes) {
+				entityStringArray.add(a.serializeToString());
+			}
+			attributesString = entityStringArray.toString();
+		}
+
+		return this.getClass().getSimpleName() + ":[" +
+			"id=<" + getId() + ">" +
+			", name=<" + getName() + ">" +
+			", text=<" + getText() + ">" +
+			", facilities=<" + facilitiesString + ">" +
+			", services=<" + servicesString + ">" +
+			", attributes=<" + attributesString + ">" +
+			']';
+	}
+
+	@Override
+	public String toString() {
+		return "Consent:[id='" + getId() +
+			"', name='" + name +
+			"', text='" + text +
+			"', facilities='" + facilities +
+			"', services='" + services +
+			"', attributes='" + attributes +
+			"']";
+	}
+
+}

--- a/perun-core/src/main/resources/postgresChangelog.txt
+++ b/perun-core/src/main/resources/postgresChangelog.txt
@@ -6,6 +6,28 @@
 -- Directly under version number should be version commands. They will be executed in the order they are written here.
 -- Comments are prefixed with -- and can be written only between version blocks, that means not in the lines with commands. They have to be at the start of the line.
 
+3.1.91
+create table consents_definitions (id integer not null, name varchar not null, text varchar, created_at timestamp default statement_timestamp() not null, created_by varchar default user not null, modified_at timestamp default statement_timestamp() not null, modified_by varchar default user not null, created_by_uid integer, modified_by_uid integer, constraint con_def_pk primary key(id), constraint con_def_u unique(name));
+create table consents (user_id integer not null, consent_def_id integer not null, status varchar not null, createdDate timestamp not null, created_at timestamp default statement_timestamp() not null, created_by varchar default user not null, modified_at timestamp default statement_timestamp() not null, modified_by varchar default user not null, created_by_uid integer, modified_by_uid integer, constraint consents_pk primary key (user_id,consent_def_id), constraint consents_user_fk foreign key (user_id) references users(id), constraint consent_cons_def_fk foreign key (consent_def_id) references consents_definitions(id), constraint consents_stat_chk check (status in ('GRANTED','REVOKED','EXPIRED')));
+create table facilities_consent_definitions (facility_id integer not null, consent_def_id integer not null, created_at timestamp default statement_timestamp() not null, created_by varchar default user not null, modified_at timestamp default statement_timestamp() not null, modified_by varchar default user not null, created_by_uid integer, modified_by_uid integer, constraint facility_consent_pk primary key (facility_id,consent_def_id), constraint facility_consent_fac_fk foreign key (facility_id) references facilities(id), constraint facility_consent_cons_def_fk foreign key (consent_def_id) references consents_definitions(id));
+create table services_consent_definitions (service_id integer not null, consent_def_id integer not null, created_at timestamp default statement_timestamp() not null, created_by varchar default user not null, modified_at timestamp default statement_timestamp() not null, modified_by varchar default user not null, created_by_uid integer, modified_by_uid integer, constraint service_consent_pk primary key (service_id,consent_def_id), constraint service_consent_service_fk foreign key(service_id) references services(id), constraint service_consent_cons_def_fk foreign key (consent_def_id) references consents_definitions(id));
+create table attrs_consent_definitions (attr_id integer not null, consent_def_id integer not null, created_at timestamp default statement_timestamp() not null, created_by varchar default user not null, modified_at timestamp default statement_timestamp() not null, modified_by varchar default user not null, created_by_uid integer, modified_by_uid integer, constraint attr_consent_pk primary key (attr_id,consent_def_id), constraint attr_consent_attr_fk foreign key (attr_id) references attr_names (id), constraint attr_consent_cons_def_fk foreign key (consent_def_id) references consents_definitions(id));
+grant all on consents_definitions to perun;
+grant all on consents to perun;
+grant all on facilities_consent_definitions to perun;
+grant all on services_consent_definitions to perun;
+grant all on attrs_consent_definitions to perun;
+create index idx_fk_cons_usr ON consents (user_id);
+create index idx_fk_cons_cons_def ON consents (consent_def_id);
+create index idx_fk_fac_cons_def_fac ON facilities_consent_definitions (facility_id);
+create index idx_fk_fac_cons_def_cons_def ON facilities_consent_definitions (consent_def_id);
+create index idx_fk_srv_cons_def_srv ON services_consent_definitions (service_id);
+create index idx_fk_srv_cons_def_cons_def ON services_consent_definitions (consent_def_id);
+create index idx_fk_attr_cons_def_attr ON attrs_consent_definitions (attr_id);
+create index idx_fk_attr_cons_def_cons_def ON attrs_consent_definitions (consent_def_id);
+create sequence "consents_definitions_id_seq";
+UPDATE configurations SET value='3.1.91' WHERE property='DATABASE VERSION';
+
 3.1.90
 create table vos_vos (vo_id integer not null, member_vo_id integer not null, created_at timestamp default statement_timestamp() not null, created_by varchar default user not null, modified_at timestamp default statement_timestamp() not null, modified_by varchar default user not null, constraint vos_vos_pk primary key (vo_id,member_vo_id), constraint vos_vos_void_fk foreign key (vo_id) references vos(id), constraint vos_vos_memid_fk foreign key (member_vo_id) references vos(id));
 grant all on vos_vos to perun;

--- a/perun-db/postgres.sql
+++ b/perun-db/postgres.sql
@@ -1,4 +1,4 @@
--- database version 3.1.90 (don't forget to update insert statement at the end of file)
+-- database version 3.1.91 (don't forget to update insert statement at the end of file)
 
 -- VOS - virtual organizations
 create table vos (
@@ -1550,6 +1550,83 @@ create table groups_to_register (
     constraint grpreg_group_fk foreign key (group_id) references groups(id) on delete cascade
 );
 
+-- CONSENTS_DEFINITIONS - consents definitions for facilities, services and attributes
+create table consents_definitions (
+	id integer not null,
+	name varchar not null,
+	text varchar,
+	created_at timestamp default statement_timestamp() not null,
+	created_by varchar default user not null,
+	modified_at timestamp default statement_timestamp() not null,
+	modified_by varchar default user not null,
+	created_by_uid integer,
+	modified_by_uid integer,
+	constraint con_def_pk primary key(id),
+	constraint con_def_u unique(name)
+);
+
+-- CONSENTS - relation between users and consent definitions
+create table consents (
+	user_id integer not null,		   --identifier of user
+	consent_def_id integer not null,   --identifier of consent definition
+	status varchar not null,
+	createdDate timestamp not null,
+	created_at timestamp default statement_timestamp() not null,
+	created_by varchar default user not null,
+	modified_at timestamp default statement_timestamp() not null,
+	modified_by varchar default user not null,
+	created_by_uid integer,
+	modified_by_uid integer,
+	constraint consents_pk primary key (user_id,consent_def_id),
+	constraint consents_user_fk foreign key (user_id) references users(id),
+	constraint consent_cons_def_fk foreign key (consent_def_id) references consents_definitions(id),
+	constraint consents_stat_chk check (status in ('GRANTED','REVOKED','EXPIRED'))
+);
+
+-- FACILITIES_CONSENT_DEFINITIONS - relation between facilities and consent definitions
+create table facilities_consent_definitions (
+	facility_id integer not null,      --identifier of facility
+	consent_def_id integer not null,   --identifier of consent definition
+	created_at timestamp default statement_timestamp() not null,
+	created_by varchar default user not null,
+	modified_at timestamp default statement_timestamp() not null,
+	modified_by varchar default user not null,
+	created_by_uid integer,
+	modified_by_uid integer,
+	constraint facility_consent_pk primary key (facility_id,consent_def_id),
+	constraint facility_consent_fac_fk foreign key (facility_id) references facilities(id),
+	constraint facility_consent_cons_def_fk foreign key (consent_def_id) references consents_definitions(id)
+);
+
+-- SERVICES_CONSENT_DEFINITIONS - relation between services and consent definitions
+create table services_consent_definitions (
+	service_id integer not null,       --identifier of service
+	consent_def_id integer not null,   --identifier of consent definition
+	created_at timestamp default statement_timestamp() not null,
+	created_by varchar default user not null,
+	modified_at timestamp default statement_timestamp() not null,
+	modified_by varchar default user not null,
+	created_by_uid integer,
+	modified_by_uid integer,
+	constraint service_consent_pk primary key (service_id,consent_def_id),
+	constraint service_consent_service_fk foreign key(service_id) references services(id),
+	constraint service_consent_cons_def_fk foreign key (consent_def_id) references consents_definitions(id)
+);
+
+-- ATTRS_CONSENT_DEFINITIONS - relation between attributes and consent definitions
+create table attrs_consent_definitions (
+	attr_id integer not null,          --identifier of attribute
+	consent_def_id integer not null,   --identifier of consent definition
+	created_at timestamp default statement_timestamp() not null,
+	created_by varchar default user not null,
+	modified_at timestamp default statement_timestamp() not null,
+	modified_by varchar default user not null,
+	created_by_uid integer,
+	modified_by_uid integer,
+	constraint attr_consent_pk primary key (attr_id,consent_def_id),
+	constraint attr_consent_attr_fk foreign key (attr_id) references attr_names (id),
+	constraint attr_consent_cons_def_fk foreign key (consent_def_id) references consents_definitions(id)
+);
 
 create sequence "attr_names_id_seq";
 create sequence "attribute_policies_id_seq";
@@ -1600,6 +1677,7 @@ create sequence "security_teams_id_seq";
 create sequence "resources_bans_id_seq";
 create sequence "facilities_bans_id_seq";
 create sequence "vos_bans_id_seq";
+create sequence "consents_definitions_id_seq";
 
 create unique index idx_grp_nam_vo_parentg_u on groups (name,vo_id,coalesce(parent_group_id,'0'));
 create index idx_namespace on attr_names(namespace);
@@ -1757,6 +1835,14 @@ CREATE INDEX uauv_idx ON user_attr_u_values (user_id, attr_id);
 CREATE INDEX uesauv_idx ON user_ext_source_attr_u_values (user_ext_source_id, attr_id);
 CREATE INDEX ufauv_idx ON user_facility_attr_u_values (user_id, facility_id, attr_id);
 CREATE INDEX vauv_idx ON vo_attr_u_values (vo_id, attr_id);
+create index idx_fk_cons_usr ON consents (user_id);
+create index idx_fk_cons_cons_def ON consents (consent_def_id);
+create index idx_fk_fac_cons_def_fac ON facilities_consent_definitions (facility_id);
+create index idx_fk_fac_cons_def_cons_def ON facilities_consent_definitions (consent_def_id);
+create index idx_fk_srv_cons_def_srv ON services_consent_definitions (service_id);
+create index idx_fk_srv_cons_def_cons_def ON services_consent_definitions (consent_def_id);
+create index idx_fk_attr_cons_def_attr ON attrs_consent_definitions (attr_id);
+create index idx_fk_attr_cons_def_cons_def ON attrs_consent_definitions (consent_def_id);
 
 grant all on users to perun;
 grant all on vos to perun;
@@ -1861,9 +1947,14 @@ grant all on user_ext_source_attr_values to perun;
 grant all on user_ext_source_attr_u_values to perun;
 grant all on members_sponsored to perun;
 grant all on groups_to_register to perun;
+grant all on consents_definitions to perun;
+grant all on consents to perun;
+grant all on facilities_consent_definitions to perun;
+grant all on services_consent_definitions to perun;
+grant all on attrs_consent_definitions to perun;
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.1.90');
+insert into configurations values ('DATABASE VERSION','3.1.91');
 
 -- insert membership types
 insert into membership_types (id, membership_type, description) values (1, 'DIRECT', 'Member is directly added into group');

--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -1385,6 +1385,24 @@ components:
         email: { type: string }
         identities: { type: array, items: { $ref: '#/components/schemas/ExtSource' } }
 
+    ConsentDefinition:
+      allOf:
+        - $ref: '#/components/schemas/Auditable'
+        - properties:
+            name: { type: string }
+            text: { type: string }
+            facilities: { type: array, items: { $ref: '#/components/schemas/Facility' } }
+            services: { type: array, items: { $ref: '#/components/schemas/Service' } }
+            attributes: { type: array, items: { $ref: '#/components/schemas/Attribute' } }
+          required:
+            - name
+            - text
+            - facilities
+            - services
+            - attributes
+      discriminator:
+        propertyName: beanName
+
   #################################################
   #                                               #
   # RESPONSES - type definitions of return values #

--- a/perun-utils/rpc-methods-javadoc-generator/parseRpcMethods.pl
+++ b/perun-utils/rpc-methods-javadoc-generator/parseRpcMethods.pl
@@ -268,6 +268,10 @@ $objectExamples{"AttributePolicyCollection"} = "{ \"id\" : 10 , \"attributeId\" 
 $objectExamples{"List&lt;AttributePolicyCollection&gt;"} = $listPrepend . $objectExamples{"AttributePolicyCollection"} . $listAppend;
 $objectExamples{"List<AttributePolicyCollection>"} = $objectExamples{"List&lt;AttributePolicyCollection&gt;"};
 
+$objectExamples{"ConsentDefinition"} = "{ \"id\" : 13 , \"name\" : \"Consent\" , \"text\" : \"My consent\" , \"facilities\" : " . $objectExamples{"List&lt;Facility&gt;"} . " , \"services\" : " . $objectExamples{"List&lt;Service&gt;"} . " , \"attributes\" : " . $objectExamples{"List&lt;Attribute&gt;"} . " }";
+$objectExamples{"List&lt;ConsentDefinition&gt;"} = $listPrepend . $objectExamples{"ConsentDefinition"} . $listAppend;
+$objectExamples{"List<ConsentDefinition>"} = $objectExamples{"List&lt;ConsentDefinition&gt;"};
+
 # SUB HELP
 # help info
 sub help {


### PR DESCRIPTION
* New object ConsentDefinition was created and added to parseRpcMethod.
* Five new tables were created to support consent.
* New object ConsentDefinition was added to openapi.yml.

BREAKING CHANGE: update DB version