### PR TITLE
fix(core): don't use undescore in name of passwd-scp attributes

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_shell_passwd_scp.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_shell_passwd_scp.java
@@ -44,7 +44,7 @@ public class urn_perun_facility_attribute_def_def_shell_passwd_scp extends Facil
 	public AttributeDefinition getAttributeDefinition() {
 		AttributeDefinition attr = new AttributeDefinition();
 		attr.setNamespace(AttributesManager.NS_FACILITY_ATTR_DEF);
-		attr.setFriendlyName("shell_passwd-scp");
+		attr.setFriendlyName("shell-passwd-scp");
 		attr.setDisplayName("Shell for passwd_scp");
 		attr.setType(String.class.getName());
 		attr.setDescription("Shell for passwd-scp service");

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_def_shell_passwd_scp.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_def_shell_passwd_scp.java
@@ -56,10 +56,10 @@ public class urn_perun_user_facility_attribute_def_def_shell_passwd_scp extends 
 	public AttributeDefinition getAttributeDefinition() {
 		AttributeDefinition attr = new AttributeDefinition();
 		attr.setNamespace(AttributesManager.NS_USER_FACILITY_ATTR_DEF);
-		attr.setFriendlyName("shell_passwd_scp");
+		attr.setFriendlyName("shell-passwd-scp");
 		attr.setDisplayName("Shell for passwd_scp");
 		attr.setType(String.class.getName());
-		attr.setDescription("Shell password.");
+		attr.setDescription("Shell for passwd-scp service.");
 		return attr;
 	}
 }


### PR DESCRIPTION
- Renamed shell_passwd-scp to shell-passwd-scp.
- Class can stay the same, since "-" is mapped to underscore when searching for attribute module