### PR TITLE
fix: allow correct usage of getAllBlockedLoginsInNamespaces in openapi

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/UsersManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/UsersManager.java
@@ -801,12 +801,12 @@ public interface UsersManager {
 	boolean isLoginAvailable(PerunSession sess, String loginNamespace, String login) throws InvalidLoginException;
 
 	/**
-	 * Returns all pairs of blocked login in namespace (if namespace is null, then this login is blocked globally)
+	 * Returns all blocked logins in namespaces (if namespace is null, then this login is blocked globally)
 	 *
 	 * @param sess
-	 * @return list of pairs login and namespace - List<Pair<login, namespace>>
+	 * @return list of all blocked logins in namespaces
 	 */
-	List<Pair<String, String>> getAllBlockedLoginsInNamespaces(PerunSession sess) throws PrivilegeException;
+	List<BlockedLogin> getAllBlockedLoginsInNamespaces(PerunSession sess) throws PrivilegeException;
 
 	/**
 	 * Return true if login is blocked (globally - for all namespaces per instance OR for some namespace), false if not.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
@@ -1235,12 +1235,12 @@ public interface UsersManagerBl {
 	void checkBlockedLogins(PerunSession sess, String namespace, String userLogin, boolean ignoreCase) throws LoginIsAlreadyBlockedException;
 
 	/**
-	 * Returns all pairs of blocked login in namespace (if namespace is null, then this login is blocked globally)
+	 * Returns all blocked logins in namespaces (if namespace is null, then this login is blocked globally)
 	 *
 	 * @param sess
-	 * @return list of pairs login and namespace - List<Pair<login, namespace>>
+	 * @return list of all blocked logins in namespaces
 	 */
-	List<Pair<String, String>> getAllBlockedLoginsInNamespaces(PerunSession sess);
+	List<BlockedLogin> getAllBlockedLoginsInNamespaces(PerunSession sess);
 
 	/**
 	 * Return true if login is blocked (globally - for all namespaces per instance OR for some namespace), false if not.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
@@ -1178,7 +1178,7 @@ public class UsersManagerBlImpl implements UsersManagerBl {
 	}
 
 	@Override
-	public List<Pair<String, String>> getAllBlockedLoginsInNamespaces(PerunSession sess) {
+	public List<BlockedLogin> getAllBlockedLoginsInNamespaces(PerunSession sess) {
 		return getUsersManagerImpl().getAllBlockedLoginsInNamespaces(sess);
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
@@ -979,7 +979,7 @@ public class UsersManagerEntry implements UsersManager {
 	}
 
 	@Override
-	public List<Pair<String, String>> getAllBlockedLoginsInNamespaces(PerunSession sess) throws PrivilegeException {
+	public List<BlockedLogin> getAllBlockedLoginsInNamespaces(PerunSession sess) throws PrivilegeException {
 		Utils.checkPerunSession(sess);
 
 		if (!AuthzResolver.authorizedInternal(sess, "getAllBlockedLoginsInNamespaces_policy")) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/UsersManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/UsersManagerImpl.java
@@ -184,15 +184,6 @@ public class UsersManagerImpl implements UsersManagerImplApi {
             return result;
         };
 
-	public static final RowMapper<Pair<String, String>> LOGIN_NAMESPACE_PAIR_MAPPER = new RowMapper<Pair<String, String>>() {
-		@Override
-		public Pair<String, String> mapRow(ResultSet rs, int rowNum) throws SQLException {
-			String login = rs.getString("login");
-			String namespace = rs.getString("namespace");
-			return new Pair<>(login, namespace);
-		}
-	};
-
 	public static final RowMapper<BlockedLogin> BLOCKED_LOGINS_MAPPER = new RowMapper<BlockedLogin>() {
 		@Override
 		public BlockedLogin mapRow(ResultSet rs, int rowNum) throws SQLException {
@@ -1190,9 +1181,9 @@ public class UsersManagerImpl implements UsersManagerImplApi {
 	}
 
 	@Override
-	public List<Pair<String, String>> getAllBlockedLoginsInNamespaces(PerunSession sess) {
+	public List<BlockedLogin> getAllBlockedLoginsInNamespaces(PerunSession sess) {
 		try {
-			return jdbc.query("select login, namespace from blocked_logins", LOGIN_NAMESPACE_PAIR_MAPPER);
+			return jdbc.query("select id, login, namespace from blocked_logins", BLOCKED_LOGINS_MAPPER);
 		} catch (RuntimeException e) {
 			throw new InternalErrorException(e);
 		}
@@ -1345,9 +1336,9 @@ public class UsersManagerImpl implements UsersManagerImplApi {
 	}
 
 	@Override
-	public Pair<String, String> getBlockedLoginById(PerunSession sess, int id) throws LoginIsNotBlockedException {
+	public BlockedLogin getBlockedLoginById(PerunSession sess, int id) throws LoginIsNotBlockedException {
 		try {
-			return jdbc.queryForObject("SELECT login, namespace FROM blocked_logins WHERE id=?", LOGIN_NAMESPACE_PAIR_MAPPER, id);
+			return jdbc.queryForObject("SELECT id, login, namespace FROM blocked_logins WHERE id=?", BLOCKED_LOGINS_MAPPER, id);
 		} catch(EmptyResultDataAccessException ex) {
 			throw new LoginIsNotBlockedException(ex);
 		} catch (RuntimeException ex) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/UsersManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/UsersManagerImplApi.java
@@ -437,12 +437,12 @@ public interface UsersManagerImplApi {
 	boolean isLoginReserved(PerunSession sess, String namespace, String login, boolean ignoreCase);
 
 	/**
-	 * Returns all pairs of blocked login in namespace (if namespace is null, then this login is blocked globally)
+	 * Returns all blocked logins in namespaces (if namespace is null, then this login is blocked globally)
 	 *
 	 * @param sess
-	 * @return list of pairs login and namespace - List<Pair<login, namespace>>
+	 * @return list of all blocked logins in namespaces
 	 */
-	List<Pair<String, String>> getAllBlockedLoginsInNamespaces(PerunSession sess);
+	List<BlockedLogin> getAllBlockedLoginsInNamespaces(PerunSession sess);
 
 	/**
 	 * Return true if login is blocked (globally - for all namespaces per instance OR for some namespace), false if not.
@@ -511,10 +511,10 @@ public interface UsersManagerImplApi {
 	 *
 	 * @param sess session
 	 * @param id id of blocked login
-	 * @return blocked login - PAIR<login, namespace>
+	 * @return blocked login
 	 * @throws LoginIsNotBlockedException when login is not blocked
 	 */
-	Pair<String, String> getBlockedLoginById(PerunSession sess, int id) throws LoginIsNotBlockedException;
+	BlockedLogin getBlockedLoginById(PerunSession sess, int id) throws LoginIsNotBlockedException;
 
 	/**
 	 * Return ID of blocked login

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/UsersManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/UsersManagerEntryIntegrationTest.java
@@ -22,7 +22,6 @@ import cz.metacentrum.perun.core.api.MemberGroupStatus;
 import cz.metacentrum.perun.core.api.Owner;
 import cz.metacentrum.perun.core.api.OwnerType;
 import cz.metacentrum.perun.core.api.Paginated;
-import cz.metacentrum.perun.core.api.Pair;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.RichUser;
 import cz.metacentrum.perun.core.api.RichUserExtSource;
@@ -848,14 +847,15 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 		perun.getUsersManager().blockLogins(sess, Collections.singletonList(login), namespace);
 		perun.getUsersManager().blockLogins(sess, Collections.singletonList(login2), namespace2);
 
-		List<Pair<String, String>> listOfBlockedLogins = perun.getUsersManager().getAllBlockedLoginsInNamespaces(sess);
+		List<BlockedLogin> listOfBlockedLogins = perun.getUsersManager().getAllBlockedLoginsInNamespaces(sess);
+
 		assertEquals(listOfBlockedLogins.size(), 3);
-		assertEquals(listOfBlockedLogins.get(0).getLeft(), login);
-		assertNull(listOfBlockedLogins.get(0).getRight());
-		assertEquals(listOfBlockedLogins.get(1).getLeft(), login);
-		assertEquals(listOfBlockedLogins.get(1).getRight(), namespace);
-		assertEquals(listOfBlockedLogins.get(2).getLeft(), login2);
-		assertEquals(listOfBlockedLogins.get(2).getRight(), namespace2);
+		assertEquals(listOfBlockedLogins.get(0).getLogin(), login);
+		assertNull(listOfBlockedLogins.get(0).getNamespace());
+		assertEquals(listOfBlockedLogins.get(1).getLogin(), login);
+		assertEquals(listOfBlockedLogins.get(1).getNamespace(), namespace);
+		assertEquals(listOfBlockedLogins.get(2).getLogin(), login2);
+		assertEquals(listOfBlockedLogins.get(2).getNamespace(), namespace2);
 	}
 
 	@Test
@@ -1015,22 +1015,22 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 
 		perun.getUsersManager().blockLogins(sess, Arrays.asList(login, login2, login3), namespace);
 
-		List<Pair<String, String>> listOfBlockedLogins = perun.getUsersManager().getAllBlockedLoginsInNamespaces(sess);
+		List<BlockedLogin> listOfBlockedLogins = perun.getUsersManager().getAllBlockedLoginsInNamespaces(sess);
 		assertEquals(listOfBlockedLogins.size(), 3);
-		assertEquals(listOfBlockedLogins.get(0).getLeft(), login);
-		assertEquals(listOfBlockedLogins.get(0).getRight(), namespace);
-		assertEquals(listOfBlockedLogins.get(1).getLeft(), login2);
-		assertEquals(listOfBlockedLogins.get(1).getRight(), namespace);
-		assertEquals(listOfBlockedLogins.get(2).getLeft(), login3);
-		assertEquals(listOfBlockedLogins.get(2).getRight(), namespace);
+		assertEquals(listOfBlockedLogins.get(0).getLogin(), login);
+		assertEquals(listOfBlockedLogins.get(0).getNamespace(), namespace);
+		assertEquals(listOfBlockedLogins.get(1).getLogin(), login2);
+		assertEquals(listOfBlockedLogins.get(1).getNamespace(), namespace);
+		assertEquals(listOfBlockedLogins.get(2).getLogin(), login3);
+		assertEquals(listOfBlockedLogins.get(2).getNamespace(), namespace);
 
 		perun.getUsersManager().unblockLogins(sess, Arrays.asList(login, login2), namespace);
 
 		listOfBlockedLogins = perun.getUsersManager().getAllBlockedLoginsInNamespaces(sess);
 
 		assertEquals(listOfBlockedLogins.size(), 1);
-		assertEquals(listOfBlockedLogins.get(0).getLeft(), login3);
-		assertEquals(listOfBlockedLogins.get(0).getRight(), namespace);
+		assertEquals(listOfBlockedLogins.get(0).getLogin(), login3);
+		assertEquals(listOfBlockedLogins.get(0).getNamespace(), namespace);
 	}
 
 	@Test

--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -10041,6 +10041,24 @@ paths:
               properties:
                 query: { $ref: '#/components/schemas/BlockedLoginsPageQuery' }
 
+  /json/usersManager/getAllBlockedLoginsInNamespaces:
+    get:
+      tags:
+        - UsersManager
+      operationId: getAllBlockedLoginsInNamespaces
+      summary: Returns all blocked logins in namespaces (if namespace is null, then this login is blocked globally)
+      responses:
+        '200':
+          description: "list of all blocked logins in namespaces"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/BlockedLogin'
+        default:
+          $ref: '#/components/responses/ExceptionResponse'
+
   /urlinjsonout/usersManager/reserveRandomPassword:
     post:
       tags:

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/UsersManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/UsersManagerMethod.java
@@ -1,6 +1,7 @@
 package cz.metacentrum.perun.rpc.methods;
 
 import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.BlockedLogin;
 import cz.metacentrum.perun.core.api.BlockedLoginsPageQuery;
 import cz.metacentrum.perun.core.api.Candidate;
 import cz.metacentrum.perun.core.api.ExtSource;
@@ -1211,7 +1212,7 @@ public enum UsersManagerMethod implements ManagerMethod {
 		}
 	},
 
-	/**
+	/*#
 	 * Get a page of blocked logins
 	 *
 	 * @param query BlockedLoginsPageQuery
@@ -1222,6 +1223,18 @@ public enum UsersManagerMethod implements ManagerMethod {
 		public Object call(ApiCaller ac, Deserializer params) throws PerunException {
 			return ac.getUsersManager().getBlockedLoginsPage(ac.getSession(),
 				params.read("query", BlockedLoginsPageQuery.class));
+		}
+	},
+
+	/*#
+	 * Returns all blocked logins in namespaces (if namespace is null, then this login is blocked globally)
+	 *
+	 * @return List<BlockedLogin> list of all blocked logins in namespaces
+	 */
+	getAllBlockedLoginsInNamespaces {
+		@Override
+		public List<BlockedLogin> call(ApiCaller ac, Deserializer parms) throws PerunException {
+			return ac.getUsersManager().getAllBlockedLoginsInNamespaces(ac.getSession());
 		}
 	},
 


### PR DESCRIPTION
* This method used to return list of pairs (left: loginValue, right: namespaceValue), but now it returns list of BlockedLogin.
* All interface and test were fixed for this return type and rpc and openapi specification for this method was added.