### PR TITLE
fix(core): add empty constructor for BlockedLoginsPageQuery

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/BlockedLoginsPageQuery.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/BlockedLoginsPageQuery.java
@@ -16,6 +16,7 @@ public class BlockedLoginsPageQuery {
 	private String searchString = "";
 	private List<String> namespaces;
 
+	public BlockedLoginsPageQuery() {}
 
 	public BlockedLoginsPageQuery(int pageSize, int offset, SortingOrder order, BlockedLoginsOrderColumn sortColumn) {
 		this.pageSize = pageSize;


### PR DESCRIPTION
* jackson mapper needs empty constructor to be able to correctly deserialize the query object, otherwise 'cannot deserialize from Object value (no delegate- or property-based Creator' error is logged and exception thrown