### PR TITLE
fix(registrar): unable members without expiration to submit extension…

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/MembersManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/MembersManager.java
@@ -53,6 +53,11 @@ public interface MembersManager {
 	String membershipExpirationRulesAttributeName = AttributesManager.NS_VO_ATTR_DEF + ":" + "membershipExpirationRules";
 
 	/**
+	 * Attribute which contains member's expiration
+	 */
+	String membershipExpirationAttributeName = AttributesManager.NS_MEMBER_ATTR_DEF + ":membershipExpiration";
+
+	/**
 	 *  Deletes only member data  appropriated by member id.
 	 *
 	 * @param sess


### PR DESCRIPTION
… app

- Members without expiration attribute (it is NEVER) now can't submit extension forms in VOs with defined expiration rules. The only exception is if the form doesn't contain any submit button - it is read only.