### PR TITLE
fix(core): add new Service parameter to AuditParser and parseRpcMethods

### DIFF
--- a/perun-auditparser/src/main/java/cz/metacentrum/perun/auditparser/AuditParser.java
+++ b/perun-auditparser/src/main/java/cz/metacentrum/perun/auditparser/AuditParser.java
@@ -443,6 +443,7 @@ public class AuditParser {
 		service.setRecurrence(Integer.valueOf(beanAttr.get("recurrence")).intValue());
 		service.setEnabled(Boolean.valueOf(beanAttr.get("enabled")).booleanValue());
 		service.setScript(BeansUtils.eraseEscaping(beanAttr.get("script")));
+		service.setUseExpiredMembers(Boolean.valueOf(beanAttr.get("useExpiredMembers")).booleanValue());
 		return service;
 	}
 

--- a/perun-auditparser/src/test/java/cz/metacentrum/perun/auditparser/AuditParserTest.java
+++ b/perun-auditparser/src/test/java/cz/metacentrum/perun/auditparser/AuditParserTest.java
@@ -326,6 +326,7 @@ public class AuditParserTest {
 		assertEquals(service.getRecurrence(), ((Service) serviceInList.get(0)).getRecurrence());
 		assertEquals(service.isEnabled(), ((Service) serviceInList.get(0)).isEnabled());
 		assertEquals(service.getScript(), ((Service) serviceInList.get(0)).getScript());
+		assertEquals(service.isUseExpiredMembers(), ((Service) serviceInList.get(0)).isUseExpiredMembers());
 
 		//FOR ATTRIBUTE DEFINITION
 		AttributeDefinition attributeDefinition1 = new AttributeDefinition(getAttributeDefinition1());

--- a/perun-utils/rpc-methods-javadoc-generator/parseRpcMethods.pl
+++ b/perun-utils/rpc-methods-javadoc-generator/parseRpcMethods.pl
@@ -142,7 +142,7 @@ $objectExamples{"List<RichMember>"} = $objectExamples{"List&lt;RichMember&gt;"};
 
 $objectExamples{"RTMessage"} = "{ \"ticketNumber\" : 32525 , \"memberPreferredEmail\" : \"mail\@mail.com\" }";
 
-$objectExamples{"Service"} = "{ \"id\" : 290 , \"name\" : \"passwd\" , \"description\" : \"Provision /etc/passwd file.\" , \"delay\" : 10 , \"recurrence\" : 2 , \"enabled\" : true , \"script\" : \"./passwd\" }";
+$objectExamples{"Service"} = "{ \"id\" : 290 , \"name\" : \"passwd\" , \"description\" : \"Provision /etc/passwd file.\" , \"delay\" : 10 , \"recurrence\" : 2 , \"enabled\" : true , \"script\" : \"./passwd\" , \"useExpiredMembers\" : false }";
 $objectExamples{"List&lt;Service&gt;"} = $listPrepend . $objectExamples{"Service"} . $listAppend;
 $objectExamples{"List<Service>"} = $objectExamples{"List&lt;Service&gt;"};
 


### PR DESCRIPTION
- New parameter useExpiredMembers in Service object was missing in
AuditParser and in file parseRpcMethods.pl. Now, it is added there.