### PR TITLE
fix(core): check memberOrganizations attribute for null values

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
@@ -1591,6 +1591,7 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 					}
 					Attribute attribute = perunBl.getAttributesManagerBl().getAttribute(sess, existingMember, A_MEMBER_DEF_MEMBER_ORGANIZATIONS);
 					ArrayList<String> currentValue = attribute.valueAsList();
+					currentValue = (currentValue == null) ? new ArrayList<>() : currentValue;
 					currentValue.add(memberVo.getShortName());
 					attribute.setValue(currentValue);
 					perunBl.getAttributesManagerBl().setAttribute(sess, existingMember, attribute);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/VosManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/VosManagerBlImpl.java
@@ -975,6 +975,7 @@ public class VosManagerBlImpl implements VosManagerBl {
 					//update memberOrganizations
 					Attribute attribute = perunBl.getAttributesManagerBl().getAttribute(sess, existingMember, A_MEMBER_DEF_MEMBER_ORGANIZATIONS);
 					ArrayList<String> currentValue = attribute.valueAsList();
+					currentValue = (currentValue == null) ? new ArrayList<>() : currentValue;
 					currentValue.add(memberVo.getShortName());
 					attribute.setValue(currentValue);
 					perunBl.getAttributesManagerBl().setAttribute(sess, existingMember, attribute);


### PR DESCRIPTION
* memberOrganizations can be empty if member comes directly from parent VO and in that case valueAsList method returns null