### PR TITLE
feat(core): add options to sort paginated members by email, organizat…

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/MembersOrderColumn.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/MembersOrderColumn.java
@@ -18,7 +18,39 @@ public enum MembersOrderColumn {
 	                 "users.first_name " + getLangSql(query) + query.getOrder().getSqlValue()
 	),
 
-	ID("", "", query -> "members.id " + query.getOrder().getSqlValue());
+	ID("", "", query -> "members.id " + query.getOrder().getSqlValue()),
+	STATUS("","", query -> "members.status " + query.getOrder().getSqlValue()),
+	GROUP_STATUS("", "", query -> "groups_members.source_group_status " + query.getOrder().getSqlValue()),
+
+	// 1. user preferred mail, 2. member mail
+	EMAIL(
+			", usrvals.attr_value, memvals.attr_value ",
+			" left join " +
+			   	"(select attr_value, member_id, attr_id from member_attr_values) as memvals " +
+				"on members.id=memvals.member_id and memvals.attr_id=" +
+			   		"(select id from attr_names where attr_name='urn:perun:member:attribute-def:def:mail') " +
+			" left join " +
+				"(select attr_value, user_id, attr_id from user_attr_values) as usrvals " +
+				"on members.user_id=usrvals.user_id and usrvals.attr_id=" +
+					"(select id from attr_names where attr_name='urn:perun:user:attribute-def:def:preferredMail') ",
+			query -> "usrvals.attr_value " + query.getOrder().getSqlValue() + ", " +
+					 "memvals.attr_value " + query.getOrder().getSqlValue()
+	),
+
+	// 1. member organization, 2. user organization (from IdP)
+	ORGANIZATION(
+		", usrvals.attr_value, memvals.attr_value ",
+		" left join " +
+			"(select attr_value, member_id, attr_id from member_attr_values) as memvals " +
+			"on members.id=memvals.member_id and memvals.attr_id=" +
+			"(select id from attr_names where attr_name='urn:perun:member:attribute-def:def:organization') " +
+			" left join " +
+			"(select attr_value, user_id, attr_id from user_attr_values) as usrvals " +
+			"on members.user_id=usrvals.user_id and usrvals.attr_id=" +
+			"(select id from attr_names where attr_name='urn:perun:user:attribute-def:def:organization') ",
+		query -> "memvals.attr_value " + query.getOrder().getSqlValue() + ", " +
+			"usrvals.attr_value " + query.getOrder().getSqlValue()
+	);
 
 	private final Function<MembersPageQuery, String> orderBySqlFunction;
 	private final String selectSql;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/MembersManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/MembersManagerEntry.java
@@ -12,6 +12,7 @@ import cz.metacentrum.perun.core.api.Sponsor;
 import cz.metacentrum.perun.core.api.ExtSource;
 import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.Member;
+import cz.metacentrum.perun.core.api.MembersOrderColumn;
 import cz.metacentrum.perun.core.api.MemberWithSponsors;
 import cz.metacentrum.perun.core.api.MembersManager;
 import cz.metacentrum.perun.core.api.PerunSession;
@@ -33,6 +34,7 @@ import cz.metacentrum.perun.core.api.exceptions.ExtendMembershipException;
 import cz.metacentrum.perun.core.api.exceptions.ExternallyManagedException;
 import cz.metacentrum.perun.core.api.exceptions.GroupNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.GroupResourceMismatchException;
+import cz.metacentrum.perun.core.api.exceptions.IllegalArgumentException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.InvalidLoginException;
 import cz.metacentrum.perun.core.api.exceptions.InvalidSponsoredUserDataException;
@@ -1648,6 +1650,10 @@ public class MembersManagerEntry implements MembersManager {
 			if (!AuthzResolver.authorizedInternal(sess, "getMembersPage_Vo_MembersPageQuery_List<String>_policy", vo)) {
 				throw new PrivilegeException(sess, "getMembersPage");
 			}
+		}
+
+		if (MembersOrderColumn.GROUP_STATUS.equals(query.getSortColumn()) && query.getGroupId() == null) {
+			throw new IllegalArgumentException("Group status cannot be used to sort VO members.");
 		}
 
 		Paginated<RichMember> result = membersManagerBl.getMembersPage(sess, vo, query, attrNames);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/MembersManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/MembersManagerImpl.java
@@ -856,11 +856,14 @@ public class MembersManagerImpl implements MembersManagerImplApi {
 		String voSelect =
 			"SELECT " + memberMappingSelectQuery +
 				" ,count(*) OVER() AS total_count" +
-				" FROM members JOIN users on members.user_id = users.id";
+				query.getSortColumn().getSqlSelect() +
+				" FROM members JOIN users on members.user_id = users.id " +
+				query.getSortColumn().getSqlJoin();
 
 		String groupSelect =
 			"SELECT " + groupsMembersMappingSelectQuery +
 				" ,count(*) OVER() AS total_count" +
+				query.getSortColumn().getSqlSelect() +
 				"       FROM" +
 				"            (SELECT group_id, member_id, min(source_group_status) as source_group_status," +
 				"    min(membership_type) as membership_type, null as source_group_id" +
@@ -868,7 +871,8 @@ public class MembersManagerImpl implements MembersManagerImplApi {
 				"    WHERE group_id = (:groupId)" +
 				"    GROUP BY group_id, member_id) groups_members" +
 				"               LEFT JOIN members on groups_members.member_id = members.id" +
-				"                    LEFT JOIN users on members.user_id = users.id";
+				"                    LEFT JOIN users on members.user_id = users.id " +
+				query.getSortColumn().getSqlJoin();
 
 		return query.getGroupId() == null ? voSelect : groupSelect;
 	}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/MembersManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/MembersManagerEntryIntegrationTest.java
@@ -2880,6 +2880,126 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 	}
 
 	@Test
+	public void getMembersPageSortsByEmail() throws Exception {
+		System.out.println(CLASS_NAME + "getMembersPageSortsByEmail");
+
+		Vo vo = perun.getVosManager().createVo(sess, new Vo(0, "testPagination", "tp"));
+
+		AttributeDefinition mailAttrDef = perun.getAttributesManagerBl().getAttributeDefinition(sess, A_M_MAIL);
+		AttributeDefinition prefMailAttrDef = perun.getAttributesManagerBl().getAttributeDefinition(sess, A_U_PREFERRED_MAIL);
+
+		Attribute memberMail = new Attribute(mailAttrDef);
+		Attribute prefMail = new Attribute(prefMailAttrDef);
+
+		Member member1 = setUpMember(vo, "Doe", "John");
+		memberMail.setValue("mail@mail.com");
+		perun.getAttributesManagerBl().setAttribute(sess, member1, memberMail);
+
+		Member member2 = setUpMember(vo, "Do", "Jo");
+		memberMail.setValue("nail@nail.com");
+		perun.getAttributesManagerBl().setAttribute(sess, member2, memberMail);
+
+		Member member3 = setUpMember(vo, "Nom Ail", "Madelin");
+
+		Member member4 = setUpMember(vo, "Don", "Joe");
+		prefMail.setValue("ali@k.com");
+		memberMail.setValue("zli@k.com");
+		perun.getAttributesManagerBl().setAttribute(sess, perun.getUsersManagerBl().getUserByMember(sess, member4), prefMail);
+		perun.getAttributesManagerBl().setAttribute(sess, member4, memberMail);
+
+		Member member5 = setUpMember(vo, "Doney", "Joey");
+		prefMail.setValue("Don@ey.com");
+		perun.getAttributesManagerBl().setAttribute(sess, perun.getUsersManagerBl().getUserByMember(sess, member5), prefMail);
+
+		MembersPageQuery query = new MembersPageQuery(5, 0, SortingOrder.ASCENDING, MembersOrderColumn.EMAIL);
+
+		Paginated<RichMember> result = perun.getMembersManager().getMembersPage(sess, vo, query, List.of(prefMail.getName(), memberMail.getName()));
+
+		List<Integer> returnedMemberIds = result.getData().stream()
+			.map(PerunBean::getId)
+			.collect(toList());
+
+		assertThat(returnedMemberIds) // alik, doney, mail, nail, NULL
+			.containsExactly(member4.getId(), member5.getId(), member1.getId(), member2.getId(), member3.getId());
+	}
+
+	@Test
+	public void getMembersPageSortsByOrganization() throws Exception {
+		System.out.println(CLASS_NAME + "getMembersPageSortsByOrganization");
+
+		Vo vo = perun.getVosManager().createVo(sess, new Vo(0, "testPagination", "tp"));
+
+		AttributeDefinition memberOrgDef = perun.getAttributesManagerBl().getAttributeDefinition(sess, AttributesManager.NS_MEMBER_ATTR_DEF + ":organization");
+		AttributeDefinition userOrgDef = perun.getAttributesManagerBl().getAttributeDefinition(sess, AttributesManager.NS_USER_ATTR_DEF + ":organization");
+
+		Attribute memberOrg = new Attribute(memberOrgDef);
+		Attribute userOrg = new Attribute(userOrgDef);
+
+		Member member3 = setUpMember(vo, "Don", "Joe");
+		userOrg.setValue("eleland");
+		memberOrg.setValue("Zazaland");
+		perun.getAttributesManagerBl().setAttribute(sess, perun.getUsersManagerBl().getUserByMember(sess, member3), userOrg);
+		perun.getAttributesManagerBl().setAttribute(sess, member3, memberOrg);
+
+		Member member1 = setUpMember(vo, "Doe", "John");
+		memberOrg.setValue("Babaland");
+		perun.getAttributesManagerBl().setAttribute(sess, member1, memberOrg);
+
+		Member member4 = setUpMember(vo, "Doney", "Joey");
+		userOrg.setValue("gagaland");
+		perun.getAttributesManagerBl().setAttribute(sess, perun.getUsersManagerBl().getUserByMember(sess, member4), userOrg);
+
+		Member member5 = setUpMember(vo, "Nom Ail", "Madelin");
+
+		Member member2 = setUpMember(vo, "Do", "Jo");
+		memberOrg.setValue("Dadaland");
+		perun.getAttributesManagerBl().setAttribute(sess, member2, memberOrg);
+
+		MembersPageQuery query = new MembersPageQuery(5, 0, SortingOrder.ASCENDING, MembersOrderColumn.ORGANIZATION);
+
+		Paginated<RichMember> result = perun.getMembersManager().getMembersPage(sess, vo, query, List.of(userOrg.getName(), memberOrg.getName()));
+
+		List<Integer> returnedMemberIds = result.getData().stream()
+			.map(PerunBean::getId)
+			.collect(toList());
+
+		assertThat(returnedMemberIds)
+			.containsExactly(member1.getId(), member2.getId(), member3.getId(), member4.getId(), member5.getId());
+	}
+
+	@Test
+	public void getMembersPageSortsByStatus() throws Exception {
+		System.out.println(CLASS_NAME + "getMembersPageSortsByStatus");
+
+		Vo vo = perun.getVosManager().createVo(sess, new Vo(0, "testPagination", "tp"));
+
+		Member member1 = setUpMember(vo, "Doe", "John");
+		perun.getMembersManagerBl().validateMember(sess, member1);
+		perun.getMembersManagerBl().setStatus(sess, member1, Status.getStatus(4));
+
+		Member member2 = setUpMember(vo, "Do", "Jo");
+		perun.getMembersManagerBl().validateMember(sess, member2);
+		perun.getMembersManagerBl().setStatus(sess, member2, Status.getStatus(3));
+
+		Member member3 = setUpMember(vo, "Do", "Jo");
+		perun.getMembersManagerBl().setStatus(sess, member3, Status.getStatus(0));
+
+		Member member4 = setUpMember(vo, "Don", "Joe");
+		perun.getMembersManagerBl().setStatus(sess, member4, Status.getStatus(1));
+
+		MembersPageQuery query = new MembersPageQuery(5, 0, SortingOrder.ASCENDING, MembersOrderColumn.STATUS);
+
+		Paginated<RichMember> result = perun.getMembersManager().getMembersPage(sess, vo, query, List.of());
+
+		List<Integer> returnedMemberIds = result.getData().stream()
+			.map(PerunBean::getId)
+			.collect(toList());
+
+		assertThat(returnedMemberIds)
+			.containsExactly(member3.getId(), member4.getId(), member2.getId(), member1.getId());
+	}
+
+	@Test
 	public void getMembersPageIdSortDescendingWorks() throws Exception {
 		System.out.println(CLASS_NAME + "getMembersPageIdSortDescendingWorks");
 
@@ -3159,6 +3279,12 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 
 		assertThat(returnedMemberIds).containsExactly(member2.getId());
 		assertThat(result.getData().get(0).getMembershipType()).isEqualTo(MembershipType.DIRECT);
+
+		query.setSortColumn(MembersOrderColumn.GROUP_STATUS);
+		query.setGroupStatuses(List.of());
+		result = perun.getMembersManager().getMembersPage(sess, vo, query, List.of());
+
+		assertThat(result.getData().get(2).getId()).isEqualTo(member2.getId());
 	}
 
 	@Test

--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -227,6 +227,10 @@ components:
       enum:
         - ID
         - NAME
+        - EMAIL
+        - GROUP_STATUS
+        - STATUS
+        - ORGANIZATION
 
     MemberGroupStatus:
       type: string


### PR DESCRIPTION
…ion and statuses

* extended membersOrderColumn with email, organization and statuses, which will enable sorting in GUI by these parameters
* preferences (order) of email and organization are taken from current GUI logic (mixing user and member attributes)
* logins are not sortable as they are not unifiable