### PR TITLE
fix(core): fix possible deadlock while evaluating consents

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/FacilitiesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/FacilitiesManagerBl.java
@@ -314,6 +314,31 @@ public interface FacilitiesManagerBl {
 	List<Member> getAllowedMembers(PerunSession sess, Facility facility);
 
 	/**
+	 * Return all members, which are "allowed" on facility through any resource assigned to the given service disregarding
+	 * their possible expired status in a group. All members include all group statuses, through which they can
+	 * be filtered if necessary.
+	 *
+	 * @param sess
+	 * @param facility
+	 * @param service
+	 *
+	 * @return list of allowed members
+	 */
+	List<Member> getAllowedMembers(PerunSession sess, Facility facility, Service service);
+
+	/**
+	 * Return all members, which are "allowed" on facility through any resource assigned to the given service
+	 * and have ACTIVE status in a group.
+	 *
+	 * @param sess
+	 * @param facility
+	 * @param service
+	 *
+	 * @return list of allowed members
+	 */
+	List<Member> getAllowedMembersNotExpiredInGroups(PerunSession sess, Facility facility, Service service);
+
+	/**
 	 * Return all members, which are associated with the facility and belong to given user.
 	 * Does not require ACTIVE group-resource status or any specific member status.
 	 *

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ConsentsManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ConsentsManagerBlImpl.java
@@ -70,7 +70,6 @@ public class ConsentsManagerBlImpl implements ConsentsManagerBl {
 	@Override
 	public Consent createConsent(PerunSession sess, Consent consent) throws ConsentExistsException, ConsentHubNotExistsException, UserNotExistsException {
 		Utils.notNull(consent, "consent");
-		PerunLocksUtils.lockUserInConsentHub(consent.getConsentHub(), consent.getUserId());
 
 		// Check if UNSIGNED consent exists and delete it
 		try {
@@ -284,6 +283,8 @@ public class ConsentsManagerBlImpl implements ConsentsManagerBl {
 		if (!consentHub.isEnforceConsents()) {
 			return members;
 		}
+
+		PerunLocksUtils.lockConsentHub(consentHub);
 
 		List<AttributeDefinition> requiredAttributes = getPerunBl().getAttributesManagerBl()
 			.getRequiredAttributesDefinition(sess, service);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/FacilitiesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/FacilitiesManagerBlImpl.java
@@ -267,6 +267,16 @@ public class FacilitiesManagerBlImpl implements FacilitiesManagerBl {
 	}
 
 	@Override
+	public List<Member> getAllowedMembers(PerunSession sess, Facility facility, Service service) {
+		return getFacilitiesManagerImpl().getAllowedMembers(sess, facility, service);
+	}
+
+	@Override
+	public List<Member> getAllowedMembersNotExpiredInGroups(PerunSession sess, Facility facility, Service service) {
+		return getFacilitiesManagerImpl().getAllowedMembersNotExpiredInGroups(sess, facility, service);
+	}
+
+	@Override
 	public List<Member> getAssociatedMembers(PerunSession sess, Facility facility, User user) {
 		return getFacilitiesManagerImpl().getAssociatedMembers(sess, facility, user);
 	}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/FacilitiesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/FacilitiesManagerImplApi.java
@@ -189,6 +189,31 @@ public interface FacilitiesManagerImplApi {
 	List<Member> getAllowedMembers(PerunSession sess, Facility facility);
 
 	/**
+	 * Return all members, which are "allowed" on facility through any resource assigned to the given service disregarding
+	 * their possible expired status in a group. All members include all group statuses, through which they can
+	 * be filtered if necessary.
+	 *
+	 * @param sess
+	 * @param facility
+	 * @param service
+	 *
+	 * @return list of allowed members
+	 */
+	List<Member> getAllowedMembers(PerunSession sess, Facility facility, Service service);
+
+	/**
+	 * Return all members, which are "allowed" on facility through any resource assigned to the given service
+	 * and have ACTIVE status in a group.
+	 *
+	 * @param sess
+	 * @param facility
+	 * @param service
+	 *
+	 * @return list of allowed members
+	 */
+	List<Member> getAllowedMembersNotExpiredInGroups(PerunSession sess, Facility facility, Service service);
+
+	/**
 	 * Return all members, which are associated with the facility and belong to given user.
 	 * Does not require ACTIVE group-resource status or any specific member status.
 	 *

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/provisioning/GroupsHashedDataGenerator.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/provisioning/GroupsHashedDataGenerator.java
@@ -63,7 +63,6 @@ public class GroupsHashedDataGenerator implements HashedDataGenerator {
 	private final Facility facility;
 	private final GenDataProvider dataProvider;
 	private final boolean filterExpiredMembers;
-	private final Set<Member> allMembers = new HashSet<>();
 	private final Set<Member> membersWithConsent = new HashSet<>();
 
 	private GroupsHashedDataGenerator(PerunSessionImpl sess, Service service, Facility facility,
@@ -97,7 +96,7 @@ public class GroupsHashedDataGenerator implements HashedDataGenerator {
 		dataProvider.getFacilityAttributesHashes();
 		Map<String, Map<String, Object>> attributes = dataProvider.getAllFetchedAttributes();
 
-		Map<Integer, Integer> memberIdsToUserIds = allMembers.stream()
+		Map<Integer, Integer> memberIdsToUserIds = membersWithConsent.stream()
 				.collect(toMap(Member::getId, Member::getUserId));
 
 		GenDataNode root = new GenDataNode.Builder()
@@ -118,8 +117,10 @@ public class GroupsHashedDataGenerator implements HashedDataGenerator {
 		if (BeansUtils.getCoreConfig().getForceConsents()) {
 			// remove the members without granted consents on required attributes
 			members.removeIf(member -> !membersWithConsent.contains(member));
+		} else {
+			// we skipped this part if consents were required, so add them now
+			membersWithConsent.addAll(members);
 		}
-		allMembers.addAll(members);
 
 		dataProvider.loadResourceAttributes(resource, members, true);
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/provisioning/HierarchicalHashedDataGenerator.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/provisioning/HierarchicalHashedDataGenerator.java
@@ -53,7 +53,6 @@ public class HierarchicalHashedDataGenerator implements HashedDataGenerator {
 	private final Service service;
 	private final Facility facility;
 	private final GenDataProvider dataProvider;
-	private final Set<Member> allMembers = new HashSet<>();
 	private final Set<Member> membersWithConsent = new HashSet<>();
 	private final boolean filterExpiredMembers;
 
@@ -89,7 +88,7 @@ public class HierarchicalHashedDataGenerator implements HashedDataGenerator {
 		dataProvider.getFacilityAttributesHashes();
 		Map<String, Map<String, Object>> attributes = dataProvider.getAllFetchedAttributes();
 
-		Map<Integer, Integer> memberIdsToUserIds = allMembers.stream()
+		Map<Integer, Integer> memberIdsToUserIds = membersWithConsent.stream()
 				.collect(toMap(Member::getId, Member::getUserId));
 
 		GenDataNode root = new GenDataNode.Builder()
@@ -110,8 +109,10 @@ public class HierarchicalHashedDataGenerator implements HashedDataGenerator {
 		if (BeansUtils.getCoreConfig().getForceConsents()) {
 			// remove the members without granted consents on required attributes
 			members.removeIf(member -> !membersWithConsent.contains(member));
+		} else {
+			// we skipped this part if consents were required, so add them now
+			membersWithConsent.addAll(members);
 		}
-		allMembers.addAll(members);
 
 		dataProvider.loadResourceAttributes(resource, members, true);
 

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntryIntegrationTest.java
@@ -2049,6 +2049,91 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 	}
 
 	@Test
+	public void getAllowedMembersForServiceAndFacility() throws Exception {
+		System.out.println(CLASS_NAME + "getAllowedMembersForServiceAndFacility");
+
+		Vo vo2 = new Vo(0, "facilityTestVo002", "facilityTestVo002");
+		vo2 = perun.getVosManagerBl().createVo(sess, vo2);
+
+		Member member11 = setUpMember(vo);
+		Member member12 = setUpMember(vo);
+		Member member21 = setUpMember(vo2);
+
+		Resource resource1 = setUpResource(vo);
+		Resource resource2 = setUpResource(vo2);
+
+		Group group1 = setUpGroup(vo, member11);
+		Group group2 = setUpGroup(vo2, member21);
+
+		// make them not-allowed
+		perun.getMembersManager().setStatus(sess, member12, Status.INVALID);
+
+		perun.getGroupsManager().addMember(sess, group1, member12);
+
+		// expired group members should be included
+		perun.getGroupsManagerBl().expireMemberInGroup(sess, member11, group1);
+
+		perun.getResourcesManager().assignGroupToResource(sess, group1, resource1, false, false, false);
+		perun.getResourcesManager().assignGroupToResource(sess, group2, resource2, false, false, false);
+
+
+		Service service = new Service(0, "TestService01", null);
+		service = perun.getServicesManager().createService(sess, service);
+
+		perun.getResourcesManager().assignService(sess, resource1, service);
+
+		List<Member> members = perun.getFacilitiesManagerBl().getAllowedMembers(sess, facility, service);
+		assertTrue(members.size() == 1);
+		assertTrue("Expired group member must be returned!", members.contains(member11));
+		assertTrue("Invalid vo member cannot be returned!", !members.contains(member12));
+		assertTrue("Member not associated with service cannot be returned", !members.contains(member21));
+	}
+
+	@Test
+	public void getAllowedMembersForServiceAndFacilityNotExpiredInGroup() throws Exception {
+		System.out.println(CLASS_NAME + "getAllowedMembersForServiceAndFacilityNotExpiredInGroup");
+
+		Vo vo2 = new Vo(0, "facilityTestVo002", "facilityTestVo002");
+		vo2 = perun.getVosManagerBl().createVo(sess, vo2);
+
+		Member member11 = setUpMember(vo);
+		Member member12 = setUpMember(vo);
+		Member member13 = setUpMember(vo);
+		Member member21 = setUpMember(vo2);
+
+		Resource resource1 = setUpResource(vo);
+		Resource resource2 = setUpResource(vo2);
+
+		Group group1 = setUpGroup(vo, member11);
+		Group group2 = setUpGroup(vo2, member21);
+
+		// make them not-allowed
+		perun.getMembersManager().setStatus(sess, member12, Status.INVALID);
+
+		perun.getGroupsManager().addMember(sess, group1, member12);
+		perun.getGroupsManager().addMember(sess, group1, member13);
+
+		// expired group members should be not be included
+		perun.getGroupsManagerBl().expireMemberInGroup(sess, member11, group1);
+
+		perun.getResourcesManager().assignGroupToResource(sess, group1, resource1, false, false, false);
+		perun.getResourcesManager().assignGroupToResource(sess, group2, resource2, false, false, false);
+
+
+		Service service = new Service(0, "TestService01", null);
+		service = perun.getServicesManager().createService(sess, service);
+
+		perun.getResourcesManager().assignService(sess, resource1, service);
+
+		List<Member> members = perun.getFacilitiesManagerBl().getAllowedMembersNotExpiredInGroups(sess, facility, service);
+		assertTrue(members.size() == 1);
+		assertTrue("Expired group member cannot be returned!", !members.contains(member11));
+		assertTrue("Invalid vo member cannot be returned!", !members.contains(member12));
+		assertTrue("Valid member was not returned!", members.contains(member13));
+		assertTrue("Member not associated with service cannot be returned", !members.contains(member21));
+	}
+
+	@Test
 	public void getAssociatedMembersForUserAndFacility() throws Exception {
 		System.out.println(CLASS_NAME + "getAssociatedMembersForUserAndFacility");
 


### PR DESCRIPTION
- A deadlock could happen while concurrently evaluating consents for the
same consent hub. If a user didn't have an existing consent, he would be
locked and a consent would be created. Evaluation1 could lock user1 and
wait for user2 locked by evaluation2. If evaluation2 wanted to lock
user1, a deadlock would happen.
- Another problem in concurrent evaluating was creating a new consent.
All concurrent evaluations could possibly create a new one - that would
create multiple ConsentCreated audit messages and therefore send
multiple emails to user.
- Now, users are not locked individually but the whole consent hub is
locked while evaluating which should solve both problems.
- Evaluating now happens only once for one propagation instead of for
every resource and every group.