### PR TITLE
fix(core): do not set attribute policy for perun admin

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -8262,7 +8262,6 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 			attr.setDescription("Contains user friendly version of MFA status in " + namespace + " namespace.");
 
 			policies = new ArrayList<>();
-			policies.add(Triple.of(Role.PERUNADMIN, READ, RoleObject.User));
 			attributes.put(attr, createInitialPolicyCollections(policies));
 
 			// pwd-reset templates


### PR DESCRIPTION
- user:virt:mfaStatus will use default policy.