### PR TITLE
feat(core): restrict adding user-related attributes on consent-requiring instances

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/ServiceAttributesCannotExtend.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/ServiceAttributesCannotExtend.java
@@ -1,0 +1,69 @@
+package cz.metacentrum.perun.core.api.exceptions;
+
+import cz.metacentrum.perun.core.api.Service;
+
+/**
+ * This exception is thrown when trying to add attributes which are forbidden unless the service is globally disabled.
+ * If such attribute would be added, consents for facility would be invalid.
+ * @author Johana Supikova <xsupikov@fi.muni.cz>
+ */
+public class ServiceAttributesCannotExtend extends PerunException {
+
+	static final long serialVersionUID = 0;
+
+	private Service service;
+	private int facilityId;
+
+	/**
+	 * Simple constructor with a message
+	 * @param message message with details about the cause
+	 */
+	public ServiceAttributesCannotExtend(String message) {
+		super(message);
+	}
+
+	/**
+	 * Constructor with a message and Throwable object
+	 * @param message message with details about the cause
+	 * @param cause Throwable that caused throwing of this exception
+	 */
+	public ServiceAttributesCannotExtend(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	/**
+	 * Constructor with a Throwable object
+	 * @param cause Throwable that caused throwing of this exception
+	 */
+	public ServiceAttributesCannotExtend(Throwable cause) {
+		super(cause);
+	}
+
+	/**
+	 * Constructor with the service and the facility
+	 * @param service service which cannot be extended by new attribute
+	 * @param facilityId id of facility on which the service would cause invalidation of consents
+	 */
+	public ServiceAttributesCannotExtend(Service service, int facilityId) {
+		this("Adding attribute to " + service.toString() + " would invalidate consents on facility with id " + facilityId);
+		this.service = service;
+		this.facilityId = facilityId;
+	}
+
+	/**
+	 * Getter for the service
+	 * @return service which cannot be extended by new attribute
+	 */
+	public Service getService() {
+		return service;
+	}
+
+	/**
+	 * Getter for the facilityId
+	 * @return facility on which the service would cause invalidation of consents
+	 */
+	public int getFacilityId() {
+		return facilityId;
+	}
+
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/ServicesManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/ServicesManager.java
@@ -15,6 +15,7 @@ import cz.metacentrum.perun.core.api.exceptions.ServiceAlreadyAssignedException;
 import cz.metacentrum.perun.core.api.exceptions.ServiceAlreadyBannedException;
 import cz.metacentrum.perun.core.api.exceptions.ServiceAlreadyRemovedException;
 import cz.metacentrum.perun.core.api.exceptions.ServiceAlreadyRemovedFromServicePackageException;
+import cz.metacentrum.perun.core.api.exceptions.ServiceAttributesCannotExtend;
 import cz.metacentrum.perun.core.api.exceptions.ServiceExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ServiceNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ServicesPackageExistsException;
@@ -797,14 +798,15 @@ public interface ServicesManager {
 	 * @throws AttributeNotExistsException if the attribute doesn't exists in underlaying data source
 	 * @throws ServiceNotExistsException if the service doesn't exists in underlaying data source
 	 * @throws AttributeAlreadyAssignedException if the attribute is already added
+	 * @throws ServiceAttributesCannotExtend if trying to add user-related attribute that could invalidate consents
 	 */
-	void addRequiredAttribute(PerunSession perunSession, Service service, AttributeDefinition attribute) throws PrivilegeException, AttributeNotExistsException, ServiceNotExistsException, AttributeAlreadyAssignedException;
+	void addRequiredAttribute(PerunSession perunSession, Service service, AttributeDefinition attribute) throws PrivilegeException, AttributeNotExistsException, ServiceNotExistsException, AttributeAlreadyAssignedException, ServiceAttributesCannotExtend;
 
 	/**
 	 *  Batch version of addRequiredAttribute
 	 *  @see cz.metacentrum.perun.core.api.ServicesManager#addRequiredAttribute(PerunSession,Service,AttributeDefinition)
 	 */
-	void addRequiredAttributes(PerunSession perunSession, Service service, List<? extends AttributeDefinition> attributes) throws PrivilegeException, AttributeNotExistsException, ServiceNotExistsException, AttributeAlreadyAssignedException;
+	void addRequiredAttributes(PerunSession perunSession, Service service, List<? extends AttributeDefinition> attributes) throws PrivilegeException, AttributeNotExistsException, ServiceNotExistsException, AttributeAlreadyAssignedException, ServiceAttributesCannotExtend;
 
 	/**
 	 * Remove required attribute from service.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ServicesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ServicesManagerBl.java
@@ -25,6 +25,7 @@ import cz.metacentrum.perun.core.api.exceptions.ServiceAlreadyAssignedException;
 import cz.metacentrum.perun.core.api.exceptions.ServiceAlreadyBannedException;
 import cz.metacentrum.perun.core.api.exceptions.ServiceAlreadyRemovedException;
 import cz.metacentrum.perun.core.api.exceptions.ServiceAlreadyRemovedFromServicePackageException;
+import cz.metacentrum.perun.core.api.exceptions.ServiceAttributesCannotExtend;
 import cz.metacentrum.perun.core.api.exceptions.ServiceExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ServiceNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ServicesPackageExistsException;
@@ -581,14 +582,15 @@ public interface ServicesManagerBl {
 	 *
 	 * @throws InternalErrorException
 	 * @throws AttributeAlreadyAssignedException
+	 * @throws ServiceAttributesCannotExtend
 	 */
-	void addRequiredAttribute(PerunSession perunSession, Service service, AttributeDefinition attribute) throws AttributeAlreadyAssignedException;
+	void addRequiredAttribute(PerunSession perunSession, Service service, AttributeDefinition attribute) throws AttributeAlreadyAssignedException, ServiceAttributesCannotExtend;
 
 	/**
 	 *  Batch version of addRequiredAttribute
 	 *  @see cz.metacentrum.perun.core.api.ServicesManager#addRequiredAttribute(PerunSession,Service,AttributeDefinition)
 	 */
-	void addRequiredAttributes(PerunSession perunSession, Service service, List<? extends AttributeDefinition> attributes) throws AttributeAlreadyAssignedException;
+	void addRequiredAttributes(PerunSession perunSession, Service service, List<? extends AttributeDefinition> attributes) throws AttributeAlreadyAssignedException, ServiceAttributesCannotExtend;
 
 	/**
 	 * Remove required attribute from service.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ServicesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ServicesManagerBlImpl.java
@@ -29,12 +29,17 @@ import cz.metacentrum.perun.audit.events.ServicesManagerEvents.ServicesPackageCr
 import cz.metacentrum.perun.audit.events.ServicesManagerEvents.ServicesPackageDeleted;
 import cz.metacentrum.perun.audit.events.ServicesManagerEvents.ServicesPackageUpdated;
 import cz.metacentrum.perun.controller.model.ServiceForGUI;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.BeansUtils;
+import cz.metacentrum.perun.core.api.ConsentHub;
 import cz.metacentrum.perun.core.api.HashedGenData;
 import cz.metacentrum.perun.core.api.MemberGroupStatus;
+import cz.metacentrum.perun.core.api.exceptions.ConsentHubNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.IllegalArgumentException;
 import cz.metacentrum.perun.core.api.exceptions.MemberGroupMismatchException;
 import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
 import cz.metacentrum.perun.core.api.exceptions.ServiceAlreadyBannedException;
+import cz.metacentrum.perun.core.api.exceptions.ServiceAttributesCannotExtend;
 import cz.metacentrum.perun.core.provisioning.GroupsHashedDataGenerator;
 import cz.metacentrum.perun.core.provisioning.HierarchicalHashedDataGenerator;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
@@ -92,6 +97,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * @author Michal Prochazka <michalp@ics.muni.cz>
@@ -727,17 +733,22 @@ public class ServicesManagerBlImpl implements ServicesManagerBl {
 	}
 
 	@Override
-	public void addRequiredAttribute(PerunSession sess, Service service, AttributeDefinition attribute) throws AttributeAlreadyAssignedException {
+	public void addRequiredAttribute(PerunSession sess, Service service, AttributeDefinition attribute) throws AttributeAlreadyAssignedException, ServiceAttributesCannotExtend {
 		//check if attribute isn't already added
 		List<AttributeDefinition> requiredAttributes = getPerunBl().getAttributesManagerBl().getRequiredAttributesDefinition(sess, service);
 		if(requiredAttributes.contains(attribute)) throw new AttributeAlreadyAssignedException(attribute);
+
+		checkCanAddAttribute(sess, service, attribute);
 
 		getServicesManagerImpl().addRequiredAttribute(sess, service, attribute);
 		getPerunBl().getAuditer().log(sess,new AttributeAddedAsRequiredToService(attribute, service));
 	}
 
 	@Override
-	public void addRequiredAttributes(PerunSession sess, Service service, List<? extends AttributeDefinition> attributes) throws AttributeAlreadyAssignedException {
+	public void addRequiredAttributes(PerunSession sess, Service service, List<? extends AttributeDefinition> attributes) throws AttributeAlreadyAssignedException, ServiceAttributesCannotExtend {
+		for (AttributeDefinition attrDef : attributes) {
+			checkCanAddAttribute(sess, service, attrDef);
+		}
 		getServicesManagerImpl().addRequiredAttributes(sess, service, attributes);
 		getPerunBl().getAuditer().log(sess, new AttributesAddedAsRequiredToService(attributes, service));
 	}
@@ -1081,5 +1092,46 @@ public class ServicesManagerBlImpl implements ServicesManagerBl {
 		this.unblockAllServicesOnDestination(sess, destination.getId());
 
 		getServicesManagerImpl().deleteDestination(sess, destination);
+	}
+
+	/**
+	 * Checks, that adding new required attribute to service which would require renewing user consents
+	 * (user-related attributes on consents-requiring instances) is done for globally disabled service.
+	 * Does not throw exception, if all facilities with given service are excluded from consents logic.
+	 * @throws ServiceAttributesCannotExtend if trying to add attribute which would invalidate consents
+	 */
+	private void checkCanAddAttribute(PerunSession sess, Service service, AttributeDefinition attribute) throws ServiceAttributesCannotExtend {
+		String attributeNamespace = attribute.getNamespace();
+		if (!attributeNamespace.startsWith(AttributesManager.NS_USER_FACILITY_ATTR) &&
+			!attributeNamespace.startsWith(AttributesManager.NS_USER_ATTR) &&
+			!attributeNamespace.startsWith(AttributesManager.NS_MEMBER_ATTR) &&
+			!attributeNamespace.startsWith(AttributesManager.NS_MEMBER_GROUP_ATTR) &&
+			!attributeNamespace.startsWith(AttributesManager.NS_MEMBER_RESOURCE_ATTR) &&
+			!attributeNamespace.startsWith(AttributesManager.NS_UES_ATTR)) {
+			return;
+		}
+
+		if (!service.isEnabled()) {
+			return;
+		}
+
+		if (!BeansUtils.getCoreConfig().getForceConsents()) {
+			return;
+		}
+
+		List<Integer> facilitiesIds = perunBl.getServicesManagerBl().getAssignedResources(sess, service).stream()
+			.map(Resource::getFacilityId)
+			.distinct()
+			.toList();
+		for (int facilityId : facilitiesIds) {
+			try {
+				ConsentHub hub = perunBl.getConsentsManagerBl().getConsentHubByFacility(sess, facilityId);
+				if (hub.isEnforceConsents()) {
+					throw new ServiceAttributesCannotExtend(service, facilityId);
+				}
+			} catch (ConsentHubNotExistsException e) {
+				throw new ConsistencyErrorException("Consent hub not found for facility with id " + facilityId, e);
+			}
+		}
 	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ServicesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ServicesManagerEntry.java
@@ -29,6 +29,7 @@ import cz.metacentrum.perun.core.api.exceptions.ServiceAlreadyAssignedException;
 import cz.metacentrum.perun.core.api.exceptions.ServiceAlreadyBannedException;
 import cz.metacentrum.perun.core.api.exceptions.ServiceAlreadyRemovedException;
 import cz.metacentrum.perun.core.api.exceptions.ServiceAlreadyRemovedFromServicePackageException;
+import cz.metacentrum.perun.core.api.exceptions.ServiceAttributesCannotExtend;
 import cz.metacentrum.perun.core.api.exceptions.ServiceExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ServiceNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ServicesPackageExistsException;
@@ -594,7 +595,7 @@ public class ServicesManagerEntry implements ServicesManager {
 	}
 
 	@Override
-	public void addRequiredAttribute(PerunSession sess, Service service, AttributeDefinition attribute) throws PrivilegeException, AttributeNotExistsException, ServiceNotExistsException, AttributeAlreadyAssignedException {
+	public void addRequiredAttribute(PerunSession sess, Service service, AttributeDefinition attribute) throws PrivilegeException, AttributeNotExistsException, ServiceNotExistsException, AttributeAlreadyAssignedException, ServiceAttributesCannotExtend {
 		Utils.checkPerunSession(sess);
 
 		// Authorization
@@ -609,7 +610,7 @@ public class ServicesManagerEntry implements ServicesManager {
 	}
 
 	@Override
-	public void addRequiredAttributes(PerunSession sess, Service service, List<? extends AttributeDefinition> attributes) throws PrivilegeException, AttributeNotExistsException, ServiceNotExistsException, AttributeAlreadyAssignedException {
+	public void addRequiredAttributes(PerunSession sess, Service service, List<? extends AttributeDefinition> attributes) throws PrivilegeException, AttributeNotExistsException, ServiceNotExistsException, AttributeAlreadyAssignedException, ServiceAttributesCannotExtend {
 		Utils.checkPerunSession(sess);
 
 		// Authorization

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/ServicesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/ServicesManagerImplApi.java
@@ -346,7 +346,6 @@ public interface ServicesManagerImplApi {
 	 * @param attribute attribute to add
 	 *
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
-	 * @throws ServiceNotExistsException if the service doesn't exists in underlaying data source
 	 * @throws AttributeAlreadyAssignedException if the attribute is already added
 	 */
 	void addRequiredAttribute(PerunSession perunSession, Service service, AttributeDefinition attribute) throws AttributeAlreadyAssignedException;

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/ServicesManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/ServicesManagerMethod.java
@@ -1306,6 +1306,7 @@ public enum ServicesManagerMethod implements ManagerMethod {
 	 *
 	 * @param service int Service <code>id</code>
 	 * @param attribute int Attribute <code>id</code>
+	 * @throw ServiceAttributesCannotExtend if trying to add user-related attribute that could invalidate consents, requires disabling service
 	 */
 	addRequiredAttribute {
 
@@ -1325,6 +1326,7 @@ public enum ServicesManagerMethod implements ManagerMethod {
 	 *
 	 * @param service int Service <code>id</code>
 	 * @param attributes int[] Attribute IDs
+	 * @throw ServiceAttributesCannotExtend if trying to add user-related attribute that could invalidate consents, requires disabling service
 	 */
 	addRequiredAttributes {
 


### PR DESCRIPTION
* if instance enforces consents and consent hubs related to service enforce consents, it is possible to add user-related attribute only if service is globally disabled