### PR TITLE
fix(registrar): quick-fix duplicate notifications

### DIFF
--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
@@ -69,6 +69,7 @@ import cz.metacentrum.perun.registrar.model.ApplicationMail.MailType;
 import cz.metacentrum.perun.registrar.MailManager;
 import cz.metacentrum.perun.registrar.RegistrarManager;
 import cz.metacentrum.perun.registrar.RegistrarModule;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import static cz.metacentrum.perun.core.api.AttributeAction.READ;
 import static cz.metacentrum.perun.core.api.AttributeAction.WRITE;
@@ -1618,6 +1619,7 @@ public class RegistrarManagerImpl implements RegistrarManager {
 		}
 
 		Member member = membersManager.getMemberByUser(sess, app.getVo(), app.getUser());
+		boolean isTransactionOngoing = TransactionSynchronizationManager.isActualTransactionActive();
 
 		try {
 
@@ -1626,11 +1628,15 @@ public class RegistrarManagerImpl implements RegistrarManager {
 			// once member is validated
 			new Thread(() -> {
 
-				try {
-					Thread.sleep(5000);
-				} catch (InterruptedException e) {
-					// TODO Auto-generated catch block
-					e.printStackTrace();
+				// if there was ongoing transaction, we have to wait before validating the member,
+				// because the member might not be committed in DB yet
+				if (isTransactionOngoing) {
+					try {
+						Thread.sleep(5000);
+					} catch (InterruptedException e) {
+						// TODO Auto-generated catch block
+						e.printStackTrace();
+					}
 				}
 
 				try {


### PR DESCRIPTION
- Two duplicate group notifications were sent to group managers when a
user submitted a group application in the following scenario:
1. first the user submitted an application to the group's VO, which was
auto-approved
2. then he submitted the group application less than ~5-6 seconds after
he submitted the VO application
- The reason is that after the VO application was approved, a new
thread was created which slept for 5 seconds and then validated the
member in VO and handled the user's group applications - sent
notifications to the group's managers. If a group application was
submitted in this time window, a notification was sent both in this
method and in the submitApplication method.
- Now, the new thread doesn't sleep for 5 seconds because it is not
needed. It was needed in the async validate method in BL layer because
the transaction that created the member might have not committed yet.
But in Registrar, such a transaction must have committed because
approveApplication doesn't run in a transaction and before creating the
thread we use method getMemberByUser, hence he should already exist in
the DB.
- This is only quick-fix because there is still a time window when this
situation can happen - especially because validate method can take a
few seconds, too.