### PR TITLE
Manual consent evaluation

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/Service.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/Service.java
@@ -13,6 +13,8 @@ public class Service extends Auditable implements Comparable<PerunBean> {
 	private boolean enabled = true;
 	private String script;
 
+	private boolean useExpiredMembers = false;
+
 	public Service(){
 		super();
 	}
@@ -81,6 +83,14 @@ public class Service extends Auditable implements Comparable<PerunBean> {
 		this.script = script;
 	}
 
+	public boolean isUseExpiredMembers() {
+		return useExpiredMembers;
+	}
+
+	public void setUseExpiredMembers(boolean useExpiredUsers) {
+		this.useExpiredMembers = useExpiredUsers;
+	}
+
 	@Override
 	public int hashCode() {
 		final int prime = 31;
@@ -115,6 +125,7 @@ public class Service extends Auditable implements Comparable<PerunBean> {
 				", recurrence=<").append(this.getRecurrence()).append(">").append(
 				", enabled=<").append(this.isEnabled()).append(">").append(
 				", script=<").append(getScript() == null ? "\\0" : BeansUtils.createEscaping(getScript())).append(">").append(
+				", useExpiredMembers=<").append(isUseExpiredMembers()).append(">").append(
 			']').toString();
 	}
 
@@ -124,7 +135,8 @@ public class Service extends Auditable implements Comparable<PerunBean> {
 		return str.append(getClass().getSimpleName()).append(":[id='").append(getId()).append("', name='").append(name)
 				.append("', description='").append(getDescription()).append("', delay='").append(getDelay())
 				.append("', recurrence='").append(getRecurrence()).append("', enabled='").append(isEnabled())
-				.append("', script='").append(getScript()).append("']").toString();
+				.append("', script='").append(getScript()).append("', useExpiredMembers='").append(isUseExpiredMembers())
+				.append("']").toString();
 	}
 
 	@Override

--- a/perun-base/src/main/resources/perun-roles.yml
+++ b/perun-base/src/main/resources/perun-roles.yml
@@ -6794,6 +6794,17 @@ perun_policies:
     include_policies:
       - default_policy
 
+  evaluateConsents_ConsentHub_policy:
+    policy_roles: []
+    include_policies:
+      - default_policy
+
+  evaluateConsents_Service_policy:
+    policy_roles: []
+    include_policies:
+      - default_policy
+
+
 # A list of Perun management rules that are loaded to the PerunPoliciesContainer.
 perun_roles_management:
 

--- a/perun-base/src/test/resources/test-schema.sql
+++ b/perun-base/src/test/resources/test-schema.sql
@@ -1,4 +1,4 @@
--- database version 3.1.91 (don't forget to update insert statement at the end of file)
+-- database version 3.1.92 (don't forget to update insert statement at the end of file)
 CREATE EXTENSION IF NOT EXISTS "unaccent";
 CREATE EXTENSION IF NOT EXISTS "pgcrypto";
 
@@ -422,6 +422,7 @@ create table services (
 						   recurrence integer not null default 2,
 						   enabled boolean default true not null,
 						   script varchar not null,
+						   use_expired_members boolean default false not null,
 						   created_at timestamp default statement_timestamp() not null,
 						   created_by varchar default user not null,
 						   modified_at timestamp default statement_timestamp() not null,
@@ -1832,7 +1833,7 @@ create index idx_fk_attr_cons_cons ON consent_attr_defs(consent_id);
 create index idx_fk_attr_cons_attr ON consent_attr_defs(attr_id);
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.1.91');
+insert into configurations values ('DATABASE VERSION','3.1.92');
 -- insert membership types
 insert into membership_types (id, membership_type, description) values (1, 'DIRECT', 'Member is directly added into group');
 insert into membership_types (id, membership_type, description) values (2, 'INDIRECT', 'Member is added indirectly through UNION relation');

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/ConsentsManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/ConsentsManager.java
@@ -181,4 +181,24 @@ public interface ConsentsManager {
 	 * @throws UserNotExistsException if user does not exist
 	 */
 	Consent changeConsentStatus(PerunSession sess, Consent consent, ConsentStatus status) throws ConsentNotExistsException, PrivilegeException, InvalidConsentStatusException, UserNotExistsException;
+
+	/**
+	 * Evaluates consents for given consent hub with enforced consents enabled.
+	 *
+	 * Service defines whether only active users will be evaluated or expired ones as well.
+	 *  @param sess session
+	 * @param consentHub consent hub
+	 */
+	void evaluateConsents(PerunSession sess, ConsentHub consentHub) throws PrivilegeException;
+
+	/**
+	 * Evaluates consents for all consent hubs with given service with enforced consents enabled.
+	 *
+	 * All services under obtained consent hubs will have consents fully evaluated
+	 * (not only for given service, but for all of them).
+	 * Service defines whether only active users will be evaluated or expired ones as well.
+	 *  @param sess session
+	 * @param service service
+	 */
+	void evaluateConsents(PerunSession sess, Service service) throws PrivilegeException;
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ConsentsManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ConsentsManagerBl.java
@@ -187,6 +187,16 @@ public interface ConsentsManagerBl {
 	ConsentHub getConsentHubByFacility(PerunSession sess, int facilityId) throws ConsentHubNotExistsException;
 
 	/**
+	 * Finds all existing Consent Hubs by service id (consent hubs that have given service assigned through facilities).
+	 *
+	 * @param sess perun session
+	 * @param serviceId service for which consent hubs is searched
+	 * @return found Consent Hubs
+	 * @throws ConsentHubNotExistsException if Consent Hub doesn't exist
+	 */
+	List<ConsentHub> getConsentHubsByService(PerunSession sess, int serviceId) throws ConsentHubNotExistsException;
+
+	/**
 	 * Creates new consent hub.
 	 * @param perunSession session
 	 * @param consentHub consent hub
@@ -282,4 +292,30 @@ public interface ConsentsManagerBl {
 	 * @param members the given members
 	 */
 	List<Member> evaluateConsents(PerunSession sess, Service service, Facility facility, List<Member> members);
+
+	/**
+	 * Evaluates consents for given consent hub with enforced consents enabled.
+	 *
+	 * For given ConsentHub, collects all attributes from services assigned to it
+	 * and compares it against attributes from users' Consent objects that are
+	 * assigned to resources of given ConsentHub object.
+	 *
+	 * Service defines whether only active users will be evaluated or expired ones as well.
+	 *
+	 *
+	 * @param sess session
+	 * @param consentHub consent hub
+	 */
+	void evaluateConsents(PerunSession sess, ConsentHub consentHub);
+
+	/**
+	 * Consolidate consents using given service for all consent hubs the service is assigned to.
+	 *
+	 * Method finds all consent hubs that contain given service in any of its facilities and start
+	 * full consent consolidation for each consent hub (all services in consent hubs will be checked).
+	 *
+	 * @param sess session
+	 * @param service service
+	 */
+	void evaluateConsents(PerunSession sess, Service service);
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ServicesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ServicesManagerBlImpl.java
@@ -29,31 +29,17 @@ import cz.metacentrum.perun.audit.events.ServicesManagerEvents.ServicesPackageCr
 import cz.metacentrum.perun.audit.events.ServicesManagerEvents.ServicesPackageDeleted;
 import cz.metacentrum.perun.audit.events.ServicesManagerEvents.ServicesPackageUpdated;
 import cz.metacentrum.perun.controller.model.ServiceForGUI;
-import cz.metacentrum.perun.core.api.AttributesManager;
-import cz.metacentrum.perun.core.api.BeansUtils;
-import cz.metacentrum.perun.core.api.ConsentHub;
-import cz.metacentrum.perun.core.api.HashedGenData;
-import cz.metacentrum.perun.core.api.MemberGroupStatus;
-import cz.metacentrum.perun.core.api.exceptions.ConsentHubNotExistsException;
-import cz.metacentrum.perun.core.api.exceptions.IllegalArgumentException;
-import cz.metacentrum.perun.core.api.exceptions.MemberGroupMismatchException;
-import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
-import cz.metacentrum.perun.core.api.exceptions.ServiceAlreadyBannedException;
-import cz.metacentrum.perun.core.api.exceptions.ServiceAttributesCannotExtend;
-import cz.metacentrum.perun.core.provisioning.GroupsHashedDataGenerator;
-import cz.metacentrum.perun.core.provisioning.HierarchicalHashedDataGenerator;
-import cz.metacentrum.perun.core.impl.PerunSessionImpl;
-import cz.metacentrum.perun.core.provisioning.HashedDataGenerator;
-import cz.metacentrum.perun.taskslib.model.TaskResult;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.BeansUtils;
+import cz.metacentrum.perun.core.api.ConsentHub;
 import cz.metacentrum.perun.core.api.Destination;
 import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.HashedGenData;
 import cz.metacentrum.perun.core.api.Host;
 import cz.metacentrum.perun.core.api.Member;
+import cz.metacentrum.perun.core.api.MemberGroupStatus;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.RichDestination;
@@ -62,9 +48,9 @@ import cz.metacentrum.perun.core.api.ServiceAttributes;
 import cz.metacentrum.perun.core.api.ServicesPackage;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.Vo;
-import cz.metacentrum.perun.core.api.VosManager;
 import cz.metacentrum.perun.core.api.exceptions.AttributeAlreadyAssignedException;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotAssignedException;
+import cz.metacentrum.perun.core.api.exceptions.ConsentHubNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ConsistencyErrorException;
 import cz.metacentrum.perun.core.api.exceptions.DestinationAlreadyAssignedException;
 import cz.metacentrum.perun.core.api.exceptions.DestinationAlreadyRemovedException;
@@ -72,12 +58,17 @@ import cz.metacentrum.perun.core.api.exceptions.DestinationExistsException;
 import cz.metacentrum.perun.core.api.exceptions.DestinationNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.FacilityNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.GroupResourceMismatchException;
+import cz.metacentrum.perun.core.api.exceptions.IllegalArgumentException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.MemberGroupMismatchException;
 import cz.metacentrum.perun.core.api.exceptions.MemberResourceMismatchException;
+import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
 import cz.metacentrum.perun.core.api.exceptions.RelationExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ServiceAlreadyAssignedException;
+import cz.metacentrum.perun.core.api.exceptions.ServiceAlreadyBannedException;
 import cz.metacentrum.perun.core.api.exceptions.ServiceAlreadyRemovedException;
 import cz.metacentrum.perun.core.api.exceptions.ServiceAlreadyRemovedFromServicePackageException;
+import cz.metacentrum.perun.core.api.exceptions.ServiceAttributesCannotExtend;
 import cz.metacentrum.perun.core.api.exceptions.ServiceExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ServiceNotAssignedException;
 import cz.metacentrum.perun.core.api.exceptions.ServiceNotExistsException;
@@ -88,8 +79,16 @@ import cz.metacentrum.perun.core.api.exceptions.VoNotExistsException;
 import cz.metacentrum.perun.core.bl.PerunBl;
 import cz.metacentrum.perun.core.bl.ResourcesManagerBl;
 import cz.metacentrum.perun.core.bl.ServicesManagerBl;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.impl.Utils;
 import cz.metacentrum.perun.core.implApi.ServicesManagerImplApi;
+import cz.metacentrum.perun.core.provisioning.GroupsHashedDataGenerator;
+import cz.metacentrum.perun.core.provisioning.HashedDataGenerator;
+import cz.metacentrum.perun.core.provisioning.HierarchicalHashedDataGenerator;
+import cz.metacentrum.perun.taskslib.model.TaskResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -97,7 +96,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * @author Michal Prochazka <michalp@ics.muni.cz>
@@ -379,6 +377,11 @@ public class ServicesManagerBlImpl implements ServicesManagerBl {
 	}
 
 	private ServiceAttributes getData(PerunSession sess, Service service, Facility facility, Resource resource, boolean filterExpiredMembers) {
+		if (filterExpiredMembers == service.isUseExpiredMembers()) {
+			service.setUseExpiredMembers(!filterExpiredMembers);
+			updateService(sess, service);
+		}
+
 		ServiceAttributes resourceServiceAttributes = new ServiceAttributes();
 		resourceServiceAttributes.addAttributes(getPerunBl().getAttributesManagerBl().getRequiredAttributes(sess, service, resource));
 
@@ -408,6 +411,10 @@ public class ServicesManagerBlImpl implements ServicesManagerBl {
 	}
 
 	private ServiceAttributes getDataWithGroups(PerunSession sess, Service service, Facility facility, Resource resource, boolean filterExpiredMembers) {
+		if (filterExpiredMembers == service.isUseExpiredMembers()) {
+			service.setUseExpiredMembers(!filterExpiredMembers);
+			updateService(sess, service);
+		}
 
 		// append resource attributes
 		ServiceAttributes resourceServiceAttributes = new ServiceAttributes();
@@ -462,6 +469,11 @@ public class ServicesManagerBlImpl implements ServicesManagerBl {
 	}
 
 	private ServiceAttributes getDataWithVo(PerunSession sess, Service service, Facility facility, Vo vo, List<Resource> resources, boolean filterExpiredMembers) {
+		if (filterExpiredMembers == service.isUseExpiredMembers()) {
+			service.setUseExpiredMembers(!filterExpiredMembers);
+			updateService(sess, service);
+		}
+
 		ServiceAttributes voServiceAttributes = new ServiceAttributes();
 		voServiceAttributes.addAttributes(getPerunBl().getAttributesManagerBl().getRequiredAttributes(sess, service, vo));
 
@@ -474,6 +486,11 @@ public class ServicesManagerBlImpl implements ServicesManagerBl {
 	}
 
 	private ServiceAttributes getData(PerunSession sess, Service service, Facility facility, Resource resource, Group group, Map<Member, ServiceAttributes> memberAttributes, boolean filterExpiredMembers) {
+		if (filterExpiredMembers == service.isUseExpiredMembers()) {
+			service.setUseExpiredMembers(!filterExpiredMembers);
+			updateService(sess, service);
+		}
+
 		ServiceAttributes groupServiceAttributes = new ServiceAttributes();
 		try {
 			// add group and group_resource attributes
@@ -545,6 +562,11 @@ public class ServicesManagerBlImpl implements ServicesManagerBl {
 
 	@Override
 	public ServiceAttributes getHierarchicalData(PerunSession sess, Service service, Facility facility, boolean filterExpiredMembers) {
+		if (filterExpiredMembers == service.isUseExpiredMembers()) {
+			service.setUseExpiredMembers(!filterExpiredMembers);
+			updateService(sess, service);
+		}
+
 		ServiceAttributes serviceAttributes = new ServiceAttributes();
 		serviceAttributes.addAttributes(getPerunBl().getAttributesManagerBl().getRequiredAttributes(sess, service, facility));
 
@@ -559,6 +581,11 @@ public class ServicesManagerBlImpl implements ServicesManagerBl {
 
 	@Override
 	public HashedGenData getHashedHierarchicalData(PerunSession sess, Service service, Facility facility, boolean filterExpiredMembers) {
+		if (filterExpiredMembers == service.isUseExpiredMembers()) {
+			service.setUseExpiredMembers(!filterExpiredMembers);
+			updateService(sess, service);
+		}
+
 		HashedDataGenerator hashedDataGenerator = new HierarchicalHashedDataGenerator.Builder()
 				.sess((PerunSessionImpl) sess)
 				.service(service)
@@ -571,6 +598,11 @@ public class ServicesManagerBlImpl implements ServicesManagerBl {
 
 	@Override
 	public HashedGenData getHashedDataWithGroups(PerunSession sess, Service service, Facility facility, boolean filterExpiredMembers) {
+		if (filterExpiredMembers == service.isUseExpiredMembers()) {
+			service.setUseExpiredMembers(!filterExpiredMembers);
+			updateService(sess, service);
+		}
+
 		HashedDataGenerator hashedDataGenerator = new GroupsHashedDataGenerator.Builder()
 				.sess((PerunSessionImpl) sess)
 				.service(service)
@@ -583,6 +615,11 @@ public class ServicesManagerBlImpl implements ServicesManagerBl {
 
 	@Override
 	public ServiceAttributes getFlatData(PerunSession sess, Service service, Facility facility, boolean filterExpiredMembers) {
+		if (filterExpiredMembers == service.isUseExpiredMembers()) {
+			service.setUseExpiredMembers(!filterExpiredMembers);
+			updateService(sess, service);
+		}
+
 		ServiceAttributes serviceAttributes = new ServiceAttributes();
 		serviceAttributes.addAttributes(getPerunBl().getAttributesManagerBl().getRequiredAttributes(sess, service, facility));
 
@@ -625,6 +662,11 @@ public class ServicesManagerBlImpl implements ServicesManagerBl {
 
 	@Override
 	public ServiceAttributes getDataWithVos(PerunSession sess, Service service, Facility facility, boolean filterExpiredMembers) throws VoNotExistsException {
+		if (filterExpiredMembers == service.isUseExpiredMembers()) {
+			service.setUseExpiredMembers(!filterExpiredMembers);
+			updateService(sess, service);
+		}
+
 		ServiceAttributes serviceAttributes = new ServiceAttributes();
 		serviceAttributes.addAttributes(getPerunBl().getAttributesManagerBl().getRequiredAttributes(sess, service, facility));
 
@@ -655,6 +697,11 @@ public class ServicesManagerBlImpl implements ServicesManagerBl {
 
 	@Override
 	public ServiceAttributes getDataWithGroups(PerunSession sess, Service service, Facility facility, boolean filterExpiredMembers) {
+		if (filterExpiredMembers == service.isUseExpiredMembers()) {
+			service.setUseExpiredMembers(!filterExpiredMembers);
+			updateService(sess, service);
+		}
+
 		ServiceAttributes serviceAttributes = new ServiceAttributes();
 		serviceAttributes.addAttributes(getPerunBl().getAttributesManagerBl().getRequiredAttributes(sess, service, facility));
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ConsentsManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ConsentsManagerEntry.java
@@ -6,6 +6,7 @@ import cz.metacentrum.perun.core.api.AuthzResolver;
 import cz.metacentrum.perun.core.api.ConsentsManager;
 import cz.metacentrum.perun.core.api.ConsentHub;
 import cz.metacentrum.perun.core.api.Facility;
+import cz.metacentrum.perun.core.api.Service;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.exceptions.ConsentHubNotExistsException;
@@ -322,6 +323,28 @@ public class ConsentsManagerEntry implements ConsentsManager {
 		}
 
 		return consentsManagerBl.changeConsentStatus(sess, consent, status);
+	}
+
+	@Override
+	public void evaluateConsents(PerunSession sess, ConsentHub consentHub) throws PrivilegeException {
+		Utils.notNull(sess, "sess");
+
+		// Authorization
+		if (!AuthzResolver.authorizedInternal(sess, "evaluateConsents_ConsentHub_policy", consentHub)) {
+			throw new PrivilegeException(sess, "evaluateConsents");
+		}
+		consentsManagerBl.evaluateConsents(sess, consentHub);
+	}
+
+	@Override
+	public void evaluateConsents(PerunSession sess, Service service) throws PrivilegeException {
+		Utils.notNull(sess, "sess");
+
+		// Authorization
+		if (!AuthzResolver.authorizedInternal(sess, "evaluateConsents_Service_policy", service)) {
+			throw new PrivilegeException(sess, "evaluateConsents");
+		}
+		consentsManagerBl.evaluateConsents(sess, service);
 	}
 
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ConsentsManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ConsentsManagerImpl.java
@@ -403,6 +403,29 @@ public class ConsentsManagerImpl implements ConsentsManagerImplApi {
 	}
 
 	@Override
+	public List<ConsentHub> getConsentHubsByService(PerunSession session, int serviceId) {
+		try {
+			List<ConsentHub> consentHubs = jdbc.query("select " + consentHubMappingSelectQuery +
+				" from consent_hubs" +
+					" join consent_hubs_facilities on consent_hubs.id=consent_hubs_facilities.consent_hub_id" +
+					" join resources on resources.facility_id = consent_hubs_facilities.facility_id" +
+					" join resource_services on resource_services.resource_id = resources.id" +
+					" join services on services.id = resource_services.service_id" +
+				" where services.id=?",
+				CONSENT_HUB_MAPPER,
+				serviceId);
+
+			// set corresponding facilities for each consent hub
+			for (ConsentHub consentHub : consentHubs) {
+				consentHub.setFacilities(getFacilitiesForConsentHub(consentHub));
+			}
+			return consentHubs;
+		} catch (RuntimeException ex) {
+			throw new InternalErrorException(ex);
+		}
+	}
+
+	@Override
 	public boolean consentHubExists(PerunSession sess, ConsentHub consentHub) {
 		try {
 			int numberOfExistences = jdbc.queryForInt("select count(1) from consent_hubs where id=?", consentHub.getId());

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ServicesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ServicesManagerImpl.java
@@ -60,7 +60,7 @@ public class ServicesManagerImpl implements ServicesManagerImplApi {
 
 	public final static String serviceMappingSelectQuery = " services.id as services_id, services.name as services_name, " +
 		"services.description as services_description, services.delay as services_delay, services.recurrence as services_recurrence, " +
-		"services.enabled as services_enabled, services.script as services_script, " +
+		"services.enabled as services_enabled, services.script as services_script, services.use_expired_members as services_use_expired_members, " +
 		"services.created_at as services_created_at, services.created_by as services_created_by, " +
 		"services.modified_by as services_modified_by, services.modified_at as services_modified_at, " +
 		"services.created_by_uid as services_created_by_uid, services.modified_by_uid as services_modified_by_uid";
@@ -101,6 +101,7 @@ public class ServicesManagerImpl implements ServicesManagerImplApi {
 		service.setRecurrence(resultSet.getInt("services_recurrence"));
 		service.setEnabled(resultSet.getBoolean("services_enabled"));
 		service.setScript(resultSet.getString("services_script"));
+		service.setUseExpiredMembers(resultSet.getBoolean("services_use_expired_members"));
 		service.setCreatedAt(resultSet.getString("services_created_at"));
 		service.setCreatedBy(resultSet.getString("services_created_by"));
 		service.setModifiedAt(resultSet.getString("services_modified_at"));
@@ -369,9 +370,9 @@ public class ServicesManagerImpl implements ServicesManagerImplApi {
 			if (service.getScript() == null || service.getScript().isEmpty()) {
 				service.setScript("./"+service.getName());
 			}
-			jdbc.update("insert into services(id,name,description,delay,recurrence,enabled,script,created_by,created_at,modified_by,modified_at,created_by_uid, modified_by_uid) " +
-					"values (?,?,?,?,?,?,?,?," + Compatibility.getSysdate() + ",?," + Compatibility.getSysdate() + ",?,?)", newId, service.getName(),
-					service.getDescription(), service.getDelay(), service.getRecurrence(), service.isEnabled(), service.getScript(),
+			jdbc.update("insert into services(id,name,description,delay,recurrence,enabled,script,use_expired_members,created_by,created_at,modified_by,modified_at,created_by_uid, modified_by_uid) " +
+					"values (?,?,?,?,?,?,?,?,?," + Compatibility.getSysdate() + ",?," + Compatibility.getSysdate() + ",?,?)", newId, service.getName(),
+					service.getDescription(), service.getDelay(), service.getRecurrence(), service.isEnabled(), service.getScript(), service.isUseExpiredMembers(),
 					sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getUserId(), sess.getPerunPrincipal().getUserId());
 			log.info("Service created: {}", service);
 
@@ -403,10 +404,10 @@ public class ServicesManagerImpl implements ServicesManagerImplApi {
 			if (service.getScript() == null || service.getScript().isEmpty()) {
 				service.setScript("./"+service.getName());
 			}
-			jdbc.update("update services set name=?, description=?, delay=?, recurrence=?, enabled=?, script=?, " +
+			jdbc.update("update services set name=?, description=?, delay=?, recurrence=?, enabled=?, script=?, use_expired_members=?," +
 							"modified_by=?, modified_by_uid=?, modified_at=" + Compatibility.getSysdate() + "  where id=?",
 					service.getName(), service.getDescription(), service.getDelay(), service.getRecurrence(),
-					service.isEnabled(), service.getScript(),
+					service.isEnabled(), service.getScript(), service.isUseExpiredMembers(),
 					sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getUserId(), service.getId());
 		} catch(RuntimeException ex) {
 			throw new InternalErrorException(ex);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/ConsentsManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/ConsentsManagerImplApi.java
@@ -189,6 +189,15 @@ public interface ConsentsManagerImplApi {
 	ConsentHub getConsentHubByFacility(PerunSession sess, int facilityId) throws ConsentHubNotExistsException;
 
 	/**
+	 * Finds all existing Consent Hubs by service (service is assigned to them)
+	 *
+	 * @param session perun session
+	 * @param serviceId service for which consent hubs are searched
+	 * @return list of consent hubs that have given service assigned to them
+	 */
+	List<ConsentHub> getConsentHubsByService(PerunSession session, int serviceId);
+
+	/**
 	 * Creates new consent hub.
 	 * @param perunSession session
 	 * @param consentHub consent hub

--- a/perun-core/src/main/resources/postgresChangelog.txt
+++ b/perun-core/src/main/resources/postgresChangelog.txt
@@ -6,6 +6,10 @@
 -- Directly under version number should be version commands. They will be executed in the order they are written here.
 -- Comments are prefixed with -- and can be written only between version blocks, that means not in the lines with commands. They have to be at the start of the line.
 
+3.1.92
+ALTER TABLE services ADD COLUMN use_expired_members boolean default false not null;
+UPDATE configurations SET value='3.1.92' WHERE property='DATABASE VERSION';
+
 3.1.91
 create table consent_hubs (id integer not null, name varchar not null, enforce_consents boolean not null, created_at timestamp default statement_timestamp() not null, created_by varchar default user not null, modified_at timestamp default statement_timestamp() not null, modified_by varchar default user not null, created_by_uid integer, modified_by_uid integer, constraint consent_hub_pk primary key (id), constraint consent_hub_name_u unique (name));
 create table consent_hubs_facilities (consent_hub_id integer not null, facility_id integer not null, created_at timestamp default statement_timestamp() not null, created_by varchar default user not null,	modified_at timestamp default statement_timestamp() not null, modified_by varchar default user not null, created_by_uid integer, modified_by_uid integer, constraint conhubfac_ch_fk foreign key(consent_hub_id) references consent_hubs(id), constraint conhubfac_fac_fk foreign key(facility_id) references facilities(id), constraint facility_id_u unique (facility_id));

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ConsentsManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ConsentsManagerEntryIntegrationTest.java
@@ -11,6 +11,7 @@ import cz.metacentrum.perun.core.api.ConsentsManager;
 import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.Member;
+import cz.metacentrum.perun.core.api.MemberGroupStatus;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.Service;
 import cz.metacentrum.perun.core.api.User;
@@ -31,11 +32,11 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 
 /**
@@ -51,7 +52,8 @@ public class ConsentsManagerEntryIntegrationTest extends AbstractPerunIntegratio
 	private Facility facility;
 	private Resource resource;
 	private Service service;
-	private Vo vo;
+	private Vo vo, otherVo;
+	private Group group, otherGroup;
 	private Member member;
 	private AttributeDefinition attrDef;
 	private AttributeDefinition facAttrDef;
@@ -61,19 +63,19 @@ public class ConsentsManagerEntryIntegrationTest extends AbstractPerunIntegratio
 		consentsManagerEntry = perun.getConsentsManager();
 
 		user = setUpUser("John", "Doe");
-		facility = setUpFacility();
-		service = setUpService();
-		vo = setUpVo();
+		facility = setUpFacility("ConsentsTestFacility");
+		service = setUpService("testService");
+		vo = setUpVo("TestVo", "TestVo");
 		member = perun.getMembersManager().createMember(sess, vo, user);
-		resource = setUpResource(facility, vo);
+		resource = setUpResource("testResource", "testResource", facility, vo);
 		perun.getResourcesManagerBl().assignService(sess, resource, service);
 		attrDef = setUpUserAttributeDefinition("testUserAttribute");
 		facAttrDef = setUpFacilityAttributeDefinition();
 		perun.getServicesManagerBl().addRequiredAttributes(sess, service, List.of(attrDef, facAttrDef));
 
 		// add member to a group assigned to the resource
-		Group group = new Group("test", "test group");
-		group = perun.getGroupsManagerBl().createGroup(sess, vo, group);
+		Group testGroup = new Group("test", "test group");
+		group = perun.getGroupsManagerBl().createGroup(sess, vo, testGroup);
 		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource, false, false, false);
 		perun.getGroupsManagerBl().addMember(sess, group, member);
 	}
@@ -295,6 +297,23 @@ public class ConsentsManagerEntryIntegrationTest extends AbstractPerunIntegratio
 		assertTrue(consentHub.getFacilities().contains(facility));
 		assertThatExceptionOfType(ConsentHubNotExistsException.class).isThrownBy(
 			() -> consentsManagerEntry.getConsentHubByName(sess, "wrongName"));
+	}
+
+	@Test
+	public void getConsentHubsByService() throws Exception {
+		System.out.println(CLASS_NAME + "getConsentHubsByService");
+
+		List<ConsentHub> consentHubs = perun.getConsentsManagerBl().getConsentHubsByService(sess, service.getId());
+
+		assertEquals(1, consentsManagerEntry.getAllConsentHubs(sess).size());
+
+		assertEquals(1, consentHubs.size());
+		assertEquals(1, consentHubs.get(0).getFacilities().size());
+
+		List<Service> assignedServicesToFacility = perun.getServicesManagerBl().getAssignedServices(sess, consentHubs.get(0).getFacilities().get(0));
+
+		assertEquals(1, assignedServicesToFacility.size());
+		assertEquals(service, assignedServicesToFacility.get(0));
 	}
 
 	@Test
@@ -620,6 +639,282 @@ public class ConsentsManagerEntryIntegrationTest extends AbstractPerunIntegratio
 		assertThat(userConsents.get(0).getStatus()).isEqualTo(ConsentStatus.UNSIGNED);
 	}
 
+	@Test
+	public void evaluateConsentsForConsentHubCreatesConsents() throws Exception {
+		System.out.println(CLASS_NAME + "evaluateConsentsForConsentHubCreatesConsents");
+
+		User user1 = setUpUser("Harry", "Doe");
+		User user2 = setUpUser("James", "Doe");
+		Member member1 = perun.getMembersManager().createMember(sess, vo, user1);
+		Member member2 = perun.getMembersManager().createMember(sess, vo, user2);
+		perun.getGroupsManagerBl().addMember(sess, group, member1);
+		perun.getGroupsManagerBl().addMember(sess, group, member2);
+		perun.getGroupsManager().setMemberGroupStatus(sess, member1, group, MemberGroupStatus.EXPIRED);
+		perun.getGroupsManager().setMemberGroupStatus(sess, member2, group, MemberGroupStatus.VALID);
+
+		// validate both members in Vo, otherwise they will be skipped
+		perun.getMembersManagerBl().validateMember(sess, member1);
+		perun.getMembersManagerBl().validateMember(sess, member2);
+
+		System.out.println("members:\n" + perun.getGroupsManagerBl().getGroupMembers(sess, group));
+
+
+
+		ConsentHub consentHub = consentsManagerEntry.getConsentHubByFacility(sess, facility.getId());
+
+		boolean originalForce = BeansUtils.getCoreConfig().getForceConsents();
+		try {
+			BeansUtils.getCoreConfig().setForceConsents(true);
+			perun.getConsentsManagerBl().evaluateConsents(sess, consentHub);
+		} finally {
+			BeansUtils.getCoreConfig().setForceConsents(originalForce);
+		}
+
+		List<Consent> consents = consentsManagerEntry.getConsentsForUserAndConsentHub(sess, user2.getId(), consentHub.getId());
+		List<Consent> shouldBeEmptyConsents = consentsManagerEntry.getConsentsForUserAndConsentHub(sess, user1.getId(), consentHub.getId());
+
+		Consent expectedConsent = new Consent(consents.get(0).getId(), user2.getId(), consentHub, List.of(attrDef));
+		assertThat(consents).containsExactly(expectedConsent);
+		assertEquals(0, shouldBeEmptyConsents.size());
+
+		// evaluate again, still should have only the one UNSIGNED consent
+		try {
+			BeansUtils.getCoreConfig().setForceConsents(true);
+			perun.getConsentsManagerBl().evaluateConsents(sess, consentHub);
+		} finally {
+			BeansUtils.getCoreConfig().setForceConsents(originalForce);
+		}
+		assertThat(consents).containsExactly(expectedConsent);
+	}
+
+	@Test
+	public void evaluateConsentsForConsentHubUseExpiredMembersCreatesConsents() throws Exception {
+		System.out.println(CLASS_NAME + "evaluateConsentsForConsentHubUseExpiredMembersCreatesConsents");
+
+		boolean originalUseExpiredMembers = service.isUseExpiredMembers();
+
+		User user1 = setUpUser("Harry", "Doe");
+		User user2 = setUpUser("James", "Doe");
+		Member member1 = perun.getMembersManager().createMember(sess, vo, user1);
+		Member member2 = perun.getMembersManager().createMember(sess, vo, user2);
+		perun.getGroupsManagerBl().addMember(sess, group, member1);
+		perun.getGroupsManagerBl().addMember(sess, group, member2);
+		perun.getGroupsManager().setMemberGroupStatus(sess, member1, group, MemberGroupStatus.VALID);
+		perun.getGroupsManager().setMemberGroupStatus(sess, member2, group, MemberGroupStatus.EXPIRED);
+
+		// validate both members in VOs, otherwise they will be skipped
+		perun.getMembersManagerBl().validateMember(sess, member1);
+		perun.getMembersManagerBl().validateMember(sess, member2);
+
+		ConsentHub consentHub = consentsManagerEntry.getConsentHubByFacility(sess, facility.getId());
+
+		boolean originalForce = BeansUtils.getCoreConfig().getForceConsents();
+		try {
+			BeansUtils.getCoreConfig().setForceConsents(true);
+			service.setUseExpiredMembers(true);
+			perun.getServicesManagerBl().updateService(sess, service);
+
+			perun.getConsentsManagerBl().evaluateConsents(sess, consentHub);
+		} finally {
+			BeansUtils.getCoreConfig().setForceConsents(originalForce);
+			service.setUseExpiredMembers(originalUseExpiredMembers);
+			perun.getServicesManagerBl().updateService(sess, service);
+		}
+
+		List<Consent> consents1 = consentsManagerEntry.getConsentsForUserAndConsentHub(sess, user1.getId(), consentHub.getId());
+		List<Consent> consents2 = consentsManagerEntry.getConsentsForUserAndConsentHub(sess, user2.getId(), consentHub.getId());
+
+		Consent expectedConsent1 = new Consent(consents1.get(0).getId(), user1.getId(), consentHub, List.of(attrDef));
+		Consent expectedConsent2 = new Consent(consents2.get(0).getId(), user2.getId(), consentHub, List.of(attrDef));
+
+		assertThat(consents1).containsExactly(expectedConsent1);
+		assertThat(consents2).containsExactly(expectedConsent2);
+
+		// evaluate again, each user still should have only the one UNSIGNED consent
+		try {
+			BeansUtils.getCoreConfig().setForceConsents(true);
+			service.setUseExpiredMembers(true);
+			perun.getServicesManagerBl().updateService(sess, service);
+
+			perun.getConsentsManagerBl().evaluateConsents(sess, consentHub);
+		} finally {
+			BeansUtils.getCoreConfig().setForceConsents(originalForce);
+			service.setUseExpiredMembers(originalUseExpiredMembers);
+			perun.getServicesManagerBl().updateService(sess, service);
+
+		}
+
+		assertThat(consents1).containsExactly(expectedConsent1);
+		assertThat(consents2).containsExactly(expectedConsent2);
+	}
+
+	@Test
+	public void evaluateConsentsForServiceCreatesConsents() throws Exception {
+		System.out.println(CLASS_NAME + "evaluateConsentsForServiceCreatesConsents");
+
+		// Structure to be tested (service highlighted by arrow):
+		//     HUB(1)    HUB(2)
+		//        \       / \
+		//        ...   ... ...
+		//          \   /     \
+		// ===>>>  service   otherService
+		//            |            |
+		//      user(2)[VALID]  user(1)[VALID]
+		//                      user(3)[EXPIRED]
+
+		boolean originalUseExpiredMembers = service.isUseExpiredMembers();
+		ConsentHub otherConsentHub = setUpAnotherConsentHub();
+
+		User user1 = setUpUser("Harry", "Doe");
+		User user2 = setUpUser("James", "Doe");
+		User user3 = setUpUser("George", "Doe");
+		Member member1 = perun.getMembersManager().createMember(sess, otherVo, user1);
+		Member member2 = perun.getMembersManager().createMember(sess, vo, user2);
+		Member member3 = perun.getMembersManager().createMember(sess, otherVo, user3);
+		perun.getGroupsManagerBl().addMember(sess, otherGroup, member1);
+		perun.getGroupsManagerBl().addMember(sess, group, member2);
+		perun.getGroupsManagerBl().addMember(sess, otherGroup, member3);
+		perun.getGroupsManager().setMemberGroupStatus(sess, member1, otherGroup, MemberGroupStatus.VALID);
+		perun.getGroupsManager().setMemberGroupStatus(sess, member2, group, MemberGroupStatus.VALID);
+		perun.getGroupsManager().setMemberGroupStatus(sess, member3, otherGroup, MemberGroupStatus.EXPIRED);
+
+		// validate all members in Vo, otherwise they will be skipped
+		perun.getMembersManagerBl().validateMember(sess, member1);
+		perun.getMembersManagerBl().validateMember(sess, member2);
+		perun.getMembersManagerBl().validateMember(sess, member3);
+
+		ConsentHub consentHub = consentsManagerEntry.getConsentHubByFacility(sess, facility.getId());
+
+		boolean originalForce = BeansUtils.getCoreConfig().getForceConsents();
+		try {
+			BeansUtils.getCoreConfig().setForceConsents(true);
+			service.setUseExpiredMembers(false);
+			perun.getServicesManagerBl().updateService(sess, service);
+
+			perun.getConsentsManagerBl().evaluateConsents(sess, service);
+		} finally {
+			BeansUtils.getCoreConfig().setForceConsents(originalForce);
+			service.setUseExpiredMembers(originalUseExpiredMembers);
+			perun.getServicesManagerBl().updateService(sess, service);
+		}
+
+		List<Consent> consents1 = consentsManagerEntry.getConsentsForUserAndConsentHub(sess, user1.getId(), otherConsentHub.getId());
+		List<Consent> consents2 = consentsManagerEntry.getConsentsForUserAndConsentHub(sess, user2.getId(), consentHub.getId());
+		List<Consent> consents3 = consentsManagerEntry.getConsentsForUserAndConsentHub(sess, user3.getId(), otherConsentHub.getId());
+
+		// EXPIRED member should be skipped (filtered out)
+		assertEquals(0, consents3.size());
+
+		Consent expectedConsent1 = new Consent(consents1.get(0).getId(), user1.getId(), otherConsentHub, List.of(attrDef));
+		Consent expectedConsent2 = new Consent(consents2.get(0).getId(), user2.getId(), consentHub, List.of(attrDef));
+
+		assertThat(consents1).containsExactly(expectedConsent1);
+		assertThat(consents2).containsExactly(expectedConsent2);
+
+		// evaluate again, each user still should have only the one UNSIGNED consent
+		try {
+			BeansUtils.getCoreConfig().setForceConsents(true);
+			service.setUseExpiredMembers(false);
+			perun.getServicesManagerBl().updateService(sess, service);
+
+			perun.getConsentsManagerBl().evaluateConsents(sess, service);
+			consents1 = consentsManagerEntry.getConsentsForUserAndConsentHub(sess, user1.getId(), otherConsentHub.getId());
+			consents2 = consentsManagerEntry.getConsentsForUserAndConsentHub(sess, user2.getId(), consentHub.getId());
+		} finally {
+			BeansUtils.getCoreConfig().setForceConsents(originalForce);
+			service.setUseExpiredMembers(originalUseExpiredMembers);
+			perun.getServicesManagerBl().updateService(sess, service);
+		}
+
+		assertThat(consents1).containsExactly(expectedConsent1);
+		assertThat(consents2).containsExactly(expectedConsent2);
+	}
+
+	@Test
+	public void evaluateConsentsForServiceUseExpiredMembersCreatesConsents() throws Exception {
+		System.out.println(CLASS_NAME + "evaluateConsentsForServiceWithExpiredMembersCreatesConsents");
+
+		boolean originalUseExpiredMembers = service.isUseExpiredMembers();
+		ConsentHub otherConsentHub = setUpAnotherConsentHub();
+
+		User user1 = setUpUser("Harry", "Doe");
+		User user2 = setUpUser("James", "Doe");
+		Member member1 = perun.getMembersManager().createMember(sess, otherVo, user1);
+		Member member2 = perun.getMembersManager().createMember(sess, vo, user2);
+		perun.getGroupsManagerBl().addMember(sess, otherGroup, member1);
+		perun.getGroupsManagerBl().addMember(sess, group, member2);
+		perun.getGroupsManager().setMemberGroupStatus(sess, member1, otherGroup, MemberGroupStatus.VALID);
+		perun.getGroupsManager().setMemberGroupStatus(sess, member2, group, MemberGroupStatus.EXPIRED);
+
+		// validate all members in VOs, otherwise they will be skipped
+		perun.getMembersManagerBl().validateMember(sess, member1);
+		perun.getMembersManagerBl().validateMember(sess, member2);
+
+		ConsentHub consentHub = consentsManagerEntry.getConsentHubByFacility(sess, facility.getId());
+
+		boolean originalForce = BeansUtils.getCoreConfig().getForceConsents();
+		try {
+			BeansUtils.getCoreConfig().setForceConsents(true);
+			service.setUseExpiredMembers(true);
+			perun.getServicesManagerBl().updateService(sess, service);
+
+			perun.getConsentsManagerBl().evaluateConsents(sess, service);
+		} finally {
+			BeansUtils.getCoreConfig().setForceConsents(originalForce);
+			service.setUseExpiredMembers(originalUseExpiredMembers);
+			perun.getServicesManagerBl().updateService(sess, service);
+		}
+
+		List<Consent> consents1 = consentsManagerEntry.getConsentsForUserAndConsentHub(sess, user1.getId(), otherConsentHub.getId());
+		List<Consent> consents2 = consentsManagerEntry.getConsentsForUserAndConsentHub(sess, user2.getId(), consentHub.getId());
+
+		Consent expectedConsent1 = new Consent(consents1.get(0).getId(), user1.getId(), otherConsentHub, List.of(attrDef));
+		Consent expectedConsent2 = new Consent(consents2.get(0).getId(), user2.getId(), consentHub, List.of(attrDef));
+
+		assertThat(consents1).containsExactly(expectedConsent1);
+		assertThat(consents2).containsExactly(expectedConsent2);
+
+		// evaluate again, each user still should have only the one UNSIGNED consent
+		try {
+			BeansUtils.getCoreConfig().setForceConsents(true);
+			service.setUseExpiredMembers(true);
+			perun.getServicesManagerBl().updateService(sess, service);
+
+			perun.getConsentsManagerBl().evaluateConsents(sess, service);
+			consents1 = consentsManagerEntry.getConsentsForUserAndConsentHub(sess, user1.getId(), otherConsentHub.getId());
+			consents2 = consentsManagerEntry.getConsentsForUserAndConsentHub(sess, user2.getId(), consentHub.getId());
+		} finally {
+			BeansUtils.getCoreConfig().setForceConsents(originalForce);
+			service.setUseExpiredMembers(originalUseExpiredMembers);
+			perun.getServicesManagerBl().updateService(sess, service);
+		}
+
+		assertThat(consents1).containsExactly(expectedConsent1);
+		assertThat(consents2).containsExactly(expectedConsent2);
+	}
+
+	private ConsentHub setUpAnotherConsentHub() throws Exception {
+		otherVo = setUpVo("otherVo", "otherVo");
+		Facility otherFacility = setUpFacility("otherFacility");
+
+		Resource anotherResource = setUpResource("anotherResource", "anotherResource", otherFacility, otherVo);
+		Resource anotherResource2 = setUpResource("anotherResource2", "anotherResource2", otherFacility, otherVo);
+
+		Service anotherService = setUpService("anotherService");
+
+		perun.getResourcesManagerBl().assignService(sess, anotherResource, service);
+		perun.getResourcesManagerBl().assignService(sess, anotherResource2, anotherService);
+
+		ConsentHub consentHub = consentsManagerEntry.getConsentHubByFacility(sess, otherFacility.getId());
+		perun.getServicesManagerBl().addRequiredAttributes(sess, anotherService, List.of(attrDef, facAttrDef));
+
+		otherGroup = new Group("otherGroup", "otherGroup description");
+		otherGroup = perun.getGroupsManagerBl().createGroup(sess, otherVo, otherGroup);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, otherGroup, anotherResource2, false, false, false);
+
+		return consentHub;
+	}
+
 	private void addAttributeToService(Service service, AttributeDefinition secondUserAttrDef) throws AttributeAlreadyAssignedException, ServiceAttributesCannotExtend {
 		service.setEnabled(false);
 		perun.getServicesManagerBl().updateService(sess, service);
@@ -648,15 +943,15 @@ public class ConsentsManagerEntryIntegrationTest extends AbstractPerunIntegratio
 		return attrDef;
 	}
 
-	private Resource setUpResource(Facility facility, Vo vo) throws Exception {
-		Resource resource = new Resource(0, "TestResource", "TestResource", facility.getId());
+	private Resource setUpResource(String name, String description, Facility facility, Vo vo) throws Exception {
+		Resource resource = new Resource(0, name, description, facility.getId());
 		resource = perun.getResourcesManagerBl().createResource(sess, resource, vo, facility);
 		return resource;
 	}
 
-	private Facility setUpFacility() throws Exception {
+	private Facility setUpFacility(String name) throws Exception {
 		Facility facility = new Facility();
-		facility.setName("ConsentsTestFacility");
+		facility.setName(name);
 		facility = perun.getFacilitiesManager().createFacility(sess, facility);
 		return facility;
 	}
@@ -673,14 +968,14 @@ public class ConsentsManagerEntryIntegrationTest extends AbstractPerunIntegratio
 		return user;
 	}
 
-	private Service setUpService() throws Exception {
-		Service service = new Service(0, "TestService");
+	private Service setUpService(String name) throws Exception {
+		Service service = new Service(0, name);
 		service = perun.getServicesManager().createService(sess, service);
 		return service;
 	}
 
-	private Vo setUpVo() throws VoExistsException, PrivilegeException {
-		Vo vo = new Vo(0, "TestVo", "TestVo");
+	private Vo setUpVo(String name, String shortName) throws VoExistsException, PrivilegeException {
+		Vo vo = new Vo(0, name, shortName);
 		vo = perun.getVosManager().createVo(sess, vo);
 		return vo;
 	}

--- a/perun-db/postgres.sql
+++ b/perun-db/postgres.sql
@@ -1,4 +1,4 @@
--- database version 3.1.91 (don't forget to update insert statement at the end of file)
+-- database version 3.1.92 (don't forget to update insert statement at the end of file)
 
 -- VOS - virtual organizations
 create table vos (
@@ -420,6 +420,7 @@ create table services (
 	recurrence integer not null default 2,
 	enabled boolean default true not null,
 	script varchar not null,
+	use_expired_members boolean default false not null,
 	created_at timestamp default statement_timestamp() not null,
 	created_by varchar default user not null,
 	modified_at timestamp default statement_timestamp() not null,
@@ -1936,7 +1937,7 @@ grant all on consents to perun;
 grant all on consent_attr_defs to perun;
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.1.91');
+insert into configurations values ('DATABASE VERSION','3.1.92');
 
 -- insert membership types
 insert into membership_types (id, membership_type, description) values (1, 'DIRECT', 'Member is directly added into group');

--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -852,6 +852,7 @@ components:
             recurrence: { type: integer }
             enabled: { type: boolean }
             script: { type: string }
+            useExpiredMembers: { type: boolean }
       discriminator:
         propertyName: beanName
 
@@ -17256,5 +17257,33 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/ConsentResponse'
+        default:
+          $ref: '#/components/responses/ExceptionResponse'
+
+  /urlinjsonout/consentsManager/evaluateConsentsForConsentHub:
+    post:
+      tags:
+        - ConsentsManager
+      operationId: evaluateConsentsForConsentHub
+      summary: Evaluates consents for given consent hub.
+      parameters:
+        - $ref: '#/components/parameters/consentHubId'
+      responses:
+        '200':
+          $ref: '#/components/responses/VoidResponse'
+        default:
+          $ref: '#/components/responses/ExceptionResponse'
+
+  /urlinjsonout/consentsManager/evaluateConsentsForService:
+    post:
+      tags:
+        - ConsentsManager
+      operationId: evaluateConsentsForService
+      summary: Evaluates consents for all consent hubs with given service.
+      parameters:
+        - $ref: '#/components/parameters/serviceId'
+      responses:
+        '200':
+          $ref: '#/components/responses/VoidResponse'
         default:
           $ref: '#/components/responses/ExceptionResponse'

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/ApiCaller.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/ApiCaller.java
@@ -1,31 +1,20 @@
 package cz.metacentrum.perun.rpc;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
-import javax.servlet.ServletContext;
-
 import cz.metacentrum.perun.cabinet.api.CabinetManager;
 import cz.metacentrum.perun.cabinet.model.Category;
 import cz.metacentrum.perun.cabinet.model.Publication;
 import cz.metacentrum.perun.cabinet.model.PublicationSystem;
 import cz.metacentrum.perun.cabinet.model.Thanks;
-import cz.metacentrum.perun.core.api.ConfigManager;
-import cz.metacentrum.perun.core.api.Consent;
-import cz.metacentrum.perun.core.api.ConsentsManager;
-import cz.metacentrum.perun.integration.api.IntegrationManagerApi;
-import cz.metacentrum.perun.core.api.PerunBean;
-import cz.metacentrum.perun.core.api.PerunClient;
-import cz.metacentrum.perun.core.api.TasksManager;
-import cz.metacentrum.perun.registrar.model.Application;
-import org.springframework.web.context.support.WebApplicationContextUtils;
 import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.AuditMessagesManager;
 import cz.metacentrum.perun.core.api.BanOnFacility;
 import cz.metacentrum.perun.core.api.BanOnResource;
+import cz.metacentrum.perun.core.api.ConfigManager;
+import cz.metacentrum.perun.core.api.Consent;
+import cz.metacentrum.perun.core.api.ConsentHub;
+import cz.metacentrum.perun.core.api.ConsentsManager;
 import cz.metacentrum.perun.core.api.DatabaseManager;
 import cz.metacentrum.perun.core.api.Destination;
 import cz.metacentrum.perun.core.api.ExtSource;
@@ -40,6 +29,8 @@ import cz.metacentrum.perun.core.api.MembersManager;
 import cz.metacentrum.perun.core.api.Owner;
 import cz.metacentrum.perun.core.api.OwnersManager;
 import cz.metacentrum.perun.core.api.Perun;
+import cz.metacentrum.perun.core.api.PerunBean;
+import cz.metacentrum.perun.core.api.PerunClient;
 import cz.metacentrum.perun.core.api.PerunPrincipal;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.RTMessagesManager;
@@ -51,6 +42,7 @@ import cz.metacentrum.perun.core.api.SecurityTeamsManager;
 import cz.metacentrum.perun.core.api.Service;
 import cz.metacentrum.perun.core.api.ServicesManager;
 import cz.metacentrum.perun.core.api.ServicesPackage;
+import cz.metacentrum.perun.core.api.TasksManager;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.UserExtSource;
 import cz.metacentrum.perun.core.api.UsersManager;
@@ -59,6 +51,7 @@ import cz.metacentrum.perun.core.api.VosManager;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.PerunException;
 import cz.metacentrum.perun.core.api.exceptions.RpcException;
+import cz.metacentrum.perun.integration.api.IntegrationManagerApi;
 import cz.metacentrum.perun.notif.entities.PerunNotifObject;
 import cz.metacentrum.perun.notif.entities.PerunNotifReceiver;
 import cz.metacentrum.perun.notif.entities.PerunNotifRegex;
@@ -66,8 +59,15 @@ import cz.metacentrum.perun.notif.entities.PerunNotifTemplate;
 import cz.metacentrum.perun.notif.entities.PerunNotifTemplateMessage;
 import cz.metacentrum.perun.notif.managers.PerunNotifNotificationManager;
 import cz.metacentrum.perun.registrar.RegistrarManager;
+import cz.metacentrum.perun.registrar.model.Application;
 import cz.metacentrum.perun.rpc.deserializer.Deserializer;
 import cz.metacentrum.perun.scim.SCIM;
+import org.springframework.web.context.support.WebApplicationContextUtils;
+
+import javax.servlet.ServletContext;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 /**
  * ApiCaller calls Perun manager methods.
@@ -254,6 +254,10 @@ public class ApiCaller {
 
 	public Consent getConsentById(int id) throws PerunException {
 		return consentsManager.getConsentById(rpcSession, id);
+	}
+
+	public ConsentHub getConsentHubById(int id) throws PerunException {
+		return consentsManager.getConsentHubById(rpcSession, id);
 	}
 
 	public Vo getVoById(int id) throws PerunException {

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/ConsentsManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/ConsentsManagerMethod.java
@@ -213,6 +213,41 @@ public enum ConsentsManagerMethod implements ManagerMethod {
 		public Consent call(ApiCaller ac, Deserializer params) throws PerunException {
 			return ac.getConsentsManager().changeConsentStatus(ac.getSession(), ac.getConsentById(params.readInt("consent")), ConsentStatus.valueOf(params.readString("status")));
 		}
+	},
+
+	/*#
+	 * Returns ConsentHub.
+	 *
+	 * @param consentHub Consent Hub
+	 * @throw ConsentNotExistsException if consent hub does not exist
+	 *
+	 * @return ConsentHub
+	 */
+	evaluateConsentsForConsentHub {
+		@Override
+		public Void call(ApiCaller ac, Deserializer params) throws PerunException {
+			ac.getConsentsManager().evaluateConsents(ac.getSession(), ac.getConsentHubById(params.readInt("consentHub")));
+			return null;
+		}
+	},
+
+	/*#
+	 * Returns Service.
+	 *
+	 * All consent hubs that contain given service will have consents fully consolidated
+	 * (not only for given service, but for all of them).
+	 *
+	 * @param service used for consents evaluation
+	 * @throw ConsentNotExistsException if consent hub does not exist
+	 *
+	 * @return ConsentHub
+	 */
+	evaluateConsentsForService {
+		@Override
+		public Void call(ApiCaller ac, Deserializer params) throws PerunException {
+			ac.getConsentsManager().evaluateConsents(ac.getSession(), ac.getServiceById(params.readInt("service")));
+			return null;
+		}
 	};
 
 }


### PR DESCRIPTION
* consents evaluation for consent hub - for all its facilities with corresponding resources and services
* consents evaluation for service - full evaluation for all consent hubs that have given service assigned
* flag for usage of expired members added to Service class (value is copied from gen script directly)
* database changed to support new flag
* openapi updated - 2 new methods added
* policies updated - 2 new methods added

breaking change: new database version (Service flag for expired members usage added)