### PR TITLE
feat: Add method to get OIDC config for Perun instance + CLi script to call this method

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/OidcConfig.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/OidcConfig.java
@@ -1,0 +1,108 @@
+package cz.metacentrum.perun.core.api;
+
+import java.util.Objects;
+
+public class OidcConfig {
+
+	private String clientId;
+	private String oidcDeviceCodeUri;
+	private String oidcTokenEndpointUri;
+	private String oidcTokenRevokeEndpointUri;
+	private String acrValues;
+	private String scopes;
+	private String perunApiEndpoint;
+	private boolean enforceMfa;
+
+	public OidcConfig() {}
+	public String getClientId() {
+		return clientId;
+	}
+
+	public void setClientId(String clientId) {
+		this.clientId = clientId;
+	}
+
+	public String getOidcDeviceCodeUri() {
+		return oidcDeviceCodeUri;
+	}
+
+	public void setOidcDeviceCodeUri(String oidcDeviceCodeUri) {
+		this.oidcDeviceCodeUri = oidcDeviceCodeUri;
+	}
+
+	public String getOidcTokenEndpointUri() {
+		return oidcTokenEndpointUri;
+	}
+
+	public void setOidcTokenEndpointUri(String oidcTokenEndpointUri) {
+		this.oidcTokenEndpointUri = oidcTokenEndpointUri;
+	}
+
+	public String getOidcTokenRevokeEndpointUri() {
+		return oidcTokenRevokeEndpointUri;
+	}
+
+	public void setOidcTokenRevokeEndpointUri(String oidcTokenRevokeEndpointUri) {
+		this.oidcTokenRevokeEndpointUri = oidcTokenRevokeEndpointUri;
+	}
+
+	public String getAcrValues() {
+		return acrValues;
+	}
+
+	public void setAcrValues(String acrValues) {
+		this.acrValues = acrValues;
+	}
+
+	public String getScopes() {
+		return scopes;
+	}
+
+	public void setScopes(String scopes) {
+		this.scopes = scopes;
+	}
+
+	public String getPerunApiEndpoint() {
+		return perunApiEndpoint;
+	}
+
+	public void setPerunApiEndpoint(String perunApiEndpoint) {
+		this.perunApiEndpoint = perunApiEndpoint;
+	}
+
+	public boolean getEnforceMfa() {
+		return enforceMfa;
+	}
+
+	public void setEnforceMfa(boolean enforceMfa) {
+		this.enforceMfa = enforceMfa;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		OidcConfig that = (OidcConfig) o;
+		return Objects.equals(getClientId(), that.getClientId()) && Objects.equals(getOidcDeviceCodeUri(), that.getOidcDeviceCodeUri()) && Objects.equals(getOidcTokenEndpointUri(), that.getOidcTokenEndpointUri()) && Objects.equals(getOidcTokenRevokeEndpointUri(), that.getOidcTokenRevokeEndpointUri())
+			&& Objects.equals(getPerunApiEndpoint(), that.getPerunApiEndpoint()) && Objects.equals(getAcrValues(), that.getAcrValues()) && Objects.equals(getScopes(), that.getScopes()) && Objects.equals(getEnforceMfa(), that.getEnforceMfa());
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(getClientId(), getOidcDeviceCodeUri(), getOidcTokenEndpointUri(), getOidcTokenRevokeEndpointUri(), getPerunApiEndpoint(), getAcrValues(), getScopes(), getEnforceMfa());
+	}
+
+	@Override
+	public String toString() {
+		return "OidcConfig{" +
+			"clientId='" + clientId + '\'' +
+			", oidcDeviceCodeUri='" + oidcDeviceCodeUri + '\'' +
+			", oidcTokenEndpointUri='" + oidcTokenEndpointUri + '\'' +
+			", oidcTokenRevokeEndpointUri='" + oidcTokenRevokeEndpointUri + '\'' +
+			", acrValues='" + acrValues + '\'' +
+			", scopes='" + scopes + '\'' +
+			", perunApiEndpoint='" + perunApiEndpoint + '\'' +
+			", enforceMfa='" + enforceMfa + '\'' +
+			'}';
+	}
+}

--- a/perun-base/src/test/resources/perun-oidc-config.yml
+++ b/perun-base/src/test/resources/perun-oidc-config.yml
@@ -1,0 +1,8 @@
+client_id: "363b656e-d139-4290-99cd-ee64eeb830d5" # Identifier of the CLI app on the OIDC server
+oidc_device_code_uri: "https://login.cesnet.cz/oidc/devicecode" # Here the CLI requests from the OIDC server to start the authentication
+oidc_token_endpoint_uri: "https://login.cesnet.cz/oidc/token" # Token endpoint URI
+oidc_token_revoke_endpoint_uri: "https://login.cesnet.cz/oidc/revoke" # Token revoke endpoint URI
+acr_values: "" # List of ACR values for authentication
+scopes: "openid perun_api perun_admin offline_access" # List of scopes the access_token should grant access to
+perun_api_endpoint: "https://perun-dev.cesnet.cz/oauth/rpc"
+enforce_mfa: false # Nastavenim true se vynuti MFA pri prihlaseni

--- a/perun-cli/Perun/Common.pm
+++ b/perun-cli/Perun/Common.pm
@@ -56,6 +56,7 @@ use Perun::beans::AssignedResource;
 use Perun::beans::AttributePolicy;
 use Perun::beans::AttributePolicyCollection;
 use Perun::beans::AttributeRules;
+use Perun::beans::OidcConfig;
 
 sub newEmptyBean
 {

--- a/perun-cli/Perun/ConfigAgent.pm
+++ b/perun-cli/Perun/ConfigAgent.pm
@@ -22,3 +22,7 @@ sub new
 sub reloadAppsConfig {
 	return Perun::Common::callManagerMethod('reloadAppsConfig', '', @_)
 }
+
+sub getPerunOidcConfig {
+	return Perun::Common::callManagerMethod('getPerunOidcConfig', '', @_)
+}

--- a/perun-cli/Perun/beans/OidcConfig.pm
+++ b/perun-cli/Perun/beans/OidcConfig.pm
@@ -1,0 +1,139 @@
+package Perun::beans::OidcConfig;
+
+use strict;
+use warnings;
+
+use Perun::Common;
+
+sub new
+{
+	bless({});
+}
+
+sub fromHash
+{
+	return Perun::Common::fromHash(@_);
+}
+
+sub TO_JSON
+{
+	my $self = shift;
+
+	my $clientId;
+	if (defined($self->{_clientId})) {
+		$clientId = "$self->{_clientId}";
+	} else {
+		$clientId = undef;
+	}
+
+	my $oidcDeviceCodeUri;
+	if (defined($self->{_oidcDeviceCodeUri})) {
+		$oidcDeviceCodeUri = "$self->{_oidcDeviceCodeUri}";
+	} else {
+		$oidcDeviceCodeUri = undef;
+	}
+
+	my $oidcTokenEndpointUri;
+	if (defined($self->{_oidcTokenEndpointUri})) {
+		$oidcTokenEndpointUri = "$self->{_oidcTokenEndpointUri}";
+	} else {
+		$oidcTokenEndpointUri = undef;
+	}
+
+	my $oidcTokenRevokeEndpointUri;
+	if (defined($self->{_oidcTokenRevokeEndpointUri})) {
+		$oidcTokenRevokeEndpointUri = "$self->{_oidcTokenRevokeEndpointUri}";
+	} else {
+		$oidcTokenRevokeEndpointUri = undef;
+	}
+
+	my $acrValues;
+	if (defined($self->{_acrValues})) {
+		$acrValues = "$self->{_acrValues}";
+	} else {
+		$acrValues = undef;
+	}
+
+	my $scopes;
+	if (defined($self->{_scopes})) {
+		$scopes = "$self->{_scopes}";
+	} else {
+		$scopes = undef;
+	}
+
+	my $perunApiEndpoint;
+	if (defined($self->{_perunApiEndpoint})) {
+		$perunApiEndpoint = "$self->{_perunApiEndpoint}";
+	} else {
+		$perunApiEndpoint = undef;
+	}
+
+	my $enforceMfa;
+	if (defined($self->{_enforceMfa})) {
+		$enforceMfa = "$self->{_enforceMfa}";
+	} else {
+		$enforceMfa = undef;
+	}
+
+	return { clientId => $clientId, oidcDeviceCodeUri => $oidcDeviceCodeUri, oidcTokenEndpointUri => $oidcTokenEndpointUri,
+		oidcTokenRevokeEndpointUri => $oidcTokenRevokeEndpointUri, acrValues => $acrValues, scopes => $scopes,
+		perunApiEndpoint => $perunApiEndpoint, enforceMfa => $enforceMfa };
+}
+
+sub getClientId
+{
+	my $self = shift;
+
+	return $self->{_clientId};
+}
+
+sub getOidcDeviceCodeUri
+{
+	my $self = shift;
+
+	return $self->{_oidcDeviceCodeUri};
+}
+
+sub getOidcTokenEndpointUri
+{
+	my $self = shift;
+
+	return $self->{_oidcTokenEndpointUri};
+}
+
+sub getOidcTokenRevokeEndpointUri
+{
+	my $self = shift;
+
+	return $self->{_oidcTokenRevokeEndpointUri};
+}
+
+sub getAcrValues
+{
+	my $self = shift;
+
+	return $self->{_acrValues};
+}
+
+sub getScopes
+{
+	my $self = shift;
+
+	return $self->{_scopes};
+}
+
+sub getPerunApiEndpoint
+{
+	my $self = shift;
+
+	return $self->{_perunApiEndpoint};
+}
+
+sub getEnforceMfa
+{
+	my $self = shift;
+
+	return $self->{_enforceMfa};
+}
+
+1;

--- a/perun-cli/getOidcConfig
+++ b/perun-cli/getOidcConfig
@@ -1,0 +1,49 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use JSON;
+
+use Perun::Agent;
+use Getopt::Long qw(:config no_ignore_case);
+
+
+sub help {
+	return qq{
+	Returns the OIDC configuration for this Perun instance.
+	The configuration can then be used in Perun/auth/oidc_config.yml to connect via OIDC.
+
+};
+}
+GetOptions("help|h"            => sub { print help(); exit 0; });
+
+my $agent = Perun::Agent->new();
+
+my $configAgent = $agent->getConfigAgent;
+
+my $oidcConfig = $configAgent->getPerunOidcConfig();
+
+my @result = ();
+
+foreach my $key (keys %$oidcConfig) {
+	my $fieldValue = $oidcConfig->{$key};
+	unless (defined $fieldValue) {
+		warn "WARNING: Field $_ is not defined in the OIDC config of this Perun instance!";
+		next;
+	}
+	push(@result, decamelize($key). ": " . encode_json($fieldValue) . "\n");
+}
+
+print(@result);
+
+
+sub decamelize {
+	my ($s) = @_;
+	$s =~ s{(\w+)}{
+		($a = $1) =~ s<(^[A-Z]|(?![a-z])[A-Z])><
+			"_" . lc $1
+		>eg;
+		substr $a, 0;
+	}eg;
+	$s;
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/ConfigManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/ConfigManager.java
@@ -15,4 +15,12 @@ public interface ConfigManager {
 	 * @throws PrivilegeException wrong privilege to call this method
 	 */
 	void reloadAppsConfig(PerunSession sess) throws PrivilegeException;
+
+	/**
+	 * Returns Oidc Configuration for this Perun instance (to be used for CLI communication).
+	 *
+	 * @param sess session
+	 * @return oidcConfig
+	 */
+	OidcConfig getPerunOidcConfig(PerunSession sess);
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ConfigManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ConfigManagerBl.java
@@ -1,6 +1,8 @@
 package cz.metacentrum.perun.core.bl;
 
 
+import cz.metacentrum.perun.core.api.OidcConfig;
+
 /**
  * ConfigManager serves to manage configuration files.
  *
@@ -12,4 +14,11 @@ public interface ConfigManagerBl {
 	 * Reloads the configuration of brandings and their respective apps (see perun-apps-config.yml)
 	 */
 	void reloadAppsConfig();
+
+	/**
+	 * Returns Oidc Configuration for this Perun instance (to be used for CLI communication).
+	 *
+	 * @return oidcConfig
+	 */
+	OidcConfig getPerunOidcConfig();
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ConfigManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ConfigManagerBlImpl.java
@@ -1,5 +1,6 @@
 package cz.metacentrum.perun.core.blImpl;
 
+import cz.metacentrum.perun.core.api.OidcConfig;
 import cz.metacentrum.perun.core.bl.ConfigManagerBl;
 import cz.metacentrum.perun.core.implApi.ConfigManagerImplApi;
 
@@ -22,6 +23,11 @@ public class ConfigManagerBlImpl implements ConfigManagerBl {
 	@Override
 	public void reloadAppsConfig() {
 		configManagerImpl.reloadAppsConfig();
+	}
+
+	@Override
+	public OidcConfig getPerunOidcConfig() {
+		return configManagerImpl.getPerunOidcConfig();
 	}
 
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ConfigManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ConfigManagerEntry.java
@@ -2,6 +2,7 @@ package cz.metacentrum.perun.core.entry;
 
 import cz.metacentrum.perun.core.api.ConfigManager;
 import cz.metacentrum.perun.core.api.AuthzResolver;
+import cz.metacentrum.perun.core.api.OidcConfig;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
 import cz.metacentrum.perun.core.bl.ConfigManagerBl;
@@ -47,5 +48,12 @@ public class ConfigManagerEntry implements ConfigManager {
 			throw new PrivilegeException(sess, "reloadAppsConfig");
 
 		configManagerBl.reloadAppsConfig();
+	}
+
+	@Override
+	public OidcConfig getPerunOidcConfig(PerunSession sess) {
+		Utils.checkPerunSession(sess);
+
+		return configManagerBl.getPerunOidcConfig();
 	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ConfigManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ConfigManagerImpl.java
@@ -1,5 +1,6 @@
 package cz.metacentrum.perun.core.impl;
 
+import cz.metacentrum.perun.core.api.OidcConfig;
 import cz.metacentrum.perun.core.implApi.ConfigManagerImplApi;
 import org.springframework.core.io.PathResource;
 import org.springframework.core.io.Resource;
@@ -11,14 +12,23 @@ import org.springframework.core.io.Resource;
 public class ConfigManagerImpl implements ConfigManagerImplApi {
 
 	private PerunAppsConfigLoader perunAppsConfigLoader;
+	private PerunOidcConfigLoader perunOidcConfigLoader;
 
 	@Override
 	public void setPerunAppsConfigLoader(PerunAppsConfigLoader perunAppsConfigLoader) {
 		this.perunAppsConfigLoader = perunAppsConfigLoader;
 	}
 
+	public void setPerunOidcConfigLoader(PerunOidcConfigLoader perunOidcConfigLoader) {
+		this.perunOidcConfigLoader = perunOidcConfigLoader;
+	}
+
 	@Override
 	public void reloadAppsConfig() {
 		perunAppsConfigLoader.initialize();
+	}
+
+	public OidcConfig getPerunOidcConfig() {
+		return perunOidcConfigLoader.loadPerunOidcConfig();
 	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/PerunOidcConfigLoader.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/PerunOidcConfigLoader.java
@@ -1,0 +1,56 @@
+package cz.metacentrum.perun.core.impl;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import cz.metacentrum.perun.core.api.OidcConfig;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import org.springframework.core.io.Resource;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+
+
+public class PerunOidcConfigLoader {
+
+	private Resource configurationPath;
+
+	public void setConfigurationPath(Resource configurationPath) {
+		this.configurationPath = configurationPath;
+	}
+
+	public OidcConfig loadPerunOidcConfig() {
+		OidcConfig oidcConfig = new OidcConfig();
+		JsonNode rootNode = loadConfigurationFile(configurationPath);
+
+		try {
+			oidcConfig.setClientId(rootNode.get("client_id").asText());
+			oidcConfig.setOidcDeviceCodeUri(rootNode.get("oidc_device_code_uri").asText());
+			oidcConfig.setOidcTokenEndpointUri(rootNode.get("oidc_token_endpoint_uri").asText());
+			oidcConfig.setOidcTokenRevokeEndpointUri(rootNode.get("oidc_token_revoke_endpoint_uri").asText());
+			oidcConfig.setAcrValues(rootNode.get("acr_values").asText());
+			oidcConfig.setScopes(rootNode.get("scopes").asText());
+			oidcConfig.setPerunApiEndpoint(rootNode.get("perun_api_endpoint").asText());
+			oidcConfig.setEnforceMfa(rootNode.get("enforce_mfa").asBoolean());
+		} catch (NullPointerException ex) {
+			throw new InternalErrorException("The format of perun-oidc-config.yml is incorrect. Check that all required fields are present.");
+		}
+		return oidcConfig;
+	}
+
+	private JsonNode loadConfigurationFile(Resource resource) {
+		ObjectMapper objectMapper = new ObjectMapper(new YAMLFactory());
+		JsonNode rootNode;
+		try (InputStream is = resource.getInputStream()) {
+			rootNode = objectMapper.readTree(is);
+		} catch (FileNotFoundException e) {
+			throw new InternalErrorException("Configuration file not found for oidc config. It should be in: " + resource, e);
+		} catch (IOException e) {
+			throw new InternalErrorException("IO exception was thrown during the processing of the file: " + resource, e);
+		}
+
+		return rootNode;
+	}
+
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/ConfigManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/ConfigManagerImplApi.java
@@ -1,7 +1,9 @@
 package cz.metacentrum.perun.core.implApi;
 
 
+import cz.metacentrum.perun.core.api.OidcConfig;
 import cz.metacentrum.perun.core.impl.PerunAppsConfigLoader;
+import cz.metacentrum.perun.core.impl.PerunOidcConfigLoader;
 
 /**
  * ConfigManager serves to manage configuration files.
@@ -18,8 +20,22 @@ public interface ConfigManagerImplApi {
 	void setPerunAppsConfigLoader(PerunAppsConfigLoader perunAppsConfigLoader);
 
 	/**
+	 * Sets the PerunOidcConfigLoader
+	 *
+	 * @param perunOidcConfigLoader loader to set
+	 */
+	void setPerunOidcConfigLoader(PerunOidcConfigLoader perunOidcConfigLoader);
+
+	/**
 	 * Reloads the configuration of brandings and their respective apps (see perun-apps-config.yml)
 	 *
 	 */
 	void reloadAppsConfig();
+
+	/**
+	 * Returns Oidc Configuration for this Perun instance (to be used for CLI communication).
+	 *
+	 * @return oidcConfig
+	 */
+	OidcConfig getPerunOidcConfig();
 }

--- a/perun-core/src/main/resources/perun-core.xml
+++ b/perun-core/src/main/resources/perun-core.xml
@@ -415,6 +415,7 @@ http://www.springframework.org/schema/task http://www.springframework.org/schema
 	</bean>
 	<bean id="configManagerImpl" class="cz.metacentrum.perun.core.impl.ConfigManagerImpl" scope="singleton" depends-on="databaseManagerBl">
 		<property name="perunAppsConfigLoader" ref="perunAppsConfigLoader"/>
+		<property name="perunOidcConfigLoader" ref="perunOidcConfigLoader"/>
 	</bean>
 	<bean id="databaseManagerImpl" class="cz.metacentrum.perun.core.impl.DatabaseManagerImpl" scope="singleton">
 		<constructor-arg ref="dataSource" />
@@ -566,6 +567,11 @@ http://www.springframework.org/schema/task http://www.springframework.org/schema
 		<bean id="perunAppsConfigLoader" class="cz.metacentrum.perun.core.impl.PerunAppsConfigLoader" init-method="initialize">
 			<property name="configPath" value="file:@perun.conf@perun-apps-config.yml"/>
 		</bean>
+
+		<!-- PerunOidcConfigLoader implementation -->
+		<bean id="perunOidcConfigLoader" class="cz.metacentrum.perun.core.impl.PerunOidcConfigLoader">
+			<property name="configurationPath" value="file:@perun.conf@perun-oidc-config.yml"/>
+		</bean>
 	</beans>
 
 	<!-- Containerized Perun for local testing -->
@@ -609,6 +615,11 @@ http://www.springframework.org/schema/task http://www.springframework.org/schema
 		<!-- Loader for the perunAppsConfig-->
 		<bean id="perunAppsConfigLoader" class="cz.metacentrum.perun.core.impl.PerunAppsConfigLoader" init-method="initialize">
 			<property name="configPath" value="classpath:perun-apps-config.yml"/>
+		</bean>
+
+		<!-- PerunOidcConfigLoader implementation -->
+		<bean id="perunOidcConfigLoader" class="cz.metacentrum.perun.core.impl.PerunOidcConfigLoader">
+			<property name="configurationPath" value="classpath:perun-oidc-config.yml"/>
 		</bean>
 
 		<!-- Spring's @Async execution runs synchronously	-->

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/PerunOidcConfigLoaderTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/PerunOidcConfigLoaderTest.java
@@ -1,0 +1,32 @@
+package cz.metacentrum.perun.core.impl;
+
+import cz.metacentrum.perun.core.AbstractPerunIntegrationTest;
+import cz.metacentrum.perun.core.api.OidcConfig;
+import org.junit.Before;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+
+
+public class PerunOidcConfigLoaderTest extends AbstractPerunIntegrationTest {
+
+	private OidcConfig expectedConfig;
+
+	@Before
+	public void setUp() {
+		expectedConfig = new OidcConfig();
+		expectedConfig.setClientId("363b656e-d139-4290-99cd-ee64eeb830d5");
+		expectedConfig.setOidcDeviceCodeUri("https://login.cesnet.cz/oidc/devicecode");
+		expectedConfig.setOidcTokenEndpointUri("https://login.cesnet.cz/oidc/token");
+		expectedConfig.setOidcTokenRevokeEndpointUri("https://login.cesnet.cz/oidc/revoke");
+		expectedConfig.setAcrValues("");
+		expectedConfig.setScopes("openid perun_api perun_admin offline_access");
+		expectedConfig.setPerunApiEndpoint("https://perun-dev.cesnet.cz/oauth/rpc");
+		expectedConfig.setEnforceMfa(false);
+	}
+
+	@Test
+	public void init() {
+		OidcConfig config = perun.getConfigManagerBl().getPerunOidcConfig();
+		assertEquals(config, expectedConfig);
+	}
+}

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/ConfigManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/ConfigManagerMethod.java
@@ -1,5 +1,6 @@
 package cz.metacentrum.perun.rpc.methods;
 
+import cz.metacentrum.perun.core.api.OidcConfig;
 import cz.metacentrum.perun.core.api.exceptions.PerunException;
 import cz.metacentrum.perun.rpc.ApiCaller;
 import cz.metacentrum.perun.rpc.ManagerMethod;
@@ -16,6 +17,15 @@ public enum ConfigManagerMethod implements ManagerMethod {
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
 			ac.getConfigManager().reloadAppsConfig(ac.getSession());
 			return null;
+		}
+	},
+	/*#
+	 * Returns Oidc Configuration for this Perun instance (to be used for CLI communication).
+	 */
+	getPerunOidcConfig {
+		@Override
+		public OidcConfig call (ApiCaller ac, Deserializer parms) throws PerunException {
+			return ac.getConfigManager().getPerunOidcConfig(ac.getSession());
 		}
 	}
 }


### PR DESCRIPTION

* Added new method to ConfigManager, which returns new OidcConfig class, which holds the fields of the config.
* The configuration file perun-oidc-config.yml is expected to be in the same directory as other config files (eg. perun.properties, perun-roles.yml, etc.)
* Added loader for the perun-oidc-config.yml
* Added CLI script, which calls the new method and prints out the configuration in the desired format