### PR TITLE
fix(core): fixed searching for candidates without VO

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/VosManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/VosManagerEntry.java
@@ -367,7 +367,12 @@ public class VosManagerEntry implements VosManager {
 			}
 
 			List<Vo> membersVos = perunBl.getUsersManagerBl().getVosWhereUserIsMember(sess, candidate.getRichUser());
-			boolean isEligible = membersVos.stream().anyMatch(vo -> AuthzResolver.authorizedInternal(sess, "filter-getCompleteCandidates_policy", vo));
+			boolean isEligible = false;
+			if (membersVos.isEmpty()) {
+				isEligible = AuthzResolver.authorizedInternal(sess, "filter-getCompleteCandidates_policy");
+			} else {
+				isEligible = membersVos.stream().anyMatch(vo -> AuthzResolver.authorizedInternal(sess, "filter-getCompleteCandidates_policy", vo));
+			}
 			if (isEligible) {
 				eligibleCandidates.add(candidate);
 			}


### PR DESCRIPTION
- We couldn't add users without any VO into their first VO, since we filtered them out based on the policy, which iterated over users VOs. Now if VOs are empty, we check same policy without any VO -> giving e.g. perun admin the right to add such users to their first VO.