### PR TITLE
fix(core): updated perunDefaultBlockedLoginChecker

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
@@ -433,6 +433,15 @@ public interface AttributesManagerBl {
 	boolean isLoginAlreadyUsed(PerunSession sess, String login, String namespace);
 
 	/**
+	 * Gets IDs of users who use the given login in any namespace.
+	 *
+	 * @param sess perun session
+	 * @param login	login
+	 * @return list of user IDs
+	 */
+	List<Integer> getUserIdsByLogin(PerunSession sess, String login);
+
+	/**
 	 * Get all attributes associated with the UserExtSource which have name in list attrNames (empty and virtual too).
 	 *
 	 * @param sess perun session

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -659,6 +659,11 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	}
 
 	@Override
+	public List<Integer> getUserIdsByLogin(PerunSession sess, String login) {
+		return getAttributesManagerImpl().getUserIdsByLogin(sess, login);
+	}
+
+	@Override
 	public List<Attribute> getAttributes(PerunSession sess, Host host) {
 		//get virtual attributes
 		List<Attribute> attributes = getAttributesManagerImpl().getVirtualAttributes(sess, host);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
@@ -1263,7 +1263,16 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 		}
 	}
 
-
+	public List<Integer> getUserIdsByLogin(PerunSession sess, String login) {
+		try {
+			return jdbc.queryForList("select distinct attr_val.user_id from attr_names as attr join user_attr_values attr_val on attr.id=attr_val.attr_id\n" +
+				"where attr.friendly_name like 'login-namespace:%%' \n" +
+				"    and attr.friendly_name not like '%%persistent%%' \n" +
+				"    and attr_val.attr_value like ?", Integer.class, login);
+		} catch (RuntimeException ex) {
+			throw new InternalErrorException(ex);
+		}
+	}
 
 	@Override
 	public List<Attribute> getAttributes(PerunSession sess, UserExtSource ues, List<String> attrNames) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
@@ -497,6 +497,15 @@ public interface AttributesManagerImplApi {
 	boolean isLoginAlreadyUsed(PerunSession sess, String login, String namespace);
 
 	/**
+	 * Gets IDs of users who use the given login in any namespace.
+	 *
+	 * @param sess perun session
+	 * @param login	login
+	 * @return list of user IDs
+	 */
+	List<Integer> getUserIdsByLogin(PerunSession sess, String login);
+
+	/**
 	 * Get all virtual attributes associated with the user.
 	 *
 	 * @param sess perun session


### PR DESCRIPTION
Edited error message to contain list of user ids.
Check usage of all default blocked logins at once.