### PR TITLE
fix(dispatcher): do not put tasks without destination to waiting queue

### DIFF
--- a/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/scheduling/TaskScheduler.java
+++ b/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/scheduling/TaskScheduler.java
@@ -373,8 +373,7 @@ public class TaskScheduler extends AbstractRunner {
 			}
 		} else {
 			log.debug("[{}] No destination found for task: {}.", task.getId(), task);
-			task.setStatus(TaskStatus.ERROR);
-			return ERROR;
+			return DENIED;
 		}
 
 		task.setDestinations(destinations);

--- a/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/scheduling/impl/SchedulingPoolImpl.java
+++ b/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/scheduling/impl/SchedulingPoolImpl.java
@@ -247,6 +247,9 @@ public class SchedulingPoolImpl implements SchedulingPool, InitializingBean {
 					log.debug("[{}] Task NOT added to waiting queue, all its destinations are blocked.", task.getId());
 					if (!removeTask) return;
 				}
+			} else {
+				log.debug("[{}] Task NOT added to waiting queue, no destination exists.", task.getId());
+				if (!removeTask) return;
 			}
 
 		} catch (ServiceNotExistsException e) {


### PR DESCRIPTION
* tasks without destination were resolved as ERROR, while tasks with blocked destinations were resolved as DENIED
* ERROR tasks get rescheduled and are put to waiting queue, while DENIED tasks are not added to queue at all
* resolving tasks without destination as DENIED should therefore prevent overfilling waiting queue