### PR TITLE
feat(cabinet): rights changed for getAuthorsByPublicationId method

### DIFF
--- a/perun-base/src/main/resources/perun-roles.yml
+++ b/perun-base/src/main/resources/perun-roles.yml
@@ -6997,7 +6997,7 @@ perun_policies:
   getAuthorsByPublicationId_int_policy:
     policy_roles:
       - PERUNOBSERVER:
-      - CABINETADMIN:
+      - SELF:
     include_policies:
       - default_policy
 

--- a/perun-cabinet/src/main/java/cz/metacentrum/perun/cabinet/api/impl/CabinetManagerImpl.java
+++ b/perun-cabinet/src/main/java/cz/metacentrum/perun/cabinet/api/impl/CabinetManagerImpl.java
@@ -347,30 +347,12 @@ public class CabinetManagerImpl implements CabinetManager {
 	@Override
 	public List<Author> getAuthorsByPublicationId(PerunSession session, int id) throws PrivilegeException, CabinetException {
 
-		List<Author> authors = getAuthorshipManagerBl().getAuthorsByPublicationId(id);
-		boolean oneOfAuthors = false;
-		for (Author author : authors) {
-			if (author.getId() == session.getPerunPrincipal().getUserId()) {
-				oneOfAuthors = true;
-				break;
-			}
-		}
-
 		//Authorization
-		if (AuthzResolver.authorizedInternal(session, "getAuthorsByPublicationId_int_policy")) {
-			oneOfAuthors = true;
+		if (!AuthzResolver.authorizedInternal(session, "getAuthorsByPublicationId_int_policy")) {
+			throw new PrivilegeException("getAuthorsByPublicationId");
 		}
 
-		if (!oneOfAuthors) {
-			// not author, but check if user created publication, then he can list current authors
-			Publication publication = getPublicationManagerBl().getPublicationById(id);
-			if ((publication.getCreatedByUid() != session.getPerunPrincipal().getUserId()) &&
-					!(Objects.equals(publication.getCreatedBy(), session.getPerunPrincipal().getActor()))) {
-				throw new PrivilegeException("getAuthorsByPublicationId");
-			}
-		}
-
-		return authors;
+		return getAuthorshipManagerBl().getAuthorsByPublicationId(id);
 
 	}
 


### PR DESCRIPTION
* This method was accessible just for perun admin/observer and for cabinet admin. Now it is accessible for SELF role because we want to have a chance to see similar publications without an error caused by this method.