### PR TITLE
feat(core): use blocked logins logic

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/CoreConfig.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/CoreConfig.java
@@ -5,6 +5,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -836,5 +837,23 @@ public class CoreConfig {
 
 	public void setIdpLoginValidityExceptions(List<String> idpLoginValidityExceptions) {
 		this.idpLoginValidityExceptions = idpLoginValidityExceptions;
+	}
+
+	/**
+	 * Get all logins blocked by default (used by internal components).
+	 *
+	 * @return set of logins used by instance
+	 */
+	public Set<String> getBlockedLogins() {
+		Set<String> blockedLogins = new HashSet<>();
+
+		blockedLogins.addAll(admins);
+		blockedLogins.addAll(enginePrincipals);
+		blockedLogins.addAll(notificationPrincipals);
+		blockedLogins.addAll(registrarPrincipals);
+		blockedLogins.addAll(dontLookupUsers);
+		blockedLogins.add(rpcPrincipal);
+
+		return blockedLogins;
 	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/UsersManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/UsersManager.java
@@ -806,33 +806,38 @@ public interface UsersManager {
 	List<Pair<String, String>> getAllBlockedLoginsInNamespaces(PerunSession sess) throws PrivilegeException;
 
 	/**
-	 * Return true if login is blocked (globally - for all namespaces per instance OR for some namespace), false if not
+	 * Return true if login is blocked (globally - for all namespaces per instance OR for some namespace), false if not.
+	 * Globally banned logins are ALWAYS case-insensitive (ignoreCase value is not taken into account for them).
 	 *
-	 * @param sess
-	 * @param login login to check
+	 * @param sess       session
+	 * @param login      login to check
+	 * @param ignoreCase ignore case
 	 * @return true if login is blocked
 	 */
-	boolean isLoginBlocked(PerunSession sess, String login) throws PrivilegeException;
+	boolean isLoginBlocked(PerunSession sess, String login, boolean ignoreCase) throws PrivilegeException;
 
 	/**
-	 * Return true if login is blocked globally (for all namespaces per instance - represented by namespace = null), false if not
+	 * Return true if login is blocked globally (for all namespaces per instance - represented by namespace = null), false if not.
+	 * Globally banned logins are ALWAYS case-insensitive.
 	 *
-	 * @param sess
+	 * @param sess  session
 	 * @param login login to check
 	 * @return true if login is blocked globally
 	 */
 	boolean isLoginBlockedGlobally(PerunSession sess, String login) throws PrivilegeException;
 
 	/**
-	 * Return true if login is blocked for given namespace, false if not
-	 * When the namespace is null, then the method behaves like isLoginBlockedGlobally(), so it checks if the login is blocked globally
+	 * Return true if login is blocked for given namespace, false if not.
+	 * When the namespace is null, then the method behaves like isLoginBlockedGlobally(), so it checks if the login is blocked globally.
+	 * Globally banned logins are ALWAYS case-insensitive.
 	 *
-	 * @param sess
-	 * @param login login to check
-	 * @param namespace namespace for login
+	 * @param sess       session
+	 * @param login      login to check
+	 * @param namespace  namespace for login
+	 * @param ignoreCase ignore case
 	 * @return true if login is blocked for given namespace (or globally for null namespace)
 	 */
-	boolean isLoginBlockedForNamespace(PerunSession sess, String login, String namespace) throws PrivilegeException;
+	boolean isLoginBlockedForNamespace(PerunSession sess, String login, String namespace, boolean ignoreCase) throws PrivilegeException;
 
 	/**
 	 * Block logins for given namespace or block logins globally (if no namespace is selected)

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
@@ -1217,6 +1217,18 @@ public interface UsersManagerBl {
 	void checkReservedLogins(PerunSession sess, String namespace, String login, boolean ignoreCase) throws AlreadyReservedLoginException;
 
 	/**
+	 * Check if login is blocked. Login can be blocked by default (used by internal components),
+	 * globally or in namespace.
+	 *
+	 * @param sess       session
+	 * @param namespace  attribute
+	 * @param userLogin  login
+	 * @param ignoreCase ignore case (work as case-insensitive)
+	 * @throws LoginIsAlreadyBlockedException when login is blocked
+	 */
+	void checkBlockedLogins(PerunSession sess, String namespace, String userLogin, boolean ignoreCase) throws LoginIsAlreadyBlockedException;
+
+	/**
 	 * Returns all pairs of blocked login in namespace (if namespace is null, then this login is blocked globally)
 	 *
 	 * @param sess
@@ -1225,16 +1237,19 @@ public interface UsersManagerBl {
 	List<Pair<String, String>> getAllBlockedLoginsInNamespaces(PerunSession sess);
 
 	/**
-	 * Return true if login is blocked (globally - for all namespaces per instance OR for some namespace), false if not
+	 * Return true if login is blocked (globally - for all namespaces per instance OR for some namespace), false if not.
+	 * Globally banned logins are ALWAYS case-insensitive (ignoreCase value is not taken into account for them).
 	 *
 	 * @param sess
-	 * @param login login to check
+	 * @param login      login to check
+	 * @param ignoreCase
 	 * @return true if login is blocked
 	 */
-	boolean isLoginBlocked(PerunSession sess, String login);
+	boolean isLoginBlocked(PerunSession sess, String login, boolean ignoreCase);
 
 	/**
 	 * Return true if login is blocked globally (for all namespaces per instance - represented by namespace = null), false if not
+	 * Globally banned logins are ALWAYS case-insensitive.
 	 *
 	 * @param sess
 	 * @param login login to check
@@ -1244,14 +1259,16 @@ public interface UsersManagerBl {
 
 	/**
 	 * Return true if login is blocked for given namespace, false if not
-	 * When the namespace is null, then the method behaves like isLoginBlockedGlobally(), so it checks if the login is blocked globally
+	 * When the namespace is null, then the method behaves like isLoginBlockedGlobally(), so it checks if the login is blocked globally.
+	 * Globally banned logins are ALWAYS case-insensitive.
 	 *
 	 * @param sess
-	 * @param login login to check
-	 * @param namespace namespace for login
+	 * @param login      login to check
+	 * @param namespace  namespace for login
+	 * @param ignoreCase
 	 * @return true if login is blocked for given namespace (or globally for null namespace)
 	 */
-	boolean isLoginBlockedForNamespace(PerunSession sess, String login, String namespace);
+	boolean isLoginBlockedForNamespace(PerunSession sess, String login, String namespace, boolean ignoreCase);
 
 	/**
 	 * Block logins for given namespace or block logins globally (if no namespace is selected)

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
@@ -987,14 +987,14 @@ public class UsersManagerEntry implements UsersManager {
 	}
 
 	@Override
-	public boolean isLoginBlocked(PerunSession sess, String login) throws PrivilegeException {
+	public boolean isLoginBlocked(PerunSession sess, String login, boolean ignoreCase) throws PrivilegeException {
 		Utils.checkPerunSession(sess);
 
 		if (!AuthzResolver.authorizedInternal(sess, "isLoginBlocked_String_policy")) {
 			throw new PrivilegeException(sess, "isLoginBlocked");
 		}
 
-		return getUsersManagerBl().isLoginBlocked(sess, login);
+		return getUsersManagerBl().isLoginBlocked(sess, login, ignoreCase);
 	}
 
 	@Override
@@ -1010,14 +1010,14 @@ public class UsersManagerEntry implements UsersManager {
 	}
 
 	@Override
-	public boolean isLoginBlockedForNamespace(PerunSession sess, String login, String namespace) throws PrivilegeException {
+	public boolean isLoginBlockedForNamespace(PerunSession sess, String login, String namespace, boolean ignoreCase) throws PrivilegeException {
 		Utils.checkPerunSession(sess);
 
 		if (!AuthzResolver.authorizedInternal(sess, "isLoginBlockedForNamespace_String_String_policy")) {
 			throw new PrivilegeException(sess, "isLoginBlockedForNamespace");
 		}
 
-		return getUsersManagerBl().isLoginBlockedForNamespace(sess, login, namespace);
+		return getUsersManagerBl().isLoginBlockedForNamespace(sess, login, namespace, ignoreCase);
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace.java
@@ -8,6 +8,7 @@ import cz.metacentrum.perun.core.api.exceptions.AlreadyReservedLoginException;
 import cz.metacentrum.perun.core.api.exceptions.ConsistencyErrorException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.InvalidLoginException;
+import cz.metacentrum.perun.core.api.exceptions.LoginIsAlreadyBlockedException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
@@ -85,9 +86,13 @@ public class urn_perun_user_attribute_def_def_login_namespace extends UserAttrib
 		}
 
 		try {
-			sess.getPerunBl().getUsersManagerBl().checkReservedLogins(sess, attribute.getFriendlyNameParameter(), userLogin, false);
+			String namespace = attribute.getFriendlyNameParameter();
+			sess.getPerunBl().getUsersManagerBl().checkReservedLogins(sess, namespace, userLogin, false);
+			sess.getPerunBl().getUsersManagerBl().checkBlockedLogins(sess, namespace, userLogin, false);
 		} catch (AlreadyReservedLoginException ex) {
 			throw new WrongReferenceAttributeValueException(attribute, null, user, null, null, null, "Login in specific namespace already reserved.", ex);
+		} catch (LoginIsAlreadyBlockedException ex) {
+			throw new WrongReferenceAttributeValueException(attribute, null, "Login is blocked.", ex);
 		}
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace_admin_meta.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace_admin_meta.java
@@ -6,6 +6,7 @@ import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.exceptions.AlreadyReservedLoginException;
 import cz.metacentrum.perun.core.api.exceptions.ConsistencyErrorException;
+import cz.metacentrum.perun.core.api.exceptions.LoginIsAlreadyBlockedException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
@@ -34,9 +35,13 @@ public class urn_perun_user_attribute_def_def_login_namespace_admin_meta extends
 		}
 
 		try {
-			sess.getPerunBl().getUsersManagerBl().checkReservedLogins(sess, attribute.getFriendlyNameParameter(), userLogin, true);
+			String namespace = attribute.getFriendlyNameParameter();
+			sess.getPerunBl().getUsersManagerBl().checkReservedLogins(sess, namespace, userLogin, true);
+			sess.getPerunBl().getUsersManagerBl().checkBlockedLogins(sess, namespace, userLogin, true);
 		} catch (AlreadyReservedLoginException ex) {
 			throw new WrongReferenceAttributeValueException(attribute, null, user, null, null, null, "Login in specific namespace already reserved.", ex);
+		} catch (LoginIsAlreadyBlockedException ex) {
+			throw new WrongReferenceAttributeValueException(attribute, null, "Login is blocked.", ex);
 		}
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/UsersManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/UsersManagerImplApi.java
@@ -443,16 +443,19 @@ public interface UsersManagerImplApi {
 	List<Pair<String, String>> getAllBlockedLoginsInNamespaces(PerunSession sess);
 
 	/**
-	 * Return true if login is blocked (globally - for all namespaces per instance OR for some namespace), false if not
+	 * Return true if login is blocked (globally - for all namespaces per instance OR for some namespace), false if not.
+	 * Globally banned logins are ALWAYS case-insensitive (ignoreCase value is not taken into account for them).
 	 *
 	 * @param sess
-	 * @param login login to check
+	 * @param login      login to check
+	 * @param ignoreCase
 	 * @return true if login is blocked
 	 */
-	boolean isLoginBlocked(PerunSession sess, String login);
+	boolean isLoginBlocked(PerunSession sess, String login, boolean ignoreCase);
 
 	/**
-	 * Return true if login is blocked globally (for all namespaces per instance - represented by namespace = null), false if not
+	 * Return true if login is blocked globally (for all namespaces per instance - represented by namespace = null), false if not.
+	 * Globally banned logins are ALWAYS case-insensitive.
 	 *
 	 * @param sess
 	 * @param login login to check
@@ -462,14 +465,16 @@ public interface UsersManagerImplApi {
 
 	/**
 	 * Return true if login is blocked for given namespace, false if not
-	 * When the namespace is null, then the method behaves like isLoginBlockedGlobally(), so it checks if the login is blocked globally
+	 * When the namespace is null, then the method behaves like isLoginBlockedGlobally(), so it checks if the login is blocked globally.
+	 * Globally banned logins are ALWAYS case-insensitive.
 	 *
 	 * @param sess
-	 * @param namespace namespace for login
-	 * @param login login to check
+	 * @param login      login to check
+	 * @param namespace  namespace for login
+	 * @param ignoreCase
 	 * @return true if login is blocked for given namespace (or globally for null namespace)
 	 */
-	boolean isLoginBlockedForNamespace(PerunSession sess, String login, String namespace);
+	boolean isLoginBlockedForNamespace(PerunSession sess, String login, String namespace, boolean ignoreCase);
 
 	/**
 	 * Block login for given namespace or block login globally (if no namespace is selected)

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/UserAttributesModuleAbstract.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/UserAttributesModuleAbstract.java
@@ -4,7 +4,6 @@ import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.exceptions.AnonymizationNotSupportedException;
-import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/UsersManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/UsersManagerEntryIntegrationTest.java
@@ -19,6 +19,7 @@ import cz.metacentrum.perun.core.api.MemberGroupStatus;
 import cz.metacentrum.perun.core.api.Owner;
 import cz.metacentrum.perun.core.api.OwnerType;
 import cz.metacentrum.perun.core.api.Paginated;
+import cz.metacentrum.perun.core.api.Pair;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.RichUser;
 import cz.metacentrum.perun.core.api.RichUserExtSource;
@@ -34,20 +35,19 @@ import cz.metacentrum.perun.core.api.UsersManager;
 import cz.metacentrum.perun.core.api.UsersOrderColumn;
 import cz.metacentrum.perun.core.api.UsersPageQuery;
 import cz.metacentrum.perun.core.api.Vo;
-import cz.metacentrum.perun.core.api.Pair;
 import cz.metacentrum.perun.core.api.exceptions.AnonymizationNotSupportedException;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ExtSourceNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.LoginExistsException;
+import cz.metacentrum.perun.core.api.exceptions.LoginIsAlreadyBlockedException;
+import cz.metacentrum.perun.core.api.exceptions.LoginIsNotBlockedException;
 import cz.metacentrum.perun.core.api.exceptions.MemberNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.RelationExistsException;
 import cz.metacentrum.perun.core.api.exceptions.RelationNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.UserExtSourceExistsException;
 import cz.metacentrum.perun.core.api.exceptions.UserExtSourceNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
-import cz.metacentrum.perun.core.api.exceptions.LoginIsAlreadyBlockedException;
-import cz.metacentrum.perun.core.api.exceptions.LoginIsNotBlockedException;
-import cz.metacentrum.perun.core.api.exceptions.LoginExistsException;
 import cz.metacentrum.perun.core.blImpl.AuthzResolverBlImpl;
 import org.json.JSONObject;
 import org.junit.Assert;
@@ -69,10 +69,10 @@ import java.util.Set;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
 
 /**
@@ -89,6 +89,10 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 	private final static String URN_ATTR_UES_O = AttributesManager.NS_UES_ATTR_DEF + ':' + ATTR_UES_O;
 	private final static String URN_ATTR_UES_CN = AttributesManager.NS_UES_ATTR_DEF + ':' + ATTR_UES_CN;
 
+	private static final String defaultBlockedLogin = "perunEngine";
+	private static final String globallyBlockedLogin = "globalLogin";
+	private static final String namespaceBlockedLogin = "namespaceLogin";
+
 	private User user;           // our User
 	private User serviceUser1;
 	private User serviceUser2;
@@ -102,7 +106,6 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 	final ExtSource extSource = new ExtSource(0, "testExtSource", "cz.metacentrum.perun.core.impl.ExtSourceInternal");
 	final UserExtSource userExtSource = new UserExtSource();   // create new User Ext Source
 	private UsersManager usersManager;
-
 
 	@Before
 	public void setUp() throws Exception {
@@ -119,7 +122,6 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 		setUpSpecificUser1ForUser(vo);
 		setUpSpecificUser2ForUser(vo);
 		setUpSponsoredUserForVo(vo);
-
 	}
 
 	@Test
@@ -735,13 +737,40 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 
 		String globalLogin = "login";
 		perun.getUsersManager().blockLogins(sess, Collections.singletonList(globalLogin), null);
-		boolean isLoginBlockedGlobally = perun.getUsersManager().isLoginBlocked(sess, globalLogin);
+		boolean isLoginBlockedGlobally = perun.getUsersManager().isLoginBlocked(sess, globalLogin, false);
+
+		assertTrue(isLoginBlockedGlobally);
+
+		isLoginBlockedGlobally = perun.getUsersManager().isLoginBlocked(sess, globalLogin.toUpperCase(), false);
+
+		// should be true, even if we should not ignore case because global logins are always case-insensitive
+		assertTrue(isLoginBlockedGlobally);
+
+		String namespaceLogin = "loginNamespace";
+		perun.getUsersManager().blockLogins(sess, Collections.singletonList(namespaceLogin), "namespace");
+		boolean isLoginBlocked = perun.getUsersManager().isLoginBlocked(sess, namespaceLogin, false);
+
+		assertTrue(isLoginBlocked);
+
+		isLoginBlocked = perun.getUsersManager().isLoginBlocked(sess, namespaceLogin.toUpperCase(), false);
+
+		// should be false, if we do NOT ignore case
+		assertFalse(isLoginBlocked);
+	}
+
+	@Test
+	public void isLoginBlockedIgnoreCase() throws Exception {
+		System.out.println(CLASS_NAME + "isLoginBlocked");
+
+		String globalLogin = "login";
+		perun.getUsersManager().blockLogins(sess, Collections.singletonList(globalLogin), null);
+		boolean isLoginBlockedGlobally = perun.getUsersManager().isLoginBlocked(sess, globalLogin, false);
 
 		assertTrue(isLoginBlockedGlobally);
 
 		String namespaceLogin = "loginNamespace";
 		perun.getUsersManager().blockLogins(sess, Collections.singletonList(namespaceLogin), "namespace");
-		isLoginBlockedGlobally = perun.getUsersManager().isLoginBlocked(sess, namespaceLogin);
+		isLoginBlockedGlobally = perun.getUsersManager().isLoginBlocked(sess, namespaceLogin, false);
 
 		assertTrue(isLoginBlockedGlobally);
 	}
@@ -764,22 +793,64 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 	}
 
 	@Test
+	public void isLoginBlockedGloballyCaseInsensitive() throws Exception {
+		System.out.println(CLASS_NAME + "isLoginBlockedGlobally");
+
+		String globalLogin = "login";
+		perun.getUsersManager().blockLogins(sess, Collections.singletonList(globalLogin), null);
+		boolean isLoginBlockedGlobally = perun.getUsersManager().isLoginBlockedGlobally(sess, globalLogin.toUpperCase());
+
+		assertTrue(isLoginBlockedGlobally);
+	}
+
+	@Test
 	public void isLoginBlockedForNamespace() throws Exception {
 		System.out.println(CLASS_NAME + "isLoginBlockedForNamespace");
 
 		String globalLogin = "login";
 		perun.getUsersManager().blockLogins(sess, Collections.singletonList(globalLogin), null);
-		boolean isLoginBlocked = perun.getUsersManager().isLoginBlockedForNamespace(sess, globalLogin, null);
+		boolean isLoginBlockedGlobally = perun.getUsersManager().isLoginBlockedForNamespace(sess, globalLogin, null, false);
+
+		assertTrue(isLoginBlockedGlobally);
+
+		isLoginBlockedGlobally = perun.getUsersManager().isLoginBlockedForNamespace(sess, globalLogin.toUpperCase(), null, false);
+
+		// should be true, since globally blocked logins are case-insensitive
+		assertTrue(isLoginBlockedGlobally);
+
+		String namespaceLogin = "loginNamespace";
+		perun.getUsersManager().blockLogins(sess, Collections.singletonList(namespaceLogin), "namespace");
+		boolean isLoginBlockedForNamespace = perun.getUsersManager().isLoginBlockedForNamespace(sess, namespaceLogin, "namespace", false);
+
+		assertTrue(isLoginBlockedForNamespace);
+
+		isLoginBlockedForNamespace = perun.getUsersManager().isLoginBlockedForNamespace(sess, namespaceLogin.toUpperCase(), "namespace", false);
+
+		// should be false, if we do NOT ignore case
+		assertFalse(isLoginBlockedForNamespace);
+
+		isLoginBlockedForNamespace = perun.getUsersManager().isLoginBlockedForNamespace(sess, namespaceLogin, "namespace_test", false);
+
+		assertFalse(isLoginBlockedForNamespace);
+	}
+
+	@Test
+	public void isLoginBlockedForNamespaceIgnoreCase() throws Exception {
+		System.out.println(CLASS_NAME + "isLoginBlockedForNamespace");
+
+		String globalLogin = "login";
+		perun.getUsersManager().blockLogins(sess, Collections.singletonList(globalLogin), null);
+		boolean isLoginBlocked = perun.getUsersManager().isLoginBlockedForNamespace(sess, globalLogin.toUpperCase(), null, true);
 
 		assertTrue(isLoginBlocked);
 
 		String namespaceLogin = "loginNamespace";
 		perun.getUsersManager().blockLogins(sess, Collections.singletonList(namespaceLogin), "namespace");
-		isLoginBlocked = perun.getUsersManager().isLoginBlockedForNamespace(sess, namespaceLogin, "namespace");
+		isLoginBlocked = perun.getUsersManager().isLoginBlockedForNamespace(sess, namespaceLogin.toUpperCase(), "namespace", true);
 
 		assertTrue(isLoginBlocked);
 
-		isLoginBlocked = perun.getUsersManager().isLoginBlockedForNamespace(sess, namespaceLogin, "namespace_test");
+		isLoginBlocked = perun.getUsersManager().isLoginBlockedForNamespace(sess, namespaceLogin.toUpperCase(), "namespace_test", true);
 
 		assertFalse(isLoginBlocked);
 	}
@@ -791,19 +862,19 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 		String login = "login";
 		String namespace = "namespace";
 
-		assertFalse(perun.getUsersManager().isLoginBlockedForNamespace(sess, login, null));
+		assertFalse(perun.getUsersManager().isLoginBlockedForNamespace(sess, login, null, false));
 
 		perun.getUsersManager().blockLogins(sess, Collections.singletonList(login), null);
-		assertTrue(perun.getUsersManager().isLoginBlockedForNamespace(sess, login, null));
+		assertTrue(perun.getUsersManager().isLoginBlockedForNamespace(sess, login, null, false));
 
 		perun.getUsersManager().unblockLogins(sess, Collections.singletonList(login), null);
-		assertFalse(perun.getUsersManager().isLoginBlockedForNamespace(sess, login, null));
+		assertFalse(perun.getUsersManager().isLoginBlockedForNamespace(sess, login, null, false));
 
 		perun.getUsersManager().blockLogins(sess, Collections.singletonList(login), namespace);
-		assertTrue(perun.getUsersManager().isLoginBlockedForNamespace(sess, login, namespace));
+		assertTrue(perun.getUsersManager().isLoginBlockedForNamespace(sess, login, namespace, false));
 
 		perun.getUsersManager().unblockLogins(sess, Collections.singletonList(login), namespace);
-		assertFalse(perun.getUsersManager().isLoginBlockedForNamespace(sess, login, namespace));
+		assertFalse(perun.getUsersManager().isLoginBlockedForNamespace(sess, login, namespace, false));
 	}
 
 	@Test
@@ -862,7 +933,7 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 		String namespace = "namespace";
 
 		perun.getUsersManager().blockLogins(sess, Collections.singletonList(login), namespace);
-		assertTrue(perun.getUsersManager().isLoginBlockedForNamespace(sess, login, namespace));
+		assertTrue(perun.getUsersManager().isLoginBlockedForNamespace(sess, login, namespace, false));
 
 		perun.getUsersManager().blockLogins(sess, Collections.singletonList(login), namespace);
 		// shouldn't block already blocked login twice
@@ -2706,6 +2777,56 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 			.isEmpty();
 		assertThat(perun.getUsersManagerBl().getUsersByAttributeValue(sess, attributeName, "chars,"))
 			.isEmpty();
+	}
+
+	@Test(expected = LoginIsAlreadyBlockedException.class)
+	public void testCheckBlockedLoginDefault() throws Exception {
+		System.out.println("testCheckBlockedLoginDefault");
+		perun.getUsersManagerBl().checkBlockedLogins(sess, "admin-meta", defaultBlockedLogin, false);
+	}
+
+	@Test(expected = LoginIsAlreadyBlockedException.class)
+	public void testCheckBlockedLoginGlobalCaseInsensitive() throws Exception {
+		System.out.println("testCheckBlockedLoginGlobalCaseInsensitive");
+
+		String namespace = "admin-meta";
+
+		// block login globally
+		perun.getUsersManager().blockLogins(sess, Collections.singletonList(globallyBlockedLogin), null);
+
+		// check if login in specific namespace can be used (check for globally blocked logins as well)
+		perun.getUsersManagerBl().checkBlockedLogins(sess, namespace, globallyBlockedLogin.toUpperCase(), true);
+	}
+
+	@Test(expected = LoginIsAlreadyBlockedException.class)
+	public void testCheckBlockedLoginGlobal() throws Exception {
+		System.out.println("testCheckBlockedLoginGlobal");
+
+		String namespace = "admin-meta";
+
+		// block login globally
+		perun.getUsersManager().blockLogins(sess, Collections.singletonList(globallyBlockedLogin), null);
+
+		// check if login in specific namespace can be used (check for globally blocked logins as well)
+		perun.getUsersManagerBl().checkBlockedLogins(sess, namespace, globallyBlockedLogin, false);
+	}
+
+	@Test(expected = LoginIsAlreadyBlockedException.class)
+	public void testCheckBlockedLoginInNamespaceIgnoreCase() throws Exception {
+		System.out.println("testCheckBlockedLoginInNamespaceIgnoreCase");
+
+		String namespace = "admin-meta";
+		perun.getUsersManager().blockLogins(sess, Collections.singletonList(namespaceBlockedLogin), namespace);
+		perun.getUsersManagerBl().checkBlockedLogins(sess, namespace, namespaceBlockedLogin.toUpperCase(), true);
+	}
+
+	@Test(expected = LoginIsAlreadyBlockedException.class)
+	public void testCheckBlockedLoginInNamespace() throws Exception {
+		System.out.println("testCheckBlockedLoginInNamespace");
+
+		String namespace = "admin-meta";
+		perun.getUsersManager().blockLogins(sess, Collections.singletonList(namespaceBlockedLogin), namespace);
+		perun.getUsersManagerBl().checkBlockedLogins(sess, namespace, namespaceBlockedLogin, false);
 	}
 
 	// PRIVATE METHODS -------------------------------------------------------------


### PR DESCRIPTION
* when creating new login (login attribute), value is checked if not blocked (namespace, globally, default)
* already existing methods for blocked logins adjusted to work with ignoreCase flag
* global logins are ALWAYS case-insensitive
* logins blocked by default (internal components) are ALWAYS case-sensitive.
* tests created/adjusted