### PR TITLE
fix(core): deleting an attribute with a namespace could remove common…

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -2599,12 +2599,9 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 			}
 		}
 
-		// try to remove and unregister attribute module
-		AttributesModuleImplApi module = (AttributesModuleImplApi) getAttributesManagerImpl().getAttributesModule(sess, attribute);
-		if (module != null) {
-			getAttributesManagerImpl().removeAttributeModule(module);
-			getAttributesManagerImpl().unregisterAttributeModule(module);
-		}
+		// try to remove and unregister attribute module, the common module (e.g. u:d:login-namespace) will stay even if
+		// the last namespace specific (e.g. u:d:login-namespace:einfra) module is removed
+		getAttributesManagerImpl().removeAndUnregisterAttrModule(sess, attribute);
 	}
 
 	/**

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
@@ -4626,6 +4626,20 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 	}
 
 	@Override
+	public void removeAndUnregisterAttrModule(PerunSession sess, AttributeDefinition attribute) {
+
+		// core attributes doesn't have modules !!
+		if (isCoreAttribute(sess, attribute)) return;
+
+		String moduleName = attributeNameToModuleName(attribute.getNamespace() + ":" + attribute.getFriendlyName());
+		AttributesModuleImplApi attributeModule = attributesModulesMap.get(moduleName);
+		if (attributeModule != null) {
+			removeAttributeModule(attributeModule);
+			unregisterAttributeModule(attributeModule);
+		}
+	}
+
+	@Override
 	public AttributesModuleImplApi getUninitializedAttributesModule(PerunSession sess, AttributeDefinition attributeDefinition) {
 
 		// core attributes doesn't have modules

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
@@ -2674,6 +2674,18 @@ public interface AttributesManagerImplApi {
 	void removeAttributeModule(AttributesModuleImplApi module);
 
 	/**
+	 * Remove attribute module of the given non-core attribute from attribute module map in Impl layer and unregister the module from Auditer,
+	 * however only if it is namespace-specific to avoid removing common module from other active namespace-specific
+	 * modules. If no namespace-specific modules remain for the attribute, the common module will not be removed. To
+	 * remove the common module, pass the common definition as parameter.
+	 *
+	 * @param sess sess
+	 * @param attribute attribute of which module to remove
+	 */
+	void removeAndUnregisterAttrModule(PerunSession sess, AttributeDefinition attribute);
+
+
+	/**
 	 * Register attribute module in Auditer for message listening (if it is not there yet).
 	 *
 	 * @see AttributesManagerBlImpl#createAttribute(PerunSession, AttributeDefinition)

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/AttributesManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/AttributesManagerEntryIntegrationTest.java
@@ -50,7 +50,9 @@ import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentExceptio
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.RoleObjectCombinationInvalidException;
 import cz.metacentrum.perun.core.blImpl.AttributesManagerBlImpl;
+import cz.metacentrum.perun.core.blImpl.PerunBlImpl;
 import cz.metacentrum.perun.core.impl.AttributesManagerImpl;
+import cz.metacentrum.perun.core.implApi.modules.attributes.AttributesModuleImplApi;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -79,6 +81,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
@@ -5888,6 +5891,51 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		// shouldn't find attribute because force deleted
 
 	}
+
+	@Test
+	public void deleteAttributeNotRemovesCommonModule() throws Exception {
+		System.out.println(CLASS_NAME + "deleteAttributeNotRemovesCommonModule");
+
+		// need this to get AttributesManagerImpl
+		PerunBlImpl perunBlImpl = ((PerunBlImpl) perun);
+
+		// create attribute in namespace under the same common namespace
+		AttributeDefinition test = new AttributeDefinition();
+		test.setNamespace(AttributesManager.NS_USER_ATTR_DEF);
+		test.setDescription("test");
+		test.setFriendlyName("login-namespace:test");
+		test.setType(String.class.getName());
+		test = attributesManager.createAttribute(sess, test);
+
+		// create common namespace attribute that has a module
+		AttributeDefinition common = new AttributeDefinition();
+		common.setNamespace(AttributesManager.NS_USER_ATTR_DEF);
+		common.setDescription("common");
+		common.setFriendlyName("login-namespace");
+		common.setType(String.class.getName());
+		attributesManager.createAttribute(sess, common);
+
+		// common module should now be initialized
+		AttributesModuleImplApi module = (AttributesModuleImplApi) perunBlImpl.getAttributesManagerImpl().getAttributesModule(sess, common);
+		assertNotNull(module);
+
+		attributesManager.deleteAttribute(sess, test);
+		// common module shouldn't be removed
+		module = (AttributesModuleImplApi) perunBlImpl.getAttributesManagerImpl().getAttributesModule(sess, common);
+		assertNotNull(module);
+
+		// try the same for namespace unspecific module, where the module should be deleted
+		AttributeDefinition pref = attributesManager.getAttributeDefinition(sess, AttributesManager.NS_USER_ATTR_DEF + ":phone");
+		AttributesModuleImplApi prefModule = (AttributesModuleImplApi) perunBlImpl.getAttributesManagerImpl().getAttributesModule(sess, pref);
+		assertNotNull(prefModule);
+
+		attributesManager.deleteAttribute(sess, pref);
+		prefModule = (AttributesModuleImplApi) perunBlImpl.getAttributesManagerImpl().getAttributesModule(sess, pref);
+		assertNull(prefModule);
+
+	}
+
+
 
 
 


### PR DESCRIPTION
… attribute module

* fixed a bug, where if an attribute had a namespace in its name that didn't have its own module, the common module was deleted
* created a new method in AttributesManagerImpl, that safely deletes namespace-specific attribute modules
* wrote a test to cover the changes made