### PR TITLE
fix(core): getAllNamespaces condition

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
@@ -4188,7 +4188,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 
 	@Override
 	public List<String> getAllNamespaces(PerunSession sess) {
-		return jdbc.query("SELECT friendly_name FROM attr_names WHERE friendly_name LIKE 'login-namespace:%%' AND friendly_name NOT LIKE '%%persistent%%'", ATTRIBUTE_FRIENDLY_NAMES_MAPPER);
+		return jdbc.query("SELECT friendly_name FROM attr_names WHERE friendly_name LIKE 'login-namespace:%%' AND attr_name NOT LIKE '%%def:virt%%'", ATTRIBUTE_FRIENDLY_NAMES_MAPPER);
 	}
 
 	/**

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/AttributesManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/AttributesManagerEntryIntegrationTest.java
@@ -934,17 +934,26 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 	public void getAllNamespaces() throws Exception {
 		System.out.println(CLASS_NAME + "getAllNamespaces");
 
-		String namespaceName = "getAllNamespacesTest";
+		String namespaceDef = "namespacesTestDef";
+		String namespaceVirt = "namespacesTestVirt";
 
-		Attribute attr = new Attribute();
-		attr.setNamespace("urn:perun:user:attribute-def:def");
-		attr.setFriendlyName("login-namespace:" + namespaceName);
-		attr.setType(String.class.getName());
-		attr.setValue("testLogin");
-		assertNotNull("unable to create attribute",attributesManager.createAttribute(sess, attr));
+		Attribute attr1 = new Attribute();
+		attr1.setNamespace("urn:perun:user:attribute-def:def");
+		attr1.setFriendlyName("login-namespace:" + namespaceDef);
+		attr1.setType(String.class.getName());
+		attr1.setValue("testLogin1");
+		assertNotNull("unable to create attribute",attributesManager.createAttribute(sess, attr1));
+
+		Attribute attr2 = new Attribute();
+		attr2.setNamespace("urn:perun:user:attribute-def:virt");
+		attr2.setFriendlyName("login-namespace:" + namespaceVirt);
+		attr2.setType(String.class.getName());
+		attr2.setValue("testLogin2");
+		assertNotNull("unable to create attribute",attributesManager.createAttribute(sess, attr2));
 
 		List<String> namespaces = perun.getAttributesManager().getAllNamespaces(sess);
-		assertThat(namespaces).contains(namespaceName);
+		assertTrue(namespaces.contains(namespaceDef));
+		assertFalse(namespaces.contains(namespaceVirt));
 	}
 
 	@Test


### PR DESCRIPTION
Updated condition from obtaining namespaces to ignore virt attributes and allow 'persistent' substrings.