### PR TITLE
ci(githubci): changed npm version from 16 to lts

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: "lts/*"
       - name: Install dependencies
         run: npm ci
       - name: "Set up JDK"


### PR DESCRIPTION
Changed version of Node.js Package Manager used for semantic-release to value recommended in documentation.