### PR TITLE
fix: mark mfaEnforced LDAP attribute as deleted

### DIFF
--- a/perun-ldapc/src/main/resources/perun-ldapc.xml
+++ b/perun-ldapc/src/main/resources/perun-ldapc.xml
@@ -1151,6 +1151,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 				<bean class="cz.metacentrum.perun.ldapc.model.impl.PerunAttributeDesc">
 					<property name="name" value="mfaEnforced;x-ns-"/>
 					<property name="required" value="false"/>
+					<property name="deleted" value="true"/>
 					<property name="singleValueExtractor">
 						<bean class="cz.metacentrum.perun.ldapc.model.impl.SingleAttributeValueExtractor">
 							<property name="nameRegexp" value="urn:perun:user:attribute-def:def:mfaEnforced:"/>


### PR DESCRIPTION
attribute is no longer used