### PR TITLE
fix(core): load all roles for service principal if not part of dontlo…

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
@@ -2499,8 +2499,8 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 		//Prepare service roles like engine, service, registrar, perunAdmin etc.
 		boolean serviceRole = prepareServiceRoles(sess);
 
-		// if have some of the service principal, we do not need to search further
-		if (!serviceRole) {
+		// no need to search further for service principals included in 'dontlookupusers' configuration
+		if (!serviceRole || !BeansUtils.getCoreConfig().getDontLookupUsers().contains(sess.getPerunPrincipal().getActor())) {
 			User user = sess.getPerunPrincipal().getUser();
 			AuthzRoles roles;
 			if (user == null) {


### PR DESCRIPTION
…okup config

* now service principals got their roles based on configuration in coreConfig and further roles were not assigned
* if service principal is missing in the dontlookupusers configuration, we should load also other roles for him