### PR TITLE
fix(openapi): Fix getBansForResource param name

### DIFF
--- a/perun-cli/listOfBans
+++ b/perun-cli/listOfBans
@@ -57,7 +57,7 @@ if (defined($resourceId) or defined($memberId)) {
 	my $banOnResourceAgent = $agent->getBanOnResourceAgent;
 
 	if (defined($resourceId)) {
-		@bans = $banOnResourceAgent->getBansForResource( resourceId => $resourceId );
+		@bans = $banOnResourceAgent->getBansForResource( resource => $resourceId );
 		@columnsNames = ('BanId', 'MemberId', 'BannedTo', 'Description');
 	}
 	if (defined($memberId)) {

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/ResourcesManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/ResourcesManagerMethod.java
@@ -1378,7 +1378,7 @@ public enum ResourcesManagerMethod implements ManagerMethod {
 		public List<BanOnResource> call(ApiCaller ac, Deserializer parms) throws PerunException {
 
 			return ac.getResourcesManager().getBansForResource(ac.getSession(),
-					parms.readInt("resourceId"));
+					parms.readInt("resource"));
 
 		}
 	},


### PR DESCRIPTION
* openapi now defines correct name for resource id: "resourceId"