### PR TITLE
fix(core): consents optimization

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/ConsentsManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/ConsentsManager.java
@@ -192,12 +192,13 @@ public interface ConsentsManager {
 	void evaluateConsents(PerunSession sess, ConsentHub consentHub) throws PrivilegeException;
 
 	/**
-	 * Evaluates consents for all consent hubs with given service with enforced consents enabled.
+	 * Evaluates consents for given service for all consent hubs with given service with enforced consents enabled.
 	 *
-	 * All services under obtained consent hubs will have consents fully evaluated
-	 * (not only for given service, but for all of them).
+	 * Corresponding consent hubs (containing the service) will have consents evaluated ONLY for selected service.
 	 * Service defines whether only active users will be evaluated or expired ones as well.
-	 *  @param sess session
+	 * If new consent is created, attributes from ALL services under given consent hub are gathered for it.
+	 *
+	 * @param sess session
 	 * @param service service
 	 */
 	void evaluateConsents(PerunSession sess, Service service) throws PrivilegeException;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ConsentsManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ConsentsManagerBl.java
@@ -338,10 +338,12 @@ public interface ConsentsManagerBl {
 	void evaluateConsents(PerunSession sess, ConsentHub consentHub);
 
 	/**
-	 * Consolidate consents using given service for all consent hubs the service is assigned to.
+	 * Consolidate consents using given service on consent hubs the service is assigned to.
 	 *
 	 * Method finds all consent hubs that contain given service in any of its facilities and start
-	 * full consent consolidation for each consent hub (all services in consent hubs will be checked).
+	 * consent consolidation for each consent hub (only selected service in consent hubs will be checked).
+	 * Service defines whether only active users will be evaluated or expired ones as well.
+	 * If new consent is created, attributes from ALL services under given consent hub are gathered for it.
 	 *
 	 * @param sess session
 	 * @param service service

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ServicesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ServicesManagerBl.java
@@ -892,4 +892,14 @@ public interface ServicesManagerBl {
 	 * @throws RelationExistsException if the destination is used by some services and facilities
 	 */
 	void deleteDestination(PerunSession sess, Destination destination) throws DestinationAlreadyRemovedException, RelationExistsException;
+
+	/**
+	 * Checks whether given service is assigned to given facility (through some resource).
+	 *
+	 * @param sess session
+	 * @param facility facility
+	 * @param service service
+	 * @return true if service is assigned to given facility, false otherwise
+	 */
+	boolean isServiceAssignedToFacility(PerunSession sess, Facility facility, Service service);
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ServicesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ServicesManagerBlImpl.java
@@ -1131,4 +1131,9 @@ public class ServicesManagerBlImpl implements ServicesManagerBl {
 			}
 		}
 	}
+
+	@Override
+	public boolean isServiceAssignedToFacility(PerunSession sess, Facility facility, Service service) {
+		return getServicesManagerImpl().isServiceAssignedToFacility(sess, facility, service);
+	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ServicesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ServicesManagerImpl.java
@@ -28,12 +28,12 @@ import cz.metacentrum.perun.core.blImpl.AuthzResolverBlImpl;
 import cz.metacentrum.perun.core.implApi.ServicesManagerImplApi;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.dao.DataAccessException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.JdbcPerunTemplate;
 import org.springframework.jdbc.core.RowMapper;
+
 import javax.sql.DataSource;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -919,4 +919,21 @@ public class ServicesManagerImpl implements ServicesManagerImplApi {
 			throw new InternalErrorException(ex);
 		}
 	}
+
+	@Override
+	public boolean isServiceAssignedToFacility(PerunSession sess, Facility facility, Service service) {
+		try {
+			int count = jdbc.queryForInt("select count(1) " +
+				"from resources" +
+					" join (select * " +
+						   "from resource_services " +
+						   "where resource_services.service_id = ?) as resource_services on resource_services.resource_id = resources.id" +
+				" where resources.facility_id=?", service.getId(), facility.getId());
+			return count != 0;
+		} catch (RuntimeException e) {
+			throw new InternalErrorException(e);
+		}
+	}
+
+
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/ServicesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/ServicesManagerImplApi.java
@@ -634,4 +634,14 @@ public interface ServicesManagerImplApi {
 	 * @throws RelationExistsException if the destination has some existing relations in DB
 	 */
 	void deleteDestination(PerunSession sess, Destination destination) throws DestinationAlreadyRemovedException, RelationExistsException;
+
+	/**
+	 * Checks whether given service is assigned to given facility (through some resource).
+	 *
+	 * @param sess session
+	 * @param facility facility
+	 * @param service service
+	 * @return true if service is assigned to given facility, false otherwise
+	 */
+	boolean isServiceAssignedToFacility(PerunSession sess, Facility facility, Service service);
 }

--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -17387,7 +17387,7 @@ paths:
       tags:
         - ConsentsManager
       operationId: evaluateConsentsForService
-      summary: Evaluates consents for all consent hubs with given service.
+      summary: Evaluates consents ONLY for given service on consent hubs containing it. If new consent is created, attributes from ALL services under given consent hub are gathered for it.
       parameters:
         - $ref: '#/components/parameters/serviceId'
       responses:

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/ConsentsManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/ConsentsManagerMethod.java
@@ -216,12 +216,10 @@ public enum ConsentsManagerMethod implements ManagerMethod {
 	},
 
 	/*#
-	 * Returns ConsentHub.
+	 * Evaluates consents for given consent hub.
 	 *
 	 * @param consentHub Consent Hub
 	 * @throw ConsentNotExistsException if consent hub does not exist
-	 *
-	 * @return ConsentHub
 	 */
 	evaluateConsentsForConsentHub {
 		@Override
@@ -232,15 +230,11 @@ public enum ConsentsManagerMethod implements ManagerMethod {
 	},
 
 	/*#
-	 * Returns Service.
-	 *
-	 * All consent hubs that contain given service will have consents fully consolidated
-	 * (not only for given service, but for all of them).
+	 * Corresponding consent hubs (containing the service) will have consents evaluated ONLY for selected service.
+	 * Service defines whether only active users will be evaluated or expired ones as well.
 	 *
 	 * @param service used for consents evaluation
 	 * @throw ConsentNotExistsException if consent hub does not exist
-	 *
-	 * @return ConsentHub
 	 */
 	evaluateConsentsForService {
 		@Override


### PR DESCRIPTION
Before, every service under every consent hub that contained selected service, was evaluated. Now, only selected service on each consent hub (and each facility) is evaluated instead. 

In other words, when we have valid consent (with all required attributes) for given service, we do not care for other services. On the other hand, when consent does not have all the required attributes, we create a new one. While creating a new consent, all the facilities with all the services under given consent hub are checked, thus all required attributes from all services will be present in the new consent.

Note: Evaluation time for service 921 went from around 100s to 16s.

* new method for checking whether service is assigned to facility
* new private method created that uses selected service to evaluate consents only for its members
* if there was no selected service (service is null), all services assigned to facilities under processed consent hub are used instead
* tests that used old logic (evaluate everything for each consent hub that contains selected service) were removed, since evaluation of other services is not done anymore.