### PR TITLE
fix(rpc): fixed (de)serialization of LocalDate/Time properties

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/Ban.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/Ban.java
@@ -11,7 +11,7 @@ import java.util.Date;
 public abstract class Ban extends Auditable implements Comparable<PerunBean> {
 	private Date validityTo;
 	private String description;
-	
+
 	/**
 	 * Constructs a new instance.
 	 */
@@ -36,6 +36,10 @@ public abstract class Ban extends Auditable implements Comparable<PerunBean> {
 		return validityTo;
 	}
 
+	public Long getValidityToAsLong() {
+		return (validityTo == null) ? null : validityTo.getTime();
+	}
+
 	public void setValidityTo(Date validityTo) {
 		//set precision for validity on seconds
 		if(validityTo == null) this.validityTo = validityTo;
@@ -57,10 +61,10 @@ public abstract class Ban extends Auditable implements Comparable<PerunBean> {
 	 * @return class name of specific ban
 	 */
 	public abstract String getType();
-	
+
 	/**
 	 * Id of subject who is banned on target.
-	 * 
+	 *
 	 * @return id of affected subject
 	 */
 	public abstract int getSubjectId();

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/Member.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/Member.java
@@ -1,9 +1,6 @@
 package cz.metacentrum.perun.core.api;
 
-import java.time.LocalDate;
-import java.time.ZoneId;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 

--- a/perun-base/src/main/java/cz/metacentrum/perun/rpc/deserializer/JsonDeserializer.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/rpc/deserializer/JsonDeserializer.java
@@ -102,12 +102,6 @@ public class JsonDeserializer extends Deserializer {
 	private static final Map<Class<?>,Class<?>> mixinMap = new HashMap<>();
 
 	static {
-
-		JavaTimeModule module = new JavaTimeModule();
-		mapper.registerModule(module);
-		// make mapper to serialize dates and timestamps like "YYYY-MM-DD" or "YYYY-MM-DDTHH:mm:ss.SSSSSS"
-		mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-
 		mixinMap.put(Attribute.class, AttributeMixIn.class);
 		mixinMap.put(AttributeDefinition.class, AttributeDefinitionMixIn.class);
 		mixinMap.put(User.class, UserMixIn.class);

--- a/perun-base/src/main/java/cz/metacentrum/perun/rpc/deserializer/JsonDeserializer.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/rpc/deserializer/JsonDeserializer.java
@@ -103,6 +103,11 @@ public class JsonDeserializer extends Deserializer {
 
 	static {
 
+		JavaTimeModule module = new JavaTimeModule();
+		mapper.registerModule(module);
+		// make mapper to serialize dates and timestamps like "YYYY-MM-DD" or "YYYY-MM-DDTHH:mm:ss.SSSSSS"
+		mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
 		mixinMap.put(Attribute.class, AttributeMixIn.class);
 		mixinMap.put(AttributeDefinition.class, AttributeDefinitionMixIn.class);
 		mixinMap.put(User.class, UserMixIn.class);

--- a/perun-base/src/main/java/cz/metacentrum/perun/rpc/serializer/JsonSerializer.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/rpc/serializer/JsonSerializer.java
@@ -16,10 +16,12 @@ import cz.metacentrum.perun.core.api.exceptions.PerunException;
 import cz.metacentrum.perun.core.api.exceptions.rt.PerunRuntimeException;
 import cz.metacentrum.perun.core.api.exceptions.RpcException;
 import cz.metacentrum.perun.taskslib.model.Task;
+import cz.metacentrum.perun.taskslib.model.TaskResult;
 
 import java.io.IOException;
 import java.io.OutputStream;
 import java.time.LocalDateTime;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -110,6 +112,30 @@ public final class JsonSerializer implements Serializer {
 		LocalDateTime getEndTime();
 	}
 
+	@SuppressWarnings("unused")
+	private interface TaskResultMixIn {
+
+		@JsonSerialize
+		@JsonProperty(value = "timestamp")
+		Long getTimestampAsLong();
+
+		@JsonIgnore
+		Date getTimestamp();
+
+	}
+
+	@SuppressWarnings("unused")
+	private interface BanMixIn {
+
+		@JsonSerialize
+		@JsonProperty(value = "validityTo")
+		Long getValidityToAsLong();
+
+		@JsonIgnore
+		Date getValidityTo();
+
+	}
+
 	public static final String CONTENT_TYPE = "application/json; charset=utf-8";
 	private static final ObjectMapper mapper = new ObjectMapper();
 	private static final Map<Class<?>,Class<?>> mixinMap = new HashMap<>();
@@ -128,6 +154,8 @@ public final class JsonSerializer implements Serializer {
 		mixinMap.put(PerunException.class, PerunExceptionMixIn.class);
 		mixinMap.put(PerunRuntimeException.class, PerunExceptionMixIn.class);
 		mixinMap.put(Task.class, TaskMixIn.class);
+		mixinMap.put(TaskResult.class, TaskResultMixIn.class);
+		mixinMap.put(Ban.class, BanMixIn.class);
 
 		mapper.setMixIns(mixinMap);
 	}

--- a/perun-base/src/main/java/cz/metacentrum/perun/rpc/serializer/JsonSerializer.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/rpc/serializer/JsonSerializer.java
@@ -8,7 +8,9 @@ import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import cz.metacentrum.perun.core.api.*;
 import cz.metacentrum.perun.core.api.exceptions.PerunException;
 import cz.metacentrum.perun.core.api.exceptions.rt.PerunRuntimeException;
@@ -113,6 +115,12 @@ public final class JsonSerializer implements Serializer {
 	private static final Map<Class<?>,Class<?>> mixinMap = new HashMap<>();
 
 	static {
+
+		JavaTimeModule module = new JavaTimeModule();
+		mapper.registerModule(module);
+		// make mapper to serialize dates and timestamps like "YYYY-MM-DD" or "YYYY-MM-DDTHH:mm:ss.SSSSSS"
+		mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
 		mixinMap.put(Attribute.class, AttributeMixIn.class);
 		mixinMap.put(AttributeDefinition.class, AttributeDefinitionMixIn.class);
 		mixinMap.put(User.class, UserMixIn.class);

--- a/perun-base/src/main/java/cz/metacentrum/perun/rpc/serializer/JsonSerializerJSONLITE.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/rpc/serializer/JsonSerializerJSONLITE.java
@@ -19,10 +19,12 @@ import cz.metacentrum.perun.core.api.exceptions.PerunException;
 import cz.metacentrum.perun.core.api.exceptions.rt.PerunRuntimeException;
 import cz.metacentrum.perun.core.api.exceptions.RpcException;
 import cz.metacentrum.perun.taskslib.model.Task;
+import cz.metacentrum.perun.taskslib.model.TaskResult;
 
 import java.io.IOException;
 import java.io.OutputStream;
 import java.time.LocalDateTime;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -36,9 +38,9 @@ public final class JsonSerializerJSONLITE implements Serializer {
 
 	@JsonIgnoreProperties({
 		"name",
-		"createdAt", "createdBy", "modifiedAt", "modifiedBy", 
-		"createdByUid",	"modifiedByUid", 
-		"valueCreatedAt", "valueCreatedBy", "valueModifiedAt", "valueModifiedBy", 
+		"createdAt", "createdBy", "modifiedAt", "modifiedBy",
+		"createdByUid",	"modifiedByUid",
+		"valueCreatedAt", "valueCreatedBy", "valueModifiedAt", "valueModifiedBy",
 		"beanName"
 		})
 	private interface AttributeMixIn {
@@ -46,9 +48,9 @@ public final class JsonSerializerJSONLITE implements Serializer {
 
 	@JsonIgnoreProperties({
 		"name",
-		"createdAt", "createdBy", "modifiedAt", "modifiedBy", 
-		"createdByUid",	"modifiedByUid", 
-		"beanName" 
+		"createdAt", "createdBy", "modifiedAt", "modifiedBy",
+		"createdByUid",	"modifiedByUid",
+		"beanName"
 		})
 	private interface AttributeDefinitionMixIn {
 	}
@@ -56,7 +58,7 @@ public final class JsonSerializerJSONLITE implements Serializer {
 	@JsonIgnoreProperties({
 		"commonName", "displayName",
 		"createdAt", "createdBy", "modifiedAt", "modifiedBy",
-		"createdByUid", "modifiedByUid", 
+		"createdByUid", "modifiedByUid",
 		"beanName"
 		})
 	private interface UserMixIn {
@@ -71,8 +73,8 @@ public final class JsonSerializerJSONLITE implements Serializer {
 	}
 
 	@JsonIgnoreProperties({
-		"createdAt", "createdBy", "modifiedAt", "modifiedBy", 
-		"createdByUid", "modifiedByUid", 
+		"createdAt", "createdBy", "modifiedAt", "modifiedBy",
+		"createdByUid", "modifiedByUid",
 		"beanName"
 		})
 	private interface PerunBeanMixIn {
@@ -146,6 +148,30 @@ public final class JsonSerializerJSONLITE implements Serializer {
 		LocalDateTime getEndTime();
 	}
 
+	@SuppressWarnings("unused")
+	private interface TaskResultMixIn {
+
+		@JsonSerialize
+		@JsonProperty(value = "timestamp")
+		Long getTimestampAsLong();
+
+		@JsonIgnore
+		Date getTimestamp();
+
+	}
+
+	@SuppressWarnings("unused")
+	private interface BanMixIn {
+
+		@JsonSerialize
+		@JsonProperty(value = "validityTo")
+		Long getValidityToAsLong();
+
+		@JsonIgnore
+		Date getValidityTo();
+
+	}
+
 	public static final String CONTENT_TYPE = "application/json; charset=utf-8";
 	private static final ObjectMapper mapper = new ObjectMapper();
 	private static final Map<Class<?>,Class<?>> mixinMap = new HashMap<>();
@@ -165,6 +191,8 @@ public final class JsonSerializerJSONLITE implements Serializer {
 		mixinMap.put(Publication.class, CabinetMixIn.class);
 		mixinMap.put(Thanks.class, CabinetMixIn.class);
 		mixinMap.put(Task.class, TaskMixIn.class);
+		mixinMap.put(TaskResult.class, TaskResultMixIn.class);
+		mixinMap.put(Ban.class, BanMixIn.class);
 
 		mapper.setMixIns(mixinMap);
 	}

--- a/perun-base/src/main/java/cz/metacentrum/perun/rpc/serializer/JsonSerializerJSONP.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/rpc/serializer/JsonSerializerJSONP.java
@@ -21,12 +21,14 @@ import cz.metacentrum.perun.core.api.exceptions.PerunException;
 import cz.metacentrum.perun.core.api.exceptions.rt.PerunRuntimeException;
 import cz.metacentrum.perun.core.api.exceptions.RpcException;
 import cz.metacentrum.perun.taskslib.model.Task;
+import cz.metacentrum.perun.taskslib.model.TaskResult;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.time.LocalDateTime;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -142,6 +144,30 @@ public final class JsonSerializerJSONP implements Serializer {
 		LocalDateTime getEndTime();
 	}
 
+	@SuppressWarnings("unused")
+	private interface TaskResultMixIn {
+
+		@JsonSerialize
+		@JsonProperty(value = "timestamp")
+		Long getTimestampAsLong();
+
+		@JsonIgnore
+		Date getTimestamp();
+
+	}
+
+	@SuppressWarnings("unused")
+	private interface BanMixIn {
+
+		@JsonSerialize
+		@JsonProperty(value = "validityTo")
+		Long getValidityToAsLong();
+
+		@JsonIgnore
+		Date getValidityTo();
+
+	}
+
 	public static final String CONTENT_TYPE = "text/javascript; charset=utf-8";
 	private static final ObjectMapper mapper = new ObjectMapper();
 	private static final Map<Class<?>,Class<?>> mixinMap = new HashMap<>();
@@ -167,6 +193,8 @@ public final class JsonSerializerJSONP implements Serializer {
 		mixinMap.put(Publication.class, CabinetMixIn.class);
 		mixinMap.put(Thanks.class, CabinetMixIn.class);
 		mixinMap.put(Task.class, TaskMixIn.class);
+		mixinMap.put(TaskResult.class, TaskResultMixIn.class);
+		mixinMap.put(Ban.class, BanMixIn.class);
 
 		mapper.setMixIns(mixinMap);
 	}

--- a/perun-base/src/main/java/cz/metacentrum/perun/rpc/serializer/JsonSerializerJSONP.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/rpc/serializer/JsonSerializerJSONP.java
@@ -8,7 +8,9 @@ import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import cz.metacentrum.perun.cabinet.model.Author;
 import cz.metacentrum.perun.cabinet.model.Authorship;
 import cz.metacentrum.perun.cabinet.model.Category;
@@ -145,6 +147,12 @@ public final class JsonSerializerJSONP implements Serializer {
 	private static final Map<Class<?>,Class<?>> mixinMap = new HashMap<>();
 
 	static {
+
+		JavaTimeModule module = new JavaTimeModule();
+		mapper.registerModule(module);
+		// make mapper to serialize dates and timestamps like "YYYY-MM-DD" or "YYYY-MM-DDTHH:mm:ss.SSSSSS"
+		mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
 		mixinMap.put(Attribute.class, AttributeMixIn.class);
 		mixinMap.put(AttributeDefinition.class, AttributeDefinitionMixIn.class);
 		mixinMap.put(User.class, UserMixIn.class);

--- a/perun-base/src/main/java/cz/metacentrum/perun/rpc/serializer/JsonSerializerJSONSIMPLE.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/rpc/serializer/JsonSerializerJSONSIMPLE.java
@@ -21,10 +21,12 @@ import cz.metacentrum.perun.core.api.exceptions.PerunException;
 import cz.metacentrum.perun.core.api.exceptions.rt.PerunRuntimeException;
 import cz.metacentrum.perun.core.api.exceptions.RpcException;
 import cz.metacentrum.perun.taskslib.model.Task;
+import cz.metacentrum.perun.taskslib.model.TaskResult;
 
 import java.io.IOException;
 import java.io.OutputStream;
 import java.time.LocalDateTime;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -132,6 +134,30 @@ public final class JsonSerializerJSONSIMPLE implements Serializer {
 		LocalDateTime getEndTime();
 	}
 
+	@SuppressWarnings("unused")
+	private interface TaskResultMixIn {
+
+		@JsonSerialize
+		@JsonProperty(value = "timestamp")
+		Long getTimestampAsLong();
+
+		@JsonIgnore
+		Date getTimestamp();
+
+	}
+
+	@SuppressWarnings("unused")
+	private interface BanMixIn {
+
+		@JsonSerialize
+		@JsonProperty(value = "validityTo")
+		Long getValidityToAsLong();
+
+		@JsonIgnore
+		Date getValidityTo();
+
+	}
+
 	public static final String CONTENT_TYPE = "application/json; charset=utf-8";
 	private static final ObjectMapper mapper = new ObjectMapper();
 	private static final Map<Class<?>,Class<?>> mixinMap = new HashMap<>();
@@ -157,6 +183,8 @@ public final class JsonSerializerJSONSIMPLE implements Serializer {
 		mixinMap.put(Publication.class, CabinetMixIn.class);
 		mixinMap.put(Thanks.class, CabinetMixIn.class);
 		mixinMap.put(Task.class, TaskMixIn.class);
+		mixinMap.put(TaskResult.class, TaskResultMixIn.class);
+		mixinMap.put(Ban.class, BanMixIn.class);
 
 		mapper.setMixIns(mixinMap);
 	}

--- a/perun-base/src/main/java/cz/metacentrum/perun/rpc/serializer/JsonSerializerJSONSIMPLE.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/rpc/serializer/JsonSerializerJSONSIMPLE.java
@@ -8,7 +8,9 @@ import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import cz.metacentrum.perun.cabinet.model.Author;
 import cz.metacentrum.perun.cabinet.model.Authorship;
 import cz.metacentrum.perun.cabinet.model.Category;
@@ -135,6 +137,12 @@ public final class JsonSerializerJSONSIMPLE implements Serializer {
 	private static final Map<Class<?>,Class<?>> mixinMap = new HashMap<>();
 
 	static {
+
+		JavaTimeModule module = new JavaTimeModule();
+		mapper.registerModule(module);
+		// make mapper to serialize dates and timestamps like "YYYY-MM-DD" or "YYYY-MM-DDTHH:mm:ss.SSSSSS"
+		mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
 		mixinMap.put(Attribute.class, AttributeMixIn.class);
 		mixinMap.put(AttributeDefinition.class, AttributeDefinitionMixIn.class);
 		mixinMap.put(User.class, UserMixIn.class);

--- a/perun-base/src/main/java/cz/metacentrum/perun/rpclib/impl/JsonDeserializer.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/rpclib/impl/JsonDeserializer.java
@@ -9,7 +9,9 @@ import java.util.Map;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import cz.metacentrum.perun.cabinet.model.Author;
 import cz.metacentrum.perun.cabinet.model.Category;
 import cz.metacentrum.perun.cabinet.model.Publication;
@@ -96,6 +98,12 @@ public class JsonDeserializer extends Deserializer {
 	private static final ObjectMapper mapper = new ObjectMapper();
 	private static final Map<Class<?>,Class<?>> mixinMap = new HashMap<>();
 	static {
+
+		JavaTimeModule module = new JavaTimeModule();
+		mapper.registerModule(module);
+		// make mapper to serialize dates and timestamps like "YYYY-MM-DD" or "YYYY-MM-DDTHH:mm:ss.SSSSSS"
+		mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
 		mixinMap.put(Attribute.class, AttributeMixIn.class);
 		mixinMap.put(AttributeDefinition.class, AttributeDefinitionMixIn.class);
 		mixinMap.put(User.class, UserMixIn.class);

--- a/perun-base/src/main/java/cz/metacentrum/perun/rpclib/impl/JsonDeserializer.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/rpclib/impl/JsonDeserializer.java
@@ -9,9 +9,7 @@ import java.util.Map;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import cz.metacentrum.perun.cabinet.model.Author;
 import cz.metacentrum.perun.cabinet.model.Category;
 import cz.metacentrum.perun.cabinet.model.Publication;
@@ -98,12 +96,6 @@ public class JsonDeserializer extends Deserializer {
 	private static final ObjectMapper mapper = new ObjectMapper();
 	private static final Map<Class<?>,Class<?>> mixinMap = new HashMap<>();
 	static {
-
-		JavaTimeModule module = new JavaTimeModule();
-		mapper.registerModule(module);
-		// make mapper to serialize dates and timestamps like "YYYY-MM-DD" or "YYYY-MM-DDTHH:mm:ss.SSSSSS"
-		mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-
 		mixinMap.put(Attribute.class, AttributeMixIn.class);
 		mixinMap.put(AttributeDefinition.class, AttributeDefinitionMixIn.class);
 		mixinMap.put(User.class, UserMixIn.class);

--- a/perun-base/src/main/java/cz/metacentrum/perun/rpclib/impl/JsonSerializer.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/rpclib/impl/JsonSerializer.java
@@ -9,6 +9,8 @@ import com.fasterxml.jackson.core.JsonEncoding;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import cz.metacentrum.perun.core.api.AuditMessage;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -42,6 +44,12 @@ public final class JsonSerializer implements Serializer {
 	private static final Map<Class<?>,Class<?>> mixinMap = new HashMap<>();
 
 	static {
+
+		JavaTimeModule module = new JavaTimeModule();
+		mapper.registerModule(module);
+		// make mapper to serialize dates and timestamps like "YYYY-MM-DD" or "YYYY-MM-DDTHH:mm:ss.SSSSSS"
+		mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
 		mixinMap.put(Attribute.class, AttributeMixIn.class);
 		mixinMap.put(AttributeDefinition.class, AttributeDefinitionMixIn.class);
 		mixinMap.put(User.class, UserMixIn.class);

--- a/perun-base/src/main/java/cz/metacentrum/perun/taskslib/model/TaskResult.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/taskslib/model/TaskResult.java
@@ -165,6 +165,10 @@ public class TaskResult extends PerunBean implements Serializable {
 		return timestamp;
 	}
 
+	public Long getTimestampAsLong() {
+		return (timestamp == null) ? null : timestamp.getTime();
+	}
+
 	public void setTimestamp(Date timestamp) {
 		this.timestamp = timestamp;
 	}


### PR DESCRIPTION
- Fixed (de)serialization support for newer java date/time classes.
- Updated objects and (de)serializers to be backwards compatible for outer API and audit log.
- Automatic whitespace and imports cleanup.