### PR TITLE
feat(core): support branding between new and old GUI

### DIFF
--- a/perun-base/src/test/resources/perun-apps-config.yml
+++ b/perun-base/src/test/resources/perun-apps-config.yml
@@ -10,14 +10,16 @@ brands:
       pwd_reset: "pwd-reset"
       publications: "publications"
     old_gui_domain: "perun-dev"
+    old_gui_alert: New GUI is <b><a href="http://www.google.com">here</a></b>
   - name: other
     new_apps:
-      api: ""
-      admin: ""
-      consolidator: ""
-      linker: ""
-      profile: ""
-      pwd_reset: ""
-      publications: ""
-    old_gui_domain: ""
+      api: "other-api"
+      admin: "other-admin"
+      consolidator: "other-consolidator"
+      linker: "other-linker"
+      profile: "other-profile"
+      pwd_reset: "other-pwd-reset"
+      publications: "other-publication"
+    old_gui_domain: "other-old_gui_domain"
+    vos: ["test_vo", "other_vo"]
 ...

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/PerunAppsConfig.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/PerunAppsConfig.java
@@ -3,6 +3,7 @@ package cz.metacentrum.perun.core.impl;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonSetter;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -53,15 +54,31 @@ public class PerunAppsConfig {
 	}
 
 	/**
+	 * Iterates brands and searches for such that contains vo's shortname.
+	 * If none found, returns default branding.
+	 */
+	public static Brand getBrandContainingVo(String voShortname) {
+		Brand defaultBrand = instance.getBrands()
+			.stream()
+			.filter(brand -> brand.getName().equals("default"))
+			.findFirst()
+			.orElse(null);
+		return instance.getBrands().stream()
+			.filter(brand -> brand.getVoShortnames().contains(voShortname))
+			.findFirst()
+			.orElse(defaultBrand);
+	}
+
+	/**
 	 * Class holding data for a single branding.
 	 */
 	public static class Brand {
 
 		private String name;
-
 		private String oldGuiDomain;
-
 		private NewApps newApps;
+		private List<String> voShortnames = new ArrayList<>();
+		private String oldGuiAlert;
 
 		@JsonGetter("name")
 		public String getName() {
@@ -83,6 +100,26 @@ public class PerunAppsConfig {
 			this.newApps = newApps;
 		}
 
+		@JsonGetter("voShortnames")
+		public List<String> getVoShortnames() {
+			return voShortnames;
+		}
+
+		@JsonSetter("vos")
+		public void setVoShortnames(List<String> voShortnames) {
+			this.voShortnames = voShortnames;
+		}
+
+		@JsonGetter("oldGuiAlert")
+		public String getOldGuiAlert() {
+			return oldGuiAlert;
+		}
+
+		@JsonSetter("old_gui_alert")
+		public void setOldGuiAlert(String oldGuiAlert) {
+			this.oldGuiAlert = oldGuiAlert;
+		}
+
 		@JsonGetter("oldGuiDomain")
 		public String getOldGuiDomain() {
 			return oldGuiDomain;
@@ -98,7 +135,9 @@ public class PerunAppsConfig {
 			return "Brand{" +
 					"name='" + name + '\'' +
 					", oldGuiDomain='" + oldGuiDomain + '\'' +
+					", oldGuiAlert='" + oldGuiAlert + '\'' +
 					", newApps=" + newApps +
+					", vos=" + voShortnames +
 					'}';
 		}
 	}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Utils.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Utils.java
@@ -1161,8 +1161,11 @@ public class Utils {
 				}
 			} else {
 				// if no brand contains specified domain, set default old gui domain
-				brand = getInstance().getBrands().get(0);
-				url = brand.getOldGuiDomain();
+				PerunAppsConfig.Brand defaultBrand = getInstance().getBrands().stream()
+					.filter(b -> b.getName().equals("default"))
+					.findFirst()
+					.orElseThrow(() -> new InternalErrorException("Default GUI branding configuration is missing"));
+				url = defaultBrand.getOldGuiDomain();
 			}
 		} catch (MalformedURLException ex) {
 			throw new InternalErrorException("Not valid URL of running Perun instance.", ex);

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/PerunAppsConfigLoaderTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/PerunAppsConfigLoaderTest.java
@@ -4,6 +4,8 @@ import cz.metacentrum.perun.core.AbstractPerunIntegrationTest;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -18,6 +20,7 @@ public class PerunAppsConfigLoaderTest extends AbstractPerunIntegrationTest {
 		expectedDefaultBrand = new PerunAppsConfig.Brand();
 		expectedDefaultBrand.setOldGuiDomain("perun-dev");
 		expectedDefaultBrand.setName("default");
+		expectedDefaultBrand.setOldGuiAlert("New GUI is <b><a href=\"http://www.google.com\">here</a></b>");
 
 		var newApps = new PerunAppsConfig.NewApps();
 		newApps.setApi("api");
@@ -42,5 +45,20 @@ public class PerunAppsConfigLoaderTest extends AbstractPerunIntegrationTest {
 		assertThat(config.getBrands().get(0))
 				.usingRecursiveComparison()
 				.isEqualTo(expectedDefaultBrand);
+		assertThat(config.getBrands().get(1).getOldGuiAlert())
+			.isNull();
+	}
+
+	@Test
+	public void vos() {
+		PerunAppsConfig config = PerunAppsConfig.getInstance();
+
+		assertThat(config)
+			.isNotNull();
+		assertThat(config.getBrands())
+			.hasSize(2);
+		assertThat(config.getBrands().get(1).getVoShortnames())
+			.containsAll(List.of("test_vo", "other_vo"));
+		assertThat(config.getBrands().get(0).getVoShortnames()).isNullOrEmpty();
 	}
 }

--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -1429,6 +1429,8 @@ components:
         name: { type: string }
         oldGuiDomain: { type: string }
         newApps: { $ref: '#/components/schemas/NewApps' }
+        vos: { type: array, items: { type: string } }
+        oldGuiAlert: { type: string }
 
     PerunAppsConfig:
       type: object
@@ -3532,6 +3534,19 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/PerunAppsConfigResponse'
+        default:
+          $ref: '#/components/responses/ExceptionResponse'
+
+  /json/utils/getNewGuiAlert:
+    get:
+      tags:
+        - Utils
+      operationId: getNewGuiAlert
+      summary: Gets new GUI alert (banner html content) for the brand of incoming request.
+      description: Returns new GUI alert
+      responses:
+        '200':
+          $ref: '#/components/responses/StringResponse'
         default:
           $ref: '#/components/responses/ExceptionResponse'
 

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/Api.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/Api.java
@@ -662,6 +662,18 @@ public class Api extends HttpServlet {
 				out.close();
 				return;
 
+			} else if ("utils".equals(manager) && "getNewGuiAlert".equals(method)) {
+
+				String requestDomain = req.getScheme() + "://" + req.getServerName();
+				if (PerunAppsConfig.getBrandContainingDomain(requestDomain) == null) {
+					ser.write(null);
+				} else {
+					ser.write(PerunAppsConfig.getBrandContainingDomain(requestDomain).getOldGuiAlert());
+				}
+				// closes the request
+				out.close();
+				return;
+
 			} else if ("utils".equals(manager) && PERUNSTATUS.equals(method)) {
 				Date date = new Date();
 				Timestamp timestamp = new Timestamp(date.getTime());

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/PerunWebSession.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/PerunWebSession.java
@@ -79,6 +79,7 @@ public class PerunWebSession {
 	private ArrayList<GeneralObject> entitiesHistoryList = new ArrayList<GeneralObject>();
 
 	private BasicOverlayType configuration;
+	private String newGuiAlert;
 
 	// RPC URL
 	private String rpcUrl = "";
@@ -885,5 +886,13 @@ public class PerunWebSession {
 
 	public void setConfiguration(BasicOverlayType configuration) {
 		this.configuration = configuration;
+	}
+
+	public String getNewGuiAlert() {
+		return newGuiAlert;
+	}
+
+	public void setNewGuiAlert(String newGuiAlert) {
+		this.newGuiAlert = newGuiAlert;
 	}
 }

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/GetNewGuiAlert.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/GetNewGuiAlert.java
@@ -1,0 +1,58 @@
+package cz.metacentrum.perun.webgui.json;
+
+import com.google.gwt.core.client.JavaScriptObject;
+import cz.metacentrum.perun.webgui.client.PerunWebSession;
+import cz.metacentrum.perun.webgui.model.PerunError;
+
+/**
+ * Class to get new GUI alert
+ */
+public class GetNewGuiAlert implements JsonCallback {
+
+	// SESSION
+	private PerunWebSession session = PerunWebSession.getInstance();
+
+	// PARAMS
+	private JsonCallbackEvents events = new JsonCallbackEvents();
+
+	// URLs
+	static private final String URL = "utils/getNewGuiAlert";
+
+	/**
+	 * New callback instance
+	 */
+	public GetNewGuiAlert() {}
+
+	/**
+	 * New callback instance
+	 */
+	public GetNewGuiAlert(JsonCallbackEvents events) {
+		this.events = events;
+	}
+
+	@Override
+	public void retrieveData() {
+
+		JsonClient js = new JsonClient();
+		js.retrieveData(URL, this);
+
+	}
+
+	@Override
+	public void onFinished(JavaScriptObject jso) {
+		session.getUiElements().setLogText("Loading new GUI alert finished.");
+		events.onFinished(jso);
+	}
+
+	@Override
+	public void onError(PerunError error) {
+		session.getUiElements().setLogErrorText("Error while loading new GUI alert.");
+		events.onError(error);
+	}
+
+	@Override
+	public void onLoadingStart() {
+		events.onLoadingStart();
+	}
+
+}

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/attributestabs/AttributeDefinitionDetailTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/attributestabs/AttributeDefinitionDetailTabItem.java
@@ -223,9 +223,11 @@ public class AttributeDefinitionDetailTabItem implements TabItem {
 		for (int i=0; i<attributeDetailTable.getRowCount(); i++) {
 			attributeDetailTable.getFlexCellFormatter().setStyleName(i, 0, "itemName");
 		}
-		String newGuiAlertContent = session.getConfiguration().getCustomProperty("newAdminGuiAlert");
+		String newGuiAlertContent = session.getNewGuiAlert();
 		final FlexTable alert = new FlexTable();
-		alert.setHTML(0,0,"<p>Setting attribute rights is no longer supported in this GUI. In order to set attribute rights please use the New GUI.</p> " + newGuiAlertContent);
+		String alertText = "<p>Setting attribute rights is no longer supported in this GUI. In order to set attribute rights please use the New GUI.</p> ";
+		if (newGuiAlertContent != null && !newGuiAlertContent.isEmpty()) alertText += newGuiAlertContent;
+		alert.setHTML(0,0, alertText);
 
 		TabMenu menu = new TabMenu();
 		menu.addWidget(UiElements.getRefreshButton(this));

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/attributestabs/CreateAttributeDefinitionTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/attributestabs/CreateAttributeDefinitionTabItem.java
@@ -221,9 +221,11 @@ public class CreateAttributeDefinitionTabItem implements TabItem {
 			}
 		}));
 
-		String newGuiAlertContent = session.getConfiguration().getCustomProperty("newAdminGuiAlert");
+		String newGuiAlertContent = session.getNewGuiAlert();
 		final FlexTable alert = new FlexTable();
-		alert.setHTML(0,0,"<p>Setting attribute rights is no longer supported in this GUI. In order to set attribute rights please use the New GUI.</p> "+ newGuiAlertContent);
+		String alertText = "<p>Setting attribute rights is no longer supported in this GUI. In order to set attribute rights please use the New GUI.</p> ";
+		if (newGuiAlertContent != null && !newGuiAlertContent.isEmpty()) alertText += newGuiAlertContent;
+		alert.setHTML(0,0,alertText);
 
 		vp.add(layout);
 		vp.add(alert);

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/entitylessattributestabs/EntitylessAttributesDetailTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/entitylessattributestabs/EntitylessAttributesDetailTabItem.java
@@ -202,9 +202,11 @@ public class EntitylessAttributesDetailTabItem implements TabItem {
 		showKeys.addClickHandler(clickEvent -> session.getTabManager().addTab(new EntitylessAttributeEditKeyTabItem(def)));
 		menu.addWidget(showKeys);
 
-		String newGuiAlertContent = session.getConfiguration().getCustomProperty("newAdminGuiAlert");
+		String newGuiAlertContent = session.getNewGuiAlert();
 		final FlexTable alert = new FlexTable();
-		alert.setHTML(0,0,"<p>Setting attribute rights is no longer supported in this GUI. In order to set attribute rights please use the New GUI.</p> " + newGuiAlertContent);
+		String alertText = "<p>Setting attribute rights is no longer supported in this GUI. In order to set attribute rights please use the New GUI.</p> ";
+		if (newGuiAlertContent != null && !newGuiAlertContent.isEmpty()) alertText += newGuiAlertContent;
+		alert.setHTML(0,0,alertText);
 
 		// create new instance for jsonCall
 		final GetServicesByAttrDefinition services = new GetServicesByAttrDefinition(def.getId());

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/CreateMailTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/CreateMailTabItem.java
@@ -371,6 +371,7 @@ public class CreateMailTabItem implements TabItem {
 				"<p><strong>{appDetailUrl-krb}</strong> - link for Kerberos authentication" +
 				"<br/><strong>{appDetailUrl-fed}</strong> - link for Shibboleth IdP (federation) authentication" +
 				"<br/><strong>{appDetailUrl-cert}</strong> - link for personal certificate authentication" +
+				"<br/><strong>{appDetailUrl-newGUI}</strong> - link for new admin GUI" +
 
 				"<p><strong><u>Perun GUI links for administrators:</u></strong>" +
 
@@ -382,6 +383,7 @@ public class CreateMailTabItem implements TabItem {
 				"<p><strong>{perunGuiUrl-krb}</strong> - link for Kerberos authentication" +
 				"<br/><strong>{perunGuiUrl-fed}</strong> - link for Shibboleth IdP (federation) authentication" +
 				"<br/><strong>{perunGuiUrl-cert}</strong> - link for personal certificate authentication" +
+				"<br/><strong>{perunGuiUrl-newGUI}</strong> - link for new admin GUI" +
 
 				"<p><strong><u>User invitations:</u></strong>" +
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/EditMailTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/EditMailTabItem.java
@@ -306,6 +306,7 @@ public class EditMailTabItem implements TabItem, TabItemWithUrl {
 				"<p><strong>{appDetailUrl-krb}</strong> - link for Kerberos authentication" +
 				"<br/><strong>{appDetailUrl-fed}</strong> - link for Shibboleth IdP (federation) authentication" +
 				"<br/><strong>{appDetailUrl-cert}</strong> - link for personal certificate authentication" +
+				"<br/><strong>{appDetailUrl-newGUI}</strong> - link for new admin GUI" +
 
 				"<p><strong><u>Perun GUI links for administrators:</u></strong>" +
 
@@ -317,6 +318,7 @@ public class EditMailTabItem implements TabItem, TabItemWithUrl {
 				"<p><strong>{perunGuiUrl-krb}</strong> - link for Kerberos authentication" +
 				"<br/><strong>{perunGuiUrl-fed}</strong> - link for Shibboleth IdP (federation) authentication" +
 				"<br/><strong>{perunGuiUrl-cert}</strong> - link for personal certificate authentication" +
+				"<br/><strong>{perunGuiUrl-newGUI}</strong> - link for new admin GUI" +
 
 				"<p><strong><u>User invitations:</u></strong>" +
 


### PR DESCRIPTION
* Added vos field to branding config to distinguish brand to which vo belongs
* Added support for tags directing to new admin-gui in manager's notifications
* Invitations etc. coming from new GUI should be directed to correct branding (vos property in apps-config should ensure that)
* Banner in old gui should be configurable in apps-config to also follow branding rules

BREAKING CHANGE: New brand properties in perun-apps-config.yml, deprecated newAdminGuiAlert in perun-web-gui.properties moved to perun-apps-config and can be branded