### PR TITLE
feat(core): check MFA for roles always requiring it

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/RoleManagementRules.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/RoleManagementRules.java
@@ -31,7 +31,7 @@ import java.util.Objects;
  *            Example list for groupadmin role - value: [GROUPOBSERVER]
  * assignableToAttributes is a flag that determines whether the role can appear in attribute policies.
  * systemRole is a flag that whether the role is a Perun system role.
- *
+ * mfaCriticalRole is a flag marking roles always requiring MFA from users having that role
  */
 public class RoleManagementRules {
 
@@ -45,8 +45,9 @@ public class RoleManagementRules {
 	private List<String> associatedReadRoles;
 	private boolean assignableToAttributes;
 	private boolean systemRole;
+	private boolean mfaCriticalRole;
 
-	public RoleManagementRules(String roleName, String primaryObject, List<Map<String, String>> privilegedRolesToManage, List<Map<String, String>> privilegedRolesToRead, Map<String, String> entitiesToManage, Map<String, String> assignedObjects, List<Map<String, String>> assignmentCheck, List<String> associatedReadRoles, boolean assignableToAttributes, boolean systemRole) {
+	public RoleManagementRules(String roleName, String primaryObject, List<Map<String, String>> privilegedRolesToManage, List<Map<String, String>> privilegedRolesToRead, Map<String, String> entitiesToManage, Map<String, String> assignedObjects, List<Map<String, String>> assignmentCheck, List<String> associatedReadRoles, boolean assignableToAttributes, boolean systemRole, boolean mfaCriticalRole) {
 		this.roleName = roleName;
 		this.primaryObject = primaryObject;
 		this.privilegedRolesToManage = privilegedRolesToManage;
@@ -57,6 +58,7 @@ public class RoleManagementRules {
 		this.associatedReadRoles = associatedReadRoles;
 		this.assignableToAttributes = assignableToAttributes;
 		this.systemRole = systemRole;
+		this.mfaCriticalRole = mfaCriticalRole;
 	}
 
 	public String getRoleName() {
@@ -139,6 +141,14 @@ public class RoleManagementRules {
 		this.systemRole = systemRole;
 	}
 
+	public boolean isMfaCriticalRole() {
+		return mfaCriticalRole;
+	}
+
+	public void setMfaCriticalRole(boolean mfaCriticalRole) {
+		this.mfaCriticalRole = mfaCriticalRole;
+	}
+
 	@Override
 	public boolean equals(Object o) {
 		if (this == o) return true;
@@ -153,12 +163,13 @@ public class RoleManagementRules {
 			Objects.equals(assignmentCheck, that.assignmentCheck) &&
 			Objects.equals(associatedReadRoles, that.associatedReadRoles) &&
 			Objects.equals(assignableToAttributes, that.assignableToAttributes) &&
-			Objects.equals(systemRole, that.systemRole);
+			Objects.equals(systemRole, that.systemRole) &&
+			Objects.equals(mfaCriticalRole, that.mfaCriticalRole);
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(roleName, primaryObject, privilegedRolesToManage, privilegedRolesToRead, entitiesToManage, assignedObjects, assignmentCheck, associatedReadRoles, assignableToAttributes, systemRole);
+		return Objects.hash(roleName, primaryObject, privilegedRolesToManage, privilegedRolesToRead, entitiesToManage, assignedObjects, assignmentCheck, associatedReadRoles, assignableToAttributes, systemRole, mfaCriticalRole);
 	}
 
 	@Override
@@ -174,6 +185,7 @@ public class RoleManagementRules {
 			", associatedReadRoles=" + associatedReadRoles +
 			", assignableToAttributes=" + assignableToAttributes +
 			", systemRole=" + systemRole +
+			", mfaCriticalRole=" + mfaCriticalRole +
 			'}';
 	}
 }

--- a/perun-base/src/main/resources/perun-roles.yml
+++ b/perun-base/src/main/resources/perun-roles.yml
@@ -7726,6 +7726,7 @@ perun_roles_management:
     associated_read_roles:
       - PERUNOBSERVER
     assignable_to_attributes: false
+    mfa_critical_role: true
 
   PERUNOBSERVER:
     primary_object:
@@ -7741,6 +7742,7 @@ perun_roles_management:
       - PERUNOBSERVER:
     associated_read_roles: []
     assignable_to_attributes: false
+    mfa_critical_role: true
 
   AUDITCONSUMERADMIN:
     primary_object:

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/exceptions/MfaRolePrivilegeException.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/exceptions/MfaRolePrivilegeException.java
@@ -1,0 +1,33 @@
+package cz.metacentrum.perun.core.api.exceptions;
+
+import cz.metacentrum.perun.core.api.PerunSession;
+import cz.metacentrum.perun.core.api.Role;
+import cz.metacentrum.perun.core.api.exceptions.rt.PerunRuntimeException;
+
+/**
+ * This exception is thrown when principal has role always requiring MFA but is not authenticated with Multi-Factor
+ * @author Johana Supikova <xsupikov@fi.muni.cz>
+ */
+public class MfaRolePrivilegeException extends MfaPrivilegeException {
+	static final long serialVersionUID = 0;
+
+	public MfaRolePrivilegeException(String message) {
+		super(message);
+	}
+
+	public MfaRolePrivilegeException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public MfaRolePrivilegeException(Throwable cause) {
+		super(cause);
+	}
+
+	public MfaRolePrivilegeException(PerunSession sess) {
+		super("Principal " + sess.getPerunPrincipal().getActor() + " is not authorized by MFA");
+	}
+
+	public MfaRolePrivilegeException(PerunSession sess, String role) {
+		super("Principal " + sess.getPerunPrincipal().getActor() + " has role " + role + " requiring MFA, but is not authorized by MFA");
+	}
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/PerunRolesLoader.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/PerunRolesLoader.java
@@ -151,8 +151,9 @@ public class PerunRolesLoader {
 			List<String> associatedReadRoles = createListFromJsonNode(roleNode.get("associated_read_roles"));
 			boolean assignableToAttribute = roleNode.get("assignable_to_attributes").asBoolean();
 			boolean systemRole = roleNode.get("system_role") != null && roleNode.get("system_role").asBoolean();
+			boolean mfaCriticalRole = roleNode.get("mfa_critical_role") != null && roleNode.get("mfa_critical_role").asBoolean();
 
-			rules.add(new RoleManagementRules(roleName, primaryObject, privilegedRolesToManage, privilegedRolesToRead, entitiesToManage, objectsToAssign, assignmentCheck, associatedReadRoles, assignableToAttribute, systemRole));
+			rules.add(new RoleManagementRules(roleName, primaryObject, privilegedRolesToManage, privilegedRolesToRead, entitiesToManage, objectsToAssign, assignmentCheck, associatedReadRoles, assignableToAttribute, systemRole, mfaCriticalRole));
 		}
 
 		return rules;


### PR DESCRIPTION
* we want to have option to configure roles which would always require MFA
* this would now apply for PERUNADMIN and PERUNOBSERVER
* user with this role will always need MFA to do ANY operation in Perun
* some internal components are given perunadmin role, which we need to skip for this check - these are defined in coreConfig