### PR TITLE
ci(githubci): ignore renovate branches by semantic release

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches-ignore:
       - master
+      - renovate/*
     tags-ignore:
       - v*
 jobs:


### PR DESCRIPTION
Renovate bot names its branches with .x at the end, which semantic release detected as release branches. Added renovate branches to the list of ignored branches for semantic release CI worflow.