### PR TITLE
fix(core): fix getMemberGroups policy resolving

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/GroupsManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/GroupsManagerEntry.java
@@ -1255,7 +1255,7 @@ public class GroupsManagerEntry implements GroupsManager {
 		}
 
 		List<Group> groups = getGroupsManagerBl().getMemberGroups(sess, member);
-		groups.removeIf(group -> !AuthzResolver.authorizedInternal(sess, "filter-getMemberGroups_Member_policy", group));
+		groups.removeIf(group -> !AuthzResolver.authorizedInternal(sess, "filter-getMemberGroups_Member_policy", member, group));
 		return groups;
 	}
 


### PR DESCRIPTION
member object was not passed to the method, so members could not see their groups unless they had another role in the group