### PR TITLE
fixup! feat(core): filter out outdated user IdP extsource's attributes

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Utils.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Utils.java
@@ -69,6 +69,8 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.ChronoField;
 import java.time.temporal.ChronoUnit;
 import java.time.temporal.TemporalUnit;
 import java.util.ArrayList;
@@ -131,7 +133,10 @@ public class Utils {
 	private static Properties properties;
 	public static final Pattern emailPattern = Pattern.compile("^[-_A-Za-z0-9+']+(\\.[-_A-Za-z0-9+']+)*@[-A-Za-z0-9]+(\\.[-A-Za-z0-9]+)*(\\.[A-Za-z]{2,})$");
 	public static final Pattern ucoEmailPattern = Pattern.compile("^[0-9]+@muni\\.cz$");
-	public static final DateTimeFormatter lastAccessFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSSSS");
+	public static final DateTimeFormatter lastAccessFormatter = new DateTimeFormatterBuilder()
+		.appendPattern("yyyy-MM-dd HH:mm:ss")
+		.appendFraction(ChronoField.MICRO_OF_SECOND, 0, 6, true)
+		.toFormatter();
 
 	private static final Pattern titleBeforePattern = Pattern.compile("^(([\\p{L}]+[.])|(et))$");
 	private static final Pattern firstNamePattern = Pattern.compile("^[\\p{L}-']+$");

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_earliestActiveLastAccessTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_earliestActiveLastAccessTest.java
@@ -16,6 +16,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -52,10 +53,11 @@ public class urn_perun_user_attribute_def_virt_earliestActiveLastAccessTest {
 		ues3 = new UserExtSource(10, new ExtSource(100, "earliestAccessExtSource3", ExtSourcesManager.EXTSOURCE_IDP), "login");
 		ues4 = new UserExtSource(10, new ExtSource(100, "earliestAccessExtSource4", ExtSourcesManager.EXTSOURCE_IDP), "login");
 
-		ues1.setLastAccess(LocalDateTime.now().minusMonths(validity+1).format(Utils.lastAccessFormatter));
+		// try variable length of seconds fractions in last access timestamp
+		ues1.setLastAccess(LocalDateTime.now().minusMonths(validity+1).format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSS")));
 		ues2.setLastAccess(LocalDateTime.now().minusMonths(validity-1).format(Utils.lastAccessFormatter));
 		ues3.setLastAccess(LocalDateTime.now().minusMonths(validity-2).format(Utils.lastAccessFormatter));
-		ues4.setLastAccess(LocalDateTime.now().minusMonths(validity-3).format(Utils.lastAccessFormatter));
+		ues4.setLastAccess(LocalDateTime.now().minusMonths(validity-3).format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS")));
 
 		attrDef = new AttributeDefinition();
 		attrDef.setNamespace(AttributesManager.NS_USER_ATTR_VIRT);


### PR DESCRIPTION
* original dateTime formatter expected 6 digits of fraction seconds, but different length of fraction seconds could be stored in the lastAccess property
* fixed formatter should correctly parse variable fraction seconds length