### PR TITLE
fix(core): fixed error handling from calls to userInfoEndpoint

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/oidc/UserInfoEndpointCall.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/oidc/UserInfoEndpointCall.java
@@ -84,10 +84,9 @@ public class UserInfoEndpointCall {
 			}
 		}
 		if(StringUtils.isEmpty(login)) {
-			log.error("user sub was empty or null: {}", login);
-			throw new InternalErrorException("user sub was empty or null: " + login);
+			log.info("user sub from user info endpoint was empty or null: {}", login);
 		}
-		return null;
+		return login;
 	}
 
 	/**
@@ -99,8 +98,7 @@ public class UserInfoEndpointCall {
 		String pathToExtSourceName = BeansUtils.getCoreConfig().getUserInfoEndpointExtSourceName();
 		String extSourceName = userInfo.path(pathToExtSourceName).asText();
 		if(StringUtils.isEmpty(extSourceName)) {
-			log.error("issuer was empty or null: {}", extSourceName);
-			throw new InternalErrorException("issuer was null: " + extSourceName);
+			log.info("issuer from user info endpoint was empty or null: {}", extSourceName);
 		}
 		return extSourceName;
 	}

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/ConsolidatorManagerImpl.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/ConsolidatorManagerImpl.java
@@ -423,7 +423,12 @@ public class ConsolidatorManagerImpl implements ConsolidatorManager {
     @Override
     public void consolidate(PerunSession sess, String accessToken) throws PerunException {
 		Map<String, String> additionalInformationNonCaller = new HashMap<>();
-		UserInfoEndpointResponse userInfoNonCaller = userInfoEndpointCall.getUserInfoEndpointData(accessToken, BeansUtils.getCoreConfig().getOidcIssuersExtsourceNames().keySet().iterator().next(), additionalInformationNonCaller);
+		UserInfoEndpointResponse userInfoNonCaller = userInfoEndpointCall.getUserInfoEndpointData(accessToken, sess.getPerunPrincipal().getAdditionalInformations().get("issuer"), additionalInformationNonCaller);
+		if (StringUtils.isEmpty(userInfoNonCaller.getSub()) || StringUtils.isEmpty(userInfoNonCaller.getIssuer()) ||
+			StringUtils.isEmpty(sess.getPerunPrincipal().getActor()) || StringUtils.isEmpty(sess.getPerunPrincipal().getExtSourceName())) {
+			log.error("Call to user info endpoint didn't found original issuer or original sub.");
+			throw new InternalErrorException("Call to user info endpoint didn't found original issuer or original sub.");
+		}
 
 		//trying to find in the perun user with identity which we obtained through access token
 		ExtSource extSource = perun.getExtSourcesManagerBl().getExtSourceByName(sess, userInfoNonCaller.getIssuer());


### PR DESCRIPTION
* fixed error handling from calls to userInfoEndpoint
* now when the
Perun Principal is created and call to user Info Endpoint fails or
original sub/issuer is not found then we set the fallback values
extsource name and login
* also when consolidating fixed the issuer to
what user info request is made