### PR TITLE
fix(core): remove duplicate combinations of facility-service-destinations, while assuring other duplicates won't happen

### DIFF
--- a/perun-base/src/test/resources/test-schema.sql
+++ b/perun-base/src/test/resources/test-schema.sql
@@ -1,4 +1,4 @@
--- database version 3.1.98 (don't forget to update insert statement at the end of file)
+-- database version 3.1.99 (don't forget to update insert statement at the end of file)
 CREATE EXTENSION IF NOT EXISTS "unaccent";
 CREATE EXTENSION IF NOT EXISTS "pgcrypto";
 
@@ -676,6 +676,7 @@ create table facility_service_destinations (
 												created_by_uid integer,
 												modified_by_uid integer,
 												propagation_type varchar default 'PARALLEL',
+												constraint fac_srv_dest_pk primary key (facility_id, service_id, destination_id),
 												constraint dest_srv_fk foreign key (service_id) references services(id),
 												constraint dest_fac_fk foreign key (facility_id) references facilities(id),
 												constraint dest_dest_fk foreign key(destination_id) references destinations(id)
@@ -1880,7 +1881,7 @@ create index idx_fk_attr_critops ON attribute_critical_actions(attr_id);
 create index app_state_idx ON application (state);
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.1.98');
+insert into configurations values ('DATABASE VERSION','3.1.99');
 -- insert membership types
 insert into membership_types (id, membership_type, description) values (1, 'DIRECT', 'Member is directly added into group');
 insert into membership_types (id, membership_type, description) values (2, 'INDIRECT', 'Member is added indirectly through UNION relation');

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ServicesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ServicesManagerBlImpl.java
@@ -788,7 +788,6 @@ public class ServicesManagerBlImpl implements ServicesManagerBl {
 				}
 			}
 		}
-		if(getServicesManagerImpl().destinationExists(sess, service, facility, destination)) throw new DestinationAlreadyAssignedException(destination);
 
 		getServicesManagerImpl().addDestination(sess, service, facility, destination);
 		getPerunBl().getAuditer().log(sess, new DestinationAddedToServiceAndFacility(destination, service, facility));
@@ -815,9 +814,11 @@ public class ServicesManagerBlImpl implements ServicesManagerBl {
 		}
 
 		for(Service s: services) {
-			if(!getServicesManagerImpl().destinationExists(perunSession, s, facility, destination)) {
+			try {
 				getServicesManagerImpl().addDestination(perunSession, s, facility, destination);
 				getPerunBl().getAuditer().log(perunSession, new DestinationAddedToServiceAndFacility(destination, s, facility));
+			} catch (DestinationAlreadyAssignedException ex) {
+				// skip service
 			}
 		}
 
@@ -843,9 +844,12 @@ public class ServicesManagerBlImpl implements ServicesManagerBl {
 			}
 		}
 		//if destination is already assigned, do not add message to the log and only return it back
-		if(getServicesManagerImpl().destinationExists(sess, service, facility, destination)) return destination;
 
-		getServicesManagerImpl().addDestination(sess, service, facility, destination);
+		try {
+			getServicesManagerImpl().addDestination(sess, service, facility, destination);
+		} catch (DestinationAlreadyAssignedException ex) {
+			return destination;
+		}
 		getPerunBl().getAuditer().log(sess, new DestinationAddedToServiceAndFacility(destination, service, facility));
 		return destination;
 	}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/ServicesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/ServicesManagerImplApi.java
@@ -439,9 +439,9 @@ public interface ServicesManagerImplApi {
 	 * @param facility
 	 * @param destination string contains destination address (mail, url, hostname, ...)
 	 * @throws InternalErrorException
-	 * @throws DestinationAlreadyAssignedException
+	 * @throws DestinationAlreadyAssignedException when the combination already exists
 	 */
-	void addDestination(PerunSession perunSession, Service service, Facility facility, Destination destination);
+	void addDestination(PerunSession perunSession, Service service, Facility facility, Destination destination) throws DestinationAlreadyAssignedException;
 
 	/**
 	 * Removes an destination from the facility and service.

--- a/perun-core/src/main/resources/postgresChangelog.txt
+++ b/perun-core/src/main/resources/postgresChangelog.txt
@@ -6,6 +6,11 @@
 -- Directly under version number should be version commands. They will be executed in the order they are written here.
 -- Comments are prefixed with -- and can be written only between version blocks, that means not in the lines with commands. They have to be at the start of the line.
 
+3.1.99
+DELETE FROM facility_service_destinations a USING (SELECT MIN(ctid) as ctid, facility_id, service_id, destination_id FROM facility_service_destinations GROUP BY facility_id, service_id, destination_id HAVING COUNT(*) > 1) b WHERE a.facility_id = b.facility_id AND a.service_id = b.service_id AND a.destination_id = b.destination_id AND a.ctid <> b.ctid;
+ALTER TABLE facility_service_destinations ADD constraint fac_srv_dest_pk primary key (facility_id, service_id, destination_id);
+UPDATE configurations set value='3.1.99' WHERE property='DATABASE VERSION';
+
 3.1.98
 create type mail_type as enum ('APP_CREATED_USER','APPROVABLE_GROUP_APP_USER','APP_CREATED_VO_ADMIN','MAIL_VALIDATION','APP_APPROVED_USER','APP_REJECTED_USER','APP_ERROR_VO_ADMIN','USER_INVITE');
 create table app_notifications_sent (app_id int not null,notification_type mail_type not null,created_at timestamp default statement_timestamp() not null,created_by varchar default user not null,constraint appnotifsent_pk primary key(app_id, notification_type),constraint appnotifsent_app_fk foreign key (app_id) references application(id) on delete cascade);

--- a/perun-db/postgres.sql
+++ b/perun-db/postgres.sql
@@ -1,4 +1,4 @@
--- database version 3.1.98 (don't forget to update insert statement at the end of file)
+-- database version 3.1.99 (don't forget to update insert statement at the end of file)
 
 -- VOS - virtual organizations
 create table vos (
@@ -674,6 +674,7 @@ create table facility_service_destinations (
 	created_by_uid integer,
 	modified_by_uid integer,
 	propagation_type varchar default 'PARALLEL',
+	constraint fac_srv_dest_pk primary key (facility_id, service_id, destination_id),
 	constraint dest_srv_fk foreign key (service_id) references services(id),
   constraint dest_fac_fk foreign key (facility_id) references facilities(id),
   constraint dest_dest_fk foreign key(destination_id) references destinations(id)
@@ -1987,7 +1988,7 @@ grant all on attribute_critical_actions to perun;
 grant all on app_notifications_sent to perun;
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.1.98');
+insert into configurations values ('DATABASE VERSION','3.1.99');
 
 -- insert membership types
 insert into membership_types (id, membership_type, description) values (1, 'DIRECT', 'Member is directly added into group');


### PR DESCRIPTION

* SQL command in postgresChangelog to delete any existing duplicates
* added primary key to the facility_service_destinations table
* throw exception when duplicate key detected

BREAKING CHANGE: db update