### PR TITLE
feat(cli): resolve MFA exception for command line tools

### DIFF
--- a/perun-cli/Perun/AuthzResolverAgent.pm
+++ b/perun-cli/Perun/AuthzResolverAgent.pm
@@ -63,4 +63,9 @@ sub getGroupRoleNames
 	return Perun::Common::callManagerMethod('getGroupRoleNames', '', @_);
 }
 
+sub refreshMfa
+{
+	return Perun::Common::callManagerMethod('refreshMfa', '', @_);
+}
+
 1;

--- a/perun-cli/Perun/auth/sample_oidc_config.yml
+++ b/perun-cli/Perun/auth/sample_oidc_config.yml
@@ -13,6 +13,7 @@ perun:
   acr_values: "" # List of ACR values for authentication
   scopes: "openid perun_api perun_admin offline_access" # List of scopes the access_token should grant access to
   perun_api_endpoint: ""
+  enforce_mfa: false # if true, requests Multi-Factor Authentication
 
 otherPerun:
   client_id: "" # Identifier of the CLI app on the OIDC server
@@ -22,4 +23,5 @@ otherPerun:
   acr_values: "" # List of ACR values for authentication
   scopes: "openid perun_api perun_admin offline_access" # List of scopes the access_token should grant access to
   perun_api_endpoint: ""
+  enforce_mfa: false # if true, requests Multi-Factor Authentication
   default: true


### PR DESCRIPTION
* if Perun throws MfaPrivilegeException, CLI tools need to instruct user to authenticate with Multi-Factor
* this is done by setting enforce_mfa property in OIDC config
* then when authentication request is sent, it prepends MFA acr value so that MFA is done along with standard OIDC authentication
* refreshMfa() needs to be called afterwards so that mfa timestamp is retrieved in Perun from UserInfoEndpoint
* if user has no active tokens, unmet_authentication_requirements error is returned from token endpoint