### PR TITLE
fix(core): remove old attribute authz if deleting attribute definition

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -2567,6 +2567,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		//TODO
 
 		//Remove attribute and all it's values
+		this.deleteAllAttributeAuthz(sess, attribute);
 		getAttributesManagerImpl().deleteAttribute(sess, attribute);
 		getPerunBl().getAuditer().log(sess, new AttributeDeleted(attribute));
 


### PR DESCRIPTION
* we're keeping old attribute authz tables for now, so we have to remove entries refering attribute definitions which are to be removed