### PR TITLE
feat(core): changed modules for lsaai and elixir

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace_lifescienceid_persistent_shadow.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace_lifescienceid_persistent_shadow.java
@@ -1,5 +1,11 @@
 package cz.metacentrum.perun.core.impl.modules.attributes;
 
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.UserPersistentShadowAttributeWithConfig;
 
 /**
@@ -12,6 +18,7 @@ public class urn_perun_user_attribute_def_def_login_namespace_lifescienceid_pers
 		extends UserPersistentShadowAttributeWithConfig {
 
 	private final static String attrNameLifeScience = "login-namespace:lifescienceid-persistent-shadow";
+	private final static String elixirShadow = "urn:perun:user:attribute-def:def:login-namespace:elixir-persistent-shadow";
 
 	private final static String CONFIG_EXT_SOURCE_NAME_LIFESCIENCE = "extSourceNameLifeScience";
 	private final static String CONFIG_DOMAIN_NAME_LIFESCIENCE = "domainNameLifeScience";
@@ -45,5 +52,26 @@ public class urn_perun_user_attribute_def_def_login_namespace_lifescienceid_pers
 	@Override
 	public String getDisplayName() {
 		return "Lifescienceid login";
+	}
+
+	@Override
+	public Attribute fillAttribute(PerunSessionImpl sess, User user, AttributeDefinition attribute) {
+		// Check if user has login in namespace elixir-persistent-shadow
+		Attribute elixirPersistentShadow = null;
+		try {
+			elixirPersistentShadow = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, user, elixirShadow);
+		} catch (WrongAttributeAssignmentException | AttributeNotExistsException ignored) {
+		}
+
+		if (elixirPersistentShadow != null && elixirPersistentShadow.getValue() != null) {
+			Attribute filledAttribute = new Attribute(attribute);
+			String value = elixirPersistentShadow.getValue().toString();
+			String valueWithoutScope = value.split("@", 2) [0];
+			String attrValue = valueWithoutScope + "@" + CONFIG_DOMAIN_NAME_LIFESCIENCE;
+			filledAttribute.setValue(attrValue);
+			return filledAttribute;
+		}
+
+		return super.fillAttribute(sess, user, attribute);
 	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace_lifescienceid_username.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace_lifescienceid_username.java
@@ -1,0 +1,44 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.blImpl.ModulesUtilsBlImpl;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+
+public class urn_perun_user_attribute_def_def_login_namespace_lifescienceid_username extends urn_perun_user_attribute_def_def_login_namespace{
+	private final static String elixirUsername = "urn:perun:user:attribute-def:def:login-namespace:elixir";
+
+	@Override
+	public void changedAttributeHook(PerunSessionImpl sess, User user, Attribute attribute) {
+		Attribute elixirPersistentShadow;
+		try {
+			elixirPersistentShadow = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, user, elixirUsername);
+		} catch (WrongAttributeAssignmentException | AttributeNotExistsException e) {
+			return;
+		}
+		elixirPersistentShadow.setValue(attribute.getValue());
+		try {
+			sess.getPerunBl().getAttributesManagerBl().setAttribute(sess, user, elixirPersistentShadow);
+		} catch (WrongAttributeValueException | WrongAttributeAssignmentException | WrongReferenceAttributeValueException e) {
+			throw new InternalErrorException(e);
+		}
+	}
+
+	@Override
+	public AttributeDefinition getAttributeDefinition() {
+		AttributeDefinition attr = new AttributeDefinition();
+		attr.setNamespace(AttributesManager.NS_USER_ATTR_DEF);
+		attr.setFriendlyName("login-namespace:lifescienceid-username");
+		attr.setDisplayName("Lifescience username (login)");
+		attr.setType(String.class.getName());
+		attr.setDescription("Login in namespaceid: lifescience");
+		return attr;
+	}
+}


### PR DESCRIPTION
- When the value of lsaai username is changed, elixir username is set to that value as well.
- lsaai and elixir persistent shadow modules now set the same identifiers
  with diferent scopes. Elixir attribute module does not create new user
  external source.