### PR TITLE
feat(core): include groups to groups in parent VOs

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/GroupsManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/GroupsManager.java
@@ -1264,8 +1264,9 @@ public interface GroupsManager {
 	 * @throws PrivilegeException
 	 * @throws WrongAttributeValueException
 	 * @throws WrongReferenceAttributeValueException
+	 * @throws VoNotExistsException
 	 */
-	Group createGroupUnion(PerunSession sess, Group resultGroup, Group operandGroup) throws GroupNotExistsException, PrivilegeException, GroupRelationNotAllowed, GroupRelationAlreadyExists, WrongAttributeValueException, WrongReferenceAttributeValueException, ExternallyManagedException;
+	Group createGroupUnion(PerunSession sess, Group resultGroup, Group operandGroup) throws GroupNotExistsException, PrivilegeException, GroupRelationNotAllowed, GroupRelationAlreadyExists, WrongAttributeValueException, WrongReferenceAttributeValueException, ExternallyManagedException, VoNotExistsException;
 
 	/**
 	 * Removes a union relation between two groups. All indirect members that originate from operand group are removed from result group.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/GroupsManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/GroupsManagerBl.java
@@ -44,10 +44,10 @@ import cz.metacentrum.perun.core.api.exceptions.MemberNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.MemberResourceMismatchException;
 import cz.metacentrum.perun.core.api.exceptions.NotGroupMemberException;
 import cz.metacentrum.perun.core.api.exceptions.ParentGroupNotExistsException;
-import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
 import cz.metacentrum.perun.core.api.exceptions.RelationExistsException;
 import cz.metacentrum.perun.core.api.exceptions.RelationNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.VoNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
@@ -1776,8 +1776,9 @@ public interface GroupsManagerBl {
 	 * @throws WrongReferenceAttributeValueException
 	 * @throws WrongAttributeValueException
 	 * @throws GroupNotExistsException
+	 * @throws VoNotExistsException
 	 */
-	Group createGroupUnion(PerunSession sess, Group resultGroup, Group operandGroup, boolean parentFlag) throws GroupRelationAlreadyExists, GroupRelationNotAllowed, WrongReferenceAttributeValueException, WrongAttributeValueException, GroupNotExistsException;
+	Group createGroupUnion(PerunSession sess, Group resultGroup, Group operandGroup, boolean parentFlag) throws GroupRelationAlreadyExists, GroupRelationNotAllowed, WrongReferenceAttributeValueException, WrongAttributeValueException, GroupNotExistsException, VoNotExistsException;
 
 	/**
 	 * Removes a union relation between two groups. All indirect members that originate from operand group are removed from result group.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
@@ -251,6 +251,9 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 			log.error("Exception thrown in createGroup method, while it shouldn't be thrown. Cause:{}",e);
 		} catch (GroupNotExistsException e) {
 			throw new ConsistencyErrorException("Database consistency error while creating group: {}",e);
+		} catch (VoNotExistsException e) {
+			// shouldn't happen with parentFlag == true
+			throw new InternalErrorException(e);
 		}
 
 		getPerunBl().getAuditer().log(sess, new GroupCreatedAsSubgroup(group, vo, parentGroup));
@@ -1043,6 +1046,28 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 	}
 
 	/**
+	 * Returns members from the given VO corresponding to the given members in another VO.
+	 *
+	 * @param sess perun session
+	 * @param voId ID of the VO to return members from
+	 * @param members members in another VO
+	 * @return list of members in the given VO corresponding to the given members
+	 */
+	private List<Member> getCorrespondingMembersFromOtherVo(PerunSession sess, int voId, List<Member> members) {
+		Vo vo;
+		try {
+			vo = perunBl.getVosManagerBl().getVoById(sess, voId);
+		} catch (VoNotExistsException e) {
+			throw new InternalErrorException(e);
+		}
+		List<Integer> usersIds = members.stream()
+			.map(Member::getUserId)
+			.toList();
+
+		return perunBl.getMembersManagerBl().getMembersByUsersIds(sess, usersIds, vo);
+	}
+
+	/**
 	 * Add records of the members with an INDIRECT membership type to the group.
 	 *
 	 * @param sess perun session
@@ -1056,6 +1081,11 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 	 * @throws WrongReferenceAttributeValueException
 	 */
 	protected List<Member> addIndirectMembers(PerunSession sess, Group group, List<Member> members, int sourceGroupId) throws AlreadyMemberException, WrongAttributeValueException, WrongReferenceAttributeValueException {
+		// if there is union between different VOs, find correct members (from the group's VO)
+		if (members.size() > 0 && members.get(0).getVoId() != group.getVoId()) {
+			members = getCorrespondingMembersFromOtherVo(sess, group.getVoId(), members);
+		}
+
 		lockGroupMembership(group, members);
 
 		List<Member> newMembers = new ArrayList<>();
@@ -1107,6 +1137,10 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 	 * @return list of members that were removed (their only record in the group was deleted)
 	 */
 	private List<Member> removeIndirectMembers(PerunSession sess, Group group, List<Member> members, int sourceGroupId) throws WrongAttributeValueException, WrongReferenceAttributeValueException, NotGroupMemberException {
+		// if there is union between different VOs, find correct members (from the group's VO)
+		if (members.size() > 0 && members.get(0).getVoId() != group.getVoId()) {
+			members = getCorrespondingMembersFromOtherVo(sess, group.getVoId(), members);
+		}
 		List<Member> membersToRemove = new ArrayList<>(members);
 
 		lockGroupMembership(group, membersToRemove);
@@ -4874,7 +4908,7 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 	}
 
 	@Override
-	public Group createGroupUnion(PerunSession sess, Group resultGroup, Group operandGroup, boolean parentFlag) throws WrongReferenceAttributeValueException, WrongAttributeValueException, GroupNotExistsException, GroupRelationAlreadyExists, GroupRelationNotAllowed {
+	public Group createGroupUnion(PerunSession sess, Group resultGroup, Group operandGroup, boolean parentFlag) throws WrongReferenceAttributeValueException, WrongAttributeValueException, GroupNotExistsException, GroupRelationAlreadyExists, GroupRelationNotAllowed, VoNotExistsException {
 
 		// block inclusion to members group, since it doesn't make sense
 		// allow inclusion of members group, since we want to delegate privileges on assigning all vo members to some service for group manager.
@@ -4884,7 +4918,16 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 
 		// check if both groups are from same VO
 		if (resultGroup.getVoId() != operandGroup.getVoId()) {
-			throw new GroupRelationNotAllowed("Union cannot be created on groups: " + resultGroup + ", " + operandGroup + ". They are not from the same VO.");
+			if (parentFlag) {
+				throw new GroupRelationNotAllowed("Union cannot be created on groups: " + resultGroup + ", " + operandGroup +
+					". They are not from the same VO.");
+			}
+
+			Vo resultGroupsVo = perunBl.getVosManagerBl().getVoById(sess, resultGroup.getVoId());
+			if (!isAllowedGroupToHierarchicalVo(sess, operandGroup, resultGroupsVo)) {
+				throw new GroupRelationNotAllowed("Union cannot be created on groups: " + resultGroup + ", " + operandGroup +
+					". They are not from the same VO and operand group is not enabled to be included to groups in result group's VO.");
+			}
 		}
 
 		// check if result group is the same as operand group
@@ -4988,6 +5031,11 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 	 * @return previous statuses of members in all result groups of the given group
 	 */
 	private Map<Integer, Map<Integer, MemberGroupStatus>> getPreviousStatuses(PerunSession sess, Group group, List<Member> members, Map<Integer, Map<Integer, MemberGroupStatus>> previousStatuses) {
+
+		// if there is union between different VOs, find correct members (from the group's VO)
+		if (members.size() > 0 && members.get(0).getVoId() != group.getVoId()) {
+			members = getCorrespondingMembersFromOtherVo(sess, group.getVoId(), members);
+		}
 
 		if (members.isEmpty()) {
 			return previousStatuses;
@@ -5176,6 +5224,8 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 				throw new InternalErrorException("Group relation cannot be created between destination group "  + destinationGroup + " and moving group " + movingGroup + ".");
 			} catch (GroupNotExistsException e) {
 				throw new ConsistencyErrorException("Some group does not exists while creating group union.", e);
+			} catch (VoNotExistsException e) {
+				throw new ConsistencyErrorException("Some group's VO does not exists while creating group union.", e);
 			}
 		}
 	}
@@ -5280,6 +5330,16 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 			return;
 		}
 
+		// if there is union between different VOs, find correct member (from the group's VO)
+		if (member.getVoId() != group.getVoId()) {
+			List<Member> members = getCorrespondingMembersFromOtherVo(sess, group.getVoId(), List.of(member));
+			if (members.isEmpty()) {
+				// this could happen if the member is INVALID/DISABLED in member VO
+				// ==> he wasn't added to parent VO
+				return;
+			}
+			member = members.get(0);
+		}
 		MemberGroupStatus newStatus = getTotalMemberGroupStatus(sess, member, group);
 
 		boolean saveStatuses = true;
@@ -5826,6 +5886,7 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 	 * are cut off after first included group. Duplicates avoided.
 	 */
 	private List<List<Group>> stepIntoGroup(PerunSession sess, Member member, Group currentGroup) {
+
 		List<List<Group>> pathsFromCurrentGroup = new ArrayList<>();
 
 		// reached source group, create empty list to which current group will be added at the end of this method call
@@ -5838,7 +5899,17 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 
 		// step into every group in which the member is recognised
 		for (Group group : relatedGroups) {
-			if (isGroupMember(sess, group, member)) {
+			// if there is union between different VOs, find correct member (from this group's VO)
+			Member correctMember = member;
+			if (correctMember.getVoId() != group.getVoId()) {
+				List<Member> members = getCorrespondingMembersFromOtherVo(sess, group.getVoId(), List.of(correctMember));
+				if (members.isEmpty()) {
+					// this should happen always when the member is not in the included group's VO
+					continue;
+				}
+				correctMember = members.get(0);
+			}
+			if (isGroupMember(sess, group, correctMember)) {
 
 				// cut paths via included groups
 				if (group.getParentGroupId() == null ||group.getParentGroupId() != currentGroup.getId()) {
@@ -5848,7 +5919,7 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 					continue;
 				}
 
-				List<List<Group>> subPaths = stepIntoGroup(sess, member, group);
+				List<List<Group>> subPaths = stepIntoGroup(sess, correctMember, group);
 				pathsFromCurrentGroup.addAll(subPaths);
 			}
 		}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
@@ -1604,6 +1604,38 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 		}
 	}
 
+	/**
+	 * Adds member to groups in parentVos, where he should be through include relation.
+	 * Include didn't happen automatically, if the member was DISABLED / INVALID in member VO.
+	 *
+	 * @param sess
+	 * @param member
+	 * @throws WrongReferenceAttributeValueException
+	 * @throws WrongAttributeValueException
+	 */
+	private void addMemberToParentVosGroups(PerunSession sess, Member member) throws WrongReferenceAttributeValueException, WrongAttributeValueException {
+		List<Vo> parentVos = getPerunBl().getVosManagerBl().getParentVos(sess, member.getVoId());
+		if (parentVos.isEmpty()) {
+			return;
+		}
+
+		List<Group> groups = perunBl.getGroupsManagerBl().getAllMemberGroups(sess, member);
+		for (Group group : groups) {
+			List<Group> resultGroups = perunBl.getGroupsManagerBl().getGroupUnions(sess, group, true);
+			for (Group resultGroup : resultGroups) {
+				if (resultGroup.getVoId() != member.getVoId()) {
+					try {
+						perunBl.getGroupsManagerBl().addRelationMembers(sess, resultGroup, List.of(member), group.getId());
+					} catch (AlreadyMemberException e) {
+						// this is OK
+					} catch (GroupNotExistsException e) {
+						throw new InternalErrorException(e);
+					}
+				}
+			}
+		}
+	}
+
 	@Override
 	public Member validateMember(PerunSession sess, Member member) throws WrongAttributeValueException, WrongReferenceAttributeValueException {
 		//this method run in nested transaction
@@ -1620,6 +1652,7 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 			try {
 				getPerunBl().getAttributesManagerBl().doTheMagic(sess, member);
 				addMemberToParentVos(sess, member);
+				addMemberToParentVosGroups(sess, member);
 			} catch (Exception ex) {
 				//return old status to object to prevent incorrect result in higher methods
 				member.setStatus(oldStatus);
@@ -1683,7 +1716,8 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 				for (Vo vo : parentVos) {
 					try {
 						Member newMember = perunBl.getMembersManagerBl().createMember(sess, vo, user);
-						perunBl.getMembersManagerBl().validateMemberAsync(sess, newMember);
+						perunBl.getMembersManagerBl().validateMember(sess, newMember);
+						addMemberToParentVosGroups(sess, member);
 					} catch (ExtendMembershipException e) {
 						throw new InternalErrorException(e);
 					} catch (AlreadyMemberException ignored) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/GroupsManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/GroupsManagerEntry.java
@@ -1380,7 +1380,7 @@ public class GroupsManagerEntry implements GroupsManager {
 	}
 
 	@Override
-	public Group createGroupUnion(PerunSession sess, Group resultGroup, Group operandGroup) throws GroupNotExistsException, PrivilegeException, GroupRelationNotAllowed, GroupRelationAlreadyExists, WrongAttributeValueException, WrongReferenceAttributeValueException, ExternallyManagedException {
+	public Group createGroupUnion(PerunSession sess, Group resultGroup, Group operandGroup) throws GroupNotExistsException, PrivilegeException, GroupRelationNotAllowed, GroupRelationAlreadyExists, WrongAttributeValueException, WrongReferenceAttributeValueException, ExternallyManagedException, VoNotExistsException {
 		Utils.checkPerunSession(sess);
 		getGroupsManagerBl().checkGroupExists(sess, resultGroup);
 		getGroupsManagerBl().checkGroupExists(sess, operandGroup);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/GroupsManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/GroupsManagerImpl.java
@@ -1158,7 +1158,8 @@ public class GroupsManagerImpl implements GroupsManagerImplApi {
 	public void setIndirectGroupStatus(PerunSession sess, Member member, Group group, MemberGroupStatus status) {
 		try {
 			jdbc.update("UPDATE groups_members SET source_group_status=?, modified_by=?, modified_at=" + Compatibility.getSysdate() +
-					" WHERE source_group_id=? AND group_id <> source_group_id AND member_id=?", status.getCode(), sess.getPerunPrincipal().getActor(), group.getId(), member.getId());
+					" WHERE source_group_id=? AND group_id <> source_group_id AND member_id IN (SELECT id FROM members where user_id=?)",
+				status.getCode(), sess.getPerunPrincipal().getActor(), group.getId(), member.getUserId());
 		} catch (RuntimeException e) {
 			throw new InternalErrorException(e);
 		}

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/GroupsManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/GroupsManagerMethod.java
@@ -149,6 +149,7 @@ public enum GroupsManagerMethod implements ManagerMethod {
 	 * @throw GroupRelationAlreadyExists When the group relation already exists
 	 * @throw WrongAttributeValueException When the value of the attribute is illegal or wrong
 	 * @throw WrongReferenceAttributeValueException When the attribute of the reference has illegal value
+	 * @throw VoNotExistsException When the groups' VO doesn't exist
 	 *
 	 * @param resultGroup int <code>id</code> of Group to have included "operandGroup"
 	 * @param operandGroup int <code>id</code> of Group to be included into "resultGroup"


### PR DESCRIPTION
- It was not possible to include groups to groups in other VOs. Now, it
is possible but only to groups in parent VOs.
- Multiple methods around indirect memberships were changed so they are
able to work with both members from member VOs and their corresponding
members in parent VOs.
- Tests for new use cases were added as well.