### PR TITLE
fix: removed unnecessary quotes in systemd units

### DIFF
--- a/perun-utils/systemd/perun-engine.service.debian
+++ b/perun-utils/systemd/perun-engine.service.debian
@@ -16,9 +16,9 @@ Environment="PERUN_CONF_DIR=/etc/perun/"
 Environment="PERUN_LOG_CONF=/etc/perun/logback-engine.xml"
 Environment="JAR=/home/perun/perun-engine/perun-engine.jar"
 # Default PERL lib paths for gen scripts
-Environment="PERL5LIB='/opt/perun-cli/lib/:.'"
+Environment="PERL5LIB=/opt/perun-cli/lib/:."
 # Disable Kerberos if someone under the same user creates the ticket
-Environment="KRB5CCNAME='/dev/null'"
+Environment="KRB5CCNAME=/dev/null"
 
 # Override default systemd unit environment using our config file
 # "-" at start means "don't fail if not present/readable"
@@ -27,9 +27,9 @@ Environment="KRB5CCNAME='/dev/null'"
 #
 # PERUN_USER=perun-engine/password
 # PERUN_URL=https://perundomain.com/ba/rpc/
-# PERL5LIB='/opt/perun-cli/lib/:.'
+# PERL5LIB="/opt/perun-cli/lib/:."
 # PERL_LWP_SSL_VERIFY_HOSTNAME=0
-# KRB5CCNAME='/path/to/ticket_or_dev_null'
+# KRB5CCNAME="/path/to/ticket_or_dev_null"
 #
 EnvironmentFile=-/etc/perun/perun-engine
 

--- a/perun-utils/systemd/perun-ldapc.service.debian
+++ b/perun-utils/systemd/perun-ldapc.service.debian
@@ -16,7 +16,7 @@ ReadWritePaths=/var/log/perun/
 Environment="PERUN_CONF_DIR=/etc/perun/"
 Environment="PERUN_LOG_CONF=/etc/perun/logback-ldapc.xml"
 Environment="JAR=/home/perun/perun-ldapc/perun-ldapc.jar"
-Environment="LAST_PROCESSED_ID='--sync'"
+Environment="LAST_PROCESSED_ID=--sync"
 
 # Override default systemd unit environment using our config file
 # "-" at start means "don't fail if not present/readable"


### PR DESCRIPTION
- Systemd environment variables are not shell variables, they are
  simple key=value pairs with their own specific rules.
- Hence we removed unnecessary quotes causing problem when passing
  actual env values to the perun-engine and perun-ldapc services.