### PR TITLE
feat(core): refresh mfa

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/CoreConfig.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/CoreConfig.java
@@ -95,6 +95,7 @@ public class CoreConfig {
 	private String userInfoEndpointMfaAcrValue;
 	private String userInfoEndpointMfaAuthTimestampPropertyName;
 	private int mfaAuthTimeout;
+	private boolean enforceMfa;
 
 	public int getGroupMaxConcurentGroupsToSynchronize() {
 		return groupMaxConcurentGroupsToSynchronize;
@@ -800,5 +801,13 @@ public class CoreConfig {
 
 	public void setMfaAuthTimeout(int mfaAuthTimeout) {
 		this.mfaAuthTimeout = mfaAuthTimeout;
+	}
+
+	public boolean isEnforceMfa() {
+		return enforceMfa;
+	}
+
+	public void setEnforceMfa(boolean enforceMfa) {
+		this.enforceMfa = enforceMfa;
 	}
 }

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/PerunPrincipal.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/PerunPrincipal.java
@@ -27,6 +27,7 @@ public class PerunPrincipal {
 	// Keywords of additionalInformations
 	public static final String MFA_TIMESTAMP = "mfaTimestamp";
 	public static final String ISSUER = "issuer";
+	public static final String ACCESS_TOKEN = "accessToken";
 
 	/**
 	 * Creates a new instance for a given string.

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/MFAuthenticationException.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/MFAuthenticationException.java
@@ -1,0 +1,37 @@
+package cz.metacentrum.perun.core.api.exceptions;
+
+/**
+ * This exception is thrown when verifying Multi-factor authentication fails.
+ * @author Johana Supikova <xsupikov@fi.muni.cz>
+ */
+public class MFAuthenticationException extends PerunException {
+	static final long serialVersionUID = 0;
+
+	/**
+	 * Simple constructor with a message
+	 *
+	 * @param message message with details about the cause
+	 */
+	public MFAuthenticationException(String message) {
+		super(message);
+	}
+
+	/**
+	 * Constructor with a message and Throwable object
+	 *
+	 * @param message message with details about the cause
+	 * @param cause   Throwable that caused throwing of this exception
+	 */
+	public MFAuthenticationException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	/**
+	 * Constructor with a Throwable object
+	 *
+	 * @param cause Throwable that caused throwing of this exception
+	 */
+	public MFAuthenticationException(Throwable cause) {
+		super(cause);
+	}
+}

--- a/perun-base/src/main/java/cz/metacentrum/perun/oidc/UserInfoEndpointCall.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/oidc/UserInfoEndpointCall.java
@@ -31,6 +31,34 @@ public class UserInfoEndpointCall {
 	private final static Logger log = LoggerFactory.getLogger(UserInfoEndpointCall.class);
 
 	public UserInfoEndpointResponse getUserInfoEndpointData(String accessToken, String issuer, Map<String, String> additionalInformation) throws ExpiredTokenException {
+		JsonNode userInfo = callUserInfo(accessToken, issuer);
+
+		fillAdditionalInformationWithDataFromUserInfo(userInfo, additionalInformation);
+
+		String mfaTimestamp = getMfaTimestamp(userInfo);
+		if (mfaTimestamp != null && !mfaTimestamp.isEmpty()) {
+			additionalInformation.put(MFA_TIMESTAMP, mfaTimestamp);
+		}
+
+		String extSourceName = getExtSourceName(userInfo);
+		String extSourceLogin = getExtSourceLogin(userInfo);
+		return new UserInfoEndpointResponse(extSourceName, extSourceLogin);
+	}
+
+	/**
+	 * Calls UserInfo endpoint and returns MFA timestamp if available and acr is equal to MFA acr
+	 * @param accessToken access token
+	 * @param issuer issuer
+	 * @throws ExpiredTokenException if access token is expired
+	 * @return mfa timestamp or null
+	 */
+	public String getUserInfoEndpointMfaData(String accessToken, String issuer) throws ExpiredTokenException {
+		JsonNode userInfo = callUserInfo(accessToken, issuer);
+
+		return getMfaTimestamp(userInfo);
+	}
+
+	private static JsonNode callUserInfo(String accessToken, String issuer) throws ExpiredTokenException {
 		RestTemplate restTemplate = new RestTemplate();
 		JsonNode config = restTemplate.getForObject(issuer + "/.well-known/openid-configuration", JsonNode.class);
 		HttpHeaders headers = new HttpHeaders();
@@ -54,15 +82,7 @@ public class UserInfoEndpointCall {
 			throw new InternalErrorException("Call to user info endpoint failed, the error is" + userInfo);
 		}
 		log.debug("user info retrieved: {}", userInfo);
-
-		fillAdditionalInformationWithDataFromUserInfo(userInfo, additionalInformation);
-		fillMfaTimestamp(userInfo, additionalInformation);
-
-		String extSourceName = getExtSourceName(userInfo);
-
-		String extSourceLogin = getExtSourceLogin(userInfo);
-
-		return new UserInfoEndpointResponse(extSourceName, extSourceLogin);
+		return userInfo;
 	}
 
 	/**
@@ -150,19 +170,20 @@ public class UserInfoEndpointCall {
 	}
 
 	/**
-	 * Filling additional information with mfa timestamp if acr value is equal to MFA acr value
-	 * @param userInfo
-	 * @param additionalInformation
+	 * Returns mfa timestamp if acr value is equal to MFA acr value
+	 * @param userInfo parsed response from userInfo endpoint
 	 */
-	private void fillMfaTimestamp(JsonNode userInfo, Map<String, String> additionalInformation) {
+	private String getMfaTimestamp(JsonNode userInfo) {
 		String acrProperty = BeansUtils.getCoreConfig().getUserInfoEndpointAcrPropertyName();
 		String acr = userInfo.path(acrProperty).asText();
 		if (StringUtils.isNotEmpty(acr) && acr.equals(BeansUtils.getCoreConfig().getUserInfoEndpointMfaAcrValue())) {
 			String mfaTimestampProperty = BeansUtils.getCoreConfig().getUserInfoEndpointMfaAuthTimestampPropertyName();
 			String mfaTimestamp = userInfo.path(mfaTimestampProperty).asText();
 			if (StringUtils.isNotEmpty(mfaTimestamp)) {
-				additionalInformation.put(MFA_TIMESTAMP, mfaTimestamp);
+				return mfaTimestamp;
 			}
 		}
+
+		return null;
 	}
 }

--- a/perun-base/src/main/resources/perun-base.xml
+++ b/perun-base/src/main/resources/perun-base.xml
@@ -76,6 +76,7 @@
 		<property name="userInfoEndpointExtSourceName" value="${perun.userInfoEndpoint.extSourceName}"/>
 		<property name="userInfoEndpointExtSourceFriendlyName" value="#{'${perun.userInfoEndpoint.extSourceFriendlyName}'.split('\s*,\s*')}"/>
 		<property name="mfaAuthTimeout" value="${perun.userInfoEndpoint.mfaAuthTimeout}"/>
+		<property name="enforceMfa" value="${perun.enforceMfa}"/>
 		<property name="userInfoEndpointMfaAuthTimestampPropertyName" value="${perun.userInfoEndpoint.mfaAuthTimestampPropertyName}"/>
 		<property name="userInfoEndpointMfaAcrValue" value="${perun.userInfoEndpoint.mfaAcrValue}"/>
 		<property name="userInfoEndpointAcrPropertyName" value="${perun.userInfoEndpoint.acrPropertyName}"/>
@@ -177,6 +178,7 @@
 				<prop key="perun.userInfoEndpoint.mfaAuthTimeout">24</prop>
 				<prop key="perun.userInfoEndpoint.acrPropertyName">acr</prop>
 				<prop key="perun.userInfoEndpoint.mfaAcrValue">https://refeds.org/profile/mfa</prop>
+				<prop key="perun.enforceMfa">false</prop>
 			</props>
 		</property>
 	</bean>

--- a/perun-base/src/main/resources/perun-roles.yml
+++ b/perun-base/src/main/resources/perun-roles.yml
@@ -463,6 +463,12 @@ perun_policies:
     include_policies:
       - default_policy
 
+  refreshMfa_policy:
+    policy_roles:
+      - SELF: User
+    include_policies:
+      - default_policy
+
   #DatabaseManagerEntry
   getCurrentDatabaseVersion_policy:
     policy_roles:

--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -4023,6 +4023,19 @@ paths:
         default:
           $ref: '#/components/responses/ExceptionResponse'
 
+  /json/authzResolver/refreshMfa:
+    get:
+      tags:
+        - AuthzResolver
+      operationId: refreshMfa
+      summary: Refreshes MFA-related data for principal.
+      parameters: [ ]
+      responses:
+        '200':
+          $ref: '#/components/responses/VoidResponse'
+        default:
+          $ref: '#/components/responses/ExceptionResponse'
+
   #################################################
   #                                               #
   # AttributesManager                             #

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/Api.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/Api.java
@@ -64,6 +64,7 @@ import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static cz.metacentrum.perun.core.api.PerunPrincipal.ACCESS_TOKEN;
 import static cz.metacentrum.perun.core.api.PerunPrincipal.ISSUER;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
@@ -252,6 +253,7 @@ public class Api extends HttpServlet {
 			String iss = req.getHeader(OIDC_CLAIM_ISS);
 			extLogin = req.getHeader(OIDC_CLAIM_SUB);
 			additionalInformations.put(ISSUER, iss);
+			additionalInformations.put(ACCESS_TOKEN, req.getHeader(OIDC_ACCESS_TOKEN));
 			//this is configurable, as the OIDC server has the source of sub claim also configurable
 			if (iss != null) {
 				extSourceName = BeansUtils.getCoreConfig().getOidcIssuersExtsourceNames().get(iss);

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/AuthzResolverMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/AuthzResolverMethod.java
@@ -1053,5 +1053,19 @@ public enum AuthzResolverMethod implements ManagerMethod {
 					roles);
 			}
 		}
+	},
+
+	/*#
+	 * Refreshes MFA-related data for principal.
+	 *
+	 * @throws ExpiredTokenException expired access token
+	 * @throws MFAuthenticationException wrong configuration or missing required information
+	 */
+	refreshMfa {
+		@Override
+		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
+			AuthzResolver.refreshMfa(ac.getSession());
+			return null;
+		}
 	};
 }


### PR DESCRIPTION
* added method which refreshes mfa information of current principal
* calls UserInfo endpoint, retrieves MFA timestamp if MFA acr is also returned and stores timestamp to principal's additionalInformations