### PR TITLE
fix(core): fixed ssh keys value normalization in registrar

### DIFF
--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
@@ -3874,12 +3874,18 @@ public class RegistrarManagerImpl implements RegistrarManager {
 	 */
 	private ArrayList<String> handleSSHKeysValue(ArrayList<String> originalValue, String newValue) {
 
+		// blank input means no change to original attribute
+		if (StringUtils.isBlank(newValue)) {
+			return originalValue;
+		}
+
 		// Normalize value of SSH keys
 		String preparedVal = newValue.replaceAll("(\n)+", ",");
 		preparedVal = preparedVal.replaceAll("(,)+", ",");
 		if (!preparedVal.endsWith(",")) {
 			preparedVal = preparedVal + ",";
 		}
+
 		List<String> newVals = (ArrayList<String>)BeansUtils.stringToAttributeValue(preparedVal, ArrayList.class.getName());
 		if (originalValue == null) {
 			return new ArrayList<>(newVals);

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
@@ -4118,6 +4118,13 @@ public class RegistrarManagerImpl implements RegistrarManager {
 		// we do not set logins by candidate object to prevent accidental overwrite while joining identities in process
 		attributes.entrySet().removeIf(entry -> entry.getKey().contains("urn:perun:user:attribute-def:def:login-namespace:"));
 
+		// NORMALIZE SSH KEYS VALUE - same as we do for existing users in #storeApplicationAttributes()
+		attributes.entrySet().forEach(entry -> {
+			if (Objects.equals(AttributesManager.NS_USER_ATTR_DEF+":sshPublicKey", entry.getKey())) {
+				entry.setValue(BeansUtils.attributeValueToString(handleSSHKeysValue(null, entry.getValue()), ArrayList.class.getName()));
+			}
+		});
+
 		Candidate candidate = new Candidate();
 		candidate.setAttributes(attributes);
 


### PR DESCRIPTION
- We have custom processing of SSH keys value in registrar. It worked
  for existing users in storeApplicationAttributes() but was missing
  from newly created users through Candidate.
- This fix adds value normalization for SSH keys when parsing Candidate
  from application data (raw values).
- Empty values (when SSH key is optional) were parsed badly by registrar.
  Such values are now converted to null and processed correctly.