### PR TITLE
feat(core): interconnect the deletion of user with blocking user's logins

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/CoreConfig.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/CoreConfig.java
@@ -52,6 +52,7 @@ public class CoreConfig {
 	private Set<String> dontLookupUsers;
 	private Set<String> extSourcesMultipleIdentifiers;
 	private boolean lookupUserByIdentifiersAndExtSourceLogin;
+	private boolean userDeletionForced;
 	private boolean forceConsents;
 	private boolean requestUserInfoEndpoint;
 	private String alternativePasswordManagerProgram;
@@ -271,6 +272,14 @@ public class CoreConfig {
 
 	public void setLookupUserByIdentifiersAndExtSourceLogin(boolean lookupUserByIdentifiersAndExtSourceLogin) {
 		this.lookupUserByIdentifiersAndExtSourceLogin = lookupUserByIdentifiersAndExtSourceLogin;
+	}
+
+	public boolean getUserDeletionForced() {
+		return userDeletionForced;
+	}
+
+	public void setUserDeletionForced(boolean userDeletionForced) {
+		this.userDeletionForced = userDeletionForced;
 	}
 
 	public boolean getForceConsents() {

--- a/perun-base/src/main/resources/perun-base.xml
+++ b/perun-base/src/main/resources/perun-base.xml
@@ -15,6 +15,7 @@
 		<property name="dontLookupUsers" value="#{'${perun.dont.lookup.users}'.split('\s*,\s*')}"/>
 		<property name="extSourcesMultipleIdentifiers" value="#{'${perun.extsources.multiple.identifiers}'.split('\s*,\s*')}"/>
 		<property name="lookupUserByIdentifiersAndExtSourceLogin" value="${perun.lookup.user.by.identifiers.and.extSourceLogin}"/>
+		<property name="userDeletionForced" value="${perun.user.deletion.forced}"/>
 		<property name="forceConsents" value="${perun.force.consents}"/>
 		<property name="requestUserInfoEndpoint" value="${perun.requestUserInfoEndpoint}"/>
 		<property name="enginePrincipals" value="#{'${perun.engine.principals}'.split('\s*,\s*')}"/>
@@ -107,6 +108,7 @@
 					perunRegistrar, perunSynchronizer, perunCabinet, perunNotifications, perunRpc, perunLdapc
 				</prop>
 				<prop key="perun.lookup.user.by.identifiers.and.extSourceLogin">false</prop>
+				<prop key="perun.user.deletion.forced">false</prop>
 				<prop key="perun.force.consents">false</prop>
 				<prop key="perun.requestUserInfoEndpoint">false</prop>
 				<prop key="perun.group.synchronization.interval">1</prop>

--- a/perun-base/src/test/resources/test-schema.sql
+++ b/perun-base/src/test/resources/test-schema.sql
@@ -1,4 +1,4 @@
--- database version 3.2.12 (don't forget to update insert statement at the end of file)
+-- database version 3.2.13 (don't forget to update insert statement at the end of file)
 CREATE EXTENSION IF NOT EXISTS "unaccent";
 CREATE EXTENSION IF NOT EXISTS "pgcrypto";
 
@@ -670,6 +670,7 @@ create table blocked_logins (
 								id integer not null,
 								login varchar not null,		--login
 								namespace varchar,			--namespace where login is blocked
+								related_user_id integer,	--id of user who was related to this login in the past
 								created_at timestamp default statement_timestamp() not null,
 								created_by_uid integer,
 								modified_by_uid integer,
@@ -1895,7 +1896,7 @@ create index idx_fk_attr_critops ON attribute_critical_actions(attr_id);
 create index app_state_idx ON application (state);
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.2.12');
+insert into configurations values ('DATABASE VERSION','3.2.13');
 -- insert membership types
 insert into membership_types (id, membership_type, description) values (1, 'DIRECT', 'Member is directly added into group');
 insert into membership_types (id, membership_type, description) values (2, 'INDIRECT', 'Member is added indirectly through UNION relation');

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/UsersManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/UsersManager.java
@@ -869,6 +869,16 @@ public interface UsersManager {
 	void unblockLoginsById(PerunSession sess, List<Integer> loginIds) throws PrivilegeException, LoginIsNotBlockedException;
 
 	/**
+	 * Get user id of the user who was related to the given login in the past
+	 *
+	 * @param sess session
+	 * @param login blocked login
+	 * @param namespace namespace where the login is blocked
+	 * @return user id or null if there is no related user id
+	 */
+	Integer getRelatedUserIdByBlockedLoginInNamespace(PerunSession sess, String login, String namespace) throws LoginIsNotBlockedException;
+
+	/**
 	 * Get page of blocked logins.
 	 *
 	 * @param sess session

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
@@ -1279,10 +1279,11 @@ public interface UsersManagerBl {
 	 * @param sess
 	 * @param logins list of logins to be blocked
 	 * @param namespace namespace where the logins should be blocked (null means block the logins globally)
+	 * @param relatedUserId id of the user related to the login or null if the relatedUserId should not be stored
 	 * @throws LoginIsAlreadyBlockedException
 	 * @throws LoginExistsException
 	 */
-	void blockLogins(PerunSession sess, List<String> logins, String namespace) throws LoginIsAlreadyBlockedException, LoginExistsException;
+	void blockLogins(PerunSession sess, List<String> logins, String namespace, Integer relatedUserId) throws LoginIsAlreadyBlockedException, LoginExistsException;
 
 	/**
 	 * Get page of blocked logins.
@@ -1319,6 +1320,16 @@ public interface UsersManagerBl {
 	 * @return id of login blocked in specified namespace
 	 */
 	int getIdOfBlockedLogin(PerunSession sess, String login, String namespace);
+
+	/**
+	 * Get user id of the user who was related to the given login in the past
+	 *
+	 * @param sess session
+	 * @param login blocked login
+	 * @param namespace namespace where the login is blocked
+	 * @return user id or null if there is no related user id
+	 */
+	Integer getRelatedUserIdByBlockedLoginInNamespace(PerunSession sess, String login, String namespace) throws LoginIsNotBlockedException;
 
 	void checkUserExists(PerunSession sess, User user) throws UserNotExistsException;
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
@@ -1030,7 +1030,7 @@ public class UsersManagerEntry implements UsersManager {
 			throw new PrivilegeException(sess, "blockLogins");
 		}
 
-		getUsersManagerBl().blockLogins(sess, logins, namespace);
+		getUsersManagerBl().blockLogins(sess, logins, namespace, null);
 	}
 
 	@Override
@@ -1063,6 +1063,11 @@ public class UsersManagerEntry implements UsersManager {
 		}
 
 		getUsersManagerBl().unblockLoginsById(sess, loginIds);
+	}
+
+	@Override
+	public Integer getRelatedUserIdByBlockedLoginInNamespace(PerunSession sess, String login, String namespace) throws LoginIsNotBlockedException {
+		return getUsersManagerBl().getRelatedUserIdByBlockedLoginInNamespace(sess, login, namespace);
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/UsersManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/UsersManagerImplApi.java
@@ -484,9 +484,10 @@ public interface UsersManagerImplApi {
 	 * @param sess
 	 * @param login login to be blocked
 	 * @param namespace namespace where the login should be blocked (null means block the login globally)
+	 * @param relatedUserId id of the user related to the login or null if the relatedUserId should not be stored
 	 * @throws LoginIsAlreadyBlockedException
 	 */
-	void blockLogin(PerunSession sess, String login, String namespace) throws LoginIsAlreadyBlockedException;
+	void blockLogin(PerunSession sess, String login, String namespace, Integer relatedUserId) throws LoginIsAlreadyBlockedException;
 
 	/**
 	 * Unblock login for given namespace or unblock login globally (if no namespace is selected)
@@ -524,6 +525,16 @@ public interface UsersManagerImplApi {
 	 * @return id of login blocked in specified namespace
 	 */
 	int getIdOfBlockedLogin(PerunSession sess, String login, String namespace);
+
+	/**
+	 * Get user id of the user who was related to the given login in the past
+	 *
+	 * @param sess session
+	 * @param login blocked login
+	 * @param namespace namespace where the login is blocked
+	 * @return user id or null if there is no related user id
+	 */
+	Integer getRelatedUserIdByBlockedLoginInNamespace(PerunSession sess, String login, String namespace) throws LoginIsNotBlockedException;
 
 	/**
 	 * Get page of blocked logins.

--- a/perun-core/src/main/resources/postgresChangelog.txt
+++ b/perun-core/src/main/resources/postgresChangelog.txt
@@ -6,6 +6,10 @@
 -- Directly under version number should be version commands. They will be executed in the order they are written here.
 -- Comments are prefixed with -- and can be written only between version blocks, that means not in the lines with commands. They have to be at the start of the line.
 
+3.2.13
+ALTER TABLE blocked_logins ADD COLUMN related_user_id integer;
+UPDATE configurations set value='3.2.13' WHERE property='DATABASE VERSION';
+
 3.2.12
 create table blocked_logins (id integer not null, login varchar not null, namespace varchar, created_at timestamp default statement_timestamp() not null, created_by_uid integer, modified_by_uid integer, constraint blocked_logins_pk primary key(id), constraint blocked_logins_u unique (login, namespace));
 create sequence "blocked_logins_id_seq";

--- a/perun-db/postgres.sql
+++ b/perun-db/postgres.sql
@@ -1,4 +1,4 @@
--- database version 3.2.12 (don't forget to update insert statement at the end of file)
+-- database version 3.2.13 (don't forget to update insert statement at the end of file)
 
 -- VOS - virtual organizations
 create table vos (
@@ -668,6 +668,7 @@ create table blocked_logins (
 	id integer not null,
 	login varchar not null,		--login
 	namespace varchar,			--namespace where login is blocked
+	related_user_id integer,	--id of user who was related to this login in the past
 	created_at timestamp default statement_timestamp() not null,
 	created_by_uid integer,
 	modified_by_uid integer,
@@ -2003,7 +2004,7 @@ grant all on app_notifications_sent to perun;
 grant all on blocked_logins to perun;
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.2.12');
+insert into configurations values ('DATABASE VERSION','3.2.13');
 
 -- insert membership types
 insert into membership_types (id, membership_type, description) values (1, 'DIRECT', 'Member is directly added into group');


### PR DESCRIPTION
* The current functionality for user deletion was extended by the new functionality of blocking user's logins.
* There is also new config property that switches between methods deleteUser()/anonymizeUser() and just only one of them will be allowed for the instance. The behavior of the new GUI will adjust to this property as well.
* Database was updated - column related_user_id was added to the table blocked_logins.

BREAKING CHANGE: According to the new config property [userDeletionForced] for the instance will be disabled to execute the deleteUser() method OR anonymizeUser() method. Just one of them will be executable according to the config. Also the database was updated.