### PR TITLE
fix(registrar): fix duplicate notifications

### DIFF
--- a/perun-base/src/test/resources/test-schema.sql
+++ b/perun-base/src/test/resources/test-schema.sql
@@ -1,4 +1,4 @@
--- database version 3.1.97 (don't forget to update insert statement at the end of file)
+-- database version 3.1.98 (don't forget to update insert statement at the end of file)
 CREATE EXTENSION IF NOT EXISTS "unaccent";
 CREATE EXTENSION IF NOT EXISTS "pgcrypto";
 
@@ -1638,6 +1638,27 @@ create table consent_attr_defs (
 	constraint consentatt_consent_fk foreign key (consent_id) references consents(id)
 );
 
+create type mail_type as enum (
+	'APP_CREATED_USER',
+	'APPROVABLE_GROUP_APP_USER',
+	'APP_CREATED_VO_ADMIN',
+	'MAIL_VALIDATION',
+	'APP_APPROVED_USER',
+	'APP_REJECTED_USER',
+	'APP_ERROR_VO_ADMIN',
+	'USER_INVITE'
+);
+
+-- APP_NOTIFICATIONS_SENT - sent applications notifications, used only for APP_CREATED_VO_ADMIN type for now
+create table app_notifications_sent (
+	app_id int not null,
+	notification_type mail_type not null,
+	created_at timestamp default statement_timestamp() not null,
+	created_by varchar default user not null,
+	constraint appnotifsent_pk primary key(app_id, notification_type),
+	constraint appnotifsent_app_fk foreign key (app_id) references application(id) on delete cascade
+);
+
 create sequence "attr_names_id_seq";
 create sequence "attribute_policies_id_seq";
 create sequence "attribute_policy_collections_id_seq";
@@ -1859,7 +1880,7 @@ create index idx_fk_attr_critops ON attribute_critical_actions(attr_id);
 create index app_state_idx ON application (state);
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.1.97');
+insert into configurations values ('DATABASE VERSION','3.1.98');
 -- insert membership types
 insert into membership_types (id, membership_type, description) values (1, 'DIRECT', 'Member is directly added into group');
 insert into membership_types (id, membership_type, description) values (2, 'INDIRECT', 'Member is added indirectly through UNION relation');

--- a/perun-core/src/main/resources/postgresChangelog.txt
+++ b/perun-core/src/main/resources/postgresChangelog.txt
@@ -6,6 +6,12 @@
 -- Directly under version number should be version commands. They will be executed in the order they are written here.
 -- Comments are prefixed with -- and can be written only between version blocks, that means not in the lines with commands. They have to be at the start of the line.
 
+3.1.98
+create type mail_type as enum ('APP_CREATED_USER','APPROVABLE_GROUP_APP_USER','APP_CREATED_VO_ADMIN','MAIL_VALIDATION','APP_APPROVED_USER','APP_REJECTED_USER','APP_ERROR_VO_ADMIN','USER_INVITE');
+create table app_notifications_sent (app_id int not null,notification_type mail_type not null,created_at timestamp default statement_timestamp() not null,created_by varchar default user not null,constraint appnotifsent_pk primary key(app_id, notification_type),constraint appnotifsent_app_fk foreign key (app_id) references application(id) on delete cascade);
+grant all on app_notifications_sent to perun;
+UPDATE configurations SET value='3.1.98' WHERE property='DATABASE VERSION';
+
 3.1.97
 create table attribute_critical_actions (attr_id integer not null, action attribute_action not null, constraint attrcritops_pk primary key (attr_id, action),	constraint attrcritops_attr_fk foreign key (attr_id) references attr_names (id) on delete cascade);
 grant all on attribute_critical_actions to perun;

--- a/perun-db/postgres.sql
+++ b/perun-db/postgres.sql
@@ -1,4 +1,4 @@
--- database version 3.1.97 (don't forget to update insert statement at the end of file)
+-- database version 3.1.98 (don't forget to update insert statement at the end of file)
 
 -- VOS - virtual organizations
 create table vos (
@@ -1635,6 +1635,27 @@ create table consent_attr_defs (
 	constraint consentatt_consent_fk foreign key (consent_id) references consents(id)
 );
 
+create type mail_type as enum (
+	'APP_CREATED_USER',
+	'APPROVABLE_GROUP_APP_USER',
+	'APP_CREATED_VO_ADMIN',
+	'MAIL_VALIDATION',
+	'APP_APPROVED_USER',
+	'APP_REJECTED_USER',
+	'APP_ERROR_VO_ADMIN',
+	'USER_INVITE'
+);
+
+-- APP_NOTIFICATIONS_SENT - sent applications notifications, used only for APP_CREATED_VO_ADMIN type for now
+create table app_notifications_sent (
+	app_id int not null,
+	notification_type mail_type not null,
+	created_at timestamp default statement_timestamp() not null,
+	created_by varchar default user not null,
+	constraint appnotifsent_pk primary key(app_id, notification_type),
+	constraint appnotifsent_app_fk foreign key (app_id) references application(id) on delete cascade
+);
+
 create sequence "attr_names_id_seq";
 create sequence "attribute_policies_id_seq";
 create sequence "attribute_policy_collections_id_seq";
@@ -1963,9 +1984,10 @@ grant all on consents to perun;
 grant all on consent_attr_defs to perun;
 grant all on allowed_groups_to_hierarchical_vo to perun;
 grant all on attribute_critical_actions to perun;
+grant all on app_notifications_sent to perun;
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.1.97');
+insert into configurations values ('DATABASE VERSION','3.1.98');
 
 -- insert membership types
 insert into membership_types (id, membership_type, description) values (1, 'DIRECT', 'Member is directly added into group');


### PR DESCRIPTION
- Two duplicate group notifications were sent to group managers when a user submitted a group application in the following scenario:

1. first the user submitted an application to the group's VO, which was auto-approved
2. then he submitted the group application in less than X seconds

- The reason is that after the VO application was approved, a new thread was created which slept for 5 seconds and then validated the member in VO and handled the user's group applications - sent notifications to the group's managers. If a group application was submitted in this time window (5 seconds + validation time) an APP_CREATED_VO_ADMIN notification was sent both in this method and in the second step - submitting the group application.
- #3694 was a quick-fix which removed the thread's sleep, but there was still a big enough time window when this bug could happen.
- Now, a new table created_app_notifications_sent is introduced to save the information whether APP_CREATED_VO_ADMIN notification was already sent.
- The notification is sent always in the second step (submitting group application) if the user has a required state.
- The notification is sent in the first step only if it wasn't sent yet and the user has a required state. There is no need for an additional synchronization (like checking if it is being sent in a concurrent thread), because the first step sends the notification only for committed applications, and they are committed together with information whether the notification was sent.

BREAKING CHANGE: update DB