### PR TITLE
feat(core): added keepMemberStatus attribute

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/GroupsManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/GroupsManager.java
@@ -87,6 +87,8 @@ public interface GroupsManager {
 	String GROUP_START_OF_LAST_SUCCESSFUL_SYNC_ATTRNAME = AttributesManager.NS_GROUP_ATTR_DEF + ":startOfLastSuccessfulSynchronization";
 	// Defines timestamp with start of last synchronization
 	String GROUP_START_OF_LAST_SYNC_ATTRNAME = AttributesManager.NS_GROUP_ATTR_DEF + ":startOfLastSynchronization";
+	// Defines if we want to update statuses of already existing members
+	String GROUP_KEEP_MEMBER_STATUS = AttributesManager.NS_GROUP_ATTR_DEF + ":keepMemberStatus";
 
 	String GROUP_SHORT_NAME_REGEXP = "^[-a-zA-Z.0-9_ ]+$";
 	String GROUP_FULL_NAME_REGEXP = "^[-a-zA-Z.0-9_ ]+([:][-a-zA-Z.0-9_ ]+)*";

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -7475,6 +7475,20 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		policies.add(Triple.of(Role.GROUPADMIN, READ, RoleObject.Group));
 		attributes.put(attr, createInitialPolicyCollections(policies));
 
+		//urn:perun:group:attribute-def:def:keepMemberStatus
+		attr = new AttributeDefinition();
+		attr.setNamespace(AttributesManager.NS_GROUP_ATTR_DEF);
+		attr.setType(Boolean.class.getName());
+		attr.setFriendlyName("keepMemberStatus");
+		attr.setDisplayName("Keep member's status");
+		attr.setDescription("Disallow changing member status during synchronization.");
+		//set attribute rights (with dummy id of attribute - not known yet)
+		policies = new ArrayList<>();
+		policies.add(Triple.of(Role.VOADMIN, READ, RoleObject.Vo));
+		policies.add(Triple.of(Role.VOADMIN, WRITE, RoleObject.Vo));
+		policies.add(Triple.of(Role.GROUPADMIN, READ, RoleObject.Group));
+		attributes.put(attr, createInitialPolicyCollections(policies));
+
 		//urn:perun:group:attribute-def:def:synchronizationEnabled
 		attr = new AttributeDefinition();
 		attr.setNamespace(AttributesManager.NS_GROUP_ATTR_DEF);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
@@ -87,7 +87,6 @@ import cz.metacentrum.perun.core.api.exceptions.GroupSynchronizationAlreadyRunni
 import cz.metacentrum.perun.core.api.exceptions.GroupSynchronizationNotEnabledException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.InvalidLoginException;
-import cz.metacentrum.perun.core.api.exceptions.LoginNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.MemberAlreadyRemovedException;
 import cz.metacentrum.perun.core.api.exceptions.MemberGroupMismatchException;
 import cz.metacentrum.perun.core.api.exceptions.MemberNotExistsException;
@@ -3704,7 +3703,31 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 		addUserExtSources(sess, candidate, memberToUpdate);
 
 		//Set correct member Status
-		updateMemberStatus(sess, memberToUpdate);
+		try {
+			if (isMemberStatusChangeAllowed(sess, group)) {
+				updateMemberStatus(sess, memberToUpdate);
+			}
+		} catch (WrongAttributeAssignmentException | AttributeNotExistsException ex) {
+			throw new InternalErrorException(ex);
+		}
+	}
+
+	/**
+	 * Return false if attribute group:keepMemberStatus is set to true.
+	 * True otherwise.
+	 *
+	 * @param sess session
+	 * @param group group to be synchronized
+	 *
+	 * @return false if change of member's status is not allowed, true otherwise
+	 *
+	 * @throws InternalErrorException if obtaining attribute failed
+	 * @throws WrongAttributeAssignmentException if incorrect assignment of attribute
+	 * @throws AttributeNotExistsException if attribute does not exist in database
+	 */
+	private boolean isMemberStatusChangeAllowed(PerunSession sess, Group group) throws WrongAttributeAssignmentException, AttributeNotExistsException {
+		Attribute keepStatusAttr = getPerunBl().getAttributesManagerBl().getAttribute(sess, group, GroupsManager.GROUP_KEEP_MEMBER_STATUS);
+		return keepStatusAttr == null || keepStatusAttr.getValue() == null;
 	}
 
 	/**

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/GroupAndGroupStructureSynchronizationIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/GroupAndGroupStructureSynchronizationIntegrationTest.java
@@ -1087,6 +1087,38 @@ public class GroupAndGroupStructureSynchronizationIntegrationTest extends Abstra
 	}
 
 	@Test
+	public void synchronizeGroupButKeepMemberStatus() throws Exception {
+		System.out.println(CLASS_NAME + "synchronizeGroupButKeepMemberStatus");
+
+		Attribute keepStatus = new Attribute(attributesManagerBl.getAttributeDefinition(sess, GroupsManager.GROUP_KEEP_MEMBER_STATUS));
+		keepStatus.setValue(true);
+		attributesManagerBl.setAttribute(sess, group, keepStatus);
+
+		when(extSourceManagerBl.getExtSourceByName(sess, ExtSourcesManager.EXTSOURCE_NAME_PERUN)).thenReturn(extSourceForUserCreation);
+
+		Attribute attr = attributesManagerBl.getAttribute(sess, group, GroupsManager.GROUPEXTSOURCE_ATTRNAME);
+		attr.setValue(extSource.getName());
+		attributesManagerBl.setAttribute(sess, group, attr);
+
+		List<Map<String, String>> subjects = new ArrayList<>();
+		Map<String, String> attributes = new HashMap<>();
+		attributes.put("login", "metodej");
+		subjects.add(attributes);
+		Candidate candidate = setUpCandidate();
+
+		member = perun.getMembersManagerBl().createMemberSync(sess, vo, candidate);
+		perun.getMembersManagerBl().setStatus(sess, member, Status.DISABLED);
+		groupsManagerBl.addMember(sess, group, member);
+
+		when(extSourceManagerBl.getCandidate(sess, attributes, (ExtSourceLdap)essa, "metodej")).thenReturn(new CandidateSync(candidate));
+		when(essa.getGroupSubjects(anyMap())).thenReturn(subjects);
+
+		assertEquals(Status.DISABLED, groupsManagerBl.getGroupMembers(sess, group).get(0).getStatus());
+		groupsManagerBl.synchronizeGroup(sess, group);
+		assertEquals(Status.DISABLED, groupsManagerBl.getGroupMembers(sess, group).get(0).getStatus());
+	}
+
+	@Test
 	public void synchronizeGroupUpdateMemberOrganizationsAttribute() throws Exception {
 		System.out.println(CLASS_NAME + "synchronizeGroupUpdateMemberOrganizationsAttribute");
 


### PR DESCRIPTION
Added attribute, which when is set to value true, statuses of existing members will not be updated during synchronization.