### PR TITLE
feat(cli): add more getters for (Rich)Member objects

### DIFF
--- a/perun-cli/Perun/beans/Member.pm
+++ b/perun-cli/Perun/beans/Member.pm
@@ -74,6 +74,19 @@ sub getSourceGroupId
 	return ($self->{_sourceGroupId}) ? $self->{_sourceGroupId} : -1;
 }
 
+sub getVoId
+{
+	my $self = shift;
+
+	return $self->{_voId};
+}
+
+sub setVoId
+{
+	my $self = shift;
+	$self->{_voId} = shift;
+}
+
 sub isSponsoredToPrint
 {
 	my $self = shift;

--- a/perun-cli/Perun/beans/RichMember.pm
+++ b/perun-cli/Perun/beans/RichMember.pm
@@ -89,18 +89,13 @@ sub isSponsored
 
 sub getCommonName
 {
-	my $user = shift->getUser();
-
-	return ($user->{_firstName}.' '.(defined $user->{_middleName} ? $user->{_middleName}.' ' : '').$user->{_lastName});
+	return shift->getUser()->getCommonName();
 }
 
 sub getDisplayName
 {
-	my $user = shift->getUser();
-
-	return (($user->{_titleBefore} ? $user->{_titleBefore}.' ' : "").($user->{_firstName} ? $user->{_firstName}.' ' : "").($user->{_middleName} ? $user->{_middleName}.' ' : "").($user->{_lastName} ? $user->{_lastName}.' ' : "").($user->{_titleAfter} ? $user->{_titleAfter} : ""));
+	return shift->getUser()->getDisplayName();
 }
-
 
 sub getSourceGroupId
 {

--- a/perun-cli/Perun/beans/RichMember.pm
+++ b/perun-cli/Perun/beans/RichMember.pm
@@ -2,7 +2,6 @@ package Perun::beans::RichMember;
 
 use strict;
 use warnings;
-use 5.010;
 
 use Perun::Common;
 
@@ -88,34 +87,44 @@ sub isSponsored
 	return ($self->{_sponsored}) ? 1 : 0;
 }
 
-sub getCommonName {
-	my $user = shift->{_user};
+sub getCommonName
+{
+	my $user = shift->getUser();
 
-	my $str = "";
-	$str .= $user->{firstName}.' ' if defined $user->{firstName};
-	$str .= $user->{middleName}.' ' if defined $user->{middleName};
-	$str .= $user->{lastName} if defined $user->{lastName};
-
-	return $str;
+	return ($user->{_firstName}.' '.(defined $user->{_middleName} ? $user->{_middleName}.' ' : '').$user->{_lastName});
 }
 
-sub getDisplayName {
-	my $user = shift->{_user};
+sub getDisplayName
+{
+	my $user = shift->getUser();
 
-	my $str = "";
-	$str .= $user->{titleBefore}.' ' if defined $user->{titleBefore};
-	$str .= $user->{firstName}.' ' if defined $user->{firstName};
-	$str .= $user->{middleName}.' ' if defined $user->{middleName};
-	$str .= $user->{lastName}.' ' if defined $user->{lastName};
-	$str .= $user->{titleAfter} if defined $user->{titleAfter};
-
-	return $str;
+	return (($user->{_titleBefore} ? $user->{_titleBefore}.' ' : "").($user->{_firstName} ? $user->{_firstName}.' ' : "").($user->{_middleName} ? $user->{_middleName}.' ' : "").($user->{_lastName} ? $user->{_lastName}.' ' : "").($user->{_titleAfter} ? $user->{_titleAfter} : ""));
 }
+
 
 sub getSourceGroupId
 {
 	my $self = shift;
 	return ($self->{_sourceGroupId}) ? $self->{_sourceGroupId} : -1;
+}
+
+sub getVoId
+{
+	my $self = shift;
+
+	return $self->{_voId};
+}
+
+sub setVoId
+{
+	my $self = shift;
+	$self->{_voId} = shift;
+}
+
+sub getUser
+{
+	my $self = shift;
+	return Perun::beans::User::fromHash("Perun::beans::User", $self->{_user});
 }
 
 sub getGroupStatus {

--- a/perun-cli/Perun/beans/RichUser.pm
+++ b/perun-cli/Perun/beans/RichUser.pm
@@ -2,7 +2,6 @@ package Perun::beans::RichUser;
 
 use strict;
 use warnings;
-use 5.010;
 
 use Perun::Common;
 
@@ -36,7 +35,7 @@ sub setId
 	return;
 }
 
-sub getUuid 
+sub getUuid
 {
 	return shift->{_uuid};
 }

--- a/perun-cli/Perun/beans/RichUser.pm
+++ b/perun-cli/Perun/beans/RichUser.pm
@@ -59,15 +59,17 @@ sub getLastName {
 sub getCommonName
 {
 	my $self = shift;
-
-	return ($self->{_firstName}.' '.(defined $self->{_middleName} ? $self->{_middleName}.' ' : '').$self->{_lastName});
+	my $commonName = $self->{_firstName}.' '.(defined $self->{_middleName} ? $self->{_middleName}.' ' : '').$self->{_lastName};
+	$commonName=~ s/^\s+|\s+$//g;
+	return $commonName;
 }
 
 sub getDisplayName
 {
 	my $self = shift;
-
-	return (($self->{_titleBefore} ? $self->{_titleBefore}.' ' : "").($self->{_firstName} ? $self->{_firstName}.' ' : "").($self->{_middleName} ? $self->{_middleName}.' ' : "").($self->{_lastName} ? $self->{_lastName}.' ' : "").($self->{_titleAfter} ? $self->{_titleAfter} : ""));
+	my $displayName = ($self->{_titleBefore} ? $self->{_titleBefore}.' ' : "").($self->{_firstName} ? $self->{_firstName}.' ' : "").($self->{_middleName} ? $self->{_middleName}.' ' : "").($self->{_lastName} ? $self->{_lastName}.' ' : "").($self->{_titleAfter} ? $self->{_titleAfter} : "");
+	$displayName =~ s/^\s+|\s+$//g;
+	return $displayName;
 }
 
 

--- a/perun-cli/Perun/beans/User.pm
+++ b/perun-cli/Perun/beans/User.pm
@@ -257,21 +257,25 @@ sub setSponsoredUser
 sub getCommonName
 {
 	my $self = shift;
-
-	return ($self->{_firstName}.' '.(defined $self->{_middleName} ? $self->{_middleName}.' ' : '').$self->{_lastName});
+	my $commonName = $self->{_firstName}.' '.(defined $self->{_middleName} ? $self->{_middleName}.' ' : '').$self->{_lastName};
+	$commonName=~ s/^\s+|\s+$//g;
+	return $commonName;
 }
 
 sub getDisplayName
 {
 	my $self = shift;
-
-	return (($self->{_titleBefore} ? $self->{_titleBefore}.' ' : "").($self->{_firstName} ? $self->{_firstName}.' ' : "").($self->{_middleName} ? $self->{_middleName}.' ' : "").($self->{_lastName} ? $self->{_lastName}.' ' : "").($self->{_titleAfter} ? $self->{_titleAfter} : ""));
+	my $displayName = ($self->{_titleBefore} ? $self->{_titleBefore}.' ' : "").($self->{_firstName} ? $self->{_firstName}.' ' : "").($self->{_middleName} ? $self->{_middleName}.' ' : "").($self->{_lastName} ? $self->{_lastName}.' ' : "").($self->{_titleAfter} ? $self->{_titleAfter} : "");
+	$displayName =~ s/^\s+|\s+$//g;
+	return $displayName;
 }
 
 # used only for sorting purpose: LastName FirstName MiddleName
 sub getSortingName {
 	my $self = shift;
-	return (($self->{_lastName} ? $self->{_lastName}.' ' : "").($self->{_firstName} ? $self->{_firstName}.' ' : "").($self->{_middleName} ? $self->{_middleName}.' ' : ""));
+	my $sortingName = ($self->{_lastName} ? $self->{_lastName}.' ' : "").($self->{_firstName} ? $self->{_firstName}.' ' : "").($self->{_middleName} ? $self->{_middleName}.' ' : "");
+	$sortingName =~ s/^\s+|\s+$//g;
+	return $sortingName;
 }
 
 sub getCommonArrayRepresentation {


### PR DESCRIPTION
- Added getVoId() and setVoId() for Member and RichMember.
- Added getUser() for RichMember.
- Fixed printing of display name and common name for RichMember
  (now it doesn't add whitespace after the name).
- Removed old perl spec from RichUser and RichMember.