### PR TITLE
fixup! feat(core): Enriched Bans On Vo

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/EnrichedBanOnVo.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/EnrichedBanOnVo.java
@@ -33,11 +33,11 @@ public class EnrichedBanOnVo {
 		this.member = member;
 	}
 
-	public BanOnVo getBanOnVo() {
+	public BanOnVo getBan() {
 		return ban;
 	}
 
-	public void setBanOnVo(BanOnVo ban) {
+	public void setBan(BanOnVo ban) {
 		this.ban = ban;
 	}
 

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/VosManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/VosManagerEntryIntegrationTest.java
@@ -596,7 +596,7 @@ public class VosManagerEntryIntegrationTest extends AbstractPerunIntegrationTest
 		List<EnrichedBanOnVo> enrichedBans = vosManagerEntry.getEnrichedBansForVo(sess, createdVo.getId(), attrNames);
 
 		assertThat(enrichedBans).hasSize(1);
-		assertThat(enrichedBans.get(0).getBanOnVo()).isEqualTo(ban);
+		assertThat(enrichedBans.get(0).getBan()).isEqualTo(ban);
 		assertThat(enrichedBans.get(0).getMember()).isEqualTo(member);
 		assertThat(enrichedBans.get(0).getVo()).isEqualTo(createdVo);
 		assertThat(enrichedBans.get(0).getMember().getMemberAttributes()).hasSize(1);
@@ -633,8 +633,8 @@ public class VosManagerEntryIntegrationTest extends AbstractPerunIntegrationTest
 		assertThat(enrichedBans.get(0).getMember().getId()).isEqualTo(member.getId());
 		assertThat(enrichedBans.get(1).getMember().getId()).isEqualTo(otherMember.getId());
 
-		assertThat(enrichedBans.get(0).getBanOnVo()).isEqualTo(ban);
-		assertThat(enrichedBans.get(1).getBanOnVo()).isEqualTo(otherBan);
+		assertThat(enrichedBans.get(0).getBan()).isEqualTo(ban);
+		assertThat(enrichedBans.get(1).getBan()).isEqualTo(otherBan);
 
 		assertThat(enrichedBans.get(0).getMember().getMemberAttributes()).hasSize(1);
 		assertThat(enrichedBans.get(0).getMember().getMemberAttributes().get(0).getFriendlyName()).isEqualTo("id");


### PR DESCRIPTION
* fixed name of getters/setters to match the openapi specification (all enriched bans will have 'ban' object now)