### PR TITLE
feat(gui): respect "block manual member adding" feature in old GUI

### DIFF
--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/GetEntityById.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/GetEntityById.java
@@ -111,6 +111,7 @@ public class GetEntityById implements JsonCallback, JsonCallbackWithCache {
 			attrNames.add("urn:perun:group:attribute-def:def:authoritativeGroup");
 			attrNames.add("urn:perun:group:attribute-def:def:groupSynchronizationTimes");
 			attrNames.add("urn:perun:group:attribute-def:def:startOfLastSuccessfulSynchronization");
+			attrNames.add("urn:perun:group:attribute-def:def:blockManualMemberAdding");
 			for (String value : attrNames) {
 				param += "&attrNames[]="+value;
 			}

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/groupsManager/GetAllRichGroups.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/groupsManager/GetAllRichGroups.java
@@ -77,6 +77,8 @@ public class GetAllRichGroups implements JsonCallback, JsonCallbackTable<RichGro
 	private boolean coreGroupsCheckable = false;
 	private boolean checkable = true;
 
+	private boolean blockManualAndSyncGroups = false;
+
 	/**
 	 * Creates a new callback
 	 *
@@ -86,6 +88,19 @@ public class GetAllRichGroups implements JsonCallback, JsonCallbackTable<RichGro
 	public GetAllRichGroups(int id, ArrayList<String> attrNames) {
 		this.voId = id;
 		this.attrNames = attrNames;
+	}
+
+	/**
+	 * Creates a new callback
+	 *
+	 * @param id ID of VO for which we want groups for
+	 * @param attrNames Attribute names which we want to get.
+	 * @param blockManualAndSyncGroups TRUE to block selection of groups with blocked manuall adding of members or synced groups
+	 */
+	public GetAllRichGroups(int id, ArrayList<String> attrNames, boolean blockManualAndSyncGroups) {
+		this.voId = id;
+		this.attrNames = attrNames;
+		this.blockManualAndSyncGroups = blockManualAndSyncGroups;
 	}
 
 	/**
@@ -155,7 +170,7 @@ public class GetAllRichGroups implements JsonCallback, JsonCallbackTable<RichGro
 		}
 
 		Column<RichGroup, RichGroup> checkBoxColumn = new Column<RichGroup, RichGroup>(
-				new PerunCheckboxCell<RichGroup>(true, false, coreGroupsCheckable)) {
+				new PerunCheckboxCell<RichGroup>(true, false, coreGroupsCheckable, blockManualAndSyncGroups)) {
 			@Override
 			public RichGroup getValue(RichGroup object) {
 				// Get the value from the selection model.
@@ -194,7 +209,7 @@ public class GetAllRichGroups implements JsonCallback, JsonCallbackTable<RichGro
 
 		table.addIdColumn("Group ID", tableFieldUpdater);
 
-		// Add a synchronization clicable icon column.
+		// Add a synchronization clickable icon column.
 		final Column<RichGroup, RichGroup> syncColumn = new Column<RichGroup, RichGroup>(
 				new CustomClickableInfoCellWithImageResource("click")) {
 			@Override
@@ -365,8 +380,11 @@ public class GetAllRichGroups implements JsonCallback, JsonCallbackTable<RichGro
 			}
 		});
 
-		table.addColumn(syncColumn, "Sync");
-		table.setColumnWidth(syncColumn, "70px");
+		if (!blockManualAndSyncGroups) {
+			// by default show the column
+			table.addColumn(syncColumn, "Sync");
+			table.setColumnWidth(syncColumn, "70px");
+		}
 
 		// set row styles based on: isCoreGroup()
 		table.setRowStyles(new RowStyles<RichGroup>(){

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/RichGroup.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/RichGroup.java
@@ -103,6 +103,16 @@ public class RichGroup extends Group {
 		return null;
 	}-*/;
 
+	public final native boolean isBlockManualMemberAdding() /*-{
+		for (var id in this.attributes) {
+			if (this.attributes[id].friendlyName === "blockManualMemberAdding") {
+				if (this.attributes[id].value === null) return false; // not blocked
+				return this.attributes[id].value;
+			}
+		}
+		return false;
+	}-*/;
+
 	/**
 	 * Compares to another object
 	 * @param o Object to compare

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/AddGroupUnionTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/AddGroupUnionTabItem.java
@@ -137,6 +137,9 @@ public class AddGroupUnionTabItem implements TabItem {
 			}
 		});
 
+		// refresh
+		menu.addWidget(UiElements.getRefreshButton(this));
+
 		menu.addFilterWidget(box, new PerunSearchEvent() {
 			@Override
 			public void searchFor(String text) {

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/GroupsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/GroupsTabItem.java
@@ -125,6 +125,7 @@ public class GroupsTabItem implements TabItem, TabItemWithUrl {
 		attrNames.add("urn:perun:group:attribute-def:def:groupSynchronizationTimes");
 		attrNames.add("urn:perun:group:attribute-def:def:startOfLastSuccessfulSynchronization");
 		attrNames.add("urn:perun:group:attribute-def:def:startOfLastSynchronization");
+		attrNames.add("urn:perun:group:attribute-def:def:blockManualMemberAdding");
 		final GetAllRichGroups groups = new GetAllRichGroups(voId, attrNames);
 		groups.setCheckable(false);
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/MemberAddToGroupTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/MemberAddToGroupTabItem.java
@@ -12,12 +12,12 @@ import cz.metacentrum.perun.webgui.client.UiElements;
 import cz.metacentrum.perun.webgui.client.resources.ButtonType;
 import cz.metacentrum.perun.webgui.client.resources.PerunSearchEvent;
 import cz.metacentrum.perun.webgui.client.resources.SmallIcons;
-import cz.metacentrum.perun.webgui.client.resources.Utils;
 import cz.metacentrum.perun.webgui.json.JsonCallbackEvents;
 import cz.metacentrum.perun.webgui.json.JsonUtils;
 import cz.metacentrum.perun.webgui.json.groupsManager.AddMember;
-import cz.metacentrum.perun.webgui.json.groupsManager.GetAllGroups;
+import cz.metacentrum.perun.webgui.json.groupsManager.GetAllRichGroups;
 import cz.metacentrum.perun.webgui.model.Group;
+import cz.metacentrum.perun.webgui.model.RichGroup;
 import cz.metacentrum.perun.webgui.model.RichMember;
 import cz.metacentrum.perun.webgui.tabs.TabItem;
 import cz.metacentrum.perun.webgui.widgets.CustomButton;
@@ -79,7 +79,21 @@ public class MemberAddToGroupTabItem implements TabItem {
 		vp.add(menu);
 		vp.setCellHeight(menu, "30px");
 
-		final GetAllGroups groups = new GetAllGroups(member.getVoId());
+		ArrayList<String> attrNames = new ArrayList<>();
+		attrNames.add("urn:perun:group:attribute-def:def:synchronizationEnabled");
+		attrNames.add("urn:perun:group:attribute-def:def:synchronizationInterval");
+		attrNames.add("urn:perun:group:attribute-def:def:lastSynchronizationState");
+		attrNames.add("urn:perun:group:attribute-def:def:lastSuccessSynchronizationTimestamp");
+		attrNames.add("urn:perun:group:attribute-def:def:lastSynchronizationTimestamp");
+		attrNames.add("urn:perun:group:attribute-def:def:authoritativeGroup");
+		attrNames.add("urn:perun:group:attribute-def:def:groupSynchronizationTimes");
+		attrNames.add("urn:perun:group:attribute-def:def:startOfLastSuccessfulSynchronization");
+		attrNames.add("urn:perun:group:attribute-def:def:startOfLastSynchronization");
+		attrNames.add("urn:perun:group:attribute-def:def:blockManualMemberAdding");
+		final GetAllRichGroups groups = new GetAllRichGroups(member.getVoId(), attrNames, true);
+
+		// refresh
+		menu.addWidget(UiElements.getRefreshButton(this));
 
 		menu.addFilterWidget(new ExtendedSuggestBox(groups.getOracle()), new PerunSearchEvent() {
 			@Override
@@ -98,11 +112,11 @@ public class MemberAddToGroupTabItem implements TabItem {
 		addButton.addClickHandler(new ClickHandler() {
 			@Override
 			public void onClick(ClickEvent clickEvent) {
-				ArrayList<Group> list = groups.getTableSelectedList();
+				ArrayList<RichGroup> list = groups.getTableSelectedList();
 				if (UiElements.cantSaveEmptyListDialogBox(list)) {
 					// TODO - should have only one callback to core
 					for (int i=0; i<list.size(); i++) {
-						final Group g = list.get(i);
+						final RichGroup g = list.get(i);
 						AddMember request = new AddMember(JsonCallbackEvents.disableButtonEvents(addButton, new JsonCallbackEvents(){
 							@Override
 							public void onFinished(JavaScriptObject jso) {
@@ -126,7 +140,7 @@ public class MemberAddToGroupTabItem implements TabItem {
 			}
 		}));
 
-		CellTable<Group> table = groups.getTable();
+		CellTable<RichGroup> table = groups.getTable();
 
 		JsonUtils.addTableManagedButton(groups, table, addButton);
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/vostabs/VoGroupsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/vostabs/VoGroupsTabItem.java
@@ -121,12 +121,13 @@ public class VoGroupsTabItem implements TabItem, TabItemWithUrl{
 		attrNames.add("urn:perun:group:attribute-def:def:groupSynchronizationTimes");
 		attrNames.add("urn:perun:group:attribute-def:def:startOfLastSuccessfulSynchronization");
 		attrNames.add("urn:perun:group:attribute-def:def:startOfLastSynchronization");
+		attrNames.add("urn:perun:group:attribute-def:def:blockManualMemberAdding");
 		final GetAllRichGroups groups = new GetAllRichGroups(voId, attrNames);
 		final JsonCallbackEvents events = JsonCallbackEvents.refreshTableEvents(groups);
 		if (!session.isVoAdmin(voId)) groups.setCheckable(false);
 
 		// refresh
-		 menu.addWidget(UiElements.getRefreshButton(this));
+		menu.addWidget(UiElements.getRefreshButton(this));
 
 		// add new group button
 		CustomButton createButton = TabMenu.getPredefinedButton(ButtonType.CREATE, true, ButtonTranslation.INSTANCE.createGroup(), new ClickHandler() {


### PR DESCRIPTION
- When trying to add member to VO/Group respect its setting, which prevents such manual addition.
- Perun admin is still allowed to add members manually.
- Fixed on VO Members and Overview tabs.
- Fixed on Group Members tab.
- Fixed on Members groups tab.
- PerunCheckboxCell can show disabled checkboxes with a message, why is selection disabled (synced or blocked groups).
- Also prevent adding when group is synchronized.
- Added missing refresh buttons.
- Retrieve RichGroup on tab reload instead of Group.