### PR TITLE
chore(githubci): enable renovate bot to automerge non-major updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,9 +4,19 @@
 		"config:base"
 	],
 	"packageRules": [
-    {
-      "matchUpdateTypes": ["major"],
-      "dependencyDashboardApproval": true
-    }
-  ]
+		{
+			"matchUpdateTypes": [
+				"major"
+			],
+			"dependencyDashboardApproval": true
+		},
+		{
+			"matchUpdateTypes": [
+				"minor",
+				"patch"
+			],
+			"matchCurrentVersion": "!/^0/",
+			"automerge": true
+		}
+	]
 }


### PR DESCRIPTION
Changes to minor version or patch level of dependencies are now automerged if tests pass