### PR TITLE
fix(core): fix generating group data when members are filtered

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/provisioning/GroupsHashedDataGenerator.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/provisioning/GroupsHashedDataGenerator.java
@@ -10,6 +10,7 @@ import cz.metacentrum.perun.core.api.HashedGenData;
 import cz.metacentrum.perun.core.api.Member;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.Service;
+import cz.metacentrum.perun.core.api.Status;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 
 import java.util.HashSet;
@@ -151,6 +152,8 @@ public class GroupsHashedDataGenerator implements HashedDataGenerator {
 		List<Member> members;
 		if (filterExpiredMembers) {
 			members = sess.getPerunBl().getGroupsManagerBl().getActiveGroupMembers(sess, group);
+			// previous method for active group members doesn't care about VO status, so we must remove INVALID and DISABLED VO members
+			members.removeIf(member -> member.getStatus().equals(Status.INVALID) || member.getStatus().equals(Status.DISABLED));
 		} else {
 			members = sess.getPerunBl().getGroupsManagerBl().getGroupMembersExceptInvalidAndDisabled(sess, group);
 		}


### PR DESCRIPTION
- When generating group hashed data we processed also INVALID and
  DISABLED group members which caused null pointer in later processing.
- Now we filter them out as it should be.
- Affected only services which filter expired members in API.