### PR TITLE
feat(core): extend brand config with api domain

### DIFF
--- a/perun-base/src/test/resources/perun-apps-config.yml
+++ b/perun-base/src/test/resources/perun-apps-config.yml
@@ -2,6 +2,7 @@
 brands:
   - name: default
     new_apps:
+      api: "api"
       admin: "gui"
       profile: "profile"
       pwd_reset: "pwd-reset"
@@ -9,6 +10,7 @@ brands:
     old_gui_domain: "perun-dev"
   - name: other
     new_apps:
+      api: ""
       admin: ""
       profile: ""
       pwd_reset: ""

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/PerunAppsConfig.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/PerunAppsConfig.java
@@ -43,7 +43,7 @@ public class PerunAppsConfig {
 		for (Brand brand : instance.getBrands()) {
 			PerunAppsConfig.NewApps newApps = brand.getNewApps();
 			if (brand.getOldGuiDomain().equals(domain) || newApps.getAdmin().equals(domain) || newApps.getProfile().equals(domain)
-				|| newApps.getPublications().equals(domain) || newApps.getPwdReset().equals(domain)) {
+				|| newApps.getPublications().equals(domain) || newApps.getPwdReset().equals(domain) || newApps.getApi().equals(domain)) {
 				return brand;
 			}
 		}
@@ -105,6 +105,9 @@ public class PerunAppsConfig {
 	 * Class holding domains of new gui applications.
 	 */
 	public static class NewApps {
+
+		private String api;
+
 		private String admin;
 
 		private String profile;
@@ -112,6 +115,16 @@ public class PerunAppsConfig {
 		private String pwdReset;
 
 		private String publications;
+
+		@JsonGetter("api")
+		public String getApi() {
+			return api;
+		}
+
+		@JsonSetter("api")
+		public void setApi(String api) {
+			this.api = api;
+		}
 
 		@JsonGetter("admin")
 		public String getAdmin() {
@@ -156,8 +169,11 @@ public class PerunAppsConfig {
 		@Override
 		public String toString() {
 			return "NewApps{" +
-					"admin='" + admin + '\'' +
+					"api='" + api + '\'' +
+					", admin='" + admin + '\'' +
 					", profile='" + profile + '\'' +
+					", pwdReset='" + pwdReset + '\'' +
+					", publications='" + publications + '\'' +
 					'}';
 		}
 	}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/PerunAppsConfigLoaderTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/PerunAppsConfigLoaderTest.java
@@ -20,6 +20,7 @@ public class PerunAppsConfigLoaderTest extends AbstractPerunIntegrationTest {
 		expectedDefaultBrand.setName("default");
 
 		var newApps = new PerunAppsConfig.NewApps();
+		newApps.setApi("api");
 		newApps.setAdmin("gui");
 		newApps.setProfile("profile");
 		newApps.setPwdReset("pwd-reset");

--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -1371,6 +1371,7 @@ components:
     NewApps:
       type: object
       properties:
+        api: { type: string }
         admin: { type: string }
         profile: { type: string }
         pwdReset: { type: string }


### PR DESCRIPTION
- We can now specify API domain for the new apps.
- Fixed toString() to contain all apps.
- Updated OpenAPI definition of NewApps object.
- When CSRF validation fails, suggest proper API domain to the caller
  in error message based on branded apps configuration.
- Fixed StringUtils imports and usage.

breaking change: new property "api" added to the perun-apps-config.yml