### PR TITLE
fix(gui): support HTML message property in notification objects

### DIFF
--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/registrarManager/UpdateApplicationMail.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/registrarManager/UpdateApplicationMail.java
@@ -94,8 +94,6 @@ public class UpdateApplicationMail {
 	 */
 	private JSONObject prepareJSONObject() {
 
-
-
 		JSONObject mail = new JSONObject();
 
 		// update send
@@ -114,12 +112,23 @@ public class UpdateApplicationMail {
 
 		mail.put("message", mailTexts);
 
+		// update HTML texts (we don't edit them in GUI)
+		JSONObject mailTextsHTML = new JSONObject();
+
+		MailText mth = appMail.getMessageHTML("en");
+		mailTextsHTML.put("en", new JSONObject(mth));
+
+		if (!Utils.getNativeLanguage().isEmpty()) {
+			MailText mth2 = appMail.getMessageHTML(Utils.getNativeLanguage().get(0));
+			mailTextsHTML.put(Utils.getNativeLanguage().get(0), new JSONObject(mth2));
+		}
+		mail.put("htmlMessage", mailTextsHTML);
+
 		// sending other values just for sure
 		mail.put("id", new JSONNumber(appMail.getId()));
 		mail.put("appType", new JSONString(appMail.getAppType()));
 		mail.put("mailType", new JSONString(appMail.getMailType()));
 		mail.put("formId", new JSONNumber(appMail.getFormId()));
-
 
 		JSONObject request = new JSONObject();
 		request.put("mail", mail);

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/ApplicationMail.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/ApplicationMail.java
@@ -108,21 +108,36 @@ public class ApplicationMail extends JavaScriptObject {
 
 	/**
 	 * Get message
-	 * @return type
+	 * @return MailText
 	 */
 	public final native MailText getMessage(String locale) /*-{
 		if(typeof this.message === 'undefined'){
 			this.message = {};
 		}
 		if(!(locale in this.message)){
-			this.message[locale] = {locale: locale, text : "", subject : ""};
+			this.message[locale] = {locale: locale, htmlFormat: false, text : "", subject : ""};
 		}
 		return this.message[locale];
 	}-*/;
 
 	/**
+	 * Get message of HTML template
+	 * @return MailText
+	 */
+	public final native MailText getMessageHTML(String locale) /*-{
+		if(typeof this.htmlMessage === 'undefined'){
+			this.htmlMessage = {};
+		}
+		if(!(locale in this.htmlMessage)){
+			this.htmlMessage[locale] = {locale: locale, htmlFormat: true, text : "", subject : ""};
+		}
+		return this.htmlMessage[locale];
+	}-*/;
+
+	/**
 	 * Set message
 	 * @param locale
+	 * @param message
 	 */
 	public final native void setMessage(String locale, MailText message) /*-{
 		if(typeof this.message === 'undefined'){
@@ -131,6 +146,17 @@ public class ApplicationMail extends JavaScriptObject {
 		this.message[locale] = message;
 	}-*/;
 
+	/**
+	 * Set message
+	 * @param locale
+	 * @param message
+	 */
+	public final native void setMessageHTML(String locale, MailText message) /*-{
+		if(typeof this.htmlMessage === 'undefined'){
+			this.htmlMessage = {};
+		}
+		this.htmlMessage[locale] = message;
+	}-*/;
 
 	/**
 	 * Get locales
@@ -142,6 +168,16 @@ public class ApplicationMail extends JavaScriptObject {
 	}
 
 	/**
+	 * Get locales of HTML message
+	 *
+	 * @return array of present locales
+	 */
+	public final ArrayList<String> getLocalesHTML() {
+		return JsonUtils.listFromJsArrayString(getLocalesNativeHTML());
+	}
+
+
+	/**
 	 * Get locales
 	 *
 	 * @return array of present locales
@@ -149,6 +185,18 @@ public class ApplicationMail extends JavaScriptObject {
 	public final native JsArrayString getLocalesNative() /*-{
 		if(typeof this.message !== 'undefined' && this.message !== null){
 			return Object.getOwnPropertyNames(this.message)
+		}
+		return null;
+	}-*/;
+
+	/**
+	 * Get locales of HTML message
+	 *
+	 * @return array of present locales
+	 */
+	public final native JsArrayString getLocalesNativeHTML() /*-{
+		if(typeof this.htmlMessage !== 'undefined' && this.htmlMessage !== null){
+			return Object.getOwnPropertyNames(this.htmlMessage)
 		}
 		return null;
 	}-*/;

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/MailText.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/MailText.java
@@ -21,13 +21,14 @@ public class MailText extends JavaScriptObject {
 	 * @param text
 	 * @return
 	 */
-	static public MailText construct(String locale, String subject, String text)
+	static public MailText construct(String locale, String subject, String text, boolean htmlFormat)
 	{
 		MailText txt = new JSONObject().getJavaScriptObject().cast();
 
 		txt.setLocale(locale);
 		txt.setSubject(subject);
 		txt.setText(text);
+		txt.setHtmlFormat(htmlFormat);
 
 		return txt;
 	}
@@ -41,79 +42,84 @@ public class MailText extends JavaScriptObject {
 		return this.subject;
 	}-*/;
 
-		/**
-		 * Set subject
-		 */
-		public final native void setSubject(String subject) /*-{
-			this.subject = subject;
-		}-*/;
+	/**
+	 * Set subject
+	 */
+	public final native void setSubject(String subject) /*-{
+		this.subject = subject;
+	}-*/;
 
 
-		/**
-		 * Get text
-		 * @return text
-		 */
-		public final native String getText() /*-{
-			if(typeof this.text === 'undefined') return "";
-			return this.text;
-		}-*/;
+	/**
+	 * Get text
+	 * @return text
+	 */
+	public final native String getText() /*-{
+		if(typeof this.text === 'undefined') return "";
+		return this.text;
+	}-*/;
 
-		/**
-		 * Set text
-		 */
-		public final native void setText(String text) /*-{
-			this.text = text;
-		}-*/;
+	/**
+	 * Set text
+	 */
+	public final native void setText(String text) /*-{
+		this.text = text;
+	}-*/;
+
+	/**
+	 * Set HTML format
+	 */
+	public final native void setHtmlFormat(boolean htmlFormat) /*-{
+		this.htmlFormat = htmlFormat;
+	}-*/;
+
+	/**
+	 * Get locale
+	 * @return locale
+	 */
+	public final native String getLocale() /*-{
+		if(typeof this.locale === 'undefined') return "";
+		return this.locale;
+	}-*/;
+
+	/**
+	 * Set locale
+	 */
+	public final native void setLocale(String locale) /*-{
+		this.locale = locale;
+	}-*/;
 
 
 
-		/**
-		 * Get locale
-		 * @return locale
-		 */
-		public final native String getLocale() /*-{
-			if(typeof this.locale === 'undefined') return "";
-			return this.locale;
-		}-*/;
 
-		/**
-		 * Set locale
-		 */
-		public final native void setLocale(String locale) /*-{
-			this.locale = locale;
-		}-*/;
-
-
-
-
-		/**
-		 * Returns Perun specific type of object
-		 *
-		 * @return type of object
-		 */
-		public final native String getObjectType() /*-{
-			if (!this.beanName) {
+	/**
+	 * Returns Perun specific type of object
+	 *
+	 * @return type of object
+	 */
+	public final native String getObjectType() /*-{
+		if (!this.beanName) {
 			return "JavaScriptObject"
-			}
-			return this.beanName;
-		}-*/;
+		}
+		return this.beanName;
+	}-*/;
 
-		/**
-		 * Sets Perun specific type of object
-		 *
-		 * @param type type of object
-		 */
-		public final native void setObjectType(String type) /*-{
-			this.beanName = type;
-		}-*/;
+	/**
+	 * Sets Perun specific type of object
+	 *
+	 * @param type type of object
+	 */
+	public final native void setObjectType(String type) /*-{
+		this.beanName = type;
+	}-*/;
 
-		/**
-		 * Returns the status of this item in Perun system as String
-		 * VALID, INVALID, EXPIRED, DISABLED
-		 *
-		 * @return string which defines item status
-		 */
-		public final native String getStatus() /*-{
-			return this.status;
-		}-*/;
+	/**
+	 * Returns the status of this item in Perun system as String
+	 * VALID, INVALID, EXPIRED, DISABLED
+	 *
+	 * @return string which defines item status
+	 */
+	public final native String getStatus() /*-{
+		return this.status;
+	}-*/;
 }

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/CreateMailTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/CreateMailTabItem.java
@@ -468,7 +468,7 @@ public class CreateMailTabItem implements TabItem {
 					String locale = entry.getKey();
 					String subject = messagesSubjects.get(entry.getKey()).getValue();
 					String text = entry.getValue().getText();
-					MailText mt = MailText.construct(locale, subject, text);
+					MailText mt = MailText.construct(locale, subject, text, false); // we don't support HTML in old GUI
 
 					messages.put(locale, mt);
 				}

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/EditMailTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/EditMailTabItem.java
@@ -391,7 +391,7 @@ public class EditMailTabItem implements TabItem, TabItemWithUrl {
 					String locale = entry.getKey();
 					String subject = messagesSubjects.get(entry.getKey()).getValue();
 					String text = entry.getValue().getText();
-					MailText mt = MailText.construct(locale, subject, text);
+					MailText mt = MailText.construct(locale, subject, text, false); // we don't support HTML in old GUI
 
 					appMail.setMessage(locale, mt);
 				}


### PR DESCRIPTION
- ApplicationMail/MailText have new property for HTML message.
- We must support it in old GUI in order to prevent data loss when
  working with the same template from the old/new GUI.