### PR TITLE
feat(core): remove redundant filterExpiredMembers parameter

### DIFF
--- a/perun-base/src/main/resources/perun-roles.yml
+++ b/perun-base/src/main/resources/perun-roles.yml
@@ -4469,7 +4469,7 @@ perun_policies:
     include_policies:
       - default_policy
 
-  getHierarchicalData_Service_Facility_boolean_policy:
+  getHierarchicalData_Service_Facility_policy:
     policy_roles:
       - FACILITYADMIN: Facility
       - FACILITYOBSERVER: Facility
@@ -4496,7 +4496,7 @@ perun_policies:
     include_policies:
       - default_policy
 
-  getFlatData_Service_Facility_boolean_policy:
+  getFlatData_Service_Facility_policy:
     policy_roles:
       - FACILITYADMIN: Facility
       - FACILITYOBSERVER: Facility
@@ -4505,7 +4505,7 @@ perun_policies:
     include_policies:
       - default_policy
 
-  getDataWithGroups_Service_Facility_boolean_policy:
+  getDataWithGroups_Service_Facility_policy:
     policy_roles:
       - FACILITYADMIN: Facility
       - FACILITYOBSERVER: Facility
@@ -4514,7 +4514,7 @@ perun_policies:
     include_policies:
       - default_policy
 
-  getDataWithVos_Service_Facility_boolean_policy:
+  getDataWithVos_Service_Facility_policy:
     policy_roles:
       - FACILITYADMIN: Facility
       - FACILITYOBSERVER: Facility

--- a/perun-cli/Perun/ServicesAgent.pm
+++ b/perun-cli/Perun/ServicesAgent.pm
@@ -132,13 +132,13 @@ sub getFlatData
 	return Perun::Common::callManagerMethod('getFlatData', 'ServiceAttributes', @_);
 }
 
-#(service => $serviceId, facility => $facilityId, filterExpiredMembers => true|false, consentEval => true|false)
+#(service => $serviceId, facility => $facilityId, consentEval => true|false)
 sub getHashedHierarchicalData
 {
 	return Perun::Common::callManagerMethod('getHashedHierarchicalData', 'HashedGenData', @_);
 }
 
-#(service => $serviceId, facility => $facilityId, filterExpiredMembers => true|false, consentEval => true|false)
+#(service => $serviceId, facility => $facilityId, consentEval => true|false)
 sub getHashedDataWithGroups
 {
 	return Perun::Common::callManagerMethod('getHashedDataWithGroups', 'HashedGenData', @_);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/ServicesManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/ServicesManager.java
@@ -345,7 +345,6 @@ public interface ServicesManager {
 	 * @param perunSession
 	 * @param service attributes required by this service you will get
 	 * @param facility you will get attributes for this facility, resources associated with it and members assigned to the resources
-	 * @param filterExpiredMembers if true the method does not take members expired in groups into account
 	 * @return attributes in special structure. Facility is in the root, facility children are resources. And resource children are members.
 	 <pre>
 	 Facility
@@ -375,7 +374,7 @@ public interface ServicesManager {
 	 * @throws FacilityNotExistsException
 	 * @throws PrivilegeException
 	 */
-	ServiceAttributes getHierarchicalData(PerunSession perunSession, Service service, Facility facility, boolean filterExpiredMembers) throws FacilityNotExistsException, ServiceNotExistsException, PrivilegeException;
+	ServiceAttributes getHierarchicalData(PerunSession perunSession, Service service, Facility facility) throws FacilityNotExistsException, ServiceNotExistsException, PrivilegeException;
 
 	/**
 	 * Generates hashed hierarchical data structure for given service and facility.
@@ -410,14 +409,13 @@ public interface ServicesManager {
 	 * @param perunSession perun session
 	 * @param service service
 	 * @param facility facility
-	 * @param filterExpiredMembers if the generator should filter expired members
 	 * @param consentEval if the generator should force evaluation of consents
 	 * @return generated hashed data structure
 	 * @throws FacilityNotExistsException if there is no such facility
 	 * @throws ServiceNotExistsException if there is no such service
 	 * @throws PrivilegeException insufficient permissions
 	 */
-	HashedGenData getHashedHierarchicalData(PerunSession perunSession, Service service, Facility facility, boolean filterExpiredMembers, boolean consentEval) throws FacilityNotExistsException, ServiceNotExistsException, PrivilegeException;
+	HashedGenData getHashedHierarchicalData(PerunSession perunSession, Service service, Facility facility, boolean consentEval) throws FacilityNotExistsException, ServiceNotExistsException, PrivilegeException;
 
 	/**
 	 * Generates hashed data with group structure for given service and facility.
@@ -462,14 +460,13 @@ public interface ServicesManager {
 	 * @param perunSession perun session
 	 * @param service service
 	 * @param facility facility
-	 * @param filterExpiredMembers if the generator should filter expired members
 	 * @param consentEval if the generator should force evaluation of consents
 	 * @return generated hashed data structure
 	 * @throws FacilityNotExistsException if there is no such facility
 	 * @throws ServiceNotExistsException if there is no such service
 	 * @throws PrivilegeException insufficient permissions
 	 */
-	HashedGenData getHashedDataWithGroups(PerunSession perunSession, Service service, Facility facility, boolean filterExpiredMembers, boolean consentEval) throws FacilityNotExistsException, ServiceNotExistsException, PrivilegeException;
+	HashedGenData getHashedDataWithGroups(PerunSession perunSession, Service service, Facility facility, boolean consentEval) throws FacilityNotExistsException, ServiceNotExistsException, PrivilegeException;
 
 	/**
 	 * Generates the list of attributes per each user and per each resource. Resources are filtered by service.
@@ -478,7 +475,6 @@ public interface ServicesManager {
 	 * @param perunSession
 	 * @param service you will get attributes required by this service
 	 * @param facility you will get attributes for this facility, resources associated with it and users assigned to the resources
-	 * @param filterExpiredMembers if true the method does not take members expired in groups into account
 	 * @return attributes in special structure. The facility is in the root. Facility first children is abstract node which contains no attributes and it's children are all resources. Facility second child is abstract node with no attribute and it's children are all users.
 	 <pre>
 	 Facility
@@ -507,7 +503,7 @@ public interface ServicesManager {
 	 * @throws FacilityNotExistsException
 	 * @throws PrivilegeException
 	 */
-	ServiceAttributes getFlatData(PerunSession perunSession, Service service, Facility facility, boolean filterExpiredMembers) throws FacilityNotExistsException, ServiceNotExistsException, PrivilegeException;
+	ServiceAttributes getFlatData(PerunSession perunSession, Service service, Facility facility) throws FacilityNotExistsException, ServiceNotExistsException, PrivilegeException;
 
 	/**
 	 * Generates the list of attributes per each member associated with the resources and groups.
@@ -515,7 +511,6 @@ public interface ServicesManager {
 	 * @param perunSession
 	 * @param service attributes required by this service you will get
 	 * @param facility you will get attributes for this facility, resources associated with it and members assigned to the resources
-	 * @param filterExpiredMembers if true the method does not take members expired in groups into account
 	 * @return attributes in special structure. Facility is in the root, facility children are resources.
 	 *         Resource first child is abstract structure which children are groups.
 	 *         Resource  second child is abstract structure which children are members.
@@ -582,7 +577,7 @@ public interface ServicesManager {
 		* @throws FacilityNotExistsException
 		* @throws PrivilegeException
 		*/
-		ServiceAttributes getDataWithGroups(PerunSession perunSession, Service service, Facility facility, boolean filterExpiredMembers) throws FacilityNotExistsException, ServiceNotExistsException, PrivilegeException;
+		ServiceAttributes getDataWithGroups(PerunSession perunSession, Service service, Facility facility) throws FacilityNotExistsException, ServiceNotExistsException, PrivilegeException;
 
 	/**
 	 * Generates the list of attributes per each member associated with the resources and groups in vos.
@@ -590,7 +585,6 @@ public interface ServicesManager {
 	 * @param perunSession
 	 * @param service attributes required by this service you will get
 	 * @param facility you will get attributes for this facility, vos associated with this facility by resources, resources associated with it and members assigned to the resources
-	 * @param filterExpiredMembers if true the method does not take members expired in groups into account
 	 * @return attributes in special structure.
 	 *        Facility is in the root, facility children are vos.
 	 *        Vo first child is abstract structure which children are resources.
@@ -668,7 +662,7 @@ public interface ServicesManager {
 	 * @throws PrivilegeException
 	 * @throws VoNotExistsException
 	 */
-	ServiceAttributes getDataWithVos(PerunSession perunSession, Service service, Facility facility, boolean filterExpiredMembers) throws VoNotExistsException, FacilityNotExistsException, ServiceNotExistsException, PrivilegeException;
+	ServiceAttributes getDataWithVos(PerunSession perunSession, Service service, Facility facility) throws VoNotExistsException, FacilityNotExistsException, ServiceNotExistsException, PrivilegeException;
 
 	/**
 	 * List packages

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ServicesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ServicesManagerBl.java
@@ -329,12 +329,11 @@ public interface ServicesManagerBl {
 	 * @param perunSession
 	 * @param service attributes required by this service you will get
 	 * @param facility you will get attributes for this facility, resources associated with it and members assigned to the resources
-	 * @param filterExpiredMembers if true the method does not take expired members into account
 	 * @return attributes in special structure. Facility is in the root, facility children are resources. And resource children are members.
 	 *
 	 * @throws InternalErrorException
 	 */
-	ServiceAttributes getHierarchicalData(PerunSession perunSession, Service service, Facility facility, boolean filterExpiredMembers);
+	ServiceAttributes getHierarchicalData(PerunSession perunSession, Service service, Facility facility);
 
 	/**
 	 * Generates hashed hierarchical data structure for given service and resource.
@@ -369,11 +368,10 @@ public interface ServicesManagerBl {
 	 * @param perunSession perun session
 	 * @param service service
 	 * @param facility facility
-	 * @param filterExpiredMembers if the generator should filter expired members
 	 * @param consentEval if the generator should force evaluation of consents
 	 * @return generated hashed data structure
 	 */
-	HashedGenData getHashedHierarchicalData(PerunSession perunSession, Service service, Facility facility, boolean filterExpiredMembers, boolean consentEval);
+	HashedGenData getHashedHierarchicalData(PerunSession perunSession, Service service, Facility facility, boolean consentEval);
 
 	/**
 	 * Generates hashed data with group structure for given service and resource.
@@ -419,11 +417,10 @@ public interface ServicesManagerBl {
 	 * @param perunSession perun session
 	 * @param service service
 	 * @param facility facility
-	 * @param filterExpiredMembers if the generator should filter expired members
 	 * @param consentEval if the generator should force evaluation of consents
 	 * @return generated hashed data structure
 	 */
-	HashedGenData getHashedDataWithGroups(PerunSession perunSession, Service service, Facility facility, boolean filterExpiredMembers, boolean consentEval);
+	HashedGenData getHashedDataWithGroups(PerunSession perunSession, Service service, Facility facility, boolean consentEval);
 
 	/**
 	 * Generates the list of attributes per each resource associated with the facility and filtered by service. Next it generates list of attributes
@@ -432,13 +429,12 @@ public interface ServicesManagerBl {
 	 * @param perunSession
 	 * @param service you will get attributes required by this service
 	 * @param facility you will get attributes for this facility, resources associated with it and users assigned to the resources
-	 * @param filterExpiredMembers if true the method does not take expired members into account
 	 * @return attributes in special structure. The facility is in the root. Facility first children is abstract node which contains no attributes and it's children are all resources.
 	 * 				Facility second child is abstract node with no attribute and it's children are all users.
 	 *
 	 * @throws InternalErrorException
 	 */
-	ServiceAttributes getFlatData(PerunSession perunSession, Service service, Facility facility, boolean filterExpiredMembers);
+	ServiceAttributes getFlatData(PerunSession perunSession, Service service, Facility facility);
 
 	/**
 	 * Generates the list of attributes per each member associated with the resources and groups.
@@ -448,21 +444,20 @@ public interface ServicesManagerBl {
 	 * @param perunSession
 	 * @param service attributes required by this service you will get
 	 * @param facility you will get attributes for this facility, resources associated with it and members assigned to the resources
-	 * @param filterExpiredMembers if true the method does not take expired members into account
 	 * @return attributes in special structure. Facility is in the root, facility children are resources.
 	 *         Resource first child is abstract structure which children are groups.
 	 *         Resource  second child is abstract structure which children are members.
 	 *         Group first child is empty structure (services expect members to be second child, here used to be subgroups).
 	 *         Group second child is abstract structure which children are members.
 	 */
-	ServiceAttributes getDataWithGroups(PerunSession perunSession, Service service, Facility facility, boolean filterExpiredMembers);
+	ServiceAttributes getDataWithGroups(PerunSession perunSession, Service service, Facility facility);
+
 	/**
 	 * Generates the list of attributes per each member associated with the resources and groups.
 	 *
 	 * @param perunSession
 	 * @param service attributes required by this service you will get
 	 * @param facility you will get attributes for this facility, resources associated with it and members assigned to the resources
-	 * @param filterExpiredMembers if true the method does not take expired members into account
 	 * @return attributes in special structure. Facility is in the root, facility children are resources.
 	 *         Resource first child is abstract structure which children are groups.
 	 *         Resource  second chi is abstract structure which children are members.
@@ -472,7 +467,7 @@ public interface ServicesManagerBl {
 	 * @throws InternalErrorException
 	 * @throws VoNotExistsException
 	 */
-	ServiceAttributes getDataWithVos(PerunSession perunSession, Service service, Facility facility, boolean filterExpiredMembers) throws VoNotExistsException;
+	ServiceAttributes getDataWithVos(PerunSession perunSession, Service service, Facility facility) throws VoNotExistsException;
 
 	/**
 	 * List packages

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ServicesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ServicesManagerEntry.java
@@ -382,22 +382,22 @@ public class ServicesManagerEntry implements ServicesManager {
 	}
 
 	@Override
-	public ServiceAttributes getHierarchicalData(PerunSession sess, Service service, Facility facility, boolean filterExpiredMembers) throws FacilityNotExistsException, ServiceNotExistsException, PrivilegeException {
+	public ServiceAttributes getHierarchicalData(PerunSession sess, Service service, Facility facility) throws FacilityNotExistsException, ServiceNotExistsException, PrivilegeException {
 		Utils.checkPerunSession(sess);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getHierarchicalData_Service_Facility_boolean_policy", Arrays.asList(service, facility))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getHierarchicalData_Service_Facility_policy", Arrays.asList(service, facility))) {
 			throw new PrivilegeException(sess, "getHierarchicalData");
 		}
 
 		getServicesManagerBl().checkServiceExists(sess, service);
 		getPerunBl().getFacilitiesManagerBl().checkFacilityExists(sess, facility);
 
-		return getServicesManagerBl().getHierarchicalData(sess, service, facility, filterExpiredMembers);
+		return getServicesManagerBl().getHierarchicalData(sess, service, facility);
 	}
 
 	@Override
-	public HashedGenData getHashedHierarchicalData(PerunSession sess, Service service, Facility facility, boolean filterExpiredMembers, boolean consentEval) throws FacilityNotExistsException, ServiceNotExistsException, PrivilegeException {
+	public HashedGenData getHashedHierarchicalData(PerunSession sess, Service service, Facility facility, boolean consentEval) throws FacilityNotExistsException, ServiceNotExistsException, PrivilegeException {
 		Utils.checkPerunSession(sess);
 
 		getServicesManagerBl().checkServiceExists(sess, service);
@@ -408,11 +408,11 @@ public class ServicesManagerEntry implements ServicesManager {
 			throw new PrivilegeException(sess, "getHashedHierarchicalData");
 		}
 
-		return getServicesManagerBl().getHashedHierarchicalData(sess, service, facility, filterExpiredMembers, consentEval);
+		return getServicesManagerBl().getHashedHierarchicalData(sess, service, facility, consentEval);
 	}
 
 	@Override
-	public HashedGenData getHashedDataWithGroups(PerunSession sess, Service service, Facility facility, boolean filterExpiredMembers, boolean consentEval) throws FacilityNotExistsException, ServiceNotExistsException, PrivilegeException {
+	public HashedGenData getHashedDataWithGroups(PerunSession sess, Service service, Facility facility, boolean consentEval) throws FacilityNotExistsException, ServiceNotExistsException, PrivilegeException {
 		Utils.checkPerunSession(sess);
 
 		getServicesManagerBl().checkServiceExists(sess, service);
@@ -423,52 +423,52 @@ public class ServicesManagerEntry implements ServicesManager {
 			throw new PrivilegeException(sess, "getHashedDataWithGroups");
 		}
 
-		return getServicesManagerBl().getHashedDataWithGroups(sess, service, facility, filterExpiredMembers, consentEval);
+		return getServicesManagerBl().getHashedDataWithGroups(sess, service, facility, consentEval);
 	}
 
 	@Override
-	public ServiceAttributes getFlatData(PerunSession sess, Service service, Facility facility, boolean filterExpiredMembers) throws FacilityNotExistsException, ServiceNotExistsException, PrivilegeException {
+	public ServiceAttributes getFlatData(PerunSession sess, Service service, Facility facility) throws FacilityNotExistsException, ServiceNotExistsException, PrivilegeException {
 		Utils.checkPerunSession(sess);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getFlatData_Service_Facility_boolean_policy", Arrays.asList(service, facility))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getFlatData_Service_Facility_policy", Arrays.asList(service, facility))) {
 			throw new PrivilegeException(sess, "getFlatData");
 		}
 
 		getServicesManagerBl().checkServiceExists(sess, service);
 		getPerunBl().getFacilitiesManagerBl().checkFacilityExists(sess, facility);
 
-		return getServicesManagerBl().getFlatData(sess, service, facility, filterExpiredMembers);
+		return getServicesManagerBl().getFlatData(sess, service, facility);
 	}
 
 	@Override
-	public ServiceAttributes getDataWithGroups(PerunSession sess, Service service, Facility facility, boolean filterExpiredMembers) throws FacilityNotExistsException, ServiceNotExistsException, PrivilegeException {
+	public ServiceAttributes getDataWithGroups(PerunSession sess, Service service, Facility facility) throws FacilityNotExistsException, ServiceNotExistsException, PrivilegeException {
 		Utils.checkPerunSession(sess);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getDataWithGroups_Service_Facility_boolean_policy", Arrays.asList(service, facility))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getDataWithGroups_Service_Facility_policy", Arrays.asList(service, facility))) {
 			throw new PrivilegeException(sess, "getDataWithGroups");
 		}
 
 		getServicesManagerBl().checkServiceExists(sess, service);
 		getPerunBl().getFacilitiesManagerBl().checkFacilityExists(sess, facility);
 
-		return getServicesManagerBl().getDataWithGroups(sess, service, facility, filterExpiredMembers);
+		return getServicesManagerBl().getDataWithGroups(sess, service, facility);
 	}
 
 	@Override
-	public ServiceAttributes getDataWithVos(PerunSession sess, Service service, Facility facility, boolean filterExpiredMembers) throws FacilityNotExistsException, VoNotExistsException, ServiceNotExistsException, PrivilegeException {
+	public ServiceAttributes getDataWithVos(PerunSession sess, Service service, Facility facility) throws FacilityNotExistsException, VoNotExistsException, ServiceNotExistsException, PrivilegeException {
 		Utils.checkPerunSession(sess);
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "getDataWithVos_Service_Facility_boolean_policy", Arrays.asList(service, facility))) {
+		if (!AuthzResolver.authorizedInternal(sess, "getDataWithVos_Service_Facility_policy", Arrays.asList(service, facility))) {
 			throw new PrivilegeException(sess, "getDataWithVos");
 		}
 
 		getServicesManagerBl().checkServiceExists(sess, service);
 		getPerunBl().getFacilitiesManagerBl().checkFacilityExists(sess, facility);
 
-		return getServicesManagerBl().getDataWithVos(sess, service, facility, filterExpiredMembers);
+		return getServicesManagerBl().getDataWithVos(sess, service, facility);
 	}
 
 	@Override

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ServicesManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ServicesManagerEntryIntegrationTest.java
@@ -1246,7 +1246,7 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 		// get data for facility and service
 		// = should be one node (facility)
 		List<ServiceAttributes> facilities = new ArrayList<>();
-		facilities.add(perun.getServicesManager().getHierarchicalData(sess, service, facility, false));
+		facilities.add(perun.getServicesManager().getHierarchicalData(sess, service, facility));
 		assertNotNull("Unable to get hierarchical data",facilities);
 		assertTrue("Only 1 facility shoud be returned",facilities.size()==1);
 		assertNotNull("returned facility shouldn't be null",facilities.get(0));
@@ -1337,12 +1337,15 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 		perun.getResourcesManager().assignService(sess, resource, service);
 
 		List<ServiceAttributes> facilities = new ArrayList<ServiceAttributes>();
-		facilities.add(perun.getServicesManager().getHierarchicalData(sess, service, facility, false));
+		facilities.add(perun.getServicesManager().getHierarchicalData(sess, service, facility));
 		assertEquals(2, facilities.get(0).getChildElements().get(0).getChildElements().size());
+
+		service.setUseExpiredMembers(false);
+		perun.getServicesManagerBl().updateService(sess, service);
 
 		// return only one member because the other one is expired
 		facilities = new ArrayList<>();
-		facilities.add(perun.getServicesManager().getHierarchicalData(sess, service, facility, true));
+		facilities.add(perun.getServicesManager().getHierarchicalData(sess, service, facility));
 		assertEquals(1,facilities.get(0).getChildElements().get(0).getChildElements().size());
 	}
 
@@ -1351,7 +1354,7 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 		System.out.println(CLASS_NAME + "getHierarchicalDataWhenFacilityNotExists");
 
 		service = setUpService();
-		perun.getServicesManager().getHierarchicalData(sess, service, new Facility(), false);
+		perun.getServicesManager().getHierarchicalData(sess, service, new Facility());
 		// shouldn't find facility
 
 	}
@@ -1361,7 +1364,7 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 		System.out.println(CLASS_NAME + "getHierarchicalDataWhenServiceNotExists");
 
 		facility = setUpFacility();
-		perun.getServicesManager().getHierarchicalData(sess, new Service(), facility, false);
+		perun.getServicesManager().getHierarchicalData(sess, new Service(), facility);
 		// shouldn't find service
 
 	}
@@ -1398,7 +1401,7 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 		perun.getResourcesManager().assignService(sess, resource, service);
 
 		List<ServiceAttributes> facilities = new ArrayList<ServiceAttributes>();
-		facilities.add(perun.getServicesManager().getFlatData(sess, service, facility, false));
+		facilities.add(perun.getServicesManager().getFlatData(sess, service, facility));
 		assertNotNull("Unable to get flat data",facilities);
 		assertEquals("Only 1 facility should be returned", 1, facilities.size());
 		assertNotNull("returned facility shouldn't be null",facilities.get(0));
@@ -1476,13 +1479,16 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 		perun.getResourcesManager().assignService(sess, resource2, service);
 
 		List<ServiceAttributes> facilities = new ArrayList<ServiceAttributes>();
-		facilities.add(perun.getServicesManager().getFlatData(sess, service, facility, false));
+		facilities.add(perun.getServicesManager().getFlatData(sess, service, facility));
 		List<ServiceAttributes> facilityElements = facilities.get(0).getChildElements();
 		List<ServiceAttributes> users = facilityElements.get(1).getChildElements();
 		assertEquals("There should be all 3 users", 3, users.size());
 
+		service.setUseExpiredMembers(false);
+		perun.getServicesManagerBl().updateService(sess, service);
+
 		facilities = new ArrayList<ServiceAttributes>();
-		facilities.add(perun.getServicesManager().getFlatData(sess, service, facility, true));
+		facilities.add(perun.getServicesManager().getFlatData(sess, service, facility));
 		facilityElements = facilities.get(0).getChildElements();
 		users = facilityElements.get(1).getChildElements();
 		// 1 user is expired in all groups so users should not contain it, the remaining 2 are not expired in one group associated to different resources
@@ -1540,7 +1546,7 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 		 */
 
 		List<ServiceAttributes> facilities = new ArrayList<>();
-		facilities.add(perun.getServicesManager().getDataWithGroups(sess, service, facility, false));
+		facilities.add(perun.getServicesManager().getDataWithGroups(sess, service, facility));
 		assertNotNull("Unable to get hierarchical data with groups",facilities);
 		assertTrue("Only 1 facility shoud be returned",facilities.size()==1);
 		assertNotNull("returned facility shouldn't be null",facilities.get(0));
@@ -1687,6 +1693,8 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 		perun.getServicesManager().addRequiredAttribute(sess, service, reqMemAttr);
 
 		// finally assign service
+		service.setUseExpiredMembers(false);
+		perun.getServicesManagerBl().updateService(sess, service);
 		perun.getResourcesManager().assignService(sess, resource, service);
 
 		perun.getGroupsManager().setMemberGroupStatus(sess, member2, group, MemberGroupStatus.EXPIRED);
@@ -1694,7 +1702,7 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 		perun.getGroupsManager().setMemberGroupStatus(sess, member3, group2, MemberGroupStatus.EXPIRED);
 
 		List<ServiceAttributes> facilities = new ArrayList<ServiceAttributes>();
-		facilities.add(perun.getServicesManager().getDataWithGroups(sess, service, facility, true));
+		facilities.add(perun.getServicesManager().getDataWithGroups(sess, service, facility));
 		List<ServiceAttributes> resources = facilities.get(0).getChildElements();
 		List<ServiceAttributes> resourceElements = resources.get(0).getChildElements();
 		List<ServiceAttributes> groups = resourceElements.get(0).getChildElements();
@@ -1717,7 +1725,7 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 		System.out.println(CLASS_NAME + "getDataWithGroupsWhenFacilityNotExists");
 
 		service = setUpService();
-		perun.getServicesManager().getDataWithGroups(sess, service, new Facility(), false);
+		perun.getServicesManager().getDataWithGroups(sess, service, new Facility());
 		// shouldn't find facility
 
 	}
@@ -1727,7 +1735,7 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 		System.out.println(CLASS_NAME + "getDataWithGroupsWhenServiceNotExists");
 
 		facility = setUpFacility();
-		perun.getServicesManager().getDataWithGroups(sess, new Service(), facility, false);
+		perun.getServicesManager().getDataWithGroups(sess, new Service(), facility);
 		// shouldn't find service
 
 	}
@@ -1766,7 +1774,7 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 		perun.getResourcesManager().assignService(sess, resource, service);
 
 		List<ServiceAttributes> facilities = new ArrayList<ServiceAttributes>();
-		facilities.add(perun.getServicesManager().getDataWithVos(sess, service, facility, false));
+		facilities.add(perun.getServicesManager().getDataWithVos(sess, service, facility));
 		assertNotNull("Unable to get data with vos",facilities);
 		assertEquals("Only 1 facility should be returned", 1, facilities.size());
 		assertNotNull("returned facility shouldn't be null",facilities.get(0));
@@ -1863,10 +1871,12 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 		perun.getServicesManager().addRequiredAttribute(sess, service, reqVoAttr);
 
 		// finally assign service
+		service.setUseExpiredMembers(false);
+		perun.getServicesManagerBl().updateService(sess, service);
 		perun.getResourcesManager().assignService(sess, resource, service);
 
 		List<ServiceAttributes> facilities = new ArrayList<ServiceAttributes>();
-		facilities.add(perun.getServicesManager().getDataWithVos(sess, service, facility, true));
+		facilities.add(perun.getServicesManager().getDataWithVos(sess, service, facility));
 		List<ServiceAttributes> vos = facilities.get(0).getChildElements();
 		List<ServiceAttributes> resources = vos.get(0).getChildElements();
 		List<ServiceAttributes> resourceElements = resources.get(0).getChildElements();
@@ -1980,7 +1990,7 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 		resource3.setName("HierarchDataResource2");
 		resource3 = perun.getResourcesManager().createResource(sess, resource3, vo, facility);
 
-		HashedGenData data = perun.getServicesManagerBl().getHashedDataWithGroups(sess, service, facility, false, false);
+		HashedGenData data = perun.getServicesManagerBl().getHashedDataWithGroups(sess, service, facility, false);
 		assertThat(data.getAttributes()).isNotEmpty();
 
 		Map<String, Map<String, Object>> attributes = data.getAttributes();
@@ -2093,7 +2103,7 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 		resource3.setName("HierarchDataResource2");
 		resource3 = perun.getResourcesManager().createResource(sess, resource3, vo, facility);
 
-		HashedGenData data = perun.getServicesManagerBl().getHashedHierarchicalData(sess, service, facility, false, false);
+		HashedGenData data = perun.getServicesManagerBl().getHashedHierarchicalData(sess, service, facility, false);
 		assertThat(data.getAttributes()).isNotEmpty();
 
 		Map<String, Map<String, Object>> attributes = data.getAttributes();

--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -15854,7 +15854,6 @@ paths:
       parameters:
         - $ref: '#/components/parameters/serviceId'
         - $ref: '#/components/parameters/facilityId'
-        - { name: filterExpiredMembers, description: "if true the method does not take members expired in groups into account", schema: { type: boolean },  in: query, required: false }
       responses:
         '200':
           $ref: '#/components/responses/ServiceAttributesResponse'
@@ -15870,7 +15869,6 @@ paths:
       parameters:
         - $ref: '#/components/parameters/serviceId'
         - $ref: '#/components/parameters/facilityId'
-        - { name: filterExpiredMembers, description: "if true the method does not take members expired in groups into account", schema: { type: boolean },  in: query, required: false }
         - { name: consentEval, description: "if true the method will run consent eval", schema: { type: boolean },  in: query, required: false }
       responses:
         '200':
@@ -15887,7 +15885,6 @@ paths:
       parameters:
         - $ref: '#/components/parameters/serviceId'
         - $ref: '#/components/parameters/facilityId'
-        - { name: filterExpiredMembers, description: "if true the method does not take members expired in groups into account", schema: { type: boolean },  in: query, required: false }
         - { name: consentEval, description: "if true the method will run consent eval", schema: { type: boolean },  in: query, required: false }
       responses:
         '200':
@@ -15904,7 +15901,6 @@ paths:
       parameters:
         - $ref: '#/components/parameters/serviceId'
         - $ref: '#/components/parameters/facilityId'
-        - { name: filterExpiredMembers, description: "if true the method does not take members expired in groups into account", schema: { type: boolean },  in: query, required: false }
       responses:
         '200':
           $ref: '#/components/responses/ServiceAttributesResponse'
@@ -15920,7 +15916,6 @@ paths:
       parameters:
         - $ref: '#/components/parameters/serviceId'
         - $ref: '#/components/parameters/facilityId'
-        - { name: filterExpiredMembers, description: "if true the method does not take members expired in groups into account", schema: { type: boolean },  in: query, required: false }
       responses:
         '200':
           $ref: '#/components/responses/ServiceAttributesResponse'
@@ -15936,7 +15931,6 @@ paths:
       parameters:
         - $ref: '#/components/parameters/serviceId'
         - $ref: '#/components/parameters/facilityId'
-        - { name: filterExpiredMembers, description: "if true the method does not take members expired in groups into account", schema: { type: boolean },  in: query, required: false }
       responses:
         '200':
           $ref: '#/components/responses/ServiceAttributesResponse'

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/ServicesManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/ServicesManagerMethod.java
@@ -463,37 +463,6 @@ public enum ServicesManagerMethod implements ManagerMethod {
 	 * @deprecated use getHashedDataWithGroups
 	 * @param service int Service <code>id</code>
 	 * @param facility int Facility <code>id</code>. You will get attributes for this facility, resources associated with it and members assigned to the resources.
-	 * @param filterExpiredMembers if true the method does not take members expired in groups into account
-	 * @return List<ServiceAttributes> Attributes in special structure. Facility is in the root, facility children are resources. And resource children are members.
-	 <pre>
-	 Facility
-	 +---Attrs
-	 +---ChildNodes
-	 +------Resource
-	 |      +---Attrs
-	 |      +---ChildNodes
-	 |             +------Member
-	 |             |        +-------Attrs
-	 |             +------Member
-	 |             |        +-------Attrs
-	 |             +...
-	 |
-	 +------Resource
-	 |      +---Attrs
-	 |      +---ChildNodes
-	 .             +------Member
-	 .             |        +-------Attrs
-	 .             +------Member
-	 |        +-------Attrs
-	 +...
-	 </pre>
-	 */
-	/*#
-	 * Generates the list of attributes per each member associated with the resource.
-	 *
-	 * @deprecated use getHashedDataWithGroups
-	 * @param service int Service <code>id</code>
-	 * @param facility int Facility <code>id</code>. You will get attributes for this facility, resources associated with it and members assigned to the resources.
 	 * @return List<ServiceAttributes> Attributes in special structure. Facility is in the root, facility children are resources. And resource children are members.
 	 <pre>
 	 Facility
@@ -522,97 +491,12 @@ public enum ServicesManagerMethod implements ManagerMethod {
 
 		@Override
 		public ServiceAttributes call(ApiCaller ac, Deserializer parms) throws PerunException {
-			if (parms.contains("filterExpiredMembers")) {
-				return ac.getServicesManager().getHierarchicalData(ac.getSession(),
-					ac.getServiceById(parms.readInt("service")),
-					ac.getFacilityById(parms.readInt("facility")),
-					parms.readBoolean("filterExpiredMembers"));
-			} else {
-				return ac.getServicesManager().getHierarchicalData(ac.getSession(),
-					ac.getServiceById(parms.readInt("service")),
-					ac.getFacilityById(parms.readInt("facility")),
-					false);
-			}
+			return ac.getServicesManager().getHierarchicalData(ac.getSession(),
+				ac.getServiceById(parms.readInt("service")),
+				ac.getFacilityById(parms.readInt("facility")));
 		}
 	},
 
-	/*#
-	 * Generates hashed hierarchical data structure for given service and facility.
-	 * If enforcing consents is turned on on the instance and on the resource's consent hub,
-	 * generates only the users that granted a consent to all the service required attributes.
-	 * New UNSIGNED consents are created to users that don't have a consent containing all the
-	 * service required attributes.
-	 *
-	 * attributes: {...hashes...}
-	 * hierarchy: {
-	 *   "1": {    ** facility id **
-	 *     members: {    ** all members on the facility **
-	 *        "4" : 5,    ** member id : user id **
-	 *        "6" : 7,    ** member id : user id **
-	 *       ...
-	 *     }
-	 *     children: [
-	 *       "2": {    ** resource id **
-	 *         children: [],
-	 *         voId: 99,
-	 *         members: {    ** all members on the resource with id 2 **
-	 *           "4" : 5    ** member id : user id **
-	 *         }
-	 *       },
-	 *       "3": {
-	 *         ...
-	 *       }
-	 *     ]
-	 *   }
-	 * }
-	 *
-	 * @param service Integer service
-	 * @param facility Integer facility
-	 * @param filterExpiredMembers Boolean if the generator should filter expired members
-	 * @param consentEval Boolean if the generator should enforce evaluation of consents
-	 * @return HashedGenData generated hashed data structure
-	 * @throw FacilityNotExistsException if there is no such facility
-	 * @throw ServiceNotExistsException if there is no such service
-	 * @throw PrivilegeException insufficient permissions
-	 */
-	/*#
-	 * Generates hashed hierarchical data structure for given service and facility.
-	 * If enforcing consents is turned on on the instance and on the resource's consent hub,
-	 * generates only the users that granted a consent to all the service required attributes.
-	 * New UNSIGNED consents are created to users that don't have a consent containing all the
-	 * service required attributes.
-	 *
-	 * attributes: {...hashes...}
-	 * hierarchy: {
-	 *   "1": {    ** facility id **
-	 *     members: {    ** all members on the facility **
-	 *        "4" : 5,    ** member id : user id **
-	 *        "6" : 7,    ** member id : user id **
-	 *       ...
-	 *     }
-	 *     children: [
-	 *       "2": {    ** resource id **
-	 *         children: [],
-	 *         voId: 99,
-	 *         members: {    ** all members on the resource with id 2 **
-	 *           "4" : 5    ** member id : user id **
-	 *         }
-	 *       },
-	 *       "3": {
-	 *         ...
-	 *       }
-	 *     ]
-	 *   }
-	 * }
-	 *
-	 * @param service Integer service
-	 * @param facility Integer facility
-	 * @param filterExpiredMembers Boolean if the generator should filter expired members
-	 * @return HashedGenData generated hashed data structure
-	 * @throw FacilityNotExistsException if there is no such facility
-	 * @throw ServiceNotExistsException if there is no such service
-	 * @throw PrivilegeException insufficient permissions
-	 */
 	/*#
 	 * Generates hashed hierarchical data structure for given service and facility.
 	 * If enforcing consents is turned on on the instance and on the resource's consent hub,
@@ -691,106 +575,14 @@ public enum ServicesManagerMethod implements ManagerMethod {
 	getHashedHierarchicalData {
 		@Override
 		public HashedGenData call(ApiCaller ac, Deserializer parms) throws PerunException {
-			boolean filterExpiredMembers = parms.contains("filterExpiredMembers") ? parms.readBoolean("filterExpiredMembers") : false;
 			boolean consentEval = parms.contains("consentEval") ? parms.readBoolean("consentEval") : false;
 			return ac.getServicesManager().getHashedHierarchicalData(ac.getSession(),
 				ac.getServiceById(parms.readInt("service")),
 				ac.getFacilityById(parms.readInt("facility")),
-				filterExpiredMembers, consentEval);
+				consentEval);
 		}
 	},
 
-	/*#
-	 * Generates hashed data with group structure for given service and resource.
-	 *
-	 * Generates data in format:
-	 *
-	 * attributes: {...hashes...}
-	 * hierarchy: {
-	 *   "1": {    ** facility id **
-	 *     members: {    ** all members on the facility **
-	 *        "4" : 5,    ** member id : user id **
-	 *        "6" : 7,    ** member id : user id **
-	 *       ...
-	 *     }
-	 *     children: [
-	 *       "2": {    ** resource id **
-	 *         voId: 99,
-	 *         children: [
-	 *           "89": {    ** group id **
-	 *              "children": {},
-	 *              "members": {
-	 *                  "91328": 57986,
-	 *                  "91330": 60838
-	 *              }
-	 *           }
-	 *         ],
-	 *         "members": {    ** all members on the resource with id 2 **
-	 *             "91328": 57986,
-	 *             "91330": 60838
-	 *         }
-	 *       },
-	 *       "3": {
-	 *         ...
-	 *       }
-	 *     ]
-	 *   }
-	 * }
-	 *
-	 * @param service Integer service
-	 * @param facility Integer facility
-	 * @param filterExpiredMembers Boolean if the generator should filter expired members
-	 * @param consentEval Boolean if the generator should enforce evaluation of consents
-	 * @return HashedGenData generated hashed data structure
-	 * @throw FacilityNotExistsException if there is no such facility
-	 * @throw ServiceNotExistsException if there is no such service
-	 * @throw PrivilegeException insufficient permissions
-	 */
-	/*#
-	 * Generates hashed data with group structure for given service and resource.
-	 *
-	 * Generates data in format:
-	 *
-	 * attributes: {...hashes...}
-	 * hierarchy: {
-	 *   "1": {    ** facility id **
-	 *     members: {    ** all members on the facility **
-	 *        "4" : 5,    ** member id : user id **
-	 *        "6" : 7,    ** member id : user id **
-	 *       ...
-	 *     }
-	 *     children: [
-	 *       "2": {    ** resource id **
-	 *         voId: 99,
-	 *         children: [
-	 *           "89": {    ** group id **
-	 *              "children": {},
-	 *              "members": {
-	 *                  "91328": 57986,
-	 *                  "91330": 60838
-	 *              }
-	 *           }
-	 *         ],
-	 *         "members": {    ** all members on the resource with id 2 **
-	 *             "91328": 57986,
-	 *             "91330": 60838
-	 *         }
-	 *       },
-	 *       "3": {
-	 *         ...
-	 *       }
-	 *     ]
-	 *   }
-	 * }
-	 *
-	 * @param service Integer service
-	 * @param facility Integer facility
-	 * @param filterExpiredMembers Boolean if the generator should filter expired members
-	 * @return HashedGenData generated hashed data structure
-	 * @throw FacilityNotExistsException if there is no such facility
-	 * @throw ServiceNotExistsException if there is no such service
-	 * @throw PrivilegeException insufficient permissions
-	 */
 	/*#
 	 * Generates hashed data with group structure for given service and resource.
 	 *
@@ -883,46 +675,14 @@ public enum ServicesManagerMethod implements ManagerMethod {
 	getHashedDataWithGroups {
 		@Override
 		public HashedGenData call(ApiCaller ac, Deserializer parms) throws PerunException {
-			boolean filterExpiredMembers = parms.contains("filterExpiredMembers") ? parms.readBoolean("filterExpiredMembers") : false;
 			boolean consentEval = parms.contains("consentEval") ? parms.readBoolean("consentEval") : false;
 			return ac.getServicesManager().getHashedDataWithGroups(ac.getSession(),
 				ac.getServiceById(parms.readInt("service")),
 				ac.getFacilityById(parms.readInt("facility")),
-				filterExpiredMembers, consentEval);
+				consentEval);
 		}
 	},
 
-	/*#
-	 * Generates the list of attributes per each user and per each resource. Never return member or member-resource attribute.
-	 *
-	 * @deprecated use getHashedHierarchicalData
-	 * @param service int Service <code>id</code>. You will get attributes required by this service
-	 * @param facility int Facility <code>id</code>. You will get attributes for this facility, resources associated with it and members assigned to the resources
-	 * @param filterExpiredMembers if true the method does not take members expired in groups into account
-	 * @return ServiceAttributes Attributes in special structure. The facility is in the root. Facility first children is abstract node which contains no attributes and it's children are all resources. Facility second child is abstract node with no attribute and it's children are all users.
-	 <pre>
-	 Facility
-	 +---Attrs
-	 +---ChildNodes
-	 +------()
-	 |      +---ChildNodes
-	 |             +------Resource
-	 |             |        +-------Attrs
-	 |             +------Resource
-	 |             |        +-------Attrs
-	 |             +...
-	 |
-	 +------()
-	 +---ChildNodes
-	 +------User
-	 |        +-------Attrs (do NOT return member, member-resource attributes)
-	 +------User
-	 |        +-------Attrs (do NOT return member, member-resource attributes)
-	 +...
-	 </pre>
-
-	 *
-	 */
 	/*#
 	 * Generates the list of attributes per each user and per each resource. Never return member or member-resource attribute.
 	 *
@@ -955,96 +715,12 @@ public enum ServicesManagerMethod implements ManagerMethod {
 
 		@Override
 		public ServiceAttributes call(ApiCaller ac, Deserializer parms) throws PerunException {
-			if (parms.contains("filterExpiredMembers")) {
-				return ac.getServicesManager().getFlatData(ac.getSession(),
-						ac.getServiceById(parms.readInt("service")),
-						ac.getFacilityById(parms.readInt("facility")),
-					parms.readBoolean("filterExpiredMembers"));
-			} else {
-				return ac.getServicesManager().getFlatData(ac.getSession(),
-					ac.getServiceById(parms.readInt("service")),
-					ac.getFacilityById(parms.readInt("facility")),
-					false);
-			}
+			return ac.getServicesManager().getFlatData(ac.getSession(),
+				ac.getServiceById(parms.readInt("service")),
+				ac.getFacilityById(parms.readInt("facility")));
 		}
 	},
 
-	/*#
-	 * Generates the list of attributes per each member associated with the resources and groups.
-	 *
-	 * @deprecated use getHashedDataWithGroups
-	 * @param service int Service <code>id</code>. You will get attributes reuqired by this service
-	 * @param facility int Facility <code>id</code>. You will get attributes for this facility, resources associated with it and members assigned to the resources
-	 * @param filterExpiredMembers if true the method does not take members expired in groups into account
-	 * @return ServiceAttributes Attributes in special structure. Facility is in the root, facility children are resources.
-	 *         Resource first chil is abstract structure which children are groups.
-	 *         Resource  second chi is abstract structure which children are members.
-	 *         Group first chil is abstract structure which children are groups.
-	 *         Group second chi is abstract structure which children are members.
-	 <pre>
-	 Facility
-	 +---Attrs                       ...................................................
-	 +---ChildNodes                  |                                                 .
-	 +------Resource                 |                                                 .
-	 |       +---Attrs               |                                                 .
-	 |       +---ChildNodes          |                                                 .
-	 |              +------()        V                                                 .
-	 |              |       +------Group                                               .
-	 |              |       |        +-------Attrs                                     .
-	 |              |       |        +-------ChildNodes                                .
-	 |              |       |                   +-------()                             .
-	 |              |       |                   |        +---ChildNodes                .
-	 |              |       |                   |               +------- GROUP (same structure as any other group)
-	 |              |       |                   |               +------- GROUP (same structure as any other group)
-	 |              |       |                   |               +...
-	 |              |       |                   +-------()
-	 |              |       |                            +---ChildNodes
-	 |              |       |                                   +------Member
-	 |              |       |                                   |        +----Attrs
-	 |              |       |                                   +------Member
-	 |              |       |                                   |        +----Attrs
-	 |              |       |                                   +...
-	 |              |       |
-	 |              |       +------Group
-	 |              |       |        +-------Attrs
-	 |              |       |        +-------ChildNodes
-	 |              |       |                   +-------()
-	 |              |       |                   |        +---ChildNodes
-	 |              |       |                   |               +------- GROUP (same structure as any other group)
-	 |              |       |                   |               +------- GROUP (same structure as any other group)
-	 |              |       |                   |               +...
-	 |              |       |                   +-------()
-	 |              |       |                            +---ChildNodes
-	 |              |       |                                   +------Member
-	 |              |       |                                   |        +----Attrs
-	 |              |       |                                   +------Member
-	 |              |       |                                   |        +----Attrs
-	 |              |       |                                   +...
-	 |              |       |
-	 |              |       +...
-	 |              |
-	 |              +------()
-	 |                      +------Member
-	 |                      |         +----Attrs
-	 |                      |
-	 |                      +------Member
-	 |                      |         +----Attrs
-	 |                      +...
-	 |
-	 +------Resource
-	 |       +---Attrs
-	 |       +---ChildNodes
-	 |              +------()
-	 |              |       +...
-	 |              |       +...
-	 |              |
-	 |              +------()
-	 |                      +...
-	 .                      +...
-	 .
-	 .
-	 </pre>
-	 */
 	/*#
 	 * Generates the list of attributes per each member associated with the resources and groups.
 	 *
@@ -1116,99 +792,12 @@ public enum ServicesManagerMethod implements ManagerMethod {
 
 		@Override
 		public ServiceAttributes call(ApiCaller ac, Deserializer parms) throws PerunException {
-			if (parms.contains("filterExpiredMembers")) {
-				return ac.getServicesManager().getDataWithGroups(ac.getSession(),
+			return ac.getServicesManager().getDataWithGroups(ac.getSession(),
 					ac.getServiceById(parms.readInt("service")),
-					ac.getFacilityById(parms.readInt("facility")),
-					parms.readBoolean("filterExpiredMembers"));
-			} else {
-				return ac.getServicesManager().getDataWithGroups(ac.getSession(),
-					ac.getServiceById(parms.readInt("service")),
-					ac.getFacilityById(parms.readInt("facility")),
-					false);
-			}
+					ac.getFacilityById(parms.readInt("facility")));
 		}
 	},
 
-	/*#
-	 * Generates the list of attributes per each member associated with the resources and groups in vos.
-	 *
-	 * @deprecated use getHashedDataWithGroups
-	 * @param service attributes required by this service you will get
-	 * @param facility you will get attributes for this facility, vos associated with this facility by resources, resources associated with it and members assigned to the resources
-	 * @param filterExpiredMembers if true the method does not take members expired in groups into account
-	 * @return attributes in special structure.
-	 *        Facility is in the root, facility children are vos.
-	 *        Vo first child is abstract structure which children are resources.
-	 *        Resource first child is abstract structure which children are groups.
-	 *        Resource  second chi is abstract structure which children are members.
-	 *        Group first child is abstract structure which children are groups.
-	 *        Group second chi is abstract structure which children are members.
-	 <pre>
-	 Facility
-	 +---Attrs
-	 +---ChildNodes
-	        +-----Vo
-	        |      +---Attrs
-	        |      +---ChildNodes
-	        |             +-------Resource
-	        |             |       +---Attrs               |-------------------------------------------------.
-	        |             |       +---ChildNodes          |                                                 .
-	        |             |              +------()        V                                                 .
-	        |             |              |       +------Group                                               .
-	        |             |              |       |        +-------Attrs                                     .
-	        |             |              |       |        +-------ChildNodes                                .
-	        |             |              |       |                   +-------()                             .
-	        |             |              |       |                   |        +---ChildNodes                .
-	        |             |              |       |                   |               +------- GROUP (same structure as any other group)
-	        |             |              |       |                   |               +------- GROUP (same structure as any other group)
-	        |             |              |       |                   |               +...
-	        |             |              |       |                   +-------()
-	        |             |              |       |                            +---ChildNodes
-	        |             |              |       |                                   +------Member
-	        |             |              |       |                                   |        +----Attrs
-	        |             |              |       |                                   +------Member
-	        |             |              |       |                                   |        +----Attrs
-	        |             |              |       |                                   +...
-	        |             |              |       |
-	        |             |              |       +------Group
-	        |             |              |       |        +-------Attrs
-	        |             |              |       |        +-------ChildNodes
-	        |             |              |       |                   +-------()
-	        |             |              |       |                   |        +---ChildNodes
-	        |             |              |       |                   |               +------- GROUP (same structure as any other group)
-	        |             |              |       |                   |               +------- GROUP (same structure as any other group)
-	        |             |              |       |                   |               +...
-	        |             |              |       |                   +-------()
-	        |             |              |       |                            +---ChildNodes
-	        |             |              |       |                                   +------Member
-	        |             |              |       |                                   |        +----Attrs
-	        |             |              |       |                                   +------Member
-	        |             |              |       |                                   |        +----Attrs
-	        |             |              |       |                                   +...
-	        |             |              |       |
-	        |             |              |       +...
-	        |             |              |
-	        |             |              +------()
-	        |             |                      +------Member
-	        |             |                      |         +----Attrs
-	        |             |                      |
-	        |             |                      +------Member
-	        |             |                      |         +----Attrs
-	        |             |                      +...
-	        |             |
-	        |             +------Resource
-	        |             |       +---Attrs
-	        |             |       +---ChildNodes
-	        |             |              +------()
-	        |             |              |       +...
-	        |             |              |       +...
-	        |             |              |
-	        |             |              +------()
-	        |             |                      +...
-	        +-----Vo ....
-	</pre>
-	 */
 	/*#
 	 * Generates the list of attributes per each member associated with the resources and groups in vos.
 	 *
@@ -1290,17 +879,9 @@ public enum ServicesManagerMethod implements ManagerMethod {
 	getDataWithVos {
 		@Override
 		public ServiceAttributes call(ApiCaller ac, Deserializer parms) throws PerunException {
-			if (parms.contains("filterExpiredMembers")) {
-				return ac.getServicesManager().getDataWithVos(ac.getSession(),
-					ac.getServiceById(parms.readInt("service")),
-					ac.getFacilityById(parms.readInt("facility")),
-					parms.readBoolean("filterExpiredMembers"));
-			} else {
-				return ac.getServicesManager().getDataWithVos(ac.getSession(),
-					ac.getServiceById(parms.readInt("service")),
-					ac.getFacilityById(parms.readInt("facility")),
-					false);
-			}
+			return ac.getServicesManager().getDataWithVos(ac.getSession(),
+				ac.getServiceById(parms.readInt("service")),
+				ac.getFacilityById(parms.readInt("facility")));
 		}
 	},
 


### PR DESCRIPTION
* the parameter was passed by perun services' gen scripts as flag if members with expired group status should be included in the retrieved data
* the information is now stored in the database with the service object and does not need to be passed separately anymore

BREAKING CHANGE: removed filterExpiredMembers parameter in getData methods