### PR TITLE
fix(core): created consents contains only possible attributes

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ConsentsManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ConsentsManagerBl.java
@@ -14,6 +14,7 @@ import cz.metacentrum.perun.core.api.exceptions.ConsentHubExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ConsentHubNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.ConsentHubAlreadyRemovedException;
+import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
 
 import java.util.List;
 
@@ -128,8 +129,9 @@ public interface ConsentsManagerBl {
 	 *
 	 * @throws ConsentExistsException if consent already exists
 	 * @throws ConsentHubNotExistsException if consent hub doesn't exist
+	 * @throws UserNotExistsException if a user with consent's userId doesn't exist
 	 */
-	Consent createConsent(PerunSession perunSession, Consent consent) throws ConsentExistsException, ConsentHubNotExistsException;
+	Consent createConsent(PerunSession perunSession, Consent consent) throws ConsentExistsException, ConsentHubNotExistsException, UserNotExistsException;
 
 	/**
 	 * Deletes consent


### PR DESCRIPTION
- When creating an UNSIGNED consent, it used to contain all user-related
attributes required on services assigned to resources of the consent
hub's facilities.
- Now, such consents contain only attributes which can be possibly
propagated - only attributes required on services assigned to resources
where the user is assigned through groups.