### PR TITLE
feat(core): add read privileges to mfaCriticalObject attribute

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -8032,6 +8032,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		attr.setDescription("Updating the external source requires Multi-factor authentication.");
 
 		policies = new ArrayList<>();
+		policies.add(Triple.of(Role.SELF, READ, RoleObject.User));
 		attributes.put(attr, createInitialPolicyCollections(policies));
 
 		//urn_perun_user_attribute_def_def_mfaCriticalObject
@@ -8043,6 +8044,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		attr.setDescription("Updating the user requires Multi-factor authentication.");
 
 		policies = new ArrayList<>();
+		policies.add(Triple.of(Role.SELF, READ, RoleObject.User));
 		attributes.put(attr, createInitialPolicyCollections(policies));
 
 		//urn_perun_member_attribute_def_def_mfaCriticalObject
@@ -8054,6 +8056,10 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		attr.setDescription("Updating the member requires Multi-factor authentication.");
 
 		policies = new ArrayList<>();
+		policies.add(Triple.of(Role.SELF, READ, RoleObject.User));
+		policies.add(Triple.of(Role.VOADMIN, READ, RoleObject.Vo));
+		policies.add(Triple.of(Role.GROUPADMIN, READ, RoleObject.Vo));
+		policies.add(Triple.of(Role.GROUPMEMBERSHIPMANAGER, READ, RoleObject.Vo));
 		attributes.put(attr, createInitialPolicyCollections(policies));
 
 		//urn_perun_group_attribute_def_def_mfaCriticalObject
@@ -8065,6 +8071,9 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		attr.setDescription("Updating the group requires Multi-factor authentication.");
 
 		policies = new ArrayList<>();
+		policies.add(Triple.of(Role.VOADMIN, READ, RoleObject.Vo));
+		policies.add(Triple.of(Role.GROUPADMIN, READ, RoleObject.Group));
+		policies.add(Triple.of(Role.GROUPMEMBERSHIPMANAGER, READ, RoleObject.Group));
 		attributes.put(attr, createInitialPolicyCollections(policies));
 
 		//urn_perun_vo_attribute_def_def_mfaCriticalObject
@@ -8076,6 +8085,10 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		attr.setDescription("Updating the organization requires Multi-factor authentication.");
 
 		policies = new ArrayList<>();
+		policies.add(Triple.of(Role.VOADMIN, READ, RoleObject.Vo));
+		policies.add(Triple.of(Role.GROUPADMIN, READ, RoleObject.Vo));
+		policies.add(Triple.of(Role.GROUPMEMBERSHIPMANAGER, READ, RoleObject.Vo));
+		policies.add(Triple.of(Role.FACILITYADMIN, READ, RoleObject.Facility));
 		attributes.put(attr, createInitialPolicyCollections(policies));
 
 		//urn_perun_resource_attribute_def_def_mfaCriticalObject
@@ -8087,6 +8100,10 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		attr.setDescription("Updating the resource requires Multi-factor authentication.");
 
 		policies = new ArrayList<>();
+		policies.add(Triple.of(Role.VOADMIN, READ, RoleObject.Vo));
+		policies.add(Triple.of(Role.GROUPADMIN, READ, RoleObject.Group));
+		policies.add(Triple.of(Role.FACILITYADMIN, READ, RoleObject.Facility));
+		policies.add(Triple.of(Role.RESOURCEADMIN, READ, RoleObject.Resource));
 		attributes.put(attr, createInitialPolicyCollections(policies));
 
 		//urn_perun_facility_attribute_def_def_mfaCriticalObject
@@ -8098,6 +8115,8 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		attr.setDescription("Updating the facility requires Multi-factor authentication.");
 
 		policies = new ArrayList<>();
+		policies.add(Triple.of(Role.VOADMIN, READ, RoleObject.Vo));
+		policies.add(Triple.of(Role.FACILITYADMIN, READ, RoleObject.Facility));
 		attributes.put(attr, createInitialPolicyCollections(policies));
 
 		//urn_perun_host_attribute_def_def_mfaCriticalObject
@@ -8109,6 +8128,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		attr.setDescription("Updating the host requires Multi-factor authentication.");
 
 		policies = new ArrayList<>();
+		policies.add(Triple.of(Role.FACILITYADMIN, READ, RoleObject.Facility));
 		attributes.put(attr, createInitialPolicyCollections(policies));
 
 		// create namespaced attributes for each namespace

--- a/perun-db/addGroupMembershipManagerPolicies
+++ b/perun-db/addGroupMembershipManagerPolicies
@@ -26,8 +26,10 @@ sub help {
 # Specific attributes besides READ for user, user-facility, member and member-group attributes
 my @readAttributes = (
 	"urn:perun:vo:attribute-def:def:blockManualMemberAdding",
+	"urn:perun:vo:attribute-def:def:mfaCriticalObject",
 	"urn:perun:group:attribute-def:def:groupMembershipExpirationRules",
-	"urn:perun:group:attribute-def:def:blockManualMemberAdding"
+	"urn:perun:group:attribute-def:def:blockManualMemberAdding",
+	"urn:perun:group:attribute-def:def:mfaCriticalObject"
 );
 my @writeAttributes = (
 	"urn:perun:member_group:attribute-def:def:groupMembershipExpiration"


### PR DESCRIPTION
* write privilege is still dedicated to perunadmin
* read privileges are added to related objects so that it is clear for managers which objects are critical