### PR TITLE
feat(core): add create/delete methods for consentHub

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/ConsentHubAlreadyRemovedException.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/ConsentHubAlreadyRemovedException.java
@@ -1,0 +1,36 @@
+package cz.metacentrum.perun.core.api.exceptions;
+
+/**
+ * Thrown when trying to removed consent hub which is not in a database.
+ * @author Johana Supikova <xsupikov@fi.muni.cz>
+ */
+public class ConsentHubAlreadyRemovedException extends PerunException {
+	static final long serialVersionUID = 0;
+
+	/**
+	 * Simple constructor with a message
+	 * @param message message with details about the cause
+	 */
+	public ConsentHubAlreadyRemovedException(String message) {
+		super(message);
+	}
+
+	/**
+	 * Constructor with a message and Throwable object
+	 * @param message message with details about the cause
+	 * @param cause Throwable that caused throwing of this exception
+	 */
+	public ConsentHubAlreadyRemovedException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	/**
+	 * Constructor with a Throwable object
+	 * @param cause Throwable that caused throwing of this exception
+	 */
+	public ConsentHubAlreadyRemovedException(Throwable cause) {
+		super(cause);
+	}
+
+}
+

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/ConsentHubExistsException.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/ConsentHubExistsException.java
@@ -1,0 +1,55 @@
+package cz.metacentrum.perun.core.api.exceptions;
+
+import cz.metacentrum.perun.core.api.ConsentHub;
+
+/**
+ * Thrown when trying to create consent hub with name that already exists.
+ * @author Johana Supikova <xsupikov@fi.muni.cz>
+ */
+public class ConsentHubExistsException extends EntityExistsException {
+	static final long serialVersionUID = 0;
+
+	private ConsentHub consentHub;
+
+	/**
+	 * Simple constructor with a message
+	 * @param message message with details about the cause
+	 */
+	public ConsentHubExistsException(String message) {
+		super(message);
+	}
+
+	/**
+	 * Constructor with a message and Throwable object
+	 * @param message message with details about the cause
+	 * @param cause Throwable that caused throwing of this exception
+	 */
+	public ConsentHubExistsException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	/**
+	 * Constructor with a Throwable object
+	 * @param cause Throwable that caused throwing of this exception
+	 */
+	public ConsentHubExistsException(Throwable cause) {
+		super(cause);
+	}
+
+	/**
+	 * Constructor with the consentHub
+	 * @param consentHub consentHub that already exists
+	 */
+	public ConsentHubExistsException(ConsentHub consentHub) {
+		super(consentHub.toString());
+		this.consentHub = consentHub;
+	}
+
+	/**
+	 * Getter for the consentHub
+	 * @return consentHub that already exists
+	 */
+	public ConsentHub getConsentHub() {
+		return this.consentHub;
+	}
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/FacilitiesManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/FacilitiesManager.java
@@ -4,6 +4,7 @@ import cz.metacentrum.perun.core.api.exceptions.AlreadyAdminException;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.BanAlreadyExistsException;
 import cz.metacentrum.perun.core.api.exceptions.BanNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.ConsentHubExistsException;
 import cz.metacentrum.perun.core.api.exceptions.FacilityAlreadyRemovedException;
 import cz.metacentrum.perun.core.api.exceptions.FacilityExistsException;
 import cz.metacentrum.perun.core.api.exceptions.FacilityNotExistsException;
@@ -247,7 +248,7 @@ public interface FacilitiesManager {
 	/**
 	 * Store the facility.
 	 */
-	Facility createFacility(PerunSession perunSession, Facility facility) throws PrivilegeException, FacilityExistsException;
+	Facility createFacility(PerunSession perunSession, Facility facility) throws PrivilegeException, FacilityExistsException, ConsentHubExistsException;
 
 	/**
 	 * Delete the facility by id.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ConsentsManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ConsentsManagerBl.java
@@ -2,8 +2,10 @@ package cz.metacentrum.perun.core.bl;
 
 import cz.metacentrum.perun.core.api.ConsentHub;
 import cz.metacentrum.perun.core.api.PerunSession;
+import cz.metacentrum.perun.core.api.exceptions.ConsentHubExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ConsentHubNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.ConsentHubAlreadyRemovedException;
 
 import java.util.List;
 
@@ -45,4 +47,37 @@ public interface ConsentsManagerBl {
 	 */
 	ConsentHub getConsentHubByName(PerunSession sess, String name) throws ConsentHubNotExistsException;
 
+
+	/**
+	 * Creates new consent hub.
+	 * @param perunSession session
+	 * @param consentHub consent hub
+	 * @return new consent hub
+	 * @throws ConsentHubExistsException if consent hub with similar name exists
+	 */
+	ConsentHub createConsentHub(PerunSession perunSession, ConsentHub consentHub) throws ConsentHubExistsException;
+
+	/**
+	 * Deletes consent hub.
+	 * @param perunSession session
+	 * @param consentHub consent hub
+	 * @throws ConsentHubAlreadyRemovedException if no such consent hub stored in db
+	 */
+	void deleteConsentHub(PerunSession perunSession, ConsentHub consentHub) throws ConsentHubAlreadyRemovedException;
+
+	/**
+	 * Returns true, if consent hub exists, false otherwise.
+	 * @param sess session
+	 * @param consentHub consent hub
+	 * @return whether consent hub exists
+	 */
+	boolean consentHubExists(PerunSession sess, ConsentHub consentHub);
+
+	/**
+	 * Throws exception if consent hub does not exist.
+	 * @param sess session
+	 * @param consentHub consent hub
+	 * @throws ConsentHubNotExistsException if consent hub does not exist
+	 */
+	void checkConsentHubExists(PerunSession sess, ConsentHub consentHub) throws ConsentHubNotExistsException;
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/FacilitiesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/FacilitiesManagerBl.java
@@ -19,6 +19,7 @@ import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.Vo;
 import cz.metacentrum.perun.core.api.exceptions.BanAlreadyExistsException;
 import cz.metacentrum.perun.core.api.exceptions.BanNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.ConsentHubExistsException;
 import cz.metacentrum.perun.core.api.exceptions.FacilityAlreadyRemovedException;
 import cz.metacentrum.perun.core.api.exceptions.FacilityExistsException;
 import cz.metacentrum.perun.core.api.exceptions.FacilityNotExistsException;
@@ -372,8 +373,9 @@ public interface FacilitiesManagerBl {
 	 * @return
 	 * @throws InternalErrorException
 	 * @throws FacilityExistsException
+	 * @throws ConsentHubExistsException
 	 */
-	Facility createFacility(PerunSession perunSession, Facility facility) throws FacilityExistsException;
+	Facility createFacility(PerunSession perunSession, Facility facility) throws FacilityExistsException, ConsentHubExistsException;
 
 	/**
 	 * Delete the facility by id.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ConsentsManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ConsentsManagerBlImpl.java
@@ -2,7 +2,9 @@ package cz.metacentrum.perun.core.blImpl;
 
 import cz.metacentrum.perun.core.api.ConsentHub;
 import cz.metacentrum.perun.core.api.PerunSession;
+import cz.metacentrum.perun.core.api.exceptions.ConsentHubExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ConsentHubNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.ConsentHubAlreadyRemovedException;
 import cz.metacentrum.perun.core.bl.ConsentsManagerBl;
 import cz.metacentrum.perun.core.bl.PerunBl;
 import cz.metacentrum.perun.core.implApi.ConsentsManagerImplApi;
@@ -50,4 +52,27 @@ public class ConsentsManagerBlImpl implements ConsentsManagerBl {
 		return getConsentsManagerImpl().getConsentHubByName(sess, name);
 	}
 
+	@Override
+	public ConsentHub createConsentHub(PerunSession sess, ConsentHub consentHub) throws ConsentHubExistsException{
+		if (consentHubExists(sess, consentHub)) {
+			throw new ConsentHubExistsException(consentHub);
+		}
+
+		return getConsentsManagerImpl().createConsentHub(sess, consentHub);
+	}
+
+	@Override
+	public void deleteConsentHub(PerunSession sess, ConsentHub consentHub) throws ConsentHubAlreadyRemovedException {
+		getConsentsManagerImpl().deleteConsentHub(sess, consentHub);
+	}
+
+	@Override
+	public boolean consentHubExists(PerunSession sess, ConsentHub consentHub) {
+		return getConsentsManagerImpl().consentHubExists(sess, consentHub);
+	}
+
+	@Override
+	public void checkConsentHubExists(PerunSession sess, ConsentHub consentHub) throws ConsentHubNotExistsException {
+		getConsentsManagerImpl().checkConsentHubExists(sess, consentHub);
+	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/FacilitiesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/FacilitiesManagerBlImpl.java
@@ -15,6 +15,7 @@ import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.BanOnFacility;
 import cz.metacentrum.perun.core.api.BeansUtils;
+import cz.metacentrum.perun.core.api.ConsentHub;
 import cz.metacentrum.perun.core.api.Destination;
 import cz.metacentrum.perun.core.api.EnrichedFacility;
 import cz.metacentrum.perun.core.api.Facility;
@@ -37,6 +38,7 @@ import cz.metacentrum.perun.core.api.exceptions.AlreadyAdminException;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.BanAlreadyExistsException;
 import cz.metacentrum.perun.core.api.exceptions.BanNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.ConsentHubExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ConsistencyErrorException;
 import cz.metacentrum.perun.core.api.exceptions.FacilityAlreadyRemovedException;
 import cz.metacentrum.perun.core.api.exceptions.FacilityExistsException;
@@ -282,7 +284,7 @@ public class FacilitiesManagerBlImpl implements FacilitiesManagerBl {
 	}
 
 	@Override
-	public Facility createFacility(PerunSession sess, Facility facility) throws FacilityExistsException {
+	public Facility createFacility(PerunSession sess, Facility facility) throws FacilityExistsException, ConsentHubExistsException {
 
 		//check facility name, it can contain only a-zA-Z.0-9_-
 		if (!facility.getName().matches("^[ a-zA-Z.0-9_-]+$")) {
@@ -310,6 +312,8 @@ public class FacilitiesManagerBlImpl implements FacilitiesManagerBl {
 		} else {
 			log.warn("Can't set Facility manager during creating of the Facility. User from perunSession is null. {} {}", facility, sess);
 		}
+
+		perunBl.getConsentsManagerBl().createConsentHub(sess, new ConsentHub(0, facility.getName(), true, List.of(facility)));
 
 		return facility;
 	}
@@ -358,6 +362,10 @@ public class FacilitiesManagerBlImpl implements FacilitiesManagerBl {
 				throw new InternalErrorException(e);
 			}
 		}
+
+		//remove consent
+		//TODO: get consent hub for this facility and remove this facility from it, or if no other facilities in there,
+		// remove the whole consent
 
 		//remove hosts
 		List<Host> hosts = this.getHosts(sess, facility);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntry.java
@@ -29,6 +29,7 @@ import cz.metacentrum.perun.core.api.exceptions.AlreadyAdminException;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.BanAlreadyExistsException;
 import cz.metacentrum.perun.core.api.exceptions.BanNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.ConsentHubExistsException;
 import cz.metacentrum.perun.core.api.exceptions.FacilityAlreadyRemovedException;
 import cz.metacentrum.perun.core.api.exceptions.FacilityExistsException;
 import cz.metacentrum.perun.core.api.exceptions.FacilityNotExistsException;
@@ -424,7 +425,7 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 	}
 
 	@Override
-	public Facility createFacility(PerunSession sess, Facility facility) throws PrivilegeException, FacilityExistsException {
+	public Facility createFacility(PerunSession sess, Facility facility) throws PrivilegeException, FacilityExistsException, ConsentHubExistsException {
 		Utils.checkPerunSession(sess);
 
 		// Authorization

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ConsentsManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ConsentsManagerImpl.java
@@ -6,6 +6,11 @@ import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.exceptions.ConsentHubNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.implApi.ConsentsManagerImplApi;
+import cz.metacentrum.perun.core.api.Facility;
+import cz.metacentrum.perun.core.api.exceptions.ConsentHubAlreadyRemovedException;
+import cz.metacentrum.perun.core.api.exceptions.ConsistencyErrorException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.JdbcPerunTemplate;
 import org.springframework.jdbc.core.RowMapper;
@@ -19,6 +24,8 @@ import java.util.List;
  * @author Radoslav Čerhák <r.cerhak@gmail.com>
  */
 public class ConsentsManagerImpl implements ConsentsManagerImplApi {
+
+	final static Logger log = LoggerFactory.getLogger(ConsentsManagerImpl.class);
 
 	private static JdbcPerunTemplate jdbc;
 
@@ -60,7 +67,7 @@ public class ConsentsManagerImpl implements ConsentsManagerImplApi {
 	public ConsentHub getConsentHubById(PerunSession sess, int id) throws ConsentHubNotExistsException {
 		try {
 			return jdbc.queryForObject("select " + consentHubMappingSelectQuery + " from consent_hubs where id=?", CONSENT_HUB_MAPPER, id);
-		} catch(EmptyResultDataAccessException ex) {
+		} catch (EmptyResultDataAccessException ex) {
 			throw new ConsentHubNotExistsException(ex);
 		} catch (RuntimeException ex) {
 			throw new InternalErrorException(ex);
@@ -71,10 +78,72 @@ public class ConsentsManagerImpl implements ConsentsManagerImplApi {
 	public ConsentHub getConsentHubByName(PerunSession sess, String name) throws ConsentHubNotExistsException {
 		try {
 			return jdbc.queryForObject("select " + consentHubMappingSelectQuery + " from consent_hubs where name=?", CONSENT_HUB_MAPPER, name);
-		} catch(EmptyResultDataAccessException ex) {
+		} catch (EmptyResultDataAccessException ex) {
 			throw new ConsentHubNotExistsException(ex);
 		} catch (RuntimeException ex) {
 			throw new InternalErrorException(ex);
 		}
+	}
+
+	@Override
+	public boolean consentHubExists(PerunSession sess, ConsentHub consentHub) {
+		try {
+			int numberOfExistences = jdbc.queryForInt("select count(1) from consent_hubs where id=?", consentHub.getId());
+			if (numberOfExistences == 1) {
+				return true;
+			} else if (numberOfExistences > 1) {
+				throw new ConsistencyErrorException("Consent hub " + consentHub + " exists more than once.");
+			}
+			return false;
+		} catch(EmptyResultDataAccessException ex) {
+			return false;
+		} catch(RuntimeException ex) {
+			throw new InternalErrorException(ex);
+		}
+	}
+
+	@Override
+	public void deleteConsentHub(PerunSession perunSession, ConsentHub consentHub) throws ConsentHubAlreadyRemovedException {
+		//TODO: remove all user consents first
+
+		try {
+			jdbc.update("delete from consent_hubs_facilities where consent_hub_id=?", consentHub.getId());
+
+			int numAffected = jdbc.update("delete from consent_hubs where id=?", consentHub.getId());
+			if (numAffected == 0) throw new ConsentHubAlreadyRemovedException("ConsentHub: " + consentHub);
+		} catch (RuntimeException e) {
+			throw new InternalErrorException(e);
+		}
+	}
+
+	@Override
+	public ConsentHub createConsentHub(PerunSession sess, ConsentHub consentHub) {
+		try {
+			int id = Utils.getNewId(jdbc, "consent_hubs_id_seq");
+			// if name not set, use facility name
+			if (consentHub.getName() == null) {
+				consentHub.setName(consentHub.getFacilities().get(0).getName());
+			}
+
+			jdbc.update("insert into consent_hubs(id,name,enforce_consents,created_by,created_at,modified_by,modified_at,created_by_uid,modified_by_uid) " +
+					"values (?,?,?,?," + Compatibility.getSysdate() + ",?," + Compatibility.getSysdate() + ",?,?)", id, consentHub.getName(),
+				consentHub.isEnforceConsents(), sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getUserId(), sess.getPerunPrincipal().getUserId());
+			for (Facility facility : consentHub.getFacilities()) {
+				jdbc.update("insert into consent_hubs_facilities(consent_hub_id,facility_id,created_by,created_at,modified_by,modified_at,created_by_uid,modified_by_uid) " +
+						"values (?,?,?," + Compatibility.getSysdate() + ",?," + Compatibility.getSysdate() + ",?,?)", id, facility.getId(),
+					sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getUserId(), sess.getPerunPrincipal().getUserId());
+			}
+			log.info("ConsentHub created: {}", consentHub);
+
+			consentHub.setId(id);
+			return consentHub;
+		} catch(RuntimeException ex) {
+			throw new InternalErrorException(ex);
+		}
+	}
+
+	@Override
+	public void checkConsentHubExists(PerunSession sess, ConsentHub consentHub) throws ConsentHubNotExistsException {
+		if(!consentHubExists(sess, consentHub)) throw new ConsentHubNotExistsException("ConsentHub not exists: " + consentHub);
 	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/ConsentsManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/ConsentsManagerImplApi.java
@@ -3,6 +3,7 @@ package cz.metacentrum.perun.core.implApi;
 import cz.metacentrum.perun.core.api.ConsentHub;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.exceptions.ConsentHubNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.ConsentHubAlreadyRemovedException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 
 import java.util.List;
@@ -44,5 +45,36 @@ public interface ConsentsManagerImplApi {
 	 * @throws InternalErrorException
 	 */
 	ConsentHub getConsentHubByName(PerunSession sess, String name) throws ConsentHubNotExistsException;
+
+	/**
+	 * Creates new consent hub.
+	 * @param perunSession session
+	 * @param consentHub consent hub
+	 * @return new consent hub
+	 */
+	ConsentHub createConsentHub(PerunSession perunSession, ConsentHub consentHub);
+
+	/**
+	 * Deletes the consent hub.
+	 * @param perunSession session
+	 * @param consentHub consent hub
+	 */
+	void deleteConsentHub(PerunSession perunSession, ConsentHub consentHub) throws ConsentHubAlreadyRemovedException;
+
+	/**
+	 * Returns true, if consent hub exists, false otherwise.
+	 * @param sess session
+	 * @param consentHub consent hub
+	 * @return whether consent hub exists
+	 */
+	boolean consentHubExists(PerunSession sess, ConsentHub consentHub);
+
+	/**
+	 * Throws exception if consent hub does not exist.
+	 * @param sess session
+	 * @param consentHub consent hub
+	 * @throws ConsentHubNotExistsException if consent hub does not exist
+	 */
+	void checkConsentHubExists(PerunSession sess, ConsentHub consentHub) throws ConsentHubNotExistsException;
 
 }

--- a/perun-core/src/main/resources/perun-core.xml
+++ b/perun-core/src/main/resources/perun-core.xml
@@ -127,6 +127,8 @@ http://www.springframework.org/schema/task http://www.springframework.org/schema
 		<!-- VosManagerImpl -->
 		<aop:advisor advice-ref="txAdviceNestedTransaction" pointcut="execution(* cz.metacentrum.perun.core.impl.VosManagerImpl.createVo(..))"/>
 		<aop:advisor advice-ref="txAdviceNestedTransaction" pointcut="execution(* cz.metacentrum.perun.core.impl.VosManagerImpl.updateVo(..))"/>
+		<!-- ConsentsManagerImpl -->
+		<aop:advisor advice-ref="txAdviceNestedTransaction" pointcut="execution(* cz.metacentrum.perun.core.impl.ConsentsManagerImpl.createConsentHub(..))"/>
 		<!-- ResourceAssignmentChecker -->
 		<aop:advisor advice-ref="txAdviceNestedTransaction" pointcut="execution(* cz.metacentrum.perun.core.impl.ResourceAssignmentChecker.removeSubgroupFromResource(..))"/>
 		<aop:advisor advice-ref="txAdviceNestedTransaction" pointcut="execution(* cz.metacentrum.perun.core.impl.ResourceAssignmentChecker.assignSubgroupsToResource(..))"/>

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ConsentsManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ConsentsManagerEntryIntegrationTest.java
@@ -1,9 +1,18 @@
 package cz.metacentrum.perun.core.entry;
 
 import cz.metacentrum.perun.core.AbstractPerunIntegrationTest;
+import cz.metacentrum.perun.core.api.ConsentHub;
 import cz.metacentrum.perun.core.api.ConsentsManager;
+import cz.metacentrum.perun.core.api.Facility;
+import cz.metacentrum.perun.core.api.exceptions.ConsentHubAlreadyRemovedException;
+import cz.metacentrum.perun.core.api.exceptions.ConsentHubExistsException;
+import cz.metacentrum.perun.core.api.exceptions.ConsentHubNotExistsException;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertTrue;
 
 /**
  * Integration tests of ConsentsManager.
@@ -11,6 +20,7 @@ import org.junit.Test;
  * @author Jakub Hejda <Jakub.Hejda@cesnet.cz>
  */
 public class ConsentsManagerEntryIntegrationTest extends AbstractPerunIntegrationTest {
+	private final String CLASS_NAME = "ConsentsManager.";
 
 	private ConsentsManager consentsManagerEntry;
 
@@ -32,6 +42,57 @@ public class ConsentsManagerEntryIntegrationTest extends AbstractPerunIntegratio
 	@Test
 	public void getConsentHubByName() throws Exception {
 		//TODO: test
+	}
+
+	@Test
+	public void createConsentHub() throws Exception {
+		System.out.println(CLASS_NAME + "createConsentHub");
+		Facility facility = setUpFacility();
+		final ConsentHub newHub = perun.getConsentsManagerBl().createConsentHub(sess, new ConsentHub(0, "testHub", true, List.of(facility)));
+
+		assertTrue("id must be greater than zero", newHub.getId() > 0);
+	}
+
+	@Test (expected = ConsentHubExistsException.class)
+	public void createExistingHub() throws Exception {
+		System.out.println(CLASS_NAME + "createExistingHub");
+		Facility facility = setUpFacility();
+		ConsentHub newHub = setUpConsentHub(List.of(facility));
+
+		perun.getConsentsManagerBl().createConsentHub(sess, newHub);
+	}
+
+	@Test (expected = ConsentHubNotExistsException.class)
+	public void deleteConsentHub() throws Exception {
+		System.out.println(CLASS_NAME + "deleteConsentHub");
+		Facility facility = setUpFacility();
+		ConsentHub newHub = setUpConsentHub(List.of(facility));
+
+		perun.getConsentsManagerBl().deleteConsentHub(sess, newHub);
+		consentsManagerEntry.getConsentHubById(sess, newHub.getId());
+	}
+
+	@Test (expected = ConsentHubAlreadyRemovedException.class)
+	public void deleteRemovedConsentHub() throws Exception {
+		System.out.println(CLASS_NAME + "deleteRemovedConsentHub");
+		Facility facility = setUpFacility();
+		ConsentHub newHub = setUpConsentHub(List.of(facility));
+
+		perun.getConsentsManagerBl().deleteConsentHub(sess, newHub);
+		perun.getConsentsManagerBl().deleteConsentHub(sess, newHub);
+	}
+
+
+	private Facility setUpFacility() throws Exception {
+		Facility facility = new Facility();
+		facility.setName("ConsentsTestFacility");
+		facility = perun.getFacilitiesManager().createFacility(sess, facility);
+		return facility;
+	}
+
+	private ConsentHub setUpConsentHub(List<Facility> facilities) throws Exception {
+		ConsentHub hub = new ConsentHub(0, "testHub", true, facilities);
+		return perun.getConsentsManagerBl().createConsentHub(sess, hub);
 	}
 
 }

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/SecurityTeamsManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/SecurityTeamsManagerEntryIntegrationTest.java
@@ -13,6 +13,7 @@ import cz.metacentrum.perun.core.api.Vo;
 import cz.metacentrum.perun.core.api.exceptions.AlreadyAdminException;
 import cz.metacentrum.perun.core.api.exceptions.AlreadyMemberException;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.ConsentHubExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ExtendMembershipException;
 import cz.metacentrum.perun.core.api.exceptions.ExternallyManagedException;
 import cz.metacentrum.perun.core.api.exceptions.FacilityExistsException;
@@ -909,7 +910,7 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 		return result;
 	}
 
-	private List<Facility> setUpFacilities() throws PrivilegeException, FacilityExistsException, SecurityTeamAlreadyAssignedException, FacilityNotExistsException, SecurityTeamNotExistsException {
+	private List<Facility> setUpFacilities() throws PrivilegeException, FacilityExistsException, SecurityTeamAlreadyAssignedException, FacilityNotExistsException, SecurityTeamNotExistsException, ConsentHubExistsException {
 		f0 = new Facility();
 		f1 = new Facility();
 		f2 = new Facility();


### PR DESCRIPTION
* for now we only need this login in BL layer
* consent hub is created automatically when new facility is created
* default name is same as for facility