### PR TITLE
fix(core): disallow to block already reserved logins

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
@@ -1211,10 +1211,10 @@ public interface UsersManagerBl {
 
 
 	/**
-	 * Check if login in specified namespace exists.
+	 * Check if login exists in specified namespace or in any namespace (if namespace is null).
 	 *
 	 * @param sess
-	 * @param namespace namespace for login
+	 * @param namespace namespace for login, null for all namespace
 	 * @param login     login to check
 	 * @param ignoreCase TRUE to perform case-insensitive check
 	 * @throws InternalErrorException

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
@@ -1203,6 +1203,10 @@ public class UsersManagerBlImpl implements UsersManagerBl {
 			if (getPerunBl().getAttributesManagerBl().isLoginAlreadyUsed(sess, login, namespace)) {
 				throw new LoginExistsException("Login: " + login + " is already in use.");
 			}
+			if (getUsersManagerImpl().isLoginReserved(sess, namespace, login, false)) {
+				throw new LoginExistsException("Login: " + login + " is already reserved.");
+			}
+
 			getUsersManagerImpl().blockLogin(sess, login, namespace, relatedUserId);
 		}
 	}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/UsersManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/UsersManagerImplApi.java
@@ -425,10 +425,10 @@ public interface UsersManagerImplApi {
 	UserExtSource getUserExtSourceByExtLogin(PerunSession perunSession, ExtSource source, String extLogin) throws UserExtSourceNotExistsException;
 
 	/**
-	 * Return true if login in specified namespace is already reserved, false if not.
+	 * Return true if login is already reserved in specified namespace or in any namespace (if namespace is null), false if not.
 	 *
 	 * @param sess
-	 * @param namespace namespace for login
+	 * @param namespace namespace for login, null for all namespace
 	 * @param login login to check
 	 * @param ignoreCase TRUE to perform case-insensitive check
 	 * @return true if login exist, false if not exist
@@ -546,10 +546,10 @@ public interface UsersManagerImplApi {
 	Paginated<BlockedLogin> getBlockedLoginsPage(PerunSession sess, BlockedLoginsPageQuery query);
 
 	/**
-	 * Check if login in specified namespace exists.
+	 * Check if login exists in specified namespace or in any namespace (if namespace is null).
 	 *
 	 * @param sess
-	 * @param namespace namespace for login
+	 * @param namespace namespace for login, null for all namespace
 	 * @param login login to check
 	 * @param ignoreCase TRUE to perform case-insensitive check
 	 * @throws InternalErrorException

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/UsersManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/UsersManagerEntryIntegrationTest.java
@@ -52,7 +52,10 @@ import cz.metacentrum.perun.core.api.exceptions.RelationNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.UserExtSourceExistsException;
 import cz.metacentrum.perun.core.api.exceptions.UserExtSourceNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
+import cz.metacentrum.perun.core.bl.PerunBl;
 import cz.metacentrum.perun.core.blImpl.AuthzResolverBlImpl;
+import cz.metacentrum.perun.core.blImpl.UsersManagerBlImpl;
+import cz.metacentrum.perun.core.implApi.UsersManagerImplApi;
 import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Before;
@@ -77,6 +80,13 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 /**
  * Integration tests of UsersManager.
@@ -1086,6 +1096,25 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 
 		perun.getUsersManager().blockLogins(sess, Collections.singletonList(login), "dummy");
 		// shouldn't block already used login
+	}
+
+	@Test (expected=LoginExistsException.class)
+	public void blockAlreadyReservedLogin() throws Exception {
+		System.out.println(CLASS_NAME + "blockAlreadyReservedLogin");
+
+		String login = "reservedLogin";
+		String namespace = "dummy";
+
+
+		UsersManagerImplApi usersManagerImplApi = mock(UsersManagerImplApi.class);
+		UsersManagerBlImpl usersManagerBlImpl = new UsersManagerBlImpl(usersManagerImplApi);
+		usersManagerBlImpl.setPerunBl(mock(PerunBl.class, RETURNS_DEEP_STUBS));
+		UsersManagerBlImpl spyUserManagerBlImpl = spy(usersManagerBlImpl);
+
+		when(spyUserManagerBlImpl.getUsersManagerImpl().isLoginReserved(any(), eq(namespace), eq(login), anyBoolean())).thenReturn(true);
+
+		spyUserManagerBlImpl.blockLogins(sess, Collections.singletonList(login), namespace, null);
+		// shouldn't block already reserved login
 	}
 
 	@Test


### PR DESCRIPTION
* Added the check to blockLogins method for already reserved logins. If the namespace is given, check reserved login for this namespace. If the login should be blocked globally, check reserved logins for all namespaces.