### PR TITLE
fix(core): commented validatePassword for lifescienceid

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/LifescienceidusernamePasswordManagerModule.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/LifescienceidusernamePasswordManagerModule.java
@@ -41,6 +41,8 @@ public class LifescienceidusernamePasswordManagerModule extends GenericPasswordM
 
 	@Override
 	public void validatePassword(PerunSession sess, String userLogin, User user) throws InvalidLoginException {
+		// FIXME Needs to be commented because it is triggered through the registrations that are not intended for the hostel users
+		/*
 		if (user == null) {
 			user = ((PerunBl) sess.getPerun()).getModulesUtilsBl().getUserByLoginInNamespace(sess, userLogin, actualLoginNamespace);
 		}
@@ -79,6 +81,7 @@ public class LifescienceidusernamePasswordManagerModule extends GenericPasswordM
 			throw new InternalErrorException(ex);
 		} catch (AlreadyMemberException ignored) {
 		}
+		 */
 
 		// validate password
 		super.validatePassword(sess, userLogin, user);


### PR DESCRIPTION
This method has to be commented so it is not triggered. we realized it is called from registrations
that were not intended for this functionality.