### PR TITLE
feat(core): allow observer roles on operand group to create union

### DIFF
--- a/perun-base/src/main/resources/perun-roles.yml
+++ b/perun-base/src/main/resources/perun-roles.yml
@@ -2008,17 +2008,37 @@ perun_policies:
     include_policies:
       - default_policy
 
-  createGroupUnion_Group_Group_policy:
+  result-createGroupUnion_Group_Group_policy:
     policy_roles:
       - GROUPADMIN: Group
       - VOADMIN: Vo
     include_policies:
       - default_policy
 
-  removeGroupUnion_Group_Group_policy:
+  operand-createGroupUnion_Group_Group_policy:
+    policy_roles:
+      - GROUPADMIN: Group
+      - GROUPOBSERVER: Group
+      - VOADMIN: Vo
+      - VOOBSERVER: Vo
+      - PERUNOBSERVER:
+    include_policies:
+      - default_policy
+
+  result-removeGroupUnion_Group_Group_policy:
     policy_roles:
       - GROUPADMIN: Group
       - VOADMIN: Vo
+    include_policies:
+      - default_policy
+
+  operand-removeGroupUnion_Group_Group_policy:
+    policy_roles:
+      - GROUPADMIN: Group
+      - GROUPOBSERVER: Group
+      - VOADMIN: Vo
+      - VOOBSERVER: Vo
+      - PERUNOBSERVER:
     include_policies:
       - default_policy
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/GroupsManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/GroupsManagerEntry.java
@@ -1390,8 +1390,8 @@ public class GroupsManagerEntry implements GroupsManager {
 		}
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "createGroupUnion_Group_Group_policy", resultGroup) ||
-			!AuthzResolver.authorizedInternal(sess, "createGroupUnion_Group_Group_policy", operandGroup)) {
+		if (!AuthzResolver.authorizedInternal(sess, "result-createGroupUnion_Group_Group_policy", resultGroup) ||
+			!AuthzResolver.authorizedInternal(sess, "operand-createGroupUnion_Group_Group_policy", operandGroup)) {
 			throw new PrivilegeException(sess, "createGroupUnion");
 		}
 
@@ -1409,8 +1409,8 @@ public class GroupsManagerEntry implements GroupsManager {
 		}
 
 		// Authorization
-		if (!AuthzResolver.authorizedInternal(sess, "removeGroupUnion_Group_Group_policy", resultGroup) ||
-			!AuthzResolver.authorizedInternal(sess, "removeGroupUnion_Group_Group_policy", operandGroup)) {
+		if (!AuthzResolver.authorizedInternal(sess, "result-removeGroupUnion_Group_Group_policy", resultGroup) ||
+			!AuthzResolver.authorizedInternal(sess, "operand-removeGroupUnion_Group_Group_policy", operandGroup)) {
 			throw new PrivilegeException(sess, "removeGroupUnion");
 		}
 


### PR DESCRIPTION
* we want to extend the rights on creating and removing group unions such that observer role is sufficient on the operand group to create/remove a union