### PR TITLE
feat(core): make roles receiving notifications configurable

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/RoleManagementRules.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/RoleManagementRules.java
@@ -34,6 +34,8 @@ import java.util.Objects;
  * skipMFA is a flag that whether the role should skip MFA check.
  * mfaCriticalRole is a flag marking roles always requiring MFA from users having that role
  * displayName is a more user-friendly name
+ * receiveNotifications contains names of objects for which the role should get notifications
+ * 			   Example value: Vo ; meaning: will receive notifications when vo application is created/failed
  */
 public class RoleManagementRules {
 
@@ -48,10 +50,10 @@ public class RoleManagementRules {
 	private boolean assignableToAttributes;
 	private boolean skipMFA;
 	private boolean mfaCriticalRole;
-
 	private String displayName;
+	private List<String> receiveNotifications;
 
-	public RoleManagementRules(String roleName, String primaryObject, List<Map<String, String>> privilegedRolesToManage, List<Map<String, String>> privilegedRolesToRead, Map<String, String> entitiesToManage, Map<String, String> assignedObjects, List<Map<String, String>> assignmentCheck, List<String> associatedReadRoles, boolean assignableToAttributes, boolean skipMFA, boolean mfaCriticalRole, String displayName) {
+	public RoleManagementRules(String roleName, String primaryObject, List<Map<String, String>> privilegedRolesToManage, List<Map<String, String>> privilegedRolesToRead, Map<String, String> entitiesToManage, Map<String, String> assignedObjects, List<Map<String, String>> assignmentCheck, List<String> associatedReadRoles, boolean assignableToAttributes, boolean skipMFA, boolean mfaCriticalRole, String displayName, List<String> receiveNotifications) {
 		this.roleName = roleName;
 		this.primaryObject = primaryObject;
 		this.privilegedRolesToManage = privilegedRolesToManage;
@@ -64,6 +66,7 @@ public class RoleManagementRules {
 		this.skipMFA = skipMFA;
 		this.mfaCriticalRole = mfaCriticalRole;
 		this.displayName = displayName;
+		this.receiveNotifications = receiveNotifications;
 	}
 
 	public String getRoleName() {
@@ -162,6 +165,14 @@ public class RoleManagementRules {
 		this.displayName = displayName;
 	}
 
+	public List<String> getReceiveNotifications() {
+		return receiveNotifications;
+	}
+
+	public void setReceiveNotifications(List<String> receiveNotifications) {
+		this.receiveNotifications = receiveNotifications;
+	}
+
 	@Override
 	public boolean equals(Object o) {
 		if (this == o) return true;
@@ -178,12 +189,13 @@ public class RoleManagementRules {
 			Objects.equals(assignableToAttributes, that.assignableToAttributes) &&
 			Objects.equals(skipMFA, that.skipMFA) &&
 			Objects.equals(mfaCriticalRole, that.mfaCriticalRole) &&
-			Objects.equals(displayName, that.displayName);
+			Objects.equals(displayName, that.displayName) &&
+			Objects.equals(receiveNotifications, that.receiveNotifications);
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(roleName, primaryObject, privilegedRolesToManage, privilegedRolesToRead, entitiesToManage, assignedObjects, assignmentCheck, associatedReadRoles, assignableToAttributes, skipMFA, mfaCriticalRole, displayName);
+		return Objects.hash(roleName, primaryObject, privilegedRolesToManage, privilegedRolesToRead, entitiesToManage, assignedObjects, assignmentCheck, associatedReadRoles, assignableToAttributes, skipMFA, mfaCriticalRole, displayName, receiveNotifications);
 	}
 
 	@Override
@@ -201,6 +213,7 @@ public class RoleManagementRules {
 			", skipMFA=" + skipMFA +
 			", mfaCriticalRole=" + mfaCriticalRole +
 			", displayName=" + displayName +
+			", receiveNotifications=" + receiveNotifications +
 			'}';
 	}
 }

--- a/perun-base/src/main/resources/perun-roles.yml
+++ b/perun-base/src/main/resources/perun-roles.yml
@@ -7847,6 +7847,8 @@ perun_policies:
 #  mfa_critical_role is a flag marking roles always requiring MFA from users having that role
 #  skip_mfa is a flag that whether the role should skip MFA check.
 #  display_name is a more user-friendly name
+#  receive_notifications contains names of objects for which the role should get notifications
+#			   Example value: Vo ; meaning: will receive notifications when vo application is created/failed
 perun_roles_management:
 
   PERUNADMIN:
@@ -7921,6 +7923,8 @@ perun_roles_management:
       - VOOBSERVER
     assignable_to_attributes: true
     display_name: "Organization admin"
+    receive_notifications:
+      - Vo
 
   GROUPADMIN:
     primary_object: Group
@@ -7949,6 +7953,8 @@ perun_roles_management:
       - GROUPOBSERVER
     assignable_to_attributes: true
     display_name: "Group admin"
+    receive_notifications:
+      - Group
 
   GROUPOBSERVER:
     primary_object: Group
@@ -8003,6 +8009,8 @@ perun_roles_management:
     associated_read_roles: []
     assignable_to_attributes: true
     display_name: "Group membership manager"
+    receive_notifications:
+      - Group
 
   SELF:
     primary_object:

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/PerunRolesLoader.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/PerunRolesLoader.java
@@ -154,8 +154,9 @@ public class PerunRolesLoader {
 			boolean mfaCriticalRole = roleNode.get("mfa_critical_role") != null && roleNode.get("mfa_critical_role").asBoolean();
 			JsonNode displayNameNode = roleNode.get("display_name");
 			String displayName = displayNameNode.isNull() ? null : displayNameNode.textValue();
+			List<String> receiveNotifications = createListFromJsonNode(roleNode.get("receive_notifications"));
 
-			rules.add(new RoleManagementRules(roleName, primaryObject, privilegedRolesToManage, privilegedRolesToRead, entitiesToManage, objectsToAssign, assignmentCheck, associatedReadRoles, assignableToAttribute, skipMFA, mfaCriticalRole, displayName));
+			rules.add(new RoleManagementRules(roleName, primaryObject, privilegedRolesToManage, privilegedRolesToRead, entitiesToManage, objectsToAssign, assignmentCheck, associatedReadRoles, assignableToAttribute, skipMFA, mfaCriticalRole, displayName, receiveNotifications));
 		}
 
 		return rules;
@@ -189,6 +190,10 @@ public class PerunRolesLoader {
 
 	private List<String> createListFromJsonNode(JsonNode node) {
 		List<String> resultList = new ArrayList<>();
+
+		if (node == null) {
+			return resultList;
+		}
 
 		Iterator<JsonNode> nodeArray = node.elements();
 		while (nodeArray.hasNext()) {


### PR DESCRIPTION
* we're expanding roles that should get notifications when application is created/failed
* extended perun-roles configuration with receive_notifications property which can contain GROUP or VO objects
* when application triggers notification, all roles that contain such object are retrieved, not only voadmin/groupadmin