### PR TITLE
refactor(core): removed unnecessary log.info() on service creation

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ServicesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ServicesManagerImpl.java
@@ -374,7 +374,6 @@ public class ServicesManagerImpl implements ServicesManagerImplApi {
 					"values (?,?,?,?,?,?,?,?,?," + Compatibility.getSysdate() + ",?," + Compatibility.getSysdate() + ",?,?)", newId, service.getName(),
 					service.getDescription(), service.getDelay(), service.getRecurrence(), service.isEnabled(), service.getScript(), service.isUseExpiredMembers(),
 					sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getUserId(), sess.getPerunPrincipal().getUserId());
-			log.info("Service created: {}", service);
 
 			service.setId(newId);
 


### PR DESCRIPTION
We do no log entity creation this way for the others, we rely on auditer logging. Also entity was
logged before its ID was set back to the object, so it was not so useful.