### PR TITLE
docs(cli): remove unused locale param from updateNotifTemplate

### DIFF
--- a/perun-cli/updateNotifTemplate
+++ b/perun-cli/updateNotifTemplate
@@ -14,7 +14,6 @@ Available options:
  --id                  | -i id of the updated NotifTemplate
  --name                | -n name
  --primaryProperty     | -p primary property (key and value divide by '=', values divide by '/', more properties allowed)
- --locale              | -l locale
  --sender              | -s sender
  --batch               | -b batch
  --help                | -h prints this help


### PR DESCRIPTION
Locale parameter is not part of NotifTemplate object. It was removed from the help of
updateNotifTemplate() tool.