### PR TITLE
fix(core): add RPC role to getConsentById policy

### DIFF
--- a/perun-base/src/main/resources/perun-roles.yml
+++ b/perun-base/src/main/resources/perun-roles.yml
@@ -6731,6 +6731,7 @@ perun_policies:
       - FACILITYADMIN: Facility
       - FACILITYOBSERVER: Facility
       - SELF: User
+      - RPC:
     include_policies:
       - default_policy
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ConsentsManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ConsentsManagerEntry.java
@@ -279,7 +279,7 @@ public class ConsentsManagerEntry implements ConsentsManager {
 		consentsManagerBl.checkConsentExists(sess, consent);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "changeConsentStatus_Consent_ConsentStatus_policy", getPerunBl().getUsersManager().getUserById(sess, consent.getUserId()))) {
+		if (!AuthzResolver.authorizedInternal(sess, "changeConsentStatus_Consent_ConsentStatus_policy", getPerunBl().getUsersManagerBl().getUserById(sess, consent.getUserId()))) {
 			throw new PrivilegeException(sess, "changeConsentStatus");
 		}
 


### PR DESCRIPTION
- Calling getConsentById from RPC failed on PrivilegeException because
the RPC role was missing in the method's policy. It is now fixed.