### PR TITLE
fix(core): correctly set default date to BanOnVo/Resource/Facility wh…

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/Ban.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/Ban.java
@@ -22,8 +22,9 @@ public abstract class Ban extends Auditable implements Comparable<PerunBean> {
 	public Ban(int id, Date validityTo) {
 		super(id);
 		//set precision for validity on seconds
-		if(validityTo == null) this.validityTo = validityTo;
-		else validityTo = new Date(validityTo.getTime() / 1000 * 1000);
+		if (validityTo != null) {
+			validityTo = new Date(validityTo.getTime() / 1000 * 1000);
+		}
 		this.validityTo = validityTo;
 	}
 

--- a/perun-base/src/test/resources/test-schema.sql
+++ b/perun-base/src/test/resources/test-schema.sql
@@ -1,4 +1,4 @@
--- database version 3.1.99 (don't forget to update insert statement at the end of file)
+-- database version 3.2.10 (don't forget to update insert statement at the end of file)
 CREATE EXTENSION IF NOT EXISTS "unaccent";
 CREATE EXTENSION IF NOT EXISTS "pgcrypto";
 
@@ -1500,7 +1500,7 @@ create table resources_bans (
 								 member_id integer not null,
 								 resource_id integer not null,
 								 description varchar,
-								 banned_to timestamp not null,
+								 banned_to timestamp not null default '2999-01-01 00:00:00' not null,
 								 created_at timestamp default statement_timestamp() not null,
 								 created_by varchar default user not null,
 								 modified_at timestamp default statement_timestamp() not null,
@@ -1518,7 +1518,7 @@ create table facilities_bans (
 								  user_id integer not null,
 								  facility_id integer not null,
 								  description varchar,
-								  banned_to timestamp not null,
+								  banned_to timestamp not null default '2999-01-01 00:00:00' not null,
 								  created_at timestamp default statement_timestamp() not null,
 								  created_by varchar default user not null,
 								  modified_at timestamp default statement_timestamp() not null,
@@ -1881,7 +1881,7 @@ create index idx_fk_attr_critops ON attribute_critical_actions(attr_id);
 create index app_state_idx ON application (state);
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.1.99');
+insert into configurations values ('DATABASE VERSION','3.2.10');
 -- insert membership types
 insert into membership_types (id, membership_type, description) values (1, 'DIRECT', 'Member is directly added into group');
 insert into membership_types (id, membership_type, description) values (2, 'INDIRECT', 'Member is added indirectly through UNION relation');

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/VosManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/VosManagerBlImpl.java
@@ -90,7 +90,6 @@ import java.util.stream.Collectors;
 public class VosManagerBlImpl implements VosManagerBl {
 
 	private final static Logger log = LoggerFactory.getLogger(VosManagerBlImpl.class);
-	private final static Date FAR_FUTURE = new GregorianCalendar(2999, Calendar.JANUARY, 1).getTime();
 	public final static String A_MEMBER_DEF_MEMBER_ORGANIZATIONS = AttributesManager.NS_MEMBER_ATTR_DEF + ":memberOrganizations";
 	public final static String A_MEMBER_DEF_MEMBER_ORGANIZATIONS_HISTORY = AttributesManager.NS_MEMBER_ATTR_DEF + ":memberOrganizationsHistory";
 
@@ -834,10 +833,6 @@ public class VosManagerBlImpl implements VosManagerBl {
 			throw new BanAlreadyExistsException(banOnVo);
 		}
 
-		// if the validity is not specified, set a date from far future
-		if (banOnVo.getValidityTo() == null) {
-			banOnVo.setValidityTo(FAR_FUTURE);
-		}
 
 		banOnVo = vosManagerImpl.setBan(sess, banOnVo);
 
@@ -882,10 +877,6 @@ public class VosManagerBlImpl implements VosManagerBl {
 	public BanOnVo updateBan(PerunSession sess, BanOnVo banOnVo) {
 		Utils.notNull(banOnVo, "banOnVo");
 
-		// if the validity is not specified, set a date from far future
-		if (banOnVo.getValidityTo() == null) {
-			banOnVo.setValidityTo(FAR_FUTURE);
-		}
 		banOnVo = getVosManagerImpl().updateBan(sess, banOnVo);
 		getPerunBl().getAuditer().log(sess, new BanUpdatedForVo(banOnVo, banOnVo.getMemberId(), banOnVo.getVoId()));
 		return banOnVo;

--- a/perun-core/src/main/resources/postgresChangelog.txt
+++ b/perun-core/src/main/resources/postgresChangelog.txt
@@ -6,6 +6,11 @@
 -- Directly under version number should be version commands. They will be executed in the order they are written here.
 -- Comments are prefixed with -- and can be written only between version blocks, that means not in the lines with commands. They have to be at the start of the line.
 
+3.2.10
+ALTER TABLE resources_bans ALTER COLUMN banned_to SET DEFAULT '2999-01-01 00:00:00';
+ALTER TABLE facilities_bans ALTER COLUMN banned_to SET DEFAULT '2999-01-01 00:00:00';
+UPDATE configurations set value='3.2.10' WHERE property='DATABASE VERSION';
+
 3.1.99
 DELETE FROM facility_service_destinations a USING (SELECT MIN(ctid) as ctid, facility_id, service_id, destination_id FROM facility_service_destinations GROUP BY facility_id, service_id, destination_id HAVING COUNT(*) > 1) b WHERE a.facility_id = b.facility_id AND a.service_id = b.service_id AND a.destination_id = b.destination_id AND a.ctid <> b.ctid;
 ALTER TABLE facility_service_destinations ADD constraint fac_srv_dest_pk primary key (facility_id, service_id, destination_id);

--- a/perun-db/postgres.sql
+++ b/perun-db/postgres.sql
@@ -1,4 +1,4 @@
--- database version 3.1.99 (don't forget to update insert statement at the end of file)
+-- database version 3.2.10 (don't forget to update insert statement at the end of file)
 
 -- VOS - virtual organizations
 create table vos (
@@ -1497,7 +1497,7 @@ create table resources_bans (
 	member_id integer not null,
 	resource_id integer not null,
 	description varchar,
-	banned_to timestamp not null,
+	banned_to timestamp not null default '2999-01-01 00:00:00' not null,
 	created_at timestamp default statement_timestamp() not null,
 	created_by varchar default user not null,
 	modified_at timestamp default statement_timestamp() not null,
@@ -1515,7 +1515,7 @@ create table facilities_bans (
 	user_id integer not null,
 	facility_id integer not null,
 	description varchar,
-	banned_to timestamp not null,
+	banned_to timestamp not null default '2999-01-01 00:00:00' not null,
 	created_at timestamp default statement_timestamp() not null,
 	created_by varchar default user not null,
 	modified_at timestamp default statement_timestamp() not null,
@@ -1988,7 +1988,7 @@ grant all on attribute_critical_actions to perun;
 grant all on app_notifications_sent to perun;
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.1.99');
+insert into configurations values ('DATABASE VERSION','3.2.10');
 
 -- insert membership types
 insert into membership_types (id, membership_type, description) values (1, 'DIRECT', 'Member is directly added into group');


### PR DESCRIPTION
…en the 'validityTo' attribute is null

* tweaked the SQL statements to set default value of 'banned_to' column if 'validityTo' attribute of the ban is null
* also now updates the called object with the default date if previously null

BREAKING CHANGE: db update