### PR TITLE
fix(cli): don't require PERUN_OIDC_CONFIG variable if not used

### DIFF
--- a/perun-cli/Perun/auth/OidcAuth.pm
+++ b/perun-cli/Perun/auth/OidcAuth.pm
@@ -9,10 +9,9 @@ use LWP::UserAgent;
 use File::Basename;
 use Perun::Exception;
 
-my $chosenConfigName = $ENV{PERUN_OIDC_CONFIG};
-if (!defined $chosenConfigName) {
-	die "ERROR: environmental variable PERUN_OIDC_CONFIG not set!\n"
-}
+my $UNDEFINED_CONFIGURATION = "UNDEFINED_OIDC_CONFIGURATION";
+
+my $chosenConfigName = $ENV{PERUN_OIDC_CONFIG} || $UNDEFINED_CONFIGURATION;
 my $PERUN_OIDC = "perun_oidc" . "_" . $chosenConfigName;
 my $PYTHON = "python3";
 my $dirname = dirname(__FILE__);
@@ -387,6 +386,9 @@ sub revokeToken
 sub checkConfigExists
 {
 	my $configName = $_[0];
+	if ($configName eq $UNDEFINED_CONFIGURATION) {
+		die "ERROR: environment variable PERUN_OIDC_CONFIG is not set!\n";
+	}
 	my %configs = % { loadAllConfigurations() };
 	if (!exists $configs{$configName}) {
 		die "ERROR: configuration \"$configName\" does not exist!\n";

--- a/perun-cli/Perun/auth/sample_oidc_config.yml
+++ b/perun-cli/Perun/auth/sample_oidc_config.yml
@@ -1,7 +1,7 @@
 # This is only a sample config file! You need to create file oidc_config.yml in this directory
 # and specify following options in it!
 # Each configuration is a dictionary entry, where the key serves as the identification of the configuration.
-# to switch between configurations, set environmental variable PERUN_OIDC_CONFIG to the id of desired configuration.
+# to switch between configurations, set environment variable PERUN_OIDC_CONFIG to the id of desired configuration.
 # The key is a string so user can freely choose the name of each configuration
 perun:
   client_id: "" # Identifier of the CLI app on the OIDC server

--- a/perun-cli/removeOidcTokens
+++ b/perun-cli/removeOidcTokens
@@ -9,7 +9,7 @@ use Perun::Common qw(printMessage);
 sub help {
 	return qq{
 	Removes access and refresh token saved for OIDC authentication. By default removes tokens of currently chosen
-	configuration (as set in environmental variable PERUN_OIDC_CONFIG)
+	configuration (as set in environment variable PERUN_OIDC_CONFIG)
 	------------------------------------
 	Available options:
 	--batch                         | -b batch
@@ -29,8 +29,8 @@ GetOptions ("help|h"    => sub {
 	"all|a"		=> \$removeAllConfigs,
 	"config|c=s"	=> \$configId
 	) || die help();
-if (!defined $configId) {
-	$configId = $ENV{PERUN_OIDC_CONFIG};
+if (!defined $configId && !defined $removeAllConfigs) {
+	$configId = $ENV{PERUN_OIDC_CONFIG} || die "ERROR: environment variable PERUN_OIDC_CONFIG not set and configuration not specified.\n";
 }
 my $message;
 if (defined $removeAllConfigs) {

--- a/perun-cli/revokeOidcToken
+++ b/perun-cli/revokeOidcToken
@@ -30,8 +30,8 @@ GetOptions ("help|h"    => sub {
 	"all|a"		=> \$removeAllConfigs,
 	"config|c=s"	=> \$configId
 ) || die help();
-if (!defined $configId) {
-	$configId = $ENV{PERUN_OIDC_CONFIG};
+if (!defined $configId && !defined $removeAllConfigs) {
+	$configId = $ENV{PERUN_OIDC_CONFIG} || die "ERROR: environment variable PERUN_OIDC_CONFIG not set and configuration not specified.\n";
 }
 
 my $message;


### PR DESCRIPTION
* env variable PERUN_OIDC_CONFIG was required to be defined even if not used, which is now fixed