### PR TITLE
fix(core): allow null domain in brand check

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/PerunAppsConfig.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/PerunAppsConfig.java
@@ -40,11 +40,12 @@ public class PerunAppsConfig {
 	 * @return brand or null if domain is not present in the configuration
 	 */
 	public static Brand getBrandContainingDomain(String domain) {
+		Utils.notNull(domain, "domain");
 		for (Brand brand : instance.getBrands()) {
 			PerunAppsConfig.NewApps newApps = brand.getNewApps();
-			if (brand.getOldGuiDomain().equals(domain) || newApps.getAdmin().equals(domain) || newApps.getProfile().equals(domain)
-				|| newApps.getPublications().equals(domain) || newApps.getPwdReset().equals(domain) || newApps.getApi().equals(domain)
-				|| newApps.getConsolidator().equals(domain) || newApps.getLinker().equals(domain)) {
+			if (domain.equals(brand.getOldGuiDomain()) || domain.equals(newApps.getAdmin()) || domain.equals(newApps.getProfile())
+				|| domain.equals(newApps.getPublications()) || domain.equals(newApps.getPwdReset()) || domain.equals(newApps.getApi())
+				|| domain.equals(newApps.getConsolidator()) || domain.equals(newApps.getLinker())) {
 				return brand;
 			}
 		}


### PR DESCRIPTION
* when searching for brand containing domain of passed URL we used not null-safe check
* switched the order of objects to not throw an exception if configuration of app does not exist