### PR TITLE
fix(core): value of member:virt:mails now contains only unique emails

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_attribute_def_virt_mails.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_attribute_def_virt_mails.java
@@ -17,6 +17,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.regex.Matcher;
 
@@ -99,8 +100,8 @@ public class urn_perun_member_attribute_def_virt_mails extends MemberVirtualAttr
 				log.trace("getAttributeValue(member={},attribute={},failedEmailAttribute={})", member, attributeDef, emailAttrDef);
 			}
 		}
-
-		newAttribute.setValue(allMails);
+		// return only unique emails
+		newAttribute.setValue(new ArrayList<>(new HashSet<>(allMails)));
 		return newAttribute;
 
 	}


### PR DESCRIPTION
* in urn_perun_member_attribute_def_virt_mails convert the returning value to set and back to list to remove duplicates