### PR TITLE
feat(core): check weak passwords according to dictionary

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/EinfraPasswordManagerModule.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/EinfraPasswordManagerModule.java
@@ -298,6 +298,8 @@ public class EinfraPasswordManagerModule extends GenericPasswordManagerModule {
 			throw new PasswordStrengthException("Password for " + actualLoginNamespace + ":" + login + " is too weak. It has to contain at least 3 kinds of characters from: lower-case letter, upper-case letter, digit, spec. character.");
 		}
 
+		super.checkPasswordStrength(sess, login, password);
+
 	}
 
 	private void handleAltPwdManagerExit(Process process, PerunRuntimeException exToThrow) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/MuadmPasswordManagerModule.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/MuadmPasswordManagerModule.java
@@ -70,5 +70,7 @@ public class MuadmPasswordManagerModule extends GenericPasswordManagerModule {
 			log.warn("Password for {}:{} is too weak. It has to contain character from at least 3 of these categories: lower-case letter, upper-case letter, digit, spec. character.", actualLoginNamespace, login);
 			throw new PasswordStrengthException("Password for " + actualLoginNamespace + ":" + login + " is too weak. It has to contain character from at least 3 of these categories: lower-case letter, upper-case letter, digit, spec. character.");
 		}
+
+		super.checkPasswordStrength(sess, login, password);
 	}
 }


### PR DESCRIPTION
* we can now add weak passwords dictionaries to reject weak passwords
* if no weakpass file is found, the information is logged and the check is skipped
* if namespace-specific file is not found, default one is tried
* weakpass file needs to be sorted by ASCII ordering and separated by newline