### PR TITLE
fix(core): LSAAI password module validation

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/LifescienceidusernamePasswordManagerModule.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/LifescienceidusernamePasswordManagerModule.java
@@ -62,7 +62,7 @@ public class LifescienceidusernamePasswordManagerModule extends GenericPasswordM
 			}
 
 			// set additional identifiers
-			Attribute additionalIdentifiers = ((PerunBl) sess.getPerun()).getAttributesManagerBl().getAttribute(sess, ues, UsersManagerBl.ADDITIONAL_IDENTIFIERS_ATTRIBUTE_NAME);
+			Attribute additionalIdentifiers = ((PerunBl) sess.getPerun()).getAttributesManagerBl().getAttribute(sess, ues, UsersManagerBl.ADDITIONAL_IDENTIFIERS_PERUN_ATTRIBUTE_NAME);
 			String newIdentifier = userLogin + LS_DOMAIN;
 			if (additionalIdentifiers.valueAsList() == null || additionalIdentifiers.valueAsList().isEmpty()) {
 				additionalIdentifiers.setValue(Lists.newArrayList(newIdentifier));


### PR DESCRIPTION
* additional identifiers are now fetched using full attribute name
* before `friendlyName` was used