### PR TITLE
feat(dispatcher): block propagation of services with no destination

### DIFF
--- a/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/scheduling/TaskScheduler.java
+++ b/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/scheduling/TaskScheduler.java
@@ -371,6 +371,10 @@ public class TaskScheduler extends AbstractRunner {
 				// when service is blocked globally in Perun or on facility as a whole.
 				return DENIED;
 			}
+		} else {
+			log.debug("[{}] No destination found for task: {}.", task.getId(), task);
+			task.setStatus(TaskStatus.ERROR);
+			return ERROR;
 		}
 
 		task.setDestinations(destinations);


### PR DESCRIPTION
* Due to the new consent logic, we don't want to allow the propagation of services without any destination.