### PR TITLE
feat(core): removed global MFA rules

### DIFF
--- a/perun-base/src/main/resources/perun-roles.yml
+++ b/perun-base/src/main/resources/perun-roles.yml
@@ -226,29 +226,21 @@ perun_policies:
     policy_roles: []
     include_policies:
       - default_policy
-    mfa_rules:
-      - MFA:
 
   deleteAttribute_AttributeDefinition_policy:
     policy_roles: []
     include_policies:
       - default_policy
-    mfa_rules:
-      - MFA:
 
   deleteAttribute_AttributeDefinition_boolean:
     policy_roles: []
     include_policies:
       - default_policy
-    mfa_rules:
-      - MFA:
 
   updateAttributeDefinition_AttributeDefinition_policy:
     policy_roles: []
     include_policies:
       - default_policy
-    mfa_rules:
-      - MFA:
 
   doTheMagic_Member_policy:
     policy_roles: []
@@ -276,8 +268,6 @@ perun_policies:
     policy_roles: []
     include_policies:
       - default_policy
-    mfa_rules:
-      - MFA:
 
   getAttributePolicyCollections_int_policy:
     policy_roles:
@@ -295,29 +285,21 @@ perun_policies:
     policy_roles: []
     include_policies:
       - default_policy
-    mfa_rules:
-      - MFA:
 
   setAttributeActionCriticality_AttributeDefinition_AttributeAction_boolean_policy:
     policy_roles: []
     include_policies:
       - default_policy
-    mfa_rules:
-      - MFA:
 
   convertAttributeToUnique_int_policy:
     policy_roles: []
     include_policies:
       - default_policy
-    mfa_rules:
-      - MFA:
 
   convertAttributeToNonunique_int_policy:
     policy_roles: []
     include_policies:
       - default_policy
-    mfa_rules:
-      - MFA:
 
   getModulesDependenciesGraph_GraphTextFormat_policy:
     policy_roles:
@@ -380,23 +362,17 @@ perun_policies:
       - AUDITCONSUMERADMIN:
     include_policies:
       - default_policy
-    mfa_rules:
-      - MFA:
 
   log_String_policy:
     policy_roles: []
     include_policies:
       - default_policy
-    mfa_rules:
-      - MFA:
 
   setLastProcessedId_String_int_policy:
     policy_roles:
       - AUDITCONSUMERADMIN:
     include_policies:
       - default_policy
-    mfa_rules:
-      - MFA:
 
   #AuthzResolver
   getUserRoleNames_User_policy:
@@ -427,8 +403,6 @@ perun_policies:
     policy_roles: []
     include_policies:
       - default_policy
-    mfa_rules:
-      - MFA:
 
   getVosWhereUserIsInRoles_User_List<String>_policy:
     policy_roles:
@@ -506,15 +480,11 @@ perun_policies:
     policy_roles: []
     include_policies:
       - default_policy
-    mfa_rules:
-      - MFA:
 
   deleteExtSource_ExtSource_policy:
     policy_roles: []
     include_policies:
       - default_policy
-    mfa_rules:
-      - MFA:
 
   getExtSourceById_int_policy:
     policy_roles:
@@ -595,8 +565,6 @@ perun_policies:
     policy_roles: []
     include_policies:
       - default_policy
-    mfa_rules:
-      - MFA:
 
   getCandidate_ExtSource_String_policy:
     policy_roles:
@@ -880,8 +848,6 @@ perun_policies:
       - FACILITYADMIN:
     include_policies:
       - default_policy
-    mfa_rules:
-      - MFA:
 
   deleteFacility_Facility_Boolean_policy:
     policy_roles:
@@ -2013,15 +1979,11 @@ perun_policies:
     policy_roles: []
     include_policies:
       - default_policy
-    mfa_rules:
-      - MFA:
 
   synchronizeGroupsStructures_policy:
     policy_roles: []
     include_policies:
       - default_policy
-    mfa_rules:
-      - MFA:
 
   getMemberGroups_Member_policy:
     policy_roles:
@@ -3493,22 +3455,16 @@ perun_policies:
     policy_roles: []
     include_policies:
       - default_policy
-    mfa_rules:
-      - MFA:
 
   deleteOwner_Owner_policy:
     policy_roles: []
     include_policies:
       - default_policy
-    mfa_rules:
-      - MFA:
 
   deleteOwner_Owner_boolean_policy:
     policy_roles: []
     include_policies:
       - default_policy
-    mfa_rules:
-      - MFA:
 
   getOwnerById_int_policy:
     policy_roles:
@@ -4837,24 +4793,18 @@ perun_policies:
       - SECURITYADMIN:
     include_policies:
       - default_policy
-    mfa_rules:
-      - MFA:
 
   updateSecurityTeam_SecurityTeam_policy:
     policy_roles:
       - SECURITYADMIN: SecurityTeam
     include_policies:
       - default_policy
-    mfa_rules:
-      - MFA:
 
   deleteSecurityTeam_SecurityTeam__boolean_policy:
     policy_roles:
       - SECURITYADMIN: SecurityTeam
     include_policies:
       - default_policy
-    mfa_rules:
-      - MFA:
 
   getSecurityTeamById_int_policy:
     policy_roles:
@@ -4895,16 +4845,12 @@ perun_policies:
       - SECURITYADMIN: SecurityTeam
     include_policies:
       - default_policy
-    mfa_rules:
-      - MFA:
 
   removeUserFromBlacklist_SecurityTeam_User_policy:
     policy_roles:
       - SECURITYADMIN: SecurityTeam
     include_policies:
       - default_policy
-    mfa_rules:
-      - MFA:
 
   getBlacklist_SecurityTeam_policy:
     policy_roles:
@@ -5048,8 +4994,6 @@ perun_policies:
       - ENGINE:
     include_policies:
       - default_policy
-    mfa_rules:
-      - MFA:
 
   planServicePropagation_Facility_Service_policy:
     policy_roles:
@@ -5066,8 +5010,6 @@ perun_policies:
       - ENGINE:
     include_policies:
       - default_policy
-    mfa_rules:
-      - MFA:
 
   getFacilityAssignedServicesForGUI_Facility_policy:
     policy_roles:
@@ -5081,22 +5023,16 @@ perun_policies:
     policy_roles: []
     include_policies:
       - default_policy
-    mfa_rules:
-      - MFA:
 
   deleteService_Service_boolean_policy:
     policy_roles: []
     include_policies:
       - default_policy
-    mfa_rules:
-      - MFA:
 
   updateService_Service_policy:
     policy_roles: []
     include_policies:
       - default_policy
-    mfa_rules:
-      - MFA:
 
   getServiceById_int_policy:
     policy_roles:
@@ -5244,36 +5180,26 @@ perun_policies:
     policy_roles: []
     include_policies:
       - default_policy
-    mfa_rules:
-      - MFA:
 
   updateServicesPackage_ServicesPackage_policy:
     policy_roles: []
     include_policies:
       - default_policy
-    mfa_rules:
-      - MFA:
 
   deleteServicesPackage_ServicesPackage_policy:
     policy_roles: []
     include_policies:
       - default_policy
-    mfa_rules:
-      - MFA:
 
   addServiceToServicesPackage_ServicesPackage_Service_policy:
     policy_roles: []
     include_policies:
       - default_policy
-    mfa_rules:
-      - MFA:
 
   removeServiceFromServicesPackage_ServicesPackage_Service_policy:
     policy_roles: []
     include_policies:
       - default_policy
-    mfa_rules:
-      - MFA:
 
   getServicesFromServicesPackage_ServicesPackage_policy:
     policy_roles:
@@ -5289,36 +5215,26 @@ perun_policies:
     policy_roles: []
     include_policies:
       - default_policy
-    mfa_rules:
-      - MFA:
 
   addRequiredAttributes_Service_List<AttributeDefinition>_policy:
     policy_roles: []
     include_policies:
       - default_policy
-    mfa_rules:
-      - MFA:
 
   removeRequiredAttribute_Service_AttributeDefinition_policy:
     policy_roles: []
     include_policies:
       - default_policy
-    mfa_rules:
-      - MFA:
 
   removeRequiredAttributes_Service_List<AttributeDefinition>_policy:
     policy_roles: []
     include_policies:
       - default_policy
-    mfa_rules:
-      - MFA:
 
   removeAllRequiredAttributes_Service_policy:
     policy_roles: []
     include_policies:
       - default_policy
-    mfa_rules:
-      - MFA:
 
   addDestination_List<Service>_Facility_Destination_policy:
     policy_roles:
@@ -5573,8 +5489,6 @@ perun_policies:
     policy_roles: []
     include_policies:
       - default_policy
-    mfa_rules:
-      - MFA:
 
   #UsersManagerEntry
   getUserByUserExtSource_UserExtSource_policy:
@@ -6382,8 +6296,6 @@ perun_policies:
       - VOADMIN:
     include_policies:
       - default_policy
-    mfa_rules:
-      - MFA:
 
   getSponsors_Member_List<String>_policy:
     policy_roles:
@@ -6449,8 +6361,6 @@ perun_policies:
     policy_roles: []
     include_policies:
       - default_policy
-    mfa_rules:
-      - MFA:
 
   getUsersPage_UsersPageQuery_List<String>_policy:
     policy_roles:
@@ -6583,8 +6493,6 @@ perun_policies:
       - VOADMIN:
     include_policies:
       - default_policy
-    mfa_rules:
-      - MFA:
 
   updateVo_Vo_policy:
     policy_roles:
@@ -6909,15 +6817,11 @@ perun_policies:
     policy_roles: []
     include_policies:
       - default_policy
-    mfa_rules:
-      - MFA:
 
   removePerunNotifReceiverById_int_policy:
     policy_roles: []
     include_policies:
       - default_policy
-    mfa_rules:
-      - MFA:
 
   getPerunNotifRegexById_int_policy:
     policy_roles:
@@ -6935,22 +6839,16 @@ perun_policies:
     policy_roles: []
     include_policies:
       - default_policy
-    mfa_rules:
-      - MFA:
 
   updatePerunNotifRegex_PerunNotifRegex_policy:
     policy_roles: []
     include_policies:
       - default_policy
-    mfa_rules:
-      - MFA:
 
   removePerunNotifRegexById_int_policy:
     policy_roles: []
     include_policies:
       - default_policy
-    mfa_rules:
-      - MFA:
 
   getPerunNotifTemplateById_int_policy:
     policy_roles:
@@ -6968,15 +6866,11 @@ perun_policies:
     policy_roles: []
     include_policies:
       - default_policy
-    mfa_rules:
-      - MFA:
 
   updatePerunNotifTemplate_PerunNotifTemplate_policy:
     policy_roles: []
     include_policies:
       - default_policy
-    mfa_rules:
-      - MFA:
 
   getPerunNotifTemplateMessageById_int_policy:
     policy_roles:
@@ -6994,29 +6888,21 @@ perun_policies:
     policy_roles: []
     include_policies:
       - default_policy
-    mfa_rules:
-      - MFA:
 
   updatePerunNotifTemplateMessage_PerunNotifTemplateMessage_policy:
     policy_roles: []
     include_policies:
       - default_policy
-    mfa_rules:
-      - MFA:
 
   stopNotifications_policy:
     policy_roles: []
     include_policies:
       - default_policy
-    mfa_rules:
-      - MFA:
 
   startNotifications_policy:
     policy_roles: []
     include_policies:
       - default_policy
-    mfa_rules:
-      - MFA:
 
   #CabinetManagerImpl
   createPublicationSystem_PublicationSystem_policy:
@@ -7888,15 +7774,11 @@ perun_policies:
     policy_roles: []
     include_policies:
       - default_policy
-    mfa_rules:
-      - MFA:
 
   evaluateConsents_Service_policy:
     policy_roles: []
     include_policies:
       - default_policy
-    mfa_rules:
-      - MFA:
 
 
 # A list of Perun management rules that are loaded to the PerunPoliciesContainer.


### PR DESCRIPTION
Global MFA rules were removed as the operations are mostly used by PERUNADMIN anyway. Moreover, we do not want to bother other roles with step-up unless they set an object as critical for now.