### PR TITLE
feat(cli): support multiple OIDC configurations

### DIFF
--- a/perun-cli/Perun/auth/sample_oidc_config.yml
+++ b/perun-cli/Perun/auth/sample_oidc_config.yml
@@ -1,10 +1,22 @@
 # This is only a sample config file! You need to create file oidc_config.yml in this directory
 # and specify following options in it!
+# Each configuration is a dictionary entry, where the key serves as the identification of the configuration.
+# to switch between configurations, set environmental variable PERUN_OIDC_CONFIG to the id of desired configuration.
+# The key is a string so user can freely choose the name of each configuration
+perun:
+  client_id: "" # Identifier of the CLI app on the OIDC server
+  oidc_device_code_uri: "" # Here the CLI requests from the OIDC server to start the authentication
+  oidc_token_endpoint_uri: "" # Token endpoint URI
+  oidc_token_revoke_endpoint_uri: "" # Token revoke endpoint URI
+  acr_values: "" # List of ACR values for authentication
+  scopes: "openid perun_api perun_admin offline_access" # List of scopes the access_token should grant access to
+  perun_api_endpoint: ""
 
-client_id: "" # Identifier of the CLI app on the OIDC server
-oidc_device_code_uri: "" # Here the CLI requests from the OIDC server to start the authentication
-oidc_token_endpoint_uri: "" # Token endpoint URI
-oidc_token_revoke_endpoint_uri: "" # Token revoke endpoint URI
-acr_values: "" # List of ACR values for authentication
-scopes: "openid perun_api perun_admin offline_access" # List of scopes the access_token should grant access to
-perun_api_endpoint: ""
+otherPerun:
+  client_id: "" # Identifier of the CLI app on the OIDC server
+  oidc_device_code_uri: "" # Here the CLI requests from the OIDC server to start the authentication
+  oidc_token_endpoint_uri: "" # Token endpoint URI
+  oidc_token_revoke_endpoint_uri: "" # Token revoke endpoint URI
+  acr_values: "" # List of ACR values for authentication
+  scopes: "openid perun_api perun_admin offline_access" # List of scopes the access_token should grant access to
+  perun_api_endpoint: ""

--- a/perun-cli/listOidcTokens
+++ b/perun-cli/listOidcTokens
@@ -1,0 +1,39 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use Getopt::Long qw(:config no_ignore_case);
+use Perun::auth::OidcAuth;
+use Perun::Common qw(printMessage);
+
+sub help {
+	return qq{
+	Prints list of stored OIDC tokens for configurations saved in config file.
+	------------------------------------
+	Available options:
+	--batch                         | -b batch
+	--help                          | -h prints this help
+};
+}
+
+our $batch;
+GetOptions ("help|h"    => sub {
+	print help();
+	exit 0;
+}, "batch|b"        => \$batch
+	) || die help();
+
+my %configs = % { Perun::auth::OidcAuth::loadAllConfigurations() };
+foreach my $config (sort keys %configs) {
+	my $endpoint = $configs{$config}->{"perun_api_endpoint"};
+	my $accessToken = Perun::auth::OidcAuth::getAccessToken($config);
+	if (!defined $accessToken) {
+		$accessToken = "none";
+	}
+	my $refreshToken = Perun::auth::OidcAuth::getRefreshToken($config);
+	if (!defined $refreshToken) {
+		$refreshToken = "none";
+	}
+	print("\n$config : $endpoint\naccessToken: $accessToken\nrefreshToken: $refreshToken\n");
+
+}

--- a/perun-cli/oidcAuthentication
+++ b/perun-cli/oidcAuthentication
@@ -28,7 +28,7 @@ unless ($auth->{"error"}) {
 	Perun::auth::OidcAuth::setAccessToken($auth->{"access_token"});
 	Perun::auth::OidcAuth::setAccessTokenValidity(time() + $auth->{"expires_in"});
 	Perun::auth::OidcAuth::setRefreshToken($auth->{"refresh_token"});
-	print "Authentication was successful.";
+	print "Authentication was successful.\n";
 } else {
 	die Perun::Exception->fromHash({ type =>  "Authentication failed." });
 }

--- a/perun-cli/removeOidcTokens
+++ b/perun-cli/removeOidcTokens
@@ -8,40 +8,55 @@ use Perun::Common qw(printMessage);
 
 sub help {
 	return qq{
-	Removes access and refresh token saved for OIDC authentication.
+	Removes access and refresh token saved for OIDC authentication. By default removes tokens of currently chosen
+	configuration (as set in environmental variable PERUN_OIDC_CONFIG)
 	------------------------------------
 	Available options:
 	--batch                         | -b batch
 	--help                          | -h prints this help
+	--all							| -a removes tokens for all configurations
+	--config						| -c id of config of which tokens to remove
 
 };
 }
 
 our $batch;
+my ($configId, $removeAllConfigs);
 GetOptions ("help|h"    => sub {
 	print help();
 	exit 0;
-}, "batch|b"        => \$batch) || die help();
-
+}, "batch|b"        => \$batch,
+	"all|a"		=> \$removeAllConfigs,
+	"config|c=s"	=> \$configId
+	) || die help();
+if (!defined $configId) {
+	$configId = $ENV{PERUN_OIDC_CONFIG};
+}
 my $message;
-
-if (Perun::auth::OidcAuth::getAccessToken()) {
-	Perun::auth::OidcAuth::removeAccessToken();
-	$message = "Removed access token. ";
+if (defined $removeAllConfigs) {
+	Perun::auth::OidcAuth::removeAllAccessTokens();
+	Perun::auth::OidcAuth::removeAllRefreshTokens();
 } else {
-	$message = "Access token is not stored. ";
-}
+	Perun::auth::OidcAuth::checkConfigExists($configId);
+	if (Perun::auth::OidcAuth::getAccessToken($configId)) {
+		Perun::auth::OidcAuth::removeAccessToken($configId);
+		$message = "Removed access token. ";
+	}
+	else {
+		$message = "Access token is not stored. ";
+	}
 
-if (Perun::auth::OidcAuth::getRefreshToken()) {
-	Perun::auth::OidcAuth::removeRefreshToken();
-	$message = $message . "Removed refresh token.";
-} else {
-	$message = $message . "Refresh token is not stored.";
-}
+	if (Perun::auth::OidcAuth::getRefreshToken($configId)) {
+		Perun::auth::OidcAuth::removeRefreshToken($configId);
+		$message = $message . "Removed refresh token.";
+	}
+	else {
+		$message = $message . "Refresh token is not stored.";
+	}
 
-if (Perun::auth::OidcAuth::getAccessToken() || Perun::auth::OidcAuth::getRefreshToken()) {
-	print STDERR "Could not remove tokens.";
-	exit 0;
+	if (Perun::auth::OidcAuth::getAccessToken($configId) || Perun::auth::OidcAuth::getRefreshToken($configId)) {
+		print STDERR "Could not remove tokens.";
+		exit 0;
+	}
 }
-
 printMessage($message, $batch);

--- a/perun-cli/revokeOidcToken
+++ b/perun-cli/revokeOidcToken
@@ -14,33 +14,45 @@ sub help {
 	------------------------------------
 	Available options:
 	--batch                         | -b batch
+	--all							| -a revokes tokens for all configurations
+	--config						| -c id of config of which tokens to revoke
 	--help                          | -h prints this help
 
 };
 }
 
 our $batch;
+my ($configId, $removeAllConfigs);
 GetOptions ("help|h"    => sub {
 	print help();
 	exit 0;
-}, "batch|b"        => \$batch) || die help();
+}, "batch|b"        => \$batch,
+	"all|a"		=> \$removeAllConfigs,
+	"config|c=s"	=> \$configId
+) || die help();
+if (!defined $configId) {
+	$configId = $ENV{PERUN_OIDC_CONFIG};
+}
 
 my $message;
-
-if (Perun::auth::OidcAuth::getRefreshToken()) {
-
-	Perun::auth::OidcAuth::revokeToken(Perun::auth::OidcAuth::getRefreshToken(), "refresh_token");
-	Perun::auth::OidcAuth::removeRefreshToken();
-
-	if (Perun::auth::OidcAuth::getAccessToken()) {
-		Perun::auth::OidcAuth::revokeToken(Perun::auth::OidcAuth::getAccessToken(), "access_token");
-		Perun::auth::OidcAuth::removeAccessToken();
-	}
-
-	$message = "Token revocation was successful.";
-
+if (defined $removeAllConfigs) {
+	Perun::auth::OidcAuth::revokeAllAccessTokens();
+	Perun::auth::OidcAuth::revokeAllRefreshTokens();
 } else {
-	die Perun::Exception->fromHash({ type =>  "No tokens are saved." });
+	Perun::auth::OidcAuth::checkConfigExists($configId);
+	if (Perun::auth::OidcAuth::getRefreshToken($configId)) {
+
+		Perun::auth::OidcAuth::revokeToken($configId, "refresh_token");
+
+		if (Perun::auth::OidcAuth::getAccessToken($configId)) {
+			Perun::auth::OidcAuth::revokeToken($configId, "access_token");
+		}
+
+		$message = "Token revocation was successful.";
+
+	} else {
+		die Perun::Exception->fromHash({ type =>  "No tokens are saved." });
+	}
 }
 
 printMessage($message, $batch);


### PR DESCRIPTION
* user can now use multiple OIDC configurations through CLI
* configurations are stored in oidc_config.yml as dictionary entries
* to swap between configurations, change environmental variable PERUN_OIDC_CONFIG to desired configuration id
* edited revokeOidcToken to support revoking specific/all configurations' tokens, same with removeOidcTokens
* added listOidcTokens, which lists all the configurations and their stored tokens (if there are any)

BREAKING CHANGE: config file oidc_config.yml changed, see sample_oidc_config.yml