### PR TITLE
feat(registrar): enabled HTML in email notifications

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/registrar/model/ApplicationMail.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/registrar/model/ApplicationMail.java
@@ -100,6 +100,12 @@ public class ApplicationMail {
 		}
 		message.put(EN,new MailText(EN));
 	}
+	private Map<Locale, MailText> htmlMessage = new HashMap<Locale, MailText>(); {
+		if (CS != null) {
+			htmlMessage.put(CS, new MailText(CS));
+		}
+		htmlMessage.put(EN, new MailText(EN));
+	}
 
 	public ApplicationMail(){};
 
@@ -114,6 +120,12 @@ public class ApplicationMail {
 	public ApplicationMail(int id,AppType appType, int formId, MailType mailType, boolean send, Map<Locale, MailText> message) {
 		this(id, appType, formId, mailType, send);
 		this.message = message;
+	}
+
+	public ApplicationMail(int id,AppType appType, int formId, MailType mailType, boolean send, Map<Locale, MailText> message, Map<Locale, MailText> htmlMessage) {
+		this(id, appType, formId, mailType, send);
+		this.message = message;
+		this.htmlMessage = htmlMessage;
 	}
 
 	/**
@@ -194,6 +206,13 @@ public class ApplicationMail {
 	}
 
 	/**
+	 * @return the html message
+	 */
+	public Map<Locale, MailText> getHtmlMessage() {
+		return htmlMessage;
+	}
+
+	/**
 	 * Return message in specific language
 	 * (empty message if not present)
 	 *
@@ -210,10 +229,33 @@ public class ApplicationMail {
 	}
 
 	/**
+	 * Return html message in specific language
+	 * (empty message if not present)
+	 *
+	 * @param locale language
+	 * @return the message
+	 */
+	public MailText getHtmlMessage(Locale locale) {
+		MailText texts = htmlMessage.get(locale);
+		if(texts==null) {
+			texts = new MailText();
+			message.put(locale,texts);
+		}
+		return texts;
+	}
+
+	/**
 	 * @param message the message to set
 	 */
 	public void setMessage(Map<Locale, MailText> message) {
 		this.message = message;
+	}
+
+	/**
+	 * @param htmlMessage the html message to set
+	 */
+	public void setHtmlMessage(Map<Locale, MailText> htmlMessage) {
+		this.htmlMessage = htmlMessage;
 	}
 
 	/**
@@ -256,6 +298,7 @@ public class ApplicationMail {
 				", mailType='" + getMailType().toString() + '\'' +
 				", send='" + getSend() + '\'' +
 				", message='" + getMessage().toString() + '\'' +
+				", htmlMessage='" + getHtmlMessage().toString() + '\'' +
 				']';
 	}
 
@@ -264,6 +307,7 @@ public class ApplicationMail {
 	 */
 	public static class MailText {
 		private Locale locale;
+		private boolean htmlFormat;
 		private String subject;
 		private String text;
 
@@ -280,6 +324,13 @@ public class ApplicationMail {
 			this.text = text;
 		}
 
+		public MailText(Locale locale, boolean htmlFormat, String subject, String text) {
+			this.locale = locale;
+			this.htmlFormat = htmlFormat;
+			this.subject = subject;
+			this.text = text;
+		}
+
 		public Locale getLocale() {
 			return locale;
 		}
@@ -287,6 +338,10 @@ public class ApplicationMail {
 		public void setLocale(Locale locale) {
 			this.locale= locale ;
 		}
+
+		public boolean getHtmlFormat() { return htmlFormat; }
+
+		public void setHtmlFormat(boolean htmlFormat) { this.htmlFormat = htmlFormat; }
 
 		public String getText() {
 			return text;

--- a/perun-base/src/test/resources/test-schema.sql
+++ b/perun-base/src/test/resources/test-schema.sql
@@ -1,4 +1,4 @@
--- database version 3.1.93 (don't forget to update insert statement at the end of file)
+-- database version 3.1.94 (don't forget to update insert statement at the end of file)
 CREATE EXTENSION IF NOT EXISTS "unaccent";
 CREATE EXTENSION IF NOT EXISTS "pgcrypto";
 
@@ -633,11 +633,12 @@ create table application_mails (
 create table application_mail_texts (
 										 mail_id integer not null,     --identifier of mail (application_mails.id)
 										 locale varchar not null,  --language for texts
+										 htmlFormat boolean default false not null,	--define if text is in html format or as a plain text
 										 subject varchar,        --subject of mail
 										 text varchar,           --text of mail
 										 created_by_uid integer,
 										 modified_by_uid integer,
-										 constraint appmailtxt_pk primary key (mail_id, locale),
+										 constraint appmailtxt_pk primary key (mail_id, locale, htmlFormat),
 										 constraint appmailtxt_appmails_fk foreign key (mail_id) references application_mails(id) on delete cascade
 );
 
@@ -1847,7 +1848,7 @@ create index idx_fk_alwd_grps_group ON allowed_groups_to_hierarchical_vo(group_i
 create index idx_fk_alwd_grps_vo ON allowed_groups_to_hierarchical_vo(vo_id);
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.1.93');
+insert into configurations values ('DATABASE VERSION','3.1.94');
 -- insert membership types
 insert into membership_types (id, membership_type, description) values (1, 'DIRECT', 'Member is directly added into group');
 insert into membership_types (id, membership_type, description) values (2, 'INDIRECT', 'Member is added indirectly through UNION relation');

--- a/perun-core/src/main/resources/postgresChangelog.txt
+++ b/perun-core/src/main/resources/postgresChangelog.txt
@@ -6,6 +6,12 @@
 -- Directly under version number should be version commands. They will be executed in the order they are written here.
 -- Comments are prefixed with -- and can be written only between version blocks, that means not in the lines with commands. They have to be at the start of the line.
 
+3.1.94
+ALTER TABLE application_mail_texts ADD COLUMN htmlFormat boolean default false not null;
+UPDATE configurations SET value='3.1.94' WHERE property='DATABASE VERSION';
+ALTER TABLE application_mail_texts DROP constraint appmailtxt_pk;
+ALTER TABLE application_mail_texts ADD constraint appmailtxt_pk primary key (mail_id, locale, htmlFormat);
+
 3.1.93
 create table allowed_groups_to_hierarchical_vo (group_id integer not null, vo_id integer not null, created_at timestamp default statement_timestamp() not null, created_by varchar default user not null, created_by_uid integer, constraint alwd_grps_pk primary key (group_id, vo_id), constraint alwd_grps_gid_fk foreign key (group_id) references groups(id) on delete cascade, constraint alwd_grps_void_fk foreign key (vo_id) references vos(id));
 grant all on allowed_groups_to_hierarchical_vo to perun;

--- a/perun-db/postgres.sql
+++ b/perun-db/postgres.sql
@@ -1,4 +1,4 @@
--- database version 3.1.93 (don't forget to update insert statement at the end of file)
+-- database version 3.1.94 (don't forget to update insert statement at the end of file)
 
 -- VOS - virtual organizations
 create table vos (
@@ -631,11 +631,12 @@ create table application_mails (
 create table application_mail_texts (
 	mail_id integer not null,     --identifier of mail (application_mails.id)
 	locale varchar not null,  --language for texts
+	htmlFormat boolean default false not null,	--define if text is in html format or as a plain text
 	subject varchar,        --subject of mail
 	text varchar,           --text of mail
 	created_by_uid integer,
 	modified_by_uid integer,
-	constraint appmailtxt_pk primary key (mail_id, locale),
+	constraint appmailtxt_pk primary key (mail_id, locale, htmlFormat),
   constraint appmailtxt_appmails_fk foreign key (mail_id) references application_mails(id) on delete cascade
 );
 
@@ -1952,7 +1953,7 @@ grant all on consent_attr_defs to perun;
 grant all on allowed_groups_to_hierarchical_vo to perun;
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.1.93');
+insert into configurations values ('DATABASE VERSION','3.1.94');
 
 -- insert membership types
 insert into membership_types (id, membership_type, description) values (1, 'DIRECT', 'Member is directly added into group');

--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -1322,6 +1322,7 @@ components:
       type: object
       properties:
         locale: { type: string }
+        htmlFormat: { type: boolean }
         subject: { type: string }
         text: { type: string }
 
@@ -1334,6 +1335,9 @@ components:
         mailType: { $ref: '#/components/schemas/MailType' }
         send: { type: boolean }
         message:
+          type: object
+          additionalProperties: { $ref: '#/components/schemas/MailText' }
+        htmlMessage:
           type: object
           additionalProperties: { $ref: '#/components/schemas/MailText' }
 


### PR DESCRIPTION
* Now is possible to set also html notification template (not only plain text).
* If is set html template, then will be send both html and plain text messages (html or plain text message will be displayed according to client settings).

BREAKING CHANGE: update DB