### PR TITLE
build(core): updated testcontainers dependency

### DIFF
--- a/perun-base/src/test/resources/jdbc.properties
+++ b/perun-base/src/test/resources/jdbc.properties
@@ -1,6 +1,6 @@
 # Containerized Postgresql
 jdbc.driver=org.testcontainers.jdbc.ContainerDatabaseDriver
-jdbc.url=jdbc:tc:postgresql:13.2:///perun?TC_TMPFS=/testtmpfs:rw&?TC_INITSCRIPT=test-schema.sql&TC_DAEMON=true
+jdbc.url=jdbc:tc:postgresql:14.5:///perun?TC_TMPFS=/testtmpfs:rw&?TC_INITSCRIPT=test-schema.sql&TC_DAEMON=true
 jdbc.username=perun
 jdbc.password=password
 

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
 		<jdom.version>1.0</jdom.version>
 		<json.version>20190722</json.version>
 		<reflections.version>0.9.11</reflections.version>
-		<testcontainers.version>1.17.3</testcontainers.version>
+		<testcontainers.version>1.17.5</testcontainers.version>
 	</properties>
 
 	<!-- DEFAULT MAVEN BUILD SETTINGS


### PR DESCRIPTION
- Update dependency to 1.17.5.
- Use postgres 14.5 docker image instead of 13.2.