### PR TITLE
fix(core): manual consent evaluation were not done properly

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ConsentsManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ConsentsManagerBlImpl.java
@@ -38,7 +38,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toMap;
@@ -364,8 +363,6 @@ public class ConsentsManagerBlImpl implements ConsentsManagerBl {
 		List<Facility> facilities = consentHub.getFacilities();
 		List<Service> facilityAssignedServices;
 
-		Set<Integer> processedUsers = new HashSet<>();
-
 		PerunLocksUtils.lockConsentHub(consentHub);
 
 		for (Facility facility : facilities) {
@@ -375,9 +372,6 @@ public class ConsentsManagerBlImpl implements ConsentsManagerBl {
 				List<Member> members = service.isUseExpiredMembers()
 					? getPerunBl().getFacilitiesManagerBl().getAllowedMembers(sess, facility, service)
 					: getPerunBl().getFacilitiesManagerBl().getAllowedMembersNotExpiredInGroups(sess, facility, service);
-
-				members.removeIf(member -> processedUsers.contains(member.getUserId()));
-				processedUsers.addAll(members.stream().map(Member::getUserId).collect(Collectors.toList()));
 
 				evaluateConsents(sess, service, facility, members);
 			}


### PR DESCRIPTION
Manual consents were not consolidated correctly because we were filtering out users that had been processed by one service already (to prevent sending multiple emails).
This caused a problem in a moment, when first service had a consent and contained all its required attributes, thus no new consent had to be created.
Then, second and all other services were 'skipped' because all members checked in the first service were filtered out (even when second service had a change in required attributes and required a new consent).

However, after closer look, when consent is created, all facilities under given consent hub are checked and all required attributes from all services are gathered for it. Thus, when we create consent for the second service, even if some next service would have some change in required attributes, they will already be contained in a newly created consent.

* filtering of already processed users removed