### PR TITLE
feat(core): exact match user attribute list/map values

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/UsersManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/UsersManagerImpl.java
@@ -37,6 +37,7 @@ import cz.metacentrum.perun.core.api.exceptions.UserExtSourceNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
 import cz.metacentrum.perun.core.bl.DatabaseManagerBl;
 import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.blImpl.AttributesManagerBlImpl;
 import cz.metacentrum.perun.core.implApi.UsersManagerImplApi;
 import cz.metacentrum.perun.core.implApi.modules.pwdmgr.PasswordManagerModule;
 import cz.metacentrum.perun.registrar.model.Application;
@@ -67,6 +68,8 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.regex.Pattern;
 
+import static cz.metacentrum.perun.core.impl.AttributesManagerImpl.KEY_VALUE_DELIMITER;
+import static cz.metacentrum.perun.core.impl.AttributesManagerImpl.LIST_DELIMITER;
 import static cz.metacentrum.perun.core.impl.ResourcesManagerImpl.RESOURCE_MAPPER;
 import static cz.metacentrum.perun.core.impl.ResourcesManagerImpl.RICH_RESOURCE_WITH_TAGS_EXTRACTOR;
 import static cz.metacentrum.perun.core.impl.ResourcesManagerImpl.resourceMappingSelectQuery;
@@ -846,36 +849,39 @@ public class UsersManagerImpl implements UsersManagerImplApi {
 
 	@Override
 	public List<User> getUsersByAttributeValue(PerunSession sess, AttributeDefinition attributeDefinition, String attributeValue) {
-		String value = "";
-		String operator = "=";
-		if (attributeDefinition.getType().equals(String.class.getName())) {
-			value = attributeValue.trim();
-			operator = "=";
-		} else if (attributeDefinition.getType().equals(Integer.class.getName())) {
-			value = attributeValue.trim();
-			operator = "=";
-		}  else if (attributeDefinition.getType().equals(Boolean.class.getName())) {
-			value = attributeValue.trim();
-			operator = "=";
-		} else if (attributeDefinition.getType().equals(ArrayList.class.getName())) {
-			value = "%" + attributeValue.trim() + "%";
-			operator = "like";
-		} else if (attributeDefinition.getType().equals(LinkedHashMap.class.getName())) {
-			value = "%" + attributeValue.trim() + "%";
-			operator = "like";
+		MapSqlParameterSource namedParams = new MapSqlParameterSource();
+		namedParams.addValue("attr_id", attributeDefinition.getId());
+		String matchingPart = "=:value";
+
+		String attributeType = attributeDefinition.getType();
+		var simpleTypes = List.of(String.class.getName(), Integer.class.getName(), Boolean.class.getName());
+		if (simpleTypes.contains(attributeType)) {
+			namedParams.addValue("value", attributeValue.trim());
+		} else if (attributeType.equals(ArrayList.class.getName())) {
+			matchingPart = "~ any(array[(:firstElementRegex),(:anyOtherElementRegex)])";
+			// escape commas in value, double escape backslashes
+			String escapedValue = AttributesManagerBlImpl.escapeListAttributeValue(attributeValue.trim()).replace("\\", "\\\\");
+			namedParams.addValue("firstElementRegex", "^" + escapedValue + LIST_DELIMITER + ".*");
+			// avoid matching escaped commas, f.e. 'corgi' in 'horse,dog\,corgi,'
+			namedParams.addValue("anyOtherElementRegex", ".*[^\\\\]" + LIST_DELIMITER  + escapedValue + LIST_DELIMITER + ".*");
+		} else if (attributeType.equals(LinkedHashMap.class.getName())) {
+			// escape commas and colons in value, double escape backslashes
+			String escapedValue = AttributesManagerBlImpl.escapeMapAttributeValue(attributeValue.trim()).replace("\\", "\\\\");
+			matchingPart = "~ any(array[(:firstKeyRegex),(:anyValueRegex),(:anyOtherKeyRegex)])";
+			namedParams.addValue("firstKeyRegex", "^" + escapedValue + KEY_VALUE_DELIMITER + ".*");
+			// avoid matching escaped delimiters, f.e. 'dalmatian' in 'animals:dog\,dalmatian,'
+			namedParams.addValue("anyValueRegex", ".*[^\\\\]" + KEY_VALUE_DELIMITER + escapedValue + LIST_DELIMITER + ".*");
+			namedParams.addValue("anyOtherKeyRegex", ".*[^\\\\]" + LIST_DELIMITER + escapedValue + KEY_VALUE_DELIMITER + ".*");
+		} else {
+			throw new InternalErrorException("Unknown attribute type: " + attributeType);
 		}
 
 		String query = "select " + userMappingSelectQuery + " from users, user_attr_values where " +
-			" user_attr_values.attr_value " + operator + " :value and users.id=user_attr_values.user_id and user_attr_values.attr_id=:attr_id";
+				" user_attr_values.attr_value " + matchingPart + " and users.id=user_attr_values.user_id and user_attr_values.attr_id=:attr_id";
 
-		MapSqlParameterSource namedParams = new MapSqlParameterSource();
-		namedParams.addValue("value", value);
-		namedParams.addValue("attr_id", attributeDefinition.getId());
 
 		try {
 			return namedParameterJdbcTemplate.query(query, namedParams, USER_MAPPER);
-		} catch (EmptyResultDataAccessException e) {
-			return new ArrayList<>();
 		} catch (RuntimeException e) {
 			throw new InternalErrorException(e);
 		}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/UsersManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/UsersManagerEntryIntegrationTest.java
@@ -2301,6 +2301,129 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 		assertTrue(users.getData().contains(usersManager.getRichUser(sess, user2)));
 	}
 
+	@Test
+	public void getUsersByAttributeValue_string() throws Exception {
+		System.out.println(CLASS_NAME + "getUsersByAttributeValue_string");
+
+		User user = setUpUser("john", "smith");
+
+		AttributeDefinition attr = new AttributeDefinition();
+		attr.setNamespace("urn:perun:user:attribute-def:def");
+		attr.setFriendlyName("getUsersByAttributeValueTest");
+		attr.setType(String.class.getName());
+		attr.setDisplayName("getUsersByAttributeValueTest");
+		attr.setDescription("getUsersByAttributeValueTest");
+
+		AttributeDefinition attrDef = perun.getAttributesManager().createAttribute(sess, attr);
+		Attribute attribute = new Attribute(attrDef, "element1");
+		perun.getAttributesManagerBl().setAttribute(sess, user, attribute);
+
+		String attributeName = attr.getNamespace() + ":" + attr.getFriendlyName();
+
+		assertThat(perun.getUsersManagerBl().getUsersByAttributeValue(sess, attributeName, "element1"))
+			.containsExactly(user);
+		assertThat(perun.getUsersManagerBl().getUsersByAttributeValue(sess, attributeName, "element"))
+			.isEmpty();
+		assertThat(perun.getUsersManagerBl().getUsersByAttributeValue(sess, attributeName, "element12"))
+			.isEmpty();
+
+		perun.getAttributesManagerBl().setAttribute(sess, user, new Attribute(attrDef, "value@1_with,wei/rd:chars"));
+		assertThat(perun.getUsersManagerBl().getUsersByAttributeValue(sess, attributeName, "value@1_with,wei/rd:chars"))
+			.containsExactly(user);
+	}
+
+	@Test
+	public void getUsersByAttributeValue_list() throws Exception {
+		System.out.println(CLASS_NAME + "getUsersByAttributeValue_list");
+
+		User user = setUpUser("john", "smith");
+
+		AttributeDefinition attr = new AttributeDefinition();
+		attr.setNamespace("urn:perun:user:attribute-def:def");
+		attr.setFriendlyName("getUsersByAttributeValueTest");
+		attr.setType(ArrayList.class.getName());
+		attr.setDisplayName("getUsersByAttributeValueTest");
+		attr.setDescription("getUsersByAttributeValueTest");
+
+		AttributeDefinition attrDef = perun.getAttributesManager().createAttribute(sess, attr);
+		Attribute attribute = new Attribute(attrDef, new ArrayList<>(List.of("element1", "ah,oj,", "middle@element", "value@1_with/weird:char,s", "lašt.eĺement")));
+		perun.getAttributesManagerBl().setAttribute(sess, user, attribute);
+
+		String attributeName = attr.getNamespace() + ":" + attr.getFriendlyName();
+
+		assertThat(perun.getUsersManagerBl().getUsersByAttributeValue(sess, attributeName, "element1"))
+			.containsExactly(user);
+		assertThat(perun.getUsersManagerBl().getUsersByAttributeValue(sess, attributeName, "middle@element"))
+			.containsExactly(user);
+		assertThat(perun.getUsersManagerBl().getUsersByAttributeValue(sess, attributeName, "lašt.eĺement"))
+			.containsExactly(user);
+		assertThat(perun.getUsersManagerBl().getUsersByAttributeValue(sess, attributeName, "ah,oj,"))
+			.containsExactly(user);
+		assertThat(perun.getUsersManagerBl().getUsersByAttributeValue(sess, attributeName, "value@1_with/weird:char,s"))
+			.containsExactly(user);
+		assertThat(perun.getUsersManagerBl().getUsersByAttributeValue(sess, attributeName, "element"))
+			.isEmpty();
+		assertThat(perun.getUsersManagerBl().getUsersByAttributeValue(sess, attributeName, "element12"))
+			.isEmpty();
+		assertThat(perun.getUsersManagerBl().getUsersByAttributeValue(sess, attributeName, "mymiddle@element"))
+			.isEmpty();
+		// substrings between commas shouldn't get matched either
+		assertThat(perun.getUsersManagerBl().getUsersByAttributeValue(sess, attributeName, "ah"))
+			.isEmpty();
+		assertThat(perun.getUsersManagerBl().getUsersByAttributeValue(sess, attributeName, "oj"))
+			.isEmpty();
+	}
+
+	@Test
+	public void getUsersByAttributeValue_map() throws Exception {
+		System.out.println(CLASS_NAME + "getUsersByAttributeValue_map");
+
+		User user = setUpUser("john", "smith");
+
+		AttributeDefinition attr = new AttributeDefinition();
+		attr.setNamespace("urn:perun:user:attribute-def:def");
+		attr.setFriendlyName("getUsersByAttributeValueTest");
+		attr.setType(LinkedHashMap.class.getName());
+		attr.setDisplayName("getUsersByAttributeValueTest");
+		attr.setDescription("getUsersByAttributeValueTest");
+
+		AttributeDefinition attrDef = perun.getAttributesManager().createAttribute(sess, attr);
+		Attribute attribute = new Attribute(attrDef, new LinkedHashMap<>(Map.of("key1", "value@1_with,wei/rd:chars", "key@2", "last val:ue, with ň")));
+		perun.getAttributesManagerBl().setAttribute(sess, user, attribute);
+
+		String attributeName = attr.getNamespace() + ":" + attr.getFriendlyName();
+
+		assertThat(perun.getUsersManagerBl().getUsersByAttributeValue(sess, attributeName, "key1"))
+			.containsExactly(user);
+		assertThat(perun.getUsersManagerBl().getUsersByAttributeValue(sess, attributeName, "value@1_with,wei/rd:chars"))
+			.containsExactly(user);
+		assertThat(perun.getUsersManagerBl().getUsersByAttributeValue(sess, attributeName, "key@2"))
+			.containsExactly(user);
+		assertThat(perun.getUsersManagerBl().getUsersByAttributeValue(sess, attributeName, "last val:ue, with ň"))
+			.containsExactly(user);
+		assertThat(perun.getUsersManagerBl().getUsersByAttributeValue(sess, attributeName, "key"))
+			.isEmpty();
+		assertThat(perun.getUsersManagerBl().getUsersByAttributeValue(sess, attributeName, "mykey1"))
+			.isEmpty();
+		assertThat(perun.getUsersManagerBl().getUsersByAttributeValue(sess, attributeName, "key@21"))
+			.isEmpty();
+		// substrings between comma and colon or colon and comma shouldn't get matched either
+		assertThat(perun.getUsersManagerBl().getUsersByAttributeValue(sess, attributeName, "wei/rd"))
+			.isEmpty();
+		assertThat(perun.getUsersManagerBl().getUsersByAttributeValue(sess, attributeName, "ue"))
+			.isEmpty();
+		assertThat(perun.getUsersManagerBl().getUsersByAttributeValue(sess, attributeName, "ue,"))
+			.isEmpty();
+		assertThat(perun.getUsersManagerBl().getUsersByAttributeValue(sess, attributeName, ":ue,"))
+			.isEmpty();
+		assertThat(perun.getUsersManagerBl().getUsersByAttributeValue(sess, attributeName, "chars"))
+			.isEmpty();
+		assertThat(perun.getUsersManagerBl().getUsersByAttributeValue(sess, attributeName, ":chars"))
+			.isEmpty();
+		assertThat(perun.getUsersManagerBl().getUsersByAttributeValue(sess, attributeName, "chars,"))
+			.isEmpty();
+	}
+
 	// PRIVATE METHODS -------------------------------------------------------------
 
 	/**


### PR DESCRIPTION
* we don't want to allow substrings to be matched in map/list attributes when calling getUsersByAttributeValue method
* these changes require the value of list/map attributes to be surrounded by it's type delimiters so substrings are not matched anymore