### PR TITLE
fix(registrar): load vo/group from db

### DIFF
--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/RegistrarManager.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/RegistrarManager.java
@@ -148,7 +148,7 @@ public interface RegistrarManager {
 	 * @param applicationForm the form
 	 * @return number of updated rows (should be 1)
 	 */
-	int updateForm(PerunSession user, ApplicationForm applicationForm) throws PrivilegeException;
+	int updateForm(PerunSession user, ApplicationForm applicationForm) throws PerunException;
 
 	/**
 	 * Removes a form item permanently. The user data associated with it remain in the database, just they lose the foreign key

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
@@ -1221,8 +1221,9 @@ public class RegistrarManagerImpl implements RegistrarManager {
 	}
 
 	@Override
-	public int updateForm(PerunSession user, ApplicationForm form) throws PrivilegeException {
+	public int updateForm(PerunSession user, ApplicationForm form) throws PrivilegeException, VoNotExistsException, GroupNotExistsException {
 
+		form.setVo(this.vosManager.getVoById(user, form.getVo().getId()));
 		//Authorization
 		if (form.getGroup() == null) {
 			// VO application
@@ -1230,6 +1231,7 @@ public class RegistrarManagerImpl implements RegistrarManager {
 				throw new PrivilegeException(user, "updateForm");
 			}
 		} else {
+			form.setGroup(this.groupsManager.getGroupById(user, form.getGroup().getId()));
 			if (!AuthzResolver.authorizedInternal(user, "group-updateForm_ApplicationForm_policy", Arrays.asList(form.getVo(), form.getGroup()))) {
 				throw new PrivilegeException(user, "updateForm");
 			}


### PR DESCRIPTION
When user passes application form as a param, vo/group objects are loaded from db by ID.