### PR TITLE
fix(openapi): group in Application and ApplictaionForm can be null

### DIFF
--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -728,6 +728,8 @@ components:
     Group:
       allOf:
         - $ref: '#/components/schemas/Auditable'
+      type: object
+      nullable: true
       properties:
         name: { type: string }
         shortName: { type: string }


### PR DESCRIPTION
On cesnet-devel there are Applications and ApplicationForms with group set as null.
In openapi generated by python generator, there is problem when group is null (None). None is NoneType object and it cannot be interpreted as Group. It causes exception on place where it probably shoud not be. 