### PR TITLE
build(openapi): upgrade OpenAPI Generator to version 6.2.0

### DIFF
--- a/perun-cli-python/README.md
+++ b/perun-cli-python/README.md
@@ -10,8 +10,15 @@ using [OpenAPI Generator](https://openapi-generator.tech/docs/usage#generate) wh
 
 The generated classes depend on "dateutil" library, which needs to be installed.
  
-Thus to prepare the CLI tools to run, do: 
+To prepare the CLI tools to run, do:
 ```bash
 ./generate.sh
-apt install python3-dateutil
+apt install python3-dateutil python3-typing-extensions
+```
+
+Run the CLI programs like:
+```bash
+./get_user.py --PERUN_URL https://cloud1.perun-aai.org/ba/rpc \
+              --PERUN_USER 'perun/test' \
+              -id 1
 ```

--- a/perun-cli-python/generate.sh
+++ b/perun-cli-python/generate.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-GENERATOR_VERSION=6.0.1
+GENERATOR_VERSION=6.2.0
 if [ ! -f  "openapi-generator-cli-$GENERATOR_VERSION.jar" ] ; then
   wget https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/$GENERATOR_VERSION/openapi-generator-cli-$GENERATOR_VERSION.jar
 fi
@@ -9,12 +9,14 @@ rm -rf perun_openapi
 # see https://openapi-generator.tech/docs/usage#generate
 # and https://openapi-generator.tech/docs/generators/python
 java \
+ --add-opens java.base/java.util=ALL-UNNAMED \
+ --add-opens java.base/java.lang=ALL-UNNAMED \
  -DapiDocs=false \
  -DapiTests=false \
  -DmodelDocs=false \
  -DmodelTests=false \
  -jar openapi-generator-cli-$GENERATOR_VERSION.jar generate \
- --generator-name python \
+ --generator-name python-prior \
  --input-spec ../perun-openapi/openapi.yml \
  --model-package model \
  --additional-properties=generateSourceCodeOnly=true,packageName=perun_openapi

--- a/perun-openapi/pom.xml
+++ b/perun-openapi/pom.xml
@@ -28,7 +28,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>6.0.1</version>
+				<version>6.2.0</version>
 				<executions>
 					<execution>
 						<goals>


### PR DESCRIPTION
OpenAPI Generator version used in modules perun-openapi and perun-cli-python was updated to 6.2.0.