### PR TITLE
feat(core): un/block login per namespace or globally

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/LoginIsAlreadyBlockedException.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/LoginIsAlreadyBlockedException.java
@@ -1,0 +1,36 @@
+package cz.metacentrum.perun.core.api.exceptions;
+
+/**
+ * Thrown when the given login is already blocked for the given namespace
+ * Thrown also if the given namespace is null and the given login is already blocked globally
+ *
+ * @author Jakub Hejda <Jakub.Hejda@cesnet.cz>
+ */
+public class LoginIsAlreadyBlockedException extends PerunException {
+	static final long serialVersionUID = 0;
+
+	/**
+	 * Simple constructor with a message
+	 * @param message message with details about the cause
+	 */
+	public LoginIsAlreadyBlockedException(String message) {
+		super(message);
+	}
+
+	/**
+	 * Constructor with a message and Throwable object
+	 * @param message message with details about the cause
+	 * @param cause Throwable that caused throwing of this exception
+	 */
+	public LoginIsAlreadyBlockedException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	/**
+	 * Constructor with a Throwable object
+	 * @param cause Throwable that caused throwing of this exception
+	 */
+	public LoginIsAlreadyBlockedException(Throwable cause) {
+		super(cause);
+	}
+}

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/LoginIsNotBlockedException.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/LoginIsNotBlockedException.java
@@ -1,0 +1,36 @@
+package cz.metacentrum.perun.core.api.exceptions;
+
+/**
+ * Thrown when the given login is not blocked for the given namespace
+ * Thrown also if the given namespace is null and the given login is not blocked globally
+ *
+ * @author Jakub Hejda <Jakub.Hejda@cesnet.cz>
+ */
+public class LoginIsNotBlockedException extends PerunException {
+	static final long serialVersionUID = 0;
+
+	/**
+	 * Simple constructor with a message
+	 * @param message message with details about the cause
+	 */
+	public LoginIsNotBlockedException(String message) {
+		super(message);
+	}
+
+	/**
+	 * Constructor with a message and Throwable object
+	 * @param message message with details about the cause
+	 * @param cause Throwable that caused throwing of this exception
+	 */
+	public LoginIsNotBlockedException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	/**
+	 * Constructor with a Throwable object
+	 * @param cause Throwable that caused throwing of this exception
+	 */
+	public LoginIsNotBlockedException(Throwable cause) {
+		super(cause);
+	}
+}

--- a/perun-base/src/main/resources/perun-roles.yml
+++ b/perun-base/src/main/resources/perun-roles.yml
@@ -6207,6 +6207,40 @@ perun_policies:
     include_policies:
       - default_policy
 
+  getAllBlockedLoginsInNamespaces_policy:
+    policy_roles:
+      - PERUNOBSERVER:
+    include_policies:
+      - default_policy
+
+  isLoginBlocked_String_policy:
+    policy_roles:
+      - PERUNOBSERVER:
+    include_policies:
+      - default_policy
+
+  isLoginBlockedGlobally_String_policy:
+    policy_roles:
+      - PERUNOBSERVER:
+    include_policies:
+      - default_policy
+
+  isLoginBlockedForNamespace_String_String_policy:
+    policy_roles:
+      - PERUNOBSERVER:
+    include_policies:
+      - default_policy
+
+  blockLogins_List<String>_String_policy:
+    policy_roles: []
+    include_policies:
+      - default_policy
+
+  unblockLogins_List<String>_String_policy:
+    policy_roles: []
+    include_policies:
+      - default_policy
+
   getUsersWithoutVoAssigned_policy:
     policy_roles:
       - PERUNOBSERVER:

--- a/perun-base/src/test/resources/test-schema.sql
+++ b/perun-base/src/test/resources/test-schema.sql
@@ -1,4 +1,4 @@
--- database version 3.2.11 (don't forget to update insert statement at the end of file)
+-- database version 3.2.12 (don't forget to update insert statement at the end of file)
 CREATE EXTENSION IF NOT EXISTS "unaccent";
 CREATE EXTENSION IF NOT EXISTS "pgcrypto";
 
@@ -663,6 +663,18 @@ create table application_reserved_logins (
 											  modified_by_uid integer,
 											  constraint app_logins_pk primary key(login, namespace),
 											  constraint applogin_userid_fk foreign key(user_id) references users(id)
+);
+
+-- BLOCKED_LOGINS - logins blocked for reservation or setting
+create table blocked_logins (
+								id integer not null,
+								login varchar not null,		--login
+								namespace varchar,			--namespace where login is blocked
+								created_at timestamp default statement_timestamp() not null,
+								created_by_uid integer,
+								modified_by_uid integer,
+								constraint blocked_logins_pk primary key(id),
+								constraint blocked_logins_u unique (login, namespace)
 );
 
 -- FACILITY_SERVICE_DESTINATIONS - destinations of services assigned to the facility
@@ -1712,6 +1724,7 @@ create sequence "resources_bans_id_seq";
 create sequence "facilities_bans_id_seq";
 create sequence "vos_bans_id_seq";
 create sequence "consents_id_seq";
+create sequence "blocked_logins_id_seq";
 
 
 create unique index idx_grp_nam_vo_parentg_u on groups (name,vo_id,coalesce(parent_group_id,'0'));
@@ -1882,7 +1895,7 @@ create index idx_fk_attr_critops ON attribute_critical_actions(attr_id);
 create index app_state_idx ON application (state);
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.2.11');
+insert into configurations values ('DATABASE VERSION','3.2.12');
 -- insert membership types
 insert into membership_types (id, membership_type, description) values (1, 'DIRECT', 'Member is directly added into group');
 insert into membership_types (id, membership_type, description) values (2, 'INDIRECT', 'Member is added indirectly through UNION relation');

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/UsersManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/UsersManager.java
@@ -37,6 +37,8 @@ import cz.metacentrum.perun.core.api.exceptions.VoNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.LoginIsAlreadyBlockedException;
+import cz.metacentrum.perun.core.api.exceptions.LoginIsNotBlockedException;
 
 import java.util.List;
 import java.util.Map;
@@ -795,6 +797,62 @@ public interface UsersManager {
 	 */
 	boolean isLoginAvailable(PerunSession sess, String loginNamespace, String login) throws InvalidLoginException;
 
+	/**
+	 * Returns all pairs of blocked login in namespace (if namespace is null, then this login is blocked globally)
+	 *
+	 * @param sess
+	 * @return list of pairs login and namespace - List<Pair<login, namespace>>
+	 */
+	List<Pair<String, String>> getAllBlockedLoginsInNamespaces(PerunSession sess) throws PrivilegeException;
+
+	/**
+	 * Return true if login is blocked (globally - for all namespaces per instance OR for some namespace), false if not
+	 *
+	 * @param sess
+	 * @param login login to check
+	 * @return true if login is blocked
+	 */
+	boolean isLoginBlocked(PerunSession sess, String login) throws PrivilegeException;
+
+	/**
+	 * Return true if login is blocked globally (for all namespaces per instance - represented by namespace = null), false if not
+	 *
+	 * @param sess
+	 * @param login login to check
+	 * @return true if login is blocked globally
+	 */
+	boolean isLoginBlockedGlobally(PerunSession sess, String login) throws PrivilegeException;
+
+	/**
+	 * Return true if login is blocked for given namespace, false if not
+	 * When the namespace is null, then the method behaves like isLoginBlockedGlobally(), so it checks if the login is blocked globally
+	 *
+	 * @param sess
+	 * @param login login to check
+	 * @param namespace namespace for login
+	 * @return true if login is blocked for given namespace (or globally for null namespace)
+	 */
+	boolean isLoginBlockedForNamespace(PerunSession sess, String login, String namespace) throws PrivilegeException;
+
+	/**
+	 * Block logins for given namespace or block logins globally (if no namespace is selected)
+	 *
+	 * @param sess
+	 * @param logins list of logins to be blocked
+	 * @param namespace namespace where the logins should be blocked (null means block the logins globally)
+	 * @throws LoginIsAlreadyBlockedException
+	 * @throws LoginExistsException
+	 */
+	void blockLogins(PerunSession sess, List<String> logins, String namespace) throws PrivilegeException, LoginIsAlreadyBlockedException, LoginExistsException;
+
+	/**
+	 * Unblock logins for given namespace or unblock logins globally (if no namespace is selected)
+	 * @param sess
+	 * @param logins list of logins to be unblocked
+	 * @param namespace namespace where the logins should be unblocked (null means unblock the logins globally)
+	 * @throws LoginIsNotBlockedException
+	 */
+	void unblockLogins(PerunSession sess, List<String> logins, String namespace) throws PrivilegeException, LoginIsNotBlockedException;
 
 	/**
 	 * Returns all users who have set the attribute with the value. Searching only def and opt attributes.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
@@ -423,6 +423,16 @@ public interface AttributesManagerBl {
 	List<Attribute> getAttributes(PerunSession sess, User user, List<String> attrNames);
 
 	/**
+	 * Check if the login is already in use for some namespace or globally
+	 *
+	 * @param sess perun session
+	 * @param login login to be checked
+	 * @param namespace login can be checked for given namespace or globally, if namespace is null
+	 * @return true if login is already in use
+	 */
+	boolean isLoginAlreadyUsed(PerunSession sess, String login, String namespace);
+
+	/**
 	 * Get all attributes associated with the UserExtSource which have name in list attrNames (empty and virtual too).
 	 *
 	 * @param sess perun session

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
@@ -51,6 +51,9 @@ import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.LoginIsAlreadyBlockedException;
+import cz.metacentrum.perun.core.api.exceptions.LoginExistsException;
+import cz.metacentrum.perun.core.api.exceptions.LoginIsNotBlockedException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.pwdmgr.PasswordManagerModule;
 
@@ -1212,6 +1215,63 @@ public interface UsersManagerBl {
 	 * @throws AlreadyReservedLoginException throw this exception if login already exist in table of reserved logins
 	 */
 	void checkReservedLogins(PerunSession sess, String namespace, String login, boolean ignoreCase) throws AlreadyReservedLoginException;
+
+	/**
+	 * Returns all pairs of blocked login in namespace (if namespace is null, then this login is blocked globally)
+	 *
+	 * @param sess
+	 * @return list of pairs login and namespace - List<Pair<login, namespace>>
+	 */
+	List<Pair<String, String>> getAllBlockedLoginsInNamespaces(PerunSession sess);
+
+	/**
+	 * Return true if login is blocked (globally - for all namespaces per instance OR for some namespace), false if not
+	 *
+	 * @param sess
+	 * @param login login to check
+	 * @return true if login is blocked
+	 */
+	boolean isLoginBlocked(PerunSession sess, String login);
+
+	/**
+	 * Return true if login is blocked globally (for all namespaces per instance - represented by namespace = null), false if not
+	 *
+	 * @param sess
+	 * @param login login to check
+	 * @return true if login is blocked globally
+	 */
+	boolean isLoginBlockedGlobally(PerunSession sess, String login);
+
+	/**
+	 * Return true if login is blocked for given namespace, false if not
+	 * When the namespace is null, then the method behaves like isLoginBlockedGlobally(), so it checks if the login is blocked globally
+	 *
+	 * @param sess
+	 * @param login login to check
+	 * @param namespace namespace for login
+	 * @return true if login is blocked for given namespace (or globally for null namespace)
+	 */
+	boolean isLoginBlockedForNamespace(PerunSession sess, String login, String namespace);
+
+	/**
+	 * Block logins for given namespace or block logins globally (if no namespace is selected)
+	 *
+	 * @param sess
+	 * @param logins list of logins to be blocked
+	 * @param namespace namespace where the logins should be blocked (null means block the logins globally)
+	 * @throws LoginIsAlreadyBlockedException
+	 * @throws LoginExistsException
+	 */
+	void blockLogins(PerunSession sess, List<String> logins, String namespace) throws LoginIsAlreadyBlockedException, LoginExistsException;
+
+	/**
+	 * Unblock logins for given namespace or unblock logins globally (if no namespace is selected)
+	 * @param sess
+	 * @param logins logins list of logins to be unblocked
+	 * @param namespace namespace where the logins should be unblocked (null means unblock the logins globally)
+	 * @throws LoginIsNotBlockedException
+	 */
+	void unblockLogins(PerunSession sess, List<String> logins, String namespace) throws LoginIsNotBlockedException;
 
 	void checkUserExists(PerunSession sess, User user) throws UserNotExistsException;
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -654,6 +654,11 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	}
 
 	@Override
+	public boolean isLoginAlreadyUsed(PerunSession sess, String login, String namespace) {
+		return getAttributesManagerImpl().isLoginAlreadyUsed(sess, login, namespace);
+	}
+
+	@Override
 	public List<Attribute> getAttributes(PerunSession sess, Host host) {
 		//get virtual attributes
 		List<Attribute> attributes = getAttributesManagerImpl().getVirtualAttributes(sess, host);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
@@ -51,6 +51,9 @@ import cz.metacentrum.perun.core.api.exceptions.IllegalArgumentException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.InvalidLoginException;
 import cz.metacentrum.perun.core.api.exceptions.LoginNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.LoginExistsException;
+import cz.metacentrum.perun.core.api.exceptions.LoginIsAlreadyBlockedException;
+import cz.metacentrum.perun.core.api.exceptions.LoginIsNotBlockedException;
 import cz.metacentrum.perun.core.api.exceptions.MemberAlreadyRemovedException;
 import cz.metacentrum.perun.core.api.exceptions.MemberNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.PasswordChangeFailedException;
@@ -1149,6 +1152,44 @@ public class UsersManagerBlImpl implements UsersManagerBl {
 		}
 
 	}
+
+	@Override
+	public List<Pair<String, String>> getAllBlockedLoginsInNamespaces(PerunSession sess) {
+		return getUsersManagerImpl().getAllBlockedLoginsInNamespaces(sess);
+	}
+
+	@Override
+	public boolean isLoginBlocked(PerunSession sess, String login) {
+		return getUsersManagerImpl().isLoginBlocked(sess, login);
+	}
+
+	@Override
+	public boolean isLoginBlockedGlobally(PerunSession sess, String login) {
+		return getUsersManagerImpl().isLoginBlockedGlobally(sess, login);
+	}
+
+	@Override
+	public boolean isLoginBlockedForNamespace(PerunSession sess, String login, String namespace) {
+		return getUsersManagerImpl().isLoginBlockedForNamespace(sess, login, namespace);
+	}
+
+	@Override
+	public void blockLogins(PerunSession sess, List<String> logins, String namespace) throws LoginIsAlreadyBlockedException, LoginExistsException {
+		for (String login : logins) {
+			if (getPerunBl().getAttributesManagerBl().isLoginAlreadyUsed(sess, login, namespace)) {
+				throw new LoginExistsException("Login: " + login + " is already in use.");
+			}
+			getUsersManagerImpl().blockLogin(sess, login, namespace);
+		}
+	}
+
+	@Override
+	public void unblockLogins(PerunSession sess, List<String> logins, String namespace) throws LoginIsNotBlockedException {
+		for (String login : logins) {
+			getUsersManagerImpl().unblockLogin(sess, login, namespace);
+		}
+	}
+
 	/**
 	 * Gets the usersManagerImpl for this instance.
 	 *

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
@@ -28,6 +28,7 @@ import cz.metacentrum.perun.core.api.UserExtSource;
 import cz.metacentrum.perun.core.api.UsersManager;
 import cz.metacentrum.perun.core.api.UsersPageQuery;
 import cz.metacentrum.perun.core.api.Vo;
+import cz.metacentrum.perun.core.api.Pair;
 import cz.metacentrum.perun.core.api.exceptions.AlreadyReservedLoginException;
 import cz.metacentrum.perun.core.api.exceptions.AnonymizationNotSupportedException;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
@@ -67,6 +68,8 @@ import cz.metacentrum.perun.core.api.exceptions.VoNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.LoginIsAlreadyBlockedException;
+import cz.metacentrum.perun.core.api.exceptions.LoginIsNotBlockedException;
 import cz.metacentrum.perun.core.bl.PerunBl;
 import cz.metacentrum.perun.core.bl.UsersManagerBl;
 import cz.metacentrum.perun.core.impl.Utils;
@@ -970,6 +973,73 @@ public class UsersManagerEntry implements UsersManager {
 		// Authorization - must be public since it's used to check anonymous users input on registration form
 
 		return getUsersManagerBl().isLoginAvailable(sess, loginNamespace, login);
+	}
+
+	@Override
+	public List<Pair<String, String>> getAllBlockedLoginsInNamespaces(PerunSession sess) throws PrivilegeException {
+		Utils.checkPerunSession(sess);
+
+		if (!AuthzResolver.authorizedInternal(sess, "getAllBlockedLoginsInNamespaces_policy")) {
+			throw new PrivilegeException(sess, "getAllBlockedLoginsInNamespaces");
+		}
+
+		return getUsersManagerBl().getAllBlockedLoginsInNamespaces(sess);
+	}
+
+	@Override
+	public boolean isLoginBlocked(PerunSession sess, String login) throws PrivilegeException {
+		Utils.checkPerunSession(sess);
+
+		if (!AuthzResolver.authorizedInternal(sess, "isLoginBlocked_String_policy")) {
+			throw new PrivilegeException(sess, "isLoginBlocked");
+		}
+
+		return getUsersManagerBl().isLoginBlocked(sess, login);
+	}
+
+	@Override
+	public boolean isLoginBlockedGlobally(PerunSession sess, String login) throws PrivilegeException {
+		Utils.checkPerunSession(sess);
+
+		if (!AuthzResolver.authorizedInternal(sess, "isLoginBlockedGlobally_String_policy")) {
+			throw new PrivilegeException(sess, "isLoginBlockedGlobally");
+		}
+
+		return getUsersManagerBl().isLoginBlockedGlobally(sess, login);
+
+	}
+
+	@Override
+	public boolean isLoginBlockedForNamespace(PerunSession sess, String login, String namespace) throws PrivilegeException {
+		Utils.checkPerunSession(sess);
+
+		if (!AuthzResolver.authorizedInternal(sess, "isLoginBlockedForNamespace_String_String_policy")) {
+			throw new PrivilegeException(sess, "isLoginBlockedForNamespace");
+		}
+
+		return getUsersManagerBl().isLoginBlockedForNamespace(sess, login, namespace);
+	}
+
+	@Override
+	public void blockLogins(PerunSession sess, List<String> logins, String namespace) throws PrivilegeException, LoginIsAlreadyBlockedException, LoginExistsException {
+		Utils.checkPerunSession(sess);
+
+		if (!AuthzResolver.authorizedInternal(sess, "blockLogins_List<String>_String_policy")) {
+			throw new PrivilegeException(sess, "blockLogins");
+		}
+
+		getUsersManagerBl().blockLogins(sess, logins, namespace);
+	}
+
+	@Override
+	public void unblockLogins(PerunSession sess, List<String> logins, String namespace) throws PrivilegeException, LoginIsNotBlockedException {
+		Utils.checkPerunSession(sess);
+
+		if (!AuthzResolver.authorizedInternal(sess, "unblockLogins_List<String>_String_policy")) {
+			throw new PrivilegeException(sess, "unblockLogins");
+		}
+
+		getUsersManagerBl().unblockLogins(sess, logins, namespace);
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
@@ -1248,6 +1248,19 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 		}
 	}
 
+	@Override
+	public boolean isLoginAlreadyUsed(PerunSession sess, String login, String namespace) {
+		try {
+			String namespaceValue = (namespace == null) ? "%" : namespace;
+			return jdbc.queryForInt(String.format("select count(*) from attr_names as attr join user_attr_values attr_val on attr.id=attr_val.attr_id\n" +
+				"where attr.friendly_name like 'login-namespace:%s' \n" +
+				"    and attr.friendly_name not like '%%persistent%%' \n" +
+				"    and attr_val.attr_value like ?", namespaceValue), login) > 0;
+		} catch (RuntimeException ex) {
+			throw new InternalErrorException(ex);
+		}
+	}
+
 
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
@@ -487,6 +487,16 @@ public interface AttributesManagerImplApi {
 	List<Attribute> getAttributes(PerunSession sess, User user, List<String> attrNames);
 
 	/**
+	 * Check if the login is already in use for some namespace or globally
+	 *
+	 * @param sess perun session
+	 * @param login login to be checked
+	 * @param namespace login can be checked for given namespace or globally, if namespace is null
+	 * @return true if login is already in use
+	 */
+	boolean isLoginAlreadyUsed(PerunSession sess, String login, String namespace);
+
+	/**
 	 * Get all virtual attributes associated with the user.
 	 *
 	 * @param sess perun session

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/UsersManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/UsersManagerImplApi.java
@@ -27,6 +27,8 @@ import cz.metacentrum.perun.core.api.exceptions.UserExtSourceAlreadyRemovedExcep
 import cz.metacentrum.perun.core.api.exceptions.UserExtSourceExistsException;
 import cz.metacentrum.perun.core.api.exceptions.UserExtSourceNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.LoginIsAlreadyBlockedException;
+import cz.metacentrum.perun.core.api.exceptions.LoginIsNotBlockedException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.pwdmgr.PasswordManagerModule;
 
@@ -431,6 +433,62 @@ public interface UsersManagerImplApi {
 	 * @throws InternalErrorException
 	 */
 	boolean isLoginReserved(PerunSession sess, String namespace, String login, boolean ignoreCase);
+
+	/**
+	 * Returns all pairs of blocked login in namespace (if namespace is null, then this login is blocked globally)
+	 *
+	 * @param sess
+	 * @return list of pairs login and namespace - List<Pair<login, namespace>>
+	 */
+	List<Pair<String, String>> getAllBlockedLoginsInNamespaces(PerunSession sess);
+
+	/**
+	 * Return true if login is blocked (globally - for all namespaces per instance OR for some namespace), false if not
+	 *
+	 * @param sess
+	 * @param login login to check
+	 * @return true if login is blocked
+	 */
+	boolean isLoginBlocked(PerunSession sess, String login);
+
+	/**
+	 * Return true if login is blocked globally (for all namespaces per instance - represented by namespace = null), false if not
+	 *
+	 * @param sess
+	 * @param login login to check
+	 * @return true if login is blocked globally
+	 */
+	boolean isLoginBlockedGlobally(PerunSession sess, String login);
+
+	/**
+	 * Return true if login is blocked for given namespace, false if not
+	 * When the namespace is null, then the method behaves like isLoginBlockedGlobally(), so it checks if the login is blocked globally
+	 *
+	 * @param sess
+	 * @param namespace namespace for login
+	 * @param login login to check
+	 * @return true if login is blocked for given namespace (or globally for null namespace)
+	 */
+	boolean isLoginBlockedForNamespace(PerunSession sess, String login, String namespace);
+
+	/**
+	 * Block login for given namespace or block login globally (if no namespace is selected)
+	 *
+	 * @param sess
+	 * @param login login to be blocked
+	 * @param namespace namespace where the login should be blocked (null means block the login globally)
+	 * @throws LoginIsAlreadyBlockedException
+	 */
+	void blockLogin(PerunSession sess, String login, String namespace) throws LoginIsAlreadyBlockedException;
+
+	/**
+	 * Unblock login for given namespace or unblock login globally (if no namespace is selected)
+	 * @param sess
+	 * @param login login to be unblocked
+	 * @param namespace namespace where the login should be unblocked (null means unblock the login globally)
+	 * @throws LoginIsNotBlockedException
+	 */
+	void unblockLogin(PerunSession sess, String login, String namespace) throws LoginIsNotBlockedException;
 
 	/**
 	 * Check if login in specified namespace exists.

--- a/perun-core/src/main/resources/postgresChangelog.txt
+++ b/perun-core/src/main/resources/postgresChangelog.txt
@@ -6,6 +6,12 @@
 -- Directly under version number should be version commands. They will be executed in the order they are written here.
 -- Comments are prefixed with -- and can be written only between version blocks, that means not in the lines with commands. They have to be at the start of the line.
 
+3.2.12
+create table blocked_logins (id integer not null, login varchar not null, namespace varchar, created_at timestamp default statement_timestamp() not null, created_by_uid integer, modified_by_uid integer, constraint blocked_logins_pk primary key(id), constraint blocked_logins_u unique (login, namespace));
+create sequence "blocked_logins_id_seq";
+grant all on blocked_logins to perun;
+UPDATE configurations set value='3.2.12' WHERE property='DATABASE VERSION';
+
 3.2.11
 ALTER TABLE vos DROP constraint vo_u;
 ALTER TABLE vos ADD CONSTRAINT vo_u unique (short_name);

--- a/perun-db/postgres.sql
+++ b/perun-db/postgres.sql
@@ -1,4 +1,4 @@
--- database version 3.2.11 (don't forget to update insert statement at the end of file)
+-- database version 3.2.12 (don't forget to update insert statement at the end of file)
 
 -- VOS - virtual organizations
 create table vos (
@@ -661,6 +661,18 @@ create table application_reserved_logins (
 	modified_by_uid integer,
 	constraint app_logins_pk primary key(login, namespace),
   constraint applogin_userid_fk foreign key(user_id) references users(id)
+);
+
+-- BLOCKED_LOGINS - logins blocked for reservation or setting
+create table blocked_logins (
+	id integer not null,
+	login varchar not null,		--login
+	namespace varchar,			--namespace where login is blocked
+	created_at timestamp default statement_timestamp() not null,
+	created_by_uid integer,
+	modified_by_uid integer,
+	constraint blocked_logins_pk primary key(id),
+  constraint blocked_logins_u unique (login, namespace)
 );
 
 -- FACILITY_SERVICE_DESTINATIONS - destinations of services assigned to the facility
@@ -1709,6 +1721,7 @@ create sequence "resources_bans_id_seq";
 create sequence "facilities_bans_id_seq";
 create sequence "vos_bans_id_seq";
 create sequence "consents_id_seq";
+create sequence "blocked_logins_id_seq";
 
 create unique index idx_grp_nam_vo_parentg_u on groups (name,vo_id,coalesce(parent_group_id,'0'));
 create index idx_namespace on attr_names(namespace);
@@ -1987,9 +2000,10 @@ grant all on consent_attr_defs to perun;
 grant all on allowed_groups_to_hierarchical_vo to perun;
 grant all on attribute_critical_actions to perun;
 grant all on app_notifications_sent to perun;
+grant all on blocked_logins to perun;
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.2.11');
+insert into configurations values ('DATABASE VERSION','3.2.12');
 
 -- insert membership types
 insert into membership_types (id, membership_type, description) values (1, 'DIRECT', 'Member is directly added into group');

--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -9922,6 +9922,36 @@ paths:
         default:
           $ref: '#/components/responses/ExceptionResponse'
 
+  /urlinjsonout/usersManager/blockLogins:
+    post:
+      tags:
+        - UsersManager
+      operationId: blockLogins
+      summary: Block logins for given namespace or block logins globally (if no namespace is selected)
+      parameters:
+        - { name: "logins[]", schema: { type: array, items: { type: string } }, in: query, required: false, description: "list of logins to be blocked" }
+        - { name: namespace, schema: { type: string }, in: query, required: false }
+      responses:
+        '200':
+          $ref: '#/components/responses/VoidResponse'
+        default:
+          $ref: '#/components/responses/ExceptionResponse'
+
+  /urlinjsonout/usersManager/unblockLogins:
+    post:
+      tags:
+        - UsersManager
+      operationId: unblockLogins
+      summary: Unblock logins for given namespace or unblock logins globally (if no namespace is selected)
+      parameters:
+        - { name: "logins[]", schema: { type: array, items: { type: string } }, in: query, required: false, description: "list of logins to be blocked" }
+        - { name: namespace, schema: { type: string }, in: query, required: false }
+      responses:
+        '200':
+          $ref: '#/components/responses/VoidResponse'
+        default:
+          $ref: '#/components/responses/ExceptionResponse'
+
   /urlinjsonout/usersManager/reserveRandomPassword:
     post:
       tags:

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/UsersManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/UsersManagerMethod.java
@@ -1129,6 +1129,60 @@ public enum UsersManagerMethod implements ManagerMethod {
 	},
 
 	/*#
+	 * Block logins for given namespace
+	 *
+	 * @param logins List<String> list of logins
+	 * @param namespace String Namespace
+	 * @throw LoginIsAlreadyBlockedException When some login is already blocked for given namespace (or globally)
+	 * @throw LoginExistsException When some login is already in use
+	 */
+	/*#
+	 * Block logins globally (for all namespaces)
+	 *
+	 * @param logins List<String> list of logins
+	 * @throw LoginIsAlreadyBlockedException When some login is already blocked for given namespace (or globally)
+	 * @throw LoginExistsException When some login is already in use
+	 */
+	blockLogins {
+		@Override
+		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
+			parms.stateChangingCheck();
+
+			ac.getUsersManager().blockLogins(ac.getSession(),
+				parms.readList("logins", String.class),
+				parms.contains("namespace") ? parms.readString("namespace") : null);
+
+			return null;
+		}
+	},
+
+	/*#
+	 * Unblock logins for given namespace
+	 *
+	 * @param logins List<String> list of logins
+	 * @param namespace String Namespace
+	 * @throw LoginIsNotBlockedException When some login is not blocked
+	 */
+	/*#
+	 * Unblock logins globally (for all namespaces)
+	 *
+	 * @param logins List<String> list of logins
+	 * @throw LoginIsNotBlockedException When some login is not blocked
+	 */
+	unblockLogins {
+		@Override
+		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
+			parms.stateChangingCheck();
+
+			ac.getUsersManager().unblockLogins(ac.getSession(),
+				parms.readList("logins", String.class),
+				parms.contains("namespace") ? parms.readString("namespace") : null);
+
+			return null;
+		}
+	},
+
+	/*#
 	 * Returns users by their IDs.
 	 *
 	 * @param ids List<Integer> list of users IDs


### PR DESCRIPTION
* Now is possible to block login for given namespace or also block login globally (for all namespaces on instance).
* It is not possible to block already blcoked login or login which is already used. It is also not possible to ublock NOT blocked login.
* We can block login for some namespace(s) and also block it globally - we don't want to unblock them automatically during the new (different) blocking for the same login.

BREAKING CHANGE: update DB