### PR TITLE
feat(core): fill bbmri/ls/elixir logins with each others values

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace_bbmri_persistent_shadow.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace_bbmri_persistent_shadow.java
@@ -1,5 +1,11 @@
 package cz.metacentrum.perun.core.impl.modules.attributes;
 
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.UserPersistentShadowAttribute;
 
 /**
@@ -18,6 +24,8 @@ public class urn_perun_user_attribute_def_def_login_namespace_bbmri_persistent_s
 	private final static String extSourceNameBbmri = "https://login.bbmri-eric.eu/idp/";
 	private final static String domainNameBbmri = "bbmri.eu";
 	private final static String attrNameBbmri = "login-namespace:bbmri-persistent-shadow";
+	private final static String lifeScienceShadow = "urn:perun:user:attribute-def:def:login-namespace:lifescienceid-persistent-shadow";
+	private final static String elixirShadow = "urn:perun:user:attribute-def:def:login-namespace:elixir-persistent-shadow";
 
 	@Override
 	public String getFriendlyName() {
@@ -48,5 +56,34 @@ public class urn_perun_user_attribute_def_def_login_namespace_bbmri_persistent_s
 	@Override
 	public String getFriendlyNameParameter() {
 		return "bbmri-persistent-shadow";
+	}
+
+	@Override
+	public Attribute fillAttribute(PerunSessionImpl sess, User user, AttributeDefinition attribute) {
+		// Check if user has login in namespace lifescienceid-persistent-shadow
+		Attribute persistentShadow = null;
+		try {
+			persistentShadow = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, user, lifeScienceShadow);
+		} catch (WrongAttributeAssignmentException | AttributeNotExistsException ignored) {
+		}
+
+		if (persistentShadow == null || persistentShadow.getValue() == null) {
+			// Check if user has login in namespace elixir-persistent-shadow
+			try {
+				persistentShadow = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, user, elixirShadow);
+			} catch (WrongAttributeAssignmentException | AttributeNotExistsException ignored) {
+			}
+		}
+
+		if (persistentShadow != null && persistentShadow.getValue() != null) {
+			Attribute filledAttribute = new Attribute(attribute);
+			String value = persistentShadow.getValue().toString();
+			String valueWithoutScope = value.split("@", 2) [0];
+			String attrValue = valueWithoutScope + "@" + domainNameBbmri;
+			filledAttribute.setValue(attrValue);
+			return filledAttribute;
+		}
+
+		return super.fillAttribute(sess, user, attribute);
 	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace_elixir_persistent_shadow.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace_elixir_persistent_shadow.java
@@ -24,6 +24,7 @@ public class urn_perun_user_attribute_def_def_login_namespace_elixir_persistent_
 	private final static String domainNameElixir = "elixir-europe.org";
 	private final static String attrNameElixir = "login-namespace:elixir-persistent-shadow";
 	private final static String lifeScienceShadow = "urn:perun:user:attribute-def:def:login-namespace:lifescienceid-persistent-shadow";
+	private final static String bbmriShadow = "urn:perun:user:attribute-def:def:login-namespace:bbmri-persistent-shadow";
 
 	@Override
 	public String getFriendlyName() {
@@ -59,15 +60,23 @@ public class urn_perun_user_attribute_def_def_login_namespace_elixir_persistent_
 	@Override
 	public Attribute fillAttribute(PerunSessionImpl sess, User user, AttributeDefinition attribute) {
 		// Check if user has login in namespace lifescienceid-persistent-shadow
-		Attribute lifesciencePersistentShadow = null;
+		Attribute persistentShadow = null;
 		try {
-			lifesciencePersistentShadow = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, user, lifeScienceShadow);
+			persistentShadow = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, user, lifeScienceShadow);
 		} catch (WrongAttributeAssignmentException | AttributeNotExistsException ignored) {
 		}
 
-		if (lifesciencePersistentShadow != null && lifesciencePersistentShadow.getValue() != null) {
+		if (persistentShadow == null || persistentShadow.getValue() == null) {
+			// Check if user has login in namespace bbmri-persistent-shadow
+			try {
+				persistentShadow = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, user, bbmriShadow);
+			} catch (WrongAttributeAssignmentException | AttributeNotExistsException ignored) {
+			}
+		}
+
+		if (persistentShadow != null && persistentShadow.getValue() != null) {
 			Attribute filledAttribute = new Attribute(attribute);
-			String value = lifesciencePersistentShadow.getValue().toString();
+			String value = persistentShadow.getValue().toString();
 			String valueWithoutScope = value.split("@", 2) [0];
 			String attrValue = valueWithoutScope + "@" + domainNameElixir;
 			filledAttribute.setValue(attrValue);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace_lifescienceid_persistent_shadow.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace_lifescienceid_persistent_shadow.java
@@ -19,6 +19,7 @@ public class urn_perun_user_attribute_def_def_login_namespace_lifescienceid_pers
 
 	private final static String attrNameLifeScience = "login-namespace:lifescienceid-persistent-shadow";
 	private final static String elixirShadow = "urn:perun:user:attribute-def:def:login-namespace:elixir-persistent-shadow";
+	private final static String bbmriShadow = "urn:perun:user:attribute-def:def:login-namespace:bbmri-persistent-shadow";
 
 	private final static String CONFIG_EXT_SOURCE_NAME_LIFESCIENCE = "extSourceNameLifeScience";
 	private final static String CONFIG_DOMAIN_NAME_LIFESCIENCE = "domainNameLifeScience";
@@ -57,15 +58,23 @@ public class urn_perun_user_attribute_def_def_login_namespace_lifescienceid_pers
 	@Override
 	public Attribute fillAttribute(PerunSessionImpl sess, User user, AttributeDefinition attribute) {
 		// Check if user has login in namespace elixir-persistent-shadow
-		Attribute elixirPersistentShadow = null;
+		Attribute persistentShadow = null;
 		try {
-			elixirPersistentShadow = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, user, elixirShadow);
+			persistentShadow = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, user, elixirShadow);
 		} catch (WrongAttributeAssignmentException | AttributeNotExistsException ignored) {
 		}
 
-		if (elixirPersistentShadow != null && elixirPersistentShadow.getValue() != null) {
+		if (persistentShadow == null || persistentShadow.getValue() == null) {
+			// Check if user has login in namespace bbmri-persistent-shadow
+			try {
+				persistentShadow = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, user, bbmriShadow);
+			} catch (WrongAttributeAssignmentException | AttributeNotExistsException ignored) {
+			}
+		}
+
+		if (persistentShadow != null && persistentShadow.getValue() != null) {
 			Attribute filledAttribute = new Attribute(attribute);
-			String value = elixirPersistentShadow.getValue().toString();
+			String value = persistentShadow.getValue().toString();
 			String valueWithoutScope = value.split("@", 2) [0];
 			String attrValue = valueWithoutScope + "@" + getDomainName();
 			filledAttribute.setValue(attrValue);


### PR DESCRIPTION
* besides filling lifescience and elixir logins with each other's values, we want to extent it also to bbmri logins
* if bbmri login is to be set, first it is checked if ls/elixir login exists
* if ls/elixir login exists, it is set as bbmri login
* and vice versa