### PR TITLE
feat(core): resolve MFA for un/setting role

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/RoleManagementRules.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/RoleManagementRules.java
@@ -23,6 +23,10 @@ import java.util.Objects;
  *            Example entry: key: User; value: user_id
  * assignedObjects is a map of objects which can be assigned with the role. Key is a object name and value is mapping to the database.
  *            Example entry: key: Resource; value: resource_id
+ * assignmentCheck is a list of maps defining which of the assigned objects should be checked for being critical (requiring MFA) when setting the role.
+ *            Example entry: key: MFA; value: Resource <- If resource is critical, MFA is required
+ *            Example entry: {} <- No MFA is required to set this role
+ *            Example entry: Key: MFA; value: <- No value means MFA is always required to set this role
  * associatedReadRoles is a list of related roles which are authorized to read attribute value if the main role is authorized.
  *            Example list for groupadmin role - value: [GROUPOBSERVER]
  * assignableToAttributes is a flag that determines whether the role can appear in attribute policies.
@@ -37,17 +41,19 @@ public class RoleManagementRules {
 	private List<Map<String, String>> privilegedRolesToRead;
 	private Map<String, String> entitiesToManage;
 	private Map<String, String> assignedObjects;
+	private List<Map<String, String>> assignmentCheck;
 	private List<String> associatedReadRoles;
 	private boolean assignableToAttributes;
 	private boolean systemRole;
 
-	public RoleManagementRules(String roleName, String primaryObject, List<Map<String, String>> privilegedRolesToManage, List<Map<String, String>> privilegedRolesToRead, Map<String, String> entitiesToManage, Map<String, String> assignedObjects, List<String> associatedReadRoles, boolean assignableToAttributes, boolean systemRole) {
+	public RoleManagementRules(String roleName, String primaryObject, List<Map<String, String>> privilegedRolesToManage, List<Map<String, String>> privilegedRolesToRead, Map<String, String> entitiesToManage, Map<String, String> assignedObjects, List<Map<String, String>> assignmentCheck, List<String> associatedReadRoles, boolean assignableToAttributes, boolean systemRole) {
 		this.roleName = roleName;
 		this.primaryObject = primaryObject;
 		this.privilegedRolesToManage = privilegedRolesToManage;
 		this.privilegedRolesToRead = privilegedRolesToRead;
 		this.entitiesToManage = entitiesToManage;
 		this.assignedObjects = assignedObjects;
+		this.assignmentCheck = assignmentCheck;
 		this.associatedReadRoles = associatedReadRoles;
 		this.assignableToAttributes = assignableToAttributes;
 		this.systemRole = systemRole;
@@ -101,6 +107,14 @@ public class RoleManagementRules {
 		this.assignedObjects = assignedObjects;
 	}
 
+	public List<Map<String, String>> getAssignmentCheck() {
+		return assignmentCheck;
+	}
+
+	public void setAssignmentCheck(List<Map<String, String>> assignmentCheck) {
+		this.assignmentCheck = assignmentCheck;
+	}
+
 	public List<String> getAssociatedReadRoles() {
 		return associatedReadRoles;
 	}
@@ -136,6 +150,7 @@ public class RoleManagementRules {
 			Objects.equals(privilegedRolesToRead, that.privilegedRolesToRead) &&
 			Objects.equals(entitiesToManage, that.entitiesToManage) &&
 			Objects.equals(assignedObjects, that.assignedObjects) &&
+			Objects.equals(assignmentCheck, that.assignmentCheck) &&
 			Objects.equals(associatedReadRoles, that.associatedReadRoles) &&
 			Objects.equals(assignableToAttributes, that.assignableToAttributes) &&
 			Objects.equals(systemRole, that.systemRole);
@@ -143,7 +158,7 @@ public class RoleManagementRules {
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(roleName, primaryObject, privilegedRolesToManage, privilegedRolesToRead, entitiesToManage, assignedObjects, associatedReadRoles, assignableToAttributes, systemRole);
+		return Objects.hash(roleName, primaryObject, privilegedRolesToManage, privilegedRolesToRead, entitiesToManage, assignedObjects, assignmentCheck, associatedReadRoles, assignableToAttributes, systemRole);
 	}
 
 	@Override
@@ -155,6 +170,7 @@ public class RoleManagementRules {
 			", privilegedRolesToRead=" + privilegedRolesToRead +
 			", entitiesToManage=" + entitiesToManage +
 			", assignedObjects=" + assignedObjects +
+			", assignmentCheck=" + assignmentCheck +
 			", associatedReadRoles=" + associatedReadRoles +
 			", assignableToAttributes=" + assignableToAttributes +
 			", systemRole=" + systemRole +

--- a/perun-base/src/main/resources/perun-roles.yml
+++ b/perun-base/src/main/resources/perun-roles.yml
@@ -7532,6 +7532,8 @@ perun_roles_management:
   PERUNADMIN:
     primary_object:
     assign_to_objects: {}
+    assignment_check:
+      - MFA:
     entities_to_manage:
       User: user_id
     privileged_roles_to_manage:
@@ -7546,6 +7548,8 @@ perun_roles_management:
   PERUNOBSERVER:
     primary_object:
     assign_to_objects: {}
+    assignment_check:
+      - MFA:
     entities_to_manage:
       User: user_id
     privileged_roles_to_manage:
@@ -7559,6 +7563,8 @@ perun_roles_management:
   AUDITCONSUMERADMIN:
     primary_object:
     assign_to_objects: {}
+    assignment_check:
+      - MFA:
     entities_to_manage:
       User: user_id
     privileged_roles_to_manage:
@@ -7573,6 +7579,8 @@ perun_roles_management:
     primary_object: Vo
     assign_to_objects:
       Vo: vo_id
+    assignment_check:
+      - MFA: Vo
     entities_to_manage:
       User: user_id
       Group: authorized_group_id
@@ -7593,6 +7601,9 @@ perun_roles_management:
     assign_to_objects:
       Group: group_id
       Vo: vo_id
+    assignment_check:
+      - MFA: Vo
+      - MFA: Group
     entities_to_manage:
       User: user_id
       Group: authorized_group_id
@@ -7616,6 +7627,9 @@ perun_roles_management:
     assign_to_objects:
       Group: group_id
       Vo: vo_id
+    assignment_check:
+      - MFA: Vo
+      - MFA: Group
     entities_to_manage:
       User: user_id
       Group: authorized_group_id
@@ -7637,6 +7651,8 @@ perun_roles_management:
     primary_object:
     assign_to_objects:
       User: user_id
+    assignment_check:
+      - MFA: User
     entities_to_manage: {}
     privileged_roles_to_manage: []
     privileged_roles_to_read: []
@@ -7647,6 +7663,8 @@ perun_roles_management:
     primary_object: Facility
     assign_to_objects:
       Facility: facility_id
+    assignment_check:
+      - MFA: Facility
     entities_to_manage:
       User: user_id
       Group: authorized_group_id
@@ -7666,6 +7684,8 @@ perun_roles_management:
     primary_object: Facility
     assign_to_objects:
       Facility: facility_id
+    assignment_check:
+      - MFA: Facility
     entities_to_manage:
       User: user_id
       Group: authorized_group_id
@@ -7684,6 +7704,8 @@ perun_roles_management:
     primary_object: Vo
     assign_to_objects:
       Vo: vo_id
+    assignment_check:
+      - MFA: Vo
     entities_to_manage:
       User: user_id
       Group: authorized_group_id
@@ -7704,6 +7726,10 @@ perun_roles_management:
       Resource: resource_id
       Vo: vo_id
       Facility: facility_id
+    assignment_check:
+      - MFA: Resource
+      - MFA: Vo
+      - MFA: Facility
     entities_to_manage:
       User: user_id
       Group: authorized_group_id
@@ -7734,6 +7760,10 @@ perun_roles_management:
       Resource: resource_id
       Vo: vo_id
       Facility: facility_id
+    assignment_check:
+      - MFA: Resource
+      - MFA: Vo
+      - MFA: Facility
     entities_to_manage:
       User: user_id
       Group: authorized_group_id
@@ -7763,6 +7793,10 @@ perun_roles_management:
       Resource: resource_id
       Vo: vo_id
       Facility: facility_id
+    assignment_check:
+      - MFA: Resource
+      - MFA: Vo
+      - MFA: Facility
     entities_to_manage:
       User: user_id
       Group: authorized_group_id
@@ -7789,6 +7823,7 @@ perun_roles_management:
   REGISTRAR:
     primary_object:
     assign_to_objects: {}
+    assignment_check: []
     entities_to_manage: {}
     privileged_roles_to_manage: []
     privileged_roles_to_read: []
@@ -7799,6 +7834,7 @@ perun_roles_management:
   ENGINE:
     primary_object:
     assign_to_objects: {}
+    assignment_check: []
     entities_to_manage: {}
     privileged_roles_to_manage: []
     privileged_roles_to_read: []
@@ -7809,6 +7845,7 @@ perun_roles_management:
   RPC:
     primary_object:
     assign_to_objects: {}
+    assignment_check: []
     entities_to_manage: {}
     privileged_roles_to_manage: []
     privileged_roles_to_read: []
@@ -7819,6 +7856,7 @@ perun_roles_management:
   NOTIFICATIONS:
     primary_object:
     assign_to_objects: {}
+    assignment_check: []
     entities_to_manage: {}
     privileged_roles_to_manage: []
     privileged_roles_to_read: []
@@ -7829,6 +7867,7 @@ perun_roles_management:
   SERVICEUSER:
     primary_object:
     assign_to_objects: {}
+    assignment_check: []
     entities_to_manage: {}
     privileged_roles_to_manage: []
     privileged_roles_to_read: []
@@ -7839,6 +7878,8 @@ perun_roles_management:
     primary_object: Vo
     assign_to_objects:
       Vo: vo_id
+    assignment_check:
+      - MFA: Vo
     entities_to_manage:
       User: user_id
       Group: authorized_group_id
@@ -7857,6 +7898,8 @@ perun_roles_management:
     primary_object: Vo
     assign_to_objects:
       Vo: vo_id
+    assignment_check:
+      - MFA: Vo
     entities_to_manage:
       User: user_id
       Group: authorized_group_id
@@ -7875,6 +7918,8 @@ perun_roles_management:
     primary_object: Vo
     assign_to_objects:
       Vo: vo_id
+    assignment_check:
+      - MFA: Vo
     entities_to_manage:
       User: user_id
       Group: authorized_group_id
@@ -7893,6 +7938,8 @@ perun_roles_management:
     primary_object: SecurityTeam
     assign_to_objects:
       SecurityTeam: security_team_id
+    assignment_check:
+      - MFA:
     entities_to_manage:
       User: user_id
       Group: authorized_group_id
@@ -7909,6 +7956,8 @@ perun_roles_management:
   CABINETADMIN:
     primary_object:
     assign_to_objects: {}
+    assignment_check:
+      - MFA:
     entities_to_manage:
       User: user_id
     privileged_roles_to_manage:
@@ -7928,6 +7977,7 @@ perun_roles_management:
       Vo: vo_id
       Facility: facility_id
       Resource: resource_id
+    assignment_check: []
     entities_to_manage: {}
     privileged_roles_to_manage: []
     privileged_roles_to_read: []
@@ -7938,6 +7988,7 @@ perun_roles_management:
     primary_object:
     assign_to_objects:
       Member: member_id
+    assignment_check: []
     entities_to_manage: {}
     privileged_roles_to_manage: []
     privileged_roles_to_read: []
@@ -7947,6 +7998,7 @@ perun_roles_management:
   UNKNOWN:
     primary_object:
     assign_to_objects: {}
+    assignment_check: []
     entities_to_manage: {}
     privileged_roles_to_manage: []
     privileged_roles_to_read: []

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/AuthzResolver.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/AuthzResolver.java
@@ -994,7 +994,7 @@ public class AuthzResolver {
 	}
 
 	/**
-	 * Check wheter the principal is authorized to manage the role on the object.
+	 * Check whether the principal is authorized to manage the role on the object.
 	 *
 	 * @param sess principal's perun session
 	 * @param complementaryObject bounded with the role

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
@@ -254,7 +254,7 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 	}
 
 	/**
-	 * Check wheter the principal is authorized to manage the role on the object.
+	 * Check whether the principal is authorized to manage the role on the object.
 	 *
 	 * @param sess principal's perun session
 	 * @param object bounded with the role
@@ -1908,6 +1908,8 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 			throw new RoleCannotBeManagedException(role, complementaryObject, user);
 		}
 
+		checkMfaForSettingRole(sess, user, complementaryObject, role);
+
 		Map<String, Integer> mappingOfValues = createMappingToManageRole(user, complementaryObject, role);
 
 		try {
@@ -1939,6 +1941,8 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 		if (!objectAndRoleManageableByEntity(authorizedGroup.getBeanName(), complementaryObject, role)) {
 			throw new RoleCannotBeManagedException(role, complementaryObject, authorizedGroup);
 		}
+
+		checkMfaForSettingRole(sess, authorizedGroup, complementaryObject, role);
 
 		Map<String, Integer> mappingOfValues = createMappingToManageRole(authorizedGroup, complementaryObject, role);
 
@@ -1973,6 +1977,8 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 		if (!objectAndRoleManageableByEntity(user.getBeanName(), complementaryObject, role)) {
 			throw new RoleCannotBeManagedException(role, complementaryObject, user);
 		}
+
+		checkMfaForSettingRole(sess, user, complementaryObject, role);
 
 		Map<String, Integer> mappingOfValues = createMappingToManageRole(user, complementaryObject, role);
 
@@ -2009,6 +2015,8 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 		if (!objectAndRoleManageableByEntity(authorizedGroup.getBeanName(), complementaryObject, role)) {
 			throw new RoleCannotBeManagedException(role, complementaryObject, authorizedGroup);
 		}
+
+		checkMfaForSettingRole(sess, authorizedGroup, complementaryObject, role);
 
 		Map<String, Integer> mappingOfValues = createMappingToManageRole(authorizedGroup, complementaryObject, role);
 
@@ -4135,6 +4143,49 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 			}
 		}
 		return false;
+	}
+
+	/**
+	 * Checks if setting role requires MFA based on configuration in perun-roles, throws MfaPrivilegeException if requirements unmet.
+	 * @param assigningEntity user or group to which the role will be assigned (User)
+	 * @param complementaryObject which will be bounded with the role (Vo)
+	 * @param role role name (VOADMIN)
+	 * @throws MfaPrivilegeException if MFA requirements are not met
+	 */
+	private static void checkMfaForSettingRole(PerunSession sess, PerunBean assigningEntity, PerunBean complementaryObject, String role) {
+		RoleManagementRules rules;
+		try {
+			rules = AuthzResolverImpl.getRoleManagementRules(role);
+		} catch (RoleManagementRulesNotExistsException e) {
+			throw new InternalErrorException("Management rules not exist for the role " + role, e);
+		}
+
+		List<Map<String, String>> mfaPolicies = rules.getAssignmentCheck();
+		Map<String, Set<Integer>> mapOfBeans = new HashMap<>();
+
+		if (mfaPolicies != null && !mfaPolicies.isEmpty() && complementaryObject != null) {
+			mapOfBeans = fetchAllRelatedObjects(Arrays.asList(complementaryObject));
+		}
+
+		// check complementary objects for MFA requirements
+		if (!mfaAuthorized(sess, mfaPolicies, mapOfBeans)) {
+			if (complementaryObject == null) {
+				throw new MfaPrivilegeException("Multi-Factor authentication is required to set this role.");
+			}
+			String message = complementaryObject.getBeanName() != null ? complementaryObject.getBeanName() : "object";
+			message += " with id " + complementaryObject.getId() + " or related object is critical.";
+			throw new MfaPrivilegeException("Multi-Factor authentication is required - " + message);
+		}
+
+		// check assigning entity for MFA requirements
+		try {
+			if (BeansUtils.getCoreConfig().isEnforceMfa() && isAnyObjectMfaCritical(sess, Arrays.asList(assigningEntity))
+			 && !sess.getPerunPrincipal().getRoles().hasRole(Role.MFA) && !hasSystemRole(sess)) {
+				throw new MfaPrivilegeException("Multi-Factor authentication is required - assigning entity is critical.");
+			}
+		} catch (RoleManagementRulesNotExistsException e) {
+			throw new InternalErrorException("Error checking system roles", e);
+		}
 	}
 
 	/**

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/PerunRolesLoader.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/PerunRolesLoader.java
@@ -143,37 +143,31 @@ public class PerunRolesLoader {
 			JsonNode roleNode = rolesNodes.get(roleName);
 			JsonNode primaryObjectNode = roleNode.get("primary_object");
 			String primaryObject = primaryObjectNode.isNull() ? null : primaryObjectNode.textValue();
-			List<Map<String, String>> privilegedRolesToManage = createMapFromPrivilegedRoles(roleNode.get("privileged_roles_to_manage"));
-			List<Map<String, String>> privilegedRolesToRead = createMapFromPrivilegedRoles(roleNode.get("privileged_roles_to_read"));
+			List<Map<String, String>> privilegedRolesToManage = createListOfMapsFromJsonNode(roleNode.get("privileged_roles_to_manage"));
+			List<Map<String, String>> privilegedRolesToRead = createListOfMapsFromJsonNode(roleNode.get("privileged_roles_to_read"));
 			Map<String, String> entitiesToManage = createMapFromJsonNode(roleNode.get("entities_to_manage"));
 			Map<String, String> objectsToAssign = createMapFromJsonNode(roleNode.get("assign_to_objects"));
+			List<Map<String, String>> assignmentCheck = createListOfMapsFromJsonNode(roleNode.get("assignment_check"));
 			List<String> associatedReadRoles = createListFromJsonNode(roleNode.get("associated_read_roles"));
 			boolean assignableToAttribute = roleNode.get("assignable_to_attributes").asBoolean();
 			boolean systemRole = roleNode.get("system_role") != null && roleNode.get("system_role").asBoolean();
 
-			rules.add(new RoleManagementRules(roleName, primaryObject, privilegedRolesToManage, privilegedRolesToRead, entitiesToManage, objectsToAssign, associatedReadRoles, assignableToAttribute, systemRole));
+			rules.add(new RoleManagementRules(roleName, primaryObject, privilegedRolesToManage, privilegedRolesToRead, entitiesToManage, objectsToAssign, assignmentCheck, associatedReadRoles, assignableToAttribute, systemRole));
 		}
 
 		return rules;
 	}
 
-	/**
-	 * Gathers privileged roles from a JsonNnode and put them into a list of maps.
-	 * Role name is stored as a key and the object for the role is stored as a value.
-	 *
-	 * @param privilegedRolesNode is a JsonNode which contains role privileges
-	 * @return a list of maps representing the role privileges
-	 */
-	private List<Map<String, String>> createMapFromPrivilegedRoles(JsonNode privilegedRolesNode) {
-		List<Map<String, String>> privilegedRoles = new ArrayList<>();
+	private List<Map<String, String>> createListOfMapsFromJsonNode(JsonNode listNode) {
+		List<Map<String, String>> rules = new ArrayList<>();
 
-		//Field privileged_roles_to_manage is saved as List of maps in the for loop
-		for (JsonNode privilegedRoleNode : privilegedRolesNode) {
-			Map<String, String> innerRoleMap = createMapFromJsonNode(privilegedRoleNode);
-			privilegedRoles.add(innerRoleMap);
+		// iterate list of maps
+		for (JsonNode node : listNode) {
+			Map<String, String> innerRoleMap = createMapFromJsonNode(node);
+			rules.add(innerRoleMap);
 		}
 
-		return privilegedRoles;
+		return rules;
 	}
 
 	private Map<String, String> createMapFromJsonNode(JsonNode node) {


### PR DESCRIPTION
* when setting role to user or group, MFA might be required globally or for specific bounded object
* if the bounded object or the entity that gets the role are critical, MFA is required
* which bounded objects should be checked is specified in assignment_check property of the role

BREAKING CHANGE: extended perun-roles.yml with property assignment_check for roles