### PR TITLE
feat(core): notification language check

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_vo_attribute_def_def_notificationsDefLang.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_vo_attribute_def_def_notificationsDefLang.java
@@ -1,0 +1,36 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Vo;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import cz.metacentrum.perun.core.implApi.modules.attributes.VoAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.VoAttributesModuleImplApi;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class urn_perun_vo_attribute_def_def_notificationsDefLang extends VoAttributesModuleAbstract implements VoAttributesModuleImplApi {
+	private final List<String> defaultLanguages = new ArrayList<>(List.of("en", "cs"));
+
+
+	@Override
+	public void checkAttributeSyntax(PerunSessionImpl perunSession, Vo vo, Attribute attribute) throws WrongAttributeValueException {
+		String value = attribute.valueAsString();
+		if (!defaultLanguages.contains(value)) {
+			throw new WrongAttributeValueException(attribute, "Language " + value + " is not supported for notifications.");
+		}
+	}
+
+	@Override
+	public AttributeDefinition getAttributeDefinition() {
+		AttributeDefinition attr = new AttributeDefinition();
+		attr.setNamespace(AttributesManager.NS_VO_ATTR_DEF);
+		attr.setFriendlyName("notificationsDefLang");
+		attr.setDisplayName("Notifications language");
+		attr.setType(String.class.getName());
+		attr.setDescription("Default notification language");
+		return attr;
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_vo_attribute_def_def_notificationsDefLangTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_vo_attribute_def_def_notificationsDefLangTest.java
@@ -1,0 +1,41 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Vo;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+
+public class urn_perun_vo_attribute_def_def_notificationsDefLangTest {
+	private static urn_perun_vo_attribute_def_def_notificationsDefLang classInstance;
+	private static PerunSessionImpl session;
+	private static Attribute attributeToCheck;
+	private static Vo vo;
+
+	@Before
+	public void setUp() {
+		classInstance = new urn_perun_vo_attribute_def_def_notificationsDefLang();
+		session = mock(PerunSessionImpl.class);
+		attributeToCheck = new Attribute();
+		vo = new Vo();
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testUnsupportedNotificationLanguage() throws Exception {
+		System.out.println("testUnsupportedNotificationLanguage()");
+		attributeToCheck.setValue("de");
+
+		classInstance.checkAttributeSyntax(session, vo, attributeToCheck);
+	}
+
+	@Test
+	public void testSupportedNotificationLanguage() throws Exception {
+		System.out.println("testSupportedNotificationLanguage()");
+		attributeToCheck.setValue("en");
+
+		classInstance.checkAttributeSyntax(session, vo, attributeToCheck);
+	}
+}


### PR DESCRIPTION
* added syntax check for notification language attribute
* by default only values "en" and "cs" are allowed
* in future this could be configured