### PR TITLE
feat(core): flag critical actions on attributes

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/AttributeRules.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/AttributeRules.java
@@ -1,0 +1,60 @@
+package cz.metacentrum.perun.core.api;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Class containing attribute policies and information which actions are critical
+ *
+ * @author Johana Supikova <xsupikov@fi.muni.cz>
+ */
+public class AttributeRules {
+
+	private List<AttributePolicyCollection> attributePolicyCollections;
+	private List<AttributeAction> criticalActions = new ArrayList<>();
+
+	public AttributeRules() {
+	}
+
+	public AttributeRules(List<AttributePolicyCollection> attributePolicyCollections) {
+		this.attributePolicyCollections = attributePolicyCollections;
+	}
+
+	public List<AttributePolicyCollection> getAttributePolicyCollections() {
+		return attributePolicyCollections;
+	}
+
+	public void setAttributePolicyCollections(List<AttributePolicyCollection> attributePolicyCollections) {
+		this.attributePolicyCollections = attributePolicyCollections;
+	}
+
+	public List<AttributeAction> getCriticalActions() {
+		return criticalActions;
+	}
+
+	public void setCriticalActions(List<AttributeAction> criticalActions) {
+		this.criticalActions = criticalActions;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		AttributeRules that = (AttributeRules) o;
+		return Objects.equals(attributePolicyCollections, that.attributePolicyCollections) && Objects.equals(criticalActions, that.criticalActions);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(attributePolicyCollections, criticalActions);
+	}
+
+	@Override
+	public String toString() {
+		return "AttributeRules{" +
+			"attributePolicyCollections=" + attributePolicyCollections +
+			", criticalActions=" + criticalActions +
+			'}';
+	}
+}

--- a/perun-base/src/main/resources/perun-roles.yml
+++ b/perun-base/src/main/resources/perun-roles.yml
@@ -271,10 +271,23 @@ perun_policies:
     include_policies:
       - default_policy
 
+  getAttributeRules_int_policy:
+    policy_roles:
+      - PERUNOBSERVER:
+    include_policies:
+      - default_policy
+
   setAttributePolicyCollections_List<AttributePolicyCollection>_int_policy:
     policy_roles: []
     include_policies:
       - default_policy
+
+  setAttributeActionCriticality_AttributeDefinition_AttributeAction_boolean_policy:
+    policy_roles: []
+    include_policies:
+      - default_policy
+    mfa_rules:
+      - MFA:
 
   convertAttributeToUnique_int_policy:
     policy_roles: []

--- a/perun-base/src/test/resources/test-schema.sql
+++ b/perun-base/src/test/resources/test-schema.sql
@@ -1,4 +1,4 @@
--- database version 3.1.96 (don't forget to update insert statement at the end of file)
+-- database version 3.1.97 (don't forget to update insert statement at the end of file)
 CREATE EXTENSION IF NOT EXISTS "unaccent";
 CREATE EXTENSION IF NOT EXISTS "pgcrypto";
 
@@ -327,6 +327,13 @@ create table attribute_policies (
 	constraint attrpol_role_fk foreign key (role_id) references roles (id)
 );
 
+-- ATTRIBUTE_CRITICAL_ACTIONS - critical actions on attributes which may require additional authentication
+create table attribute_critical_actions (
+	attr_id integer not null,  --identifier of attribute (attr_names.id)
+	action attribute_action not null,  --action on attribute (READ/WRITE)
+	constraint attrcritops_pk primary key (attr_id, action),
+	constraint attrcritops_attr_fk foreign key (attr_id) references attr_names (id) on delete cascade
+);
 
 -- CONSENT_HUBS -- list of facilities with joint consent management
 create table consent_hubs (
@@ -1848,9 +1855,10 @@ create index idx_fk_attr_cons_cons ON consent_attr_defs(consent_id);
 create index idx_fk_attr_cons_attr ON consent_attr_defs(attr_id);
 create index idx_fk_alwd_grps_group ON allowed_groups_to_hierarchical_vo(group_id);
 create index idx_fk_alwd_grps_vo ON allowed_groups_to_hierarchical_vo(vo_id);
+create index idx_fk_attr_critops ON attribute_critical_actions(attr_id);
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.1.96');
+insert into configurations values ('DATABASE VERSION','3.1.97');
 -- insert membership types
 insert into membership_types (id, membership_type, description) values (1, 'DIRECT', 'Member is directly added into group');
 insert into membership_types (id, membership_type, description) values (2, 'INDIRECT', 'Member is added indirectly through UNION relation');

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/AttributesManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/AttributesManager.java
@@ -13,6 +13,8 @@ import cz.metacentrum.perun.core.api.exceptions.MemberGroupMismatchException;
 import cz.metacentrum.perun.core.api.exceptions.MemberNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.MemberResourceMismatchException;
 import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
+import cz.metacentrum.perun.core.api.exceptions.RelationExistsException;
+import cz.metacentrum.perun.core.api.exceptions.RelationNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ResourceNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.RoleObjectCombinationInvalidException;
 import cz.metacentrum.perun.core.api.exceptions.RoleNotSupportedException;
@@ -4069,6 +4071,16 @@ public interface AttributesManager {
 	List<AttributePolicyCollection> getAttributePolicyCollections(PerunSession sess, int attributeId) throws PrivilegeException, AttributeNotExistsException;
 
 	/**
+	 * Gets attribute rules containing policy collections and critical actions for an attribute definition with given id
+	 *
+	 * @param sess perun session
+	 * @param attributeId id of the attribute definition
+	 * @return attribute rules of the attribute definition
+	 * @throws AttributeNotExistsException when there is no attribute definition with such id
+	 */
+	AttributeRules getAttributeRules(PerunSession sess, int attributeId) throws PrivilegeException, AttributeNotExistsException;
+
+	/**
 	 * Converts attribute to unique.
 	 * Marks the attribute definition as unique, and copies all values to a special table with unique constraint
 	 * that ensures that all values remain unique. Values of type ArrayList and LinkedHashMap are splitted into
@@ -4119,4 +4131,19 @@ public interface AttributesManager {
 	 * @throws PrivilegeException insufficient permissions
 	 */
 	GraphDTO getModulesDependenciesGraph(PerunSession session, GraphTextFormat format, String attributeName) throws PrivilegeException, AttributeNotExistsException;
+
+	/**
+	 * Marks the action on attribute as critical, which may require additional authentication of user
+	 * performing that action on attribute.
+	 *
+	 * @param sess session
+	 * @param attr attribute definition
+	 * @param action critical action
+	 * @param critical true if action should be set critical, false to non-critical
+	 *
+	 * @throws RelationExistsException if trying to mark already critical action
+	 * @throws RelationNotExistsException if trying to unmark not critical action
+	 * @throws PrivilegeException insufficient permissions
+	 */
+	void setAttributeActionCriticality(PerunSession sess, AttributeDefinition attr, AttributeAction action, boolean critical) throws RelationExistsException, RelationNotExistsException, PrivilegeException;
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
@@ -2,9 +2,11 @@ package cz.metacentrum.perun.core.bl;
 
 import cz.metacentrum.perun.core.api.ActionType;
 import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeAction;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributePolicyCollection;
 import cz.metacentrum.perun.core.api.AttributeRights;
+import cz.metacentrum.perun.core.api.AttributeRules;
 import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.Host;
@@ -29,6 +31,8 @@ import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.MemberGroupMismatchException;
 import cz.metacentrum.perun.core.api.exceptions.MemberResourceMismatchException;
 import cz.metacentrum.perun.core.api.exceptions.ModuleNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.RelationExistsException;
+import cz.metacentrum.perun.core.api.exceptions.RelationNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.VoNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
@@ -4645,6 +4649,15 @@ public interface AttributesManagerBl {
 	List<AttributePolicyCollection> getAttributePolicyCollections(PerunSession sess, int attributeId);
 
 	/**
+	 * Gets attribute rules containing policy collections and critical actions for an attribute definition with given id
+	 *
+	 * @param sess perun session
+	 * @param attributeId id of the attribute definition
+	 * @return attribute rules of the attribute definition
+	 */
+	AttributeRules getAttributeRules(PerunSession sess, int attributeId);
+
+	/**
 	 * Get user virtual attribute module by the attribute.
 	 *
 	 * @param sess
@@ -4776,5 +4789,38 @@ public interface AttributesManagerBl {
 	 * @throws InternalErrorException if both handlers are empty or namespace for handlers can't be found
 	 */
 	void checkAttributeAssignment(PerunSession sess, AttributeDefinition attributeDefinition, PerunBean handler1, PerunBean handler2) throws WrongAttributeAssignmentException;
+
+	/**
+	 * Checks if the action is critical on given attribute.
+	 *
+	 * @param sess session
+	 * @param attr attribute definition
+	 * @param action critical action
+	 * @return true if action is critical, false otherwise
+	 */
+	boolean isAttributeActionCritical(PerunSession sess, AttributeDefinition attr, AttributeAction action);
+
+	/**
+	 * Returns critical actions on given attribute.
+	 *
+	 * @param sess session
+	 * @param attrId attribute definition id
+	 * @return list of critical actions
+	 */
+	List<AttributeAction> getCriticalAttributeActions(PerunSession sess, int attrId);
+
+	/**
+	 * Marks the action on attribute as critical, which may require additional authentication of user 
+	 * performing that action on attribute.
+	 *
+	 * @param sess session
+	 * @param attr attribute definition
+	 * @param action critical action
+	 * @param critical true if action should be set critical, false to non-critical
+	 *
+	 * @throws RelationExistsException if trying to mark already critical action
+	 * @throws RelationNotExistsException if trying to unmark not critical action
+	 */
+	void setAttributeActionCriticality(PerunSession sess, AttributeDefinition attr, AttributeAction action, boolean critical) throws RelationExistsException, RelationNotExistsException;
 }
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/AttributesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/AttributesManagerEntry.java
@@ -6,6 +6,7 @@ import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributePolicy;
 import cz.metacentrum.perun.core.api.AttributePolicyCollection;
 import cz.metacentrum.perun.core.api.AttributeRights;
+import cz.metacentrum.perun.core.api.AttributeRules;
 import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.AuthzResolver;
 import cz.metacentrum.perun.core.api.Facility;
@@ -37,6 +38,8 @@ import cz.metacentrum.perun.core.api.exceptions.MemberGroupMismatchException;
 import cz.metacentrum.perun.core.api.exceptions.MemberNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.MemberResourceMismatchException;
 import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
+import cz.metacentrum.perun.core.api.exceptions.RelationExistsException;
+import cz.metacentrum.perun.core.api.exceptions.RelationNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ResourceNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.RoleManagementRulesNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.RoleNotSupportedException;
@@ -4584,6 +4587,19 @@ public class AttributesManagerEntry implements AttributesManager {
 	}
 
 	@Override
+	public AttributeRules getAttributeRules(PerunSession sess, int attributeId) throws PrivilegeException, AttributeNotExistsException {
+		Utils.checkPerunSession(sess);
+		getAttributeDefinitionById(sess, attributeId);
+
+		// Authorization
+		if (!AuthzResolver.authorizedInternal(sess, "getAttributeRules_int_policy")) {
+			throw new PrivilegeException("getAttributeRules");
+		}
+
+		return getAttributesManagerBl().getAttributeRules(sess, attributeId);
+	}
+
+	@Override
 	public void convertAttributeToUnique(PerunSession session, int attrId) throws PrivilegeException, AttributeNotExistsException, AttributeAlreadyMarkedUniqueException {
 		Utils.checkPerunSession(session);
 
@@ -4629,6 +4645,17 @@ public class AttributesManagerEntry implements AttributesManager {
 		AttributeDefinition definition = attributesManagerBl.getAttributeDefinition(session, attributeName);
 
 		return new GraphDTO(attributesManagerBl.getAttributeModulesDependenciesGraphAsString(session, format, definition), format.name());
+	}
+
+	@Override
+	public void setAttributeActionCriticality(PerunSession sess, AttributeDefinition attr, AttributeAction action, boolean critical) throws RelationExistsException, RelationNotExistsException, PrivilegeException {
+
+		// Authorization
+		if (!AuthzResolver.authorizedInternal(sess, "setAttributeActionCriticality_AttributeDefinition_AttributeAction_boolean_policy")) {
+			throw new PrivilegeException("setAttributeActionCriticality");
+		}
+
+		attributesManagerBl.setAttributeActionCriticality(sess, attr, action, critical);
 	}
 
 	public PerunBl getPerunBl() {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
@@ -5,6 +5,7 @@ package cz.metacentrum.perun.core.implApi;
 
 import cz.metacentrum.perun.core.api.ActionType;
 import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeAction;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributePolicyCollection;
 import cz.metacentrum.perun.core.api.AttributeRights;
@@ -27,6 +28,8 @@ import cz.metacentrum.perun.core.api.exceptions.AttributeDefinitionExistsExcepti
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.ModuleNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.RelationExistsException;
+import cz.metacentrum.perun.core.api.exceptions.RelationNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongModuleTypeException;
@@ -2730,4 +2733,38 @@ public interface AttributesManagerImplApi {
 	 * @throws InternalErrorException
 	 */
 	List<AttributePolicyCollection> getAttributePolicyCollections(PerunSession sess, int attributeId);
+
+	/**
+	 * Checks if the action is critical on given attribute.
+	 *
+	 * @param sess session
+	 * @param attr attribute definition
+	 * @param action critical action
+	 * @return true if action is critical, false otherwise
+	 */
+	boolean isAttributeActionCritical(PerunSession sess, AttributeDefinition attr, AttributeAction action);
+
+	/**
+	 * Returns critical actions on given attribute.
+	 *
+	 * @param sess session
+	 * @param attrId attribute definition id
+	 * @return list of critical actions
+	 */
+	List<AttributeAction> getCriticalAttributeActions(PerunSession sess, int attrId);
+
+	/**
+	 * Marks the action on attribute as critical, which may require additional authentication of user
+	 * performing that action on attribute.
+	 *
+	 * @param sess session
+	 * @param attr attribute definition
+	 * @param action critical action
+	 * @param critical true if action should be set critical, false to non-critical
+	 *
+	 * @throws RelationExistsException if trying to mark already critical action
+	 * @throws RelationNotExistsException if trying to unmark not critical action
+	 */
+	void setAttributeActionCriticality(PerunSession sess, AttributeDefinition attr, AttributeAction action, boolean critical) throws RelationExistsException, RelationNotExistsException;
+
 }

--- a/perun-core/src/main/resources/perun-core.xml
+++ b/perun-core/src/main/resources/perun-core.xml
@@ -57,6 +57,7 @@ http://www.springframework.org/schema/task http://www.springframework.org/schema
 		<aop:advisor advice-ref="txAdviceNestedTransaction" pointcut="execution(* cz.metacentrum.perun.core.impl.AttributesManagerImpl.updateAttributeDefinition(..))"/>
 		<aop:advisor advice-ref="txAdviceNestedTransaction" pointcut="execution(* cz.metacentrum.perun.core.impl.AttributesManagerImpl.setAttributeRight(..))"/>
 		<aop:advisor advice-ref="txAdviceNestedTransaction" pointcut="execution(* cz.metacentrum.perun.core.impl.AttributesManagerImpl.setAttributePolicyCollections(..))"/>
+		<aop:advisor advice-ref="txAdviceNestedTransaction" pointcut="execution(* cz.metacentrum.perun.core.impl.AttributesManagerImpl.setAttributeActionCriticality(..))"/>
 		<!-- AuthzResolverImpl -->
 		<aop:advisor advice-ref="txAdviceNestedTransaction" pointcut="execution(* cz.metacentrum.perun.core.impl.AuthzResolverImpl.addAdmin(..))"/>
 		<aop:advisor advice-ref="txAdviceNestedTransaction" pointcut="execution(* cz.metacentrum.perun.core.impl.AuthzResolverImpl.setRole(..))"/>

--- a/perun-core/src/main/resources/postgresChangelog.txt
+++ b/perun-core/src/main/resources/postgresChangelog.txt
@@ -6,6 +6,13 @@
 -- Directly under version number should be version commands. They will be executed in the order they are written here.
 -- Comments are prefixed with -- and can be written only between version blocks, that means not in the lines with commands. They have to be at the start of the line.
 
+3.1.97
+create table attribute_critical_actions (attr_id integer not null, action attribute_action not null, constraint attrcritops_pk primary key (attr_id, action),	constraint attrcritops_attr_fk foreign key (attr_id) references attr_names (id) on delete cascade);
+grant all on attribute_critical_actions to perun;
+create index idx_fk_attr_critops ON attribute_critical_actions(attr_id);
+UPDATE configurations SET value='3.1.97' WHERE property='DATABASE VERSION';
+INSERT INTO attribute_critical_actions (attr_id, action) SELECT attr_names.id, 'WRITE' FROM attr_names;
+
 3.1.96
 ALTER TABLE application_reserved_logins ADD COLUMN user_id integer;
 ALTER TABLE application_reserved_logins ADD COLUMN extsourcename varchar;

--- a/perun-db/postgres.sql
+++ b/perun-db/postgres.sql
@@ -1,4 +1,4 @@
--- database version 3.1.96 (don't forget to update insert statement at the end of file)
+-- database version 3.1.97 (don't forget to update insert statement at the end of file)
 
 -- VOS - virtual organizations
 create table vos (
@@ -325,6 +325,13 @@ create table attribute_policies (
 	constraint attrpol_role_fk foreign key (role_id) references roles (id)
 );
 
+-- ATTRIBUTE_CRITICAL_ACTIONS - critical actions on attributes which may require additional authentication
+create table attribute_critical_actions (
+	attr_id integer not null,  --identifier of attribute (attr_names.id)
+	action attribute_action not null,  --action on attribute (READ/WRITE)
+	constraint attrcritops_pk primary key (attr_id, action),
+	constraint attrcritops_attr_fk foreign key (attr_id) references attr_names (id) on delete cascade
+);
 
 -- CONSENT_HUBS -- list of facilities with joint consent management
 create table consent_hubs (
@@ -1844,6 +1851,7 @@ create index idx_fk_attr_cons_cons ON consent_attr_defs(consent_id);
 create index idx_fk_attr_cons_attr ON consent_attr_defs(attr_id);
 create index idx_fk_alwd_grps_group ON allowed_groups_to_hierarchical_vo(group_id);
 create index idx_fk_alwd_grps_vo ON allowed_groups_to_hierarchical_vo(vo_id);
+create index idx_fk_attr_critops ON attribute_critical_actions(attr_id);
 
 grant all on users to perun;
 grant all on vos to perun;
@@ -1953,9 +1961,10 @@ grant all on groups_to_register to perun;
 grant all on consents to perun;
 grant all on consent_attr_defs to perun;
 grant all on allowed_groups_to_hierarchical_vo to perun;
+grant all on attribute_critical_actions to perun;
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.1.96');
+insert into configurations values ('DATABASE VERSION','3.1.97');
 
 -- insert membership types
 insert into membership_types (id, membership_type, description) values (1, 'DIRECT', 'Member is directly added into group');

--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -317,6 +317,18 @@ components:
       discriminator:
         propertyName: beanName
 
+    AttributeRules:
+      type: object
+      properties:
+        attributePolicyCollections:
+          type: array
+          items:
+            $ref: '#/components/schemas/AttributePolicyCollection'
+        criticalActions:
+          type: array
+          items:
+            $ref: '#/components/schemas/AttributeAction'
+
     AuditEvent:
       type: object
       properties:
@@ -1864,6 +1876,13 @@ components:
             type: array
             items:
               $ref: "#/components/schemas/AttributePolicyCollection"
+
+    AttributeRulesResponse:
+      description: "returns AttributeRules"
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/AttributeRules"
 
     AttributeResponse:
       description: "returns Attribute"
@@ -7106,6 +7125,20 @@ paths:
         default:
           $ref: '#/components/responses/ExceptionResponse'
 
+  /json/attributesManager/getAttributeRules:
+    get:
+      tags:
+        - AttributesManager
+      operationId: getAttributeRules
+      summary: "Gets attribute rules containing policy collections and critical actions for an attribute definition with given id"
+      parameters:
+        - $ref: '#/components/parameters/attributeDefinitionId'
+      responses:
+        '200':
+          $ref: '#/components/responses/AttributeRulesResponse'
+        default:
+          $ref: '#/components/responses/ExceptionResponse'
+
   /json/attributesManager/setAttributePolicyCollections:
     post:
       tags:
@@ -7127,6 +7160,22 @@ paths:
                   type: array
                   items:
                     $ref: '#/components/schemas/AttributePolicyCollection'
+      responses:
+        '200':
+          $ref: '#/components/responses/VoidResponse'
+        default:
+          $ref: '#/components/responses/ExceptionResponse'
+
+  /urlinjsonout/attributesManager/setAttributeActionCriticality:
+    post:
+      tags:
+        - AttributesManager
+      operationId: setAttributeActionCriticality
+      summary: Marks the action on attribute as critical, which may require additional authentication of user performing that action on attribute.
+      parameters:
+        - $ref: '#/components/parameters/attributeDefinitionId'
+        - {name: action, in: query, schema: { $ref: '#/components/schemas/AttributeAction' }, required: true}
+        - {name: critical, description: "if action should be marked as critical", schema: { type: boolean }, in: query, required: true}
       responses:
         '200':
           $ref: '#/components/responses/VoidResponse'

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/AttributesManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/AttributesManagerMethod.java
@@ -4072,5 +4072,47 @@ public enum AttributesManagerMethod implements ManagerMethod {
 
 			return ac.getAttributesManager().getModulesDependenciesGraph(ac.getSession(), format);
 		}
+	},
+
+	/*#
+	 * Marks the action on attribute as critical, which may require additional authentication of user
+	 * performing that action on attribute.
+	 *
+	 * @param sess session
+	 * @param attributeDefinition attribute definition id
+	 * @param action critical action
+	 * @param critical true if action should be set critical, false to non-critical
+	 *
+	 * @throws RelationExistsException if trying to mark already critical action
+	 * @throws RelationNotExistsException if trying to unmark not critical action
+	 */
+	setAttributeActionCriticality {
+		@Override
+		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
+			parms.stateChangingCheck();
+			ac.getAttributesManager().setAttributeActionCriticality(
+				ac.getSession(),
+				ac.getAttributeDefinitionById(parms.readInt("attributeDefinition")),
+				AttributeAction.valueOf(parms.readString("action").toUpperCase()),
+				parms.readBoolean("critical"));
+			return null;
+		}
+	},
+
+	/*#
+	 * Gets attribute rules containing policy collections and critical actions for an attribute definition with given id
+	 *
+	 * @param sess perun session
+	 * @param attributeDefinition id of the attribute definition
+	 * @return attribute rules of the attribute definition
+	 * @throws AttributeNotExistsException when there is no attribute definition with such id
+	 */
+	getAttributeRules {
+		@Override
+		public AttributeRules call(ApiCaller ac, Deserializer parms) throws PerunException {
+			return ac.getAttributesManager().getAttributeRules(
+				ac.getSession(),
+				parms.readInt("attributeDefinition"));
+		}
 	}
 }

--- a/perun-utils/rpc-methods-javadoc-generator/parseRpcMethods.pl
+++ b/perun-utils/rpc-methods-javadoc-generator/parseRpcMethods.pl
@@ -272,6 +272,8 @@ $objectExamples{"AttributePolicyCollection"} = "{ \"id\" : 10 , \"attributeId\" 
 $objectExamples{"List&lt;AttributePolicyCollection&gt;"} = $listPrepend . $objectExamples{"AttributePolicyCollection"} . $listAppend;
 $objectExamples{"List<AttributePolicyCollection>"} = $objectExamples{"List&lt;AttributePolicyCollection&gt;"};
 
+$objectExamples{"AttributeRules"} = "{\"attributePolicyCollections\": " . $objectExamples{"List&lt;AttributePolicyCollection&gt;"} . ", \"criticalActions\": [\"WRITE\" , \"READ\"]}";
+
 $objectExamples{"ConsentHub"} = "{ \"id\" : 10 , \"name\" : \"Test Consent Hub\" , \"enforceConsents\" : false , \"facilities\" : " . $objectExamples{"List&lt;Facility&gt;"} . " , \"beanName\" : \"ConsentHub\" }";
 $objectExamples{"List&lt;ConsentHub&gt;"} = $listPrepend . $objectExamples{"ConsentHub"} . $listAppend;
 $objectExamples{"List<ConsentHub>"} = $objectExamples{"List&lt;ConsentHub&gt;"};


### PR DESCRIPTION
* by default every WRITE operation on attribute should require MFA
* this will be saved to DB as critical action
* created new class AttributeRules that contains attribute policies and critical actions to reduce number of RPC calls from GUI

BREAKING CHANGE: update db