### PR TITLE
feat: critical operations in Registrar, Mail, Notif, Consent managers

### DIFF
--- a/perun-base/src/main/resources/perun-roles.yml
+++ b/perun-base/src/main/resources/perun-roles.yml
@@ -6438,11 +6438,15 @@ perun_policies:
     policy_roles: []
     include_policies:
       - default_policy
+    mfa_rules:
+      - MFA:
 
   removePerunNotifReceiverById_int_policy:
     policy_roles: []
     include_policies:
       - default_policy
+    mfa_rules:
+      - MFA:
 
   getPerunNotifRegexById_int_policy:
     policy_roles:
@@ -6460,16 +6464,22 @@ perun_policies:
     policy_roles: []
     include_policies:
       - default_policy
+    mfa_rules:
+      - MFA:
 
   updatePerunNotifRegex_PerunNotifRegex_policy:
     policy_roles: []
     include_policies:
       - default_policy
+    mfa_rules:
+      - MFA:
 
   removePerunNotifRegexById_int_policy:
     policy_roles: []
     include_policies:
       - default_policy
+    mfa_rules:
+      - MFA:
 
   getPerunNotifTemplateById_int_policy:
     policy_roles:
@@ -6487,11 +6497,15 @@ perun_policies:
     policy_roles: []
     include_policies:
       - default_policy
+    mfa_rules:
+      - MFA:
 
   updatePerunNotifTemplate_PerunNotifTemplate_policy:
     policy_roles: []
     include_policies:
       - default_policy
+    mfa_rules:
+      - MFA:
 
   getPerunNotifTemplateMessageById_int_policy:
     policy_roles:
@@ -6509,21 +6523,29 @@ perun_policies:
     policy_roles: []
     include_policies:
       - default_policy
+    mfa_rules:
+      - MFA:
 
   updatePerunNotifTemplateMessage_PerunNotifTemplateMessage_policy:
     policy_roles: []
     include_policies:
       - default_policy
+    mfa_rules:
+      - MFA:
 
   stopNotifications_policy:
     policy_roles: []
     include_policies:
       - default_policy
+    mfa_rules:
+      - MFA:
 
   startNotifications_policy:
     policy_roles: []
     include_policies:
       - default_policy
+    mfa_rules:
+      - MFA:
 
   #CabinetManagerImpl
   createPublicationSystem_PublicationSystem_policy:
@@ -6653,12 +6675,17 @@ perun_policies:
       - GROUPADMIN: Group
     include_policies:
       - default_policy
+    mfa_rules:
+      - MFA: Vo
+      - MFA: Group
 
   vo-addMail_ApplicationForm_ApplicationMail_policy:
     policy_roles:
       - VOADMIN: Vo
     include_policies:
       - default_policy
+    mfa_rules:
+      - MFA: Vo
 
   group-deleteMailById_ApplicationForm_Integer_policy:
     policy_roles:
@@ -6666,18 +6693,25 @@ perun_policies:
       - GROUPADMIN: Group
     include_policies:
       - default_policy
+    mfa_rules:
+      - MFA: Vo
+      - MFA: Group
 
   vo-deleteMailById_ApplicationForm_Integer_policy:
     policy_roles:
       - VOADMIN: Vo
     include_policies:
       - default_policy
+    mfa_rules:
+      - MFA: Vo
 
   copyMailsFromVoToVo_Vo_Vo_policy:
     policy_roles:
       - VOADMIN: Vo
     include_policies:
       - default_policy
+    mfa_rules:
+      - MFA: Vo
 
   copyMailsFromVoToGroup_Vo_Group_boolean_policy:
     policy_roles:
@@ -6685,6 +6719,9 @@ perun_policies:
       - GROUPADMIN: Group
     include_policies:
       - default_policy
+    mfa_rules:
+      - MFA: Vo
+      - MFA: Group
 
   copyMailsFromGroupToGroup_Group_Group_policy:
     policy_roles:
@@ -6692,6 +6729,9 @@ perun_policies:
       - GROUPADMIN: Group
     include_policies:
       - default_policy
+    mfa_rules:
+      - MFA: Vo
+      - MFA: Group
 
   group-sendMessage_Application_MailType_String_policy:
     policy_roles:
@@ -6699,12 +6739,17 @@ perun_policies:
       - GROUPADMIN: Group
     include_policies:
       - default_policy
+    mfa_rules:
+      - MFA: Vo
+      - MFA: Group
 
   vo-sendMessage_Application_MailType_String_policy:
     policy_roles:
       - VOADMIN: Vo
     include_policies:
       - default_policy
+    mfa_rules:
+      - MFA: Vo
 
   group-sendInvitation_Vo_Group_String_String_String_policy:
     policy_roles:
@@ -6712,6 +6757,9 @@ perun_policies:
       - GROUPADMIN: Group
     include_policies:
       - default_policy
+    mfa_rules:
+      - MFA: Vo
+      - MFA: Group
 
   vo-sendInvitation_Vo_Group_String_String_String_policy:
     policy_roles:
@@ -6719,6 +6767,8 @@ perun_policies:
       - TOPGROUPCREATOR: Vo
     include_policies:
       - default_policy
+    mfa_rules:
+      - MFA: Vo
 
   group-sendInvitation_Vo_Group_User_policy:
     policy_roles:
@@ -6726,12 +6776,17 @@ perun_policies:
       - GROUPADMIN: Group
     include_policies:
       - default_policy
+    mfa_rules:
+      - MFA: Vo
+      - MFA: Group
 
   vo-sendInvitation_Vo_Group_User_policy:
     policy_roles:
       - VOADMIN: Vo
     include_policies:
       - default_policy
+    mfa_rules:
+      - MFA: Vo
 
   #RegistrarManagerImpl
   createApplicationFormInVo_Vo_policy:
@@ -6739,6 +6794,8 @@ perun_policies:
       - VOADMIN: Vo
     include_policies:
       - default_policy
+    mfa_rules:
+      - MFA: Vo
 
   createApplicationFormInGroup_Group_policy:
     policy_roles:
@@ -6746,6 +6803,9 @@ perun_policies:
       - VOADMIN: Vo
     include_policies:
       - default_policy
+    mfa_rules:
+      - MFA: Vo
+      - MFA: Group
 
   vo-getFormById_int_policy:
     policy_roles:
@@ -6790,6 +6850,8 @@ perun_policies:
       - VOADMIN: Vo
     include_policies:
       - default_policy
+    mfa_rules:
+      - MFA: Vo
 
   group-addFormItem_ApplicationForm_ApplicationFormItem_policy:
     policy_roles:
@@ -6797,12 +6859,17 @@ perun_policies:
       - GROUPADMIN: Group
     include_policies:
       - default_policy
+    mfa_rules:
+      - MFA: Vo
+      - MFA: Group
 
   vo-updateFormItems_ApplicationForm_List<ApplicationFormItem>_policy:
     policy_roles:
       - VOADMIN: Vo
     include_policies:
       - default_policy
+    mfa_rules:
+      - MFA: Vo
 
   group-updateFormItems_ApplicationForm_List<ApplicationFormItem>_policy:
     policy_roles:
@@ -6810,12 +6877,17 @@ perun_policies:
       - GROUPADMIN: Group
     include_policies:
       - default_policy
+    mfa_rules:
+      - MFA: Vo
+      - MFA: Group
 
   vo-updateForm_ApplicationForm_policy:
     policy_roles:
       - VOADMIN: Vo
     include_policies:
       - default_policy
+    mfa_rules:
+      - MFA: Vo
 
   group-updateForm_ApplicationForm_policy:
     policy_roles:
@@ -6823,24 +6895,33 @@ perun_policies:
       - GROUPADMIN: Group
     include_policies:
       - default_policy
+    mfa_rules:
+      - MFA: Vo
+      - MFA: Group
 
   deleteFormItem_ApplicationForm_int_policy:
     policy_roles:
       - VOADMIN: Vo
     include_policies:
       - default_policy
+    mfa_rules:
+      - MFA: Vo
 
   moveFormItem_ApplicationForm_int_boolean_policy:
     policy_roles:
       - VOADMIN: Vo
     include_policies:
       - default_policy
+    mfa_rules:
+      - MFA: Vo
 
   vo-updateFormItemTexts_ApplicationFormItem_policy:
     policy_roles:
       - VOADMIN: Vo
     include_policies:
       - default_policy
+    mfa_rules:
+      - MFA: Vo
 
   group-updateFormItemTexts_ApplicationFormItem_policy:
     policy_roles:
@@ -6848,12 +6929,17 @@ perun_policies:
       - GROUPADMIN: Group
     include_policies:
       - default_policy
+    mfa_rules:
+      - MFA: Vo
+      - MFA: Group
 
   vo-deleteApplication_Application_policy:
     policy_roles:
       - VOADMIN: Vo
     include_policies:
       - default_policy
+    mfa_rules:
+      - MFA: Vo
 
   group-deleteApplication_Application_policy:
     policy_roles:
@@ -6861,12 +6947,17 @@ perun_policies:
       - GROUPADMIN: Group
     include_policies:
       - default_policy
+    mfa_rules:
+      - MFA: Vo
+      - MFA: Group
 
   vo-verifyApplication_int_policy:
     policy_roles:
       - VOADMIN: Vo
     include_policies:
       - default_policy
+    mfa_rules:
+      - MFA: Vo
 
   group-verifyApplication_int_policy:
     policy_roles:
@@ -6874,12 +6965,17 @@ perun_policies:
       - GROUPADMIN: Group
     include_policies:
       - default_policy
+    mfa_rules:
+      - MFA: Vo
+      - MFA: Group
 
   vo-rejectApplication_int_String_policy:
     policy_roles:
       - VOADMIN: Vo
     include_policies:
       - default_policy
+    mfa_rules:
+      - MFA: Vo
 
   group-rejectApplication_int_String_policy:
     policy_roles:
@@ -6887,12 +6983,17 @@ perun_policies:
       - GROUPADMIN: Group
     include_policies:
       - default_policy
+    mfa_rules:
+      - MFA: Vo
+      - MFA: Group
 
   vo-approveApplicationInternal_int_policy:
     policy_roles:
       - VOADMIN: Vo
     include_policies:
       - default_policy
+    mfa_rules:
+      - MFA: Vo
 
   group-approveApplicationInternal_int_policy:
     policy_roles:
@@ -6900,6 +7001,9 @@ perun_policies:
       - GROUPADMIN: Group
     include_policies:
       - default_policy
+    mfa_rules:
+      - MFA: Vo
+      - MFA: Group
 
   vo-canBeApproved_Application_policy:
     policy_roles:
@@ -7016,6 +7120,8 @@ perun_policies:
       - VOADMIN: Vo
     include_policies:
       - default_policy
+    mfa_rules:
+      - MFA: Vo
 
   group-updateFormItem_ApplicationFormItem_policy:
     policy_roles:
@@ -7023,18 +7129,25 @@ perun_policies:
       - GROUPADMIN: Group
     include_policies:
       - default_policy
+    mfa_rules:
+      - MFA: Vo
+      - MFA: Group
 
   copyFormFromVoToVo_Vo_Vo_policy:
     policy_roles:
       - VOADMIN: Vo
     include_policies:
       - default_policy
+    mfa_rules:
+      - MFA: Vo
 
   source-copyFormFromVoToGroup_Vo_Group_Policy:
     policy_roles:
       - VOADMIN: Vo
     include_policies:
       - default_policy
+    mfa_rules:
+      - MFA: Vo
 
   destination-copyFormFromVoToGroup_Vo_Group_Policy:
     policy_roles:
@@ -7042,6 +7155,9 @@ perun_policies:
       - GROUPADMIN: Group
     include_policies:
       - default_policy
+    mfa_rules:
+      - MFA: Vo
+      - MFA: Group
 
   source-copyFormFromGroupToGroup_Group_Group_policy:
     policy_roles:
@@ -7056,11 +7172,17 @@ perun_policies:
       - GROUPADMIN: Group
     include_policies:
       - default_policy
+    mfa_rules:
+      - MFA: Vo
+      - MFA: Group
 
   updateFormItemData_int_ApplicationFormItemData_policy:
     policy_roles: []
     include_policies:
       - default_policy
+    mfa_rules:
+      - MFA: Vo
+      - MFA: Group
 
   #integrationManagerEntry
   getGroupMemberData_policy:
@@ -7189,22 +7311,30 @@ perun_policies:
       - FACILITYOBSERVER: Facility
     include_policies:
       - default_policy
+    mfa_rules:
+      - MFA: Facility
 
   changeConsentStatus_Consent_ConsentStatus_policy:
     policy_roles:
       - SELF: User
     include_policies:
       - default_policy
+    mfa_rules:
+      - MFA: User
 
   evaluateConsents_ConsentHub_policy:
     policy_roles: []
     include_policies:
       - default_policy
+    mfa_rules:
+      - MFA:
 
   evaluateConsents_Service_policy:
     policy_roles: []
     include_policies:
       - default_policy
+    mfa_rules:
+      - MFA:
 
 
 # A list of Perun management rules that are loaded to the PerunPoliciesContainer.


### PR DESCRIPTION
- mfa_rules in perun-roles.yml were added for Registrar, Mail,
Notification and Consent managers.