### PR TITLE
feat: use introspection data saved in request headers for MFA

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/CoreConfig.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/CoreConfig.java
@@ -94,9 +94,7 @@ public class CoreConfig {
 	private List<String> userInfoEndpointExtSourceLogin;
 	private String userInfoEndpointExtSourceName;
 	private List<String> userInfoEndpointExtSourceFriendlyName;
-	private String userInfoEndpointAcrPropertyName;
-	private String userInfoEndpointMfaAcrValue;
-	private String userInfoEndpointMfaAuthTimestampPropertyName;
+	private String introspectionEndpointMfaAcrValue;
 	private int mfaAuthTimeout;
 	private boolean enforceMfa;
 	private int idpLoginValidity;
@@ -792,28 +790,12 @@ public class CoreConfig {
 		this.userInfoEndpointExtSourceFriendlyName = userInfoEndpointExtSourceFriendlyName;
 	}
 
-	public String getUserInfoEndpointAcrPropertyName() {
-		return userInfoEndpointAcrPropertyName;
+	public String getIntrospectionEndpointMfaAcrValue() {
+		return introspectionEndpointMfaAcrValue;
 	}
 
-	public void setUserInfoEndpointAcrPropertyName(String userInfoEndpointAcrPropertyName) {
-		this.userInfoEndpointAcrPropertyName = userInfoEndpointAcrPropertyName;
-	}
-
-	public String getUserInfoEndpointMfaAuthTimestampPropertyName() {
-		return userInfoEndpointMfaAuthTimestampPropertyName;
-	}
-
-	public void setUserInfoEndpointMfaAuthTimestampPropertyName(String userInfoEndpointMfaAuthTimestampPropertyName) {
-		this.userInfoEndpointMfaAuthTimestampPropertyName = userInfoEndpointMfaAuthTimestampPropertyName;
-	}
-
-	public String getUserInfoEndpointMfaAcrValue() {
-		return userInfoEndpointMfaAcrValue;
-	}
-
-	public void setUserInfoEndpointMfaAcrValue(String userInfoEndpointAcrValue) {
-		this.userInfoEndpointMfaAcrValue = userInfoEndpointAcrValue;
+	public void setIntrospectionEndpointMfaAcrValue(String introspectionEndpointMfaAcrValue) {
+		this.introspectionEndpointMfaAcrValue = introspectionEndpointMfaAcrValue;
 	}
 
 	public int getMfaAuthTimeout() {

--- a/perun-base/src/main/java/cz/metacentrum/perun/oidc/UserInfoEndpointCall.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/oidc/UserInfoEndpointCall.java
@@ -19,7 +19,6 @@ import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
 
-import static cz.metacentrum.perun.core.api.PerunPrincipal.MFA_TIMESTAMP;
 
 /**
  * Class for executing call to User info endpoint.
@@ -35,27 +34,9 @@ public class UserInfoEndpointCall {
 
 		fillAdditionalInformationWithDataFromUserInfo(userInfo, additionalInformation);
 
-		String mfaTimestamp = getMfaTimestamp(userInfo);
-		if (mfaTimestamp != null && !mfaTimestamp.isEmpty()) {
-			additionalInformation.put(MFA_TIMESTAMP, mfaTimestamp);
-		}
-
 		String extSourceName = getExtSourceName(userInfo);
 		String extSourceLogin = getExtSourceLogin(userInfo);
 		return new UserInfoEndpointResponse(extSourceName, extSourceLogin);
-	}
-
-	/**
-	 * Calls UserInfo endpoint and returns MFA timestamp if available and acr is equal to MFA acr
-	 * @param accessToken access token
-	 * @param issuer issuer
-	 * @throws ExpiredTokenException if access token is expired
-	 * @return mfa timestamp or null
-	 */
-	public String getUserInfoEndpointMfaData(String accessToken, String issuer) throws ExpiredTokenException {
-		JsonNode userInfo = callUserInfo(accessToken, issuer);
-
-		return getMfaTimestamp(userInfo);
 	}
 
 	private static JsonNode callUserInfo(String accessToken, String issuer) throws ExpiredTokenException {
@@ -167,23 +148,5 @@ public class UserInfoEndpointCall {
 		if(StringUtils.isNotEmpty(idpName)) {
 			additionalInformation.put("sourceIdPName", idpName);
 		}
-	}
-
-	/**
-	 * Returns mfa timestamp if acr value is equal to MFA acr value
-	 * @param userInfo parsed response from userInfo endpoint
-	 */
-	private String getMfaTimestamp(JsonNode userInfo) {
-		String acrProperty = BeansUtils.getCoreConfig().getUserInfoEndpointAcrPropertyName();
-		String acr = userInfo.path(acrProperty).asText();
-		if (StringUtils.isNotEmpty(acr) && acr.equals(BeansUtils.getCoreConfig().getUserInfoEndpointMfaAcrValue())) {
-			String mfaTimestampProperty = BeansUtils.getCoreConfig().getUserInfoEndpointMfaAuthTimestampPropertyName();
-			String mfaTimestamp = userInfo.path(mfaTimestampProperty).asText();
-			if (StringUtils.isNotEmpty(mfaTimestamp)) {
-				return mfaTimestamp;
-			}
-		}
-
-		return null;
 	}
 }

--- a/perun-base/src/main/resources/perun-base.xml
+++ b/perun-base/src/main/resources/perun-base.xml
@@ -77,11 +77,9 @@
 		<property name="userInfoEndpointExtSourceLogin" value="#{'${perun.userInfoEndpoint.extSourceLogin}'.split('\s*,\s*')}"/>
 		<property name="userInfoEndpointExtSourceName" value="${perun.userInfoEndpoint.extSourceName}"/>
 		<property name="userInfoEndpointExtSourceFriendlyName" value="#{'${perun.userInfoEndpoint.extSourceFriendlyName}'.split('\s*,\s*')}"/>
-		<property name="mfaAuthTimeout" value="${perun.userInfoEndpoint.mfaAuthTimeout}"/>
+		<property name="mfaAuthTimeout" value="${perun.introspectionEndpoint.mfaAuthTimeout}"/>
 		<property name="enforceMfa" value="${perun.enforceMfa}"/>
-		<property name="userInfoEndpointMfaAuthTimestampPropertyName" value="${perun.userInfoEndpoint.mfaAuthTimestampPropertyName}"/>
-		<property name="userInfoEndpointMfaAcrValue" value="${perun.userInfoEndpoint.mfaAcrValue}"/>
-		<property name="userInfoEndpointAcrPropertyName" value="${perun.userInfoEndpoint.acrPropertyName}"/>
+		<property name="introspectionEndpointMfaAcrValue" value="${perun.introspectionEndpoint.mfaAcrValue}"/>
 		<property name="idpLoginValidity" value="${perun.idpLoginValidity}"/>
 		<property name="idpLoginValidityExceptions" value="#{'${perun.idpLoginValidityExceptions}'.split('\s*,\s*')}"/>
 	</bean>
@@ -182,10 +180,8 @@
 				<prop key="perun.userInfoEndpoint.extSourceLogin">eduperson_unique_id, eduperson_principal_name, saml2_nameid_persistent, eduperson_targeted_id, voperson_external_id</prop>
 				<prop key="perun.userInfoEndpoint.extSourceName">target_issuer</prop>
 				<prop key="perun.userInfoEndpoint.extSourceFriendlyName">target_backend, display_name, text</prop>
-				<prop key="perun.userInfoEndpoint.mfaAuthTimestampPropertyName">authn_instant</prop>
-				<prop key="perun.userInfoEndpoint.mfaAuthTimeout">24</prop>
-				<prop key="perun.userInfoEndpoint.acrPropertyName">acr</prop>
-				<prop key="perun.userInfoEndpoint.mfaAcrValue">https://refeds.org/profile/mfa</prop>
+				<prop key="perun.introspectionEndpoint.mfaAuthTimeout">24</prop>
+				<prop key="perun.introspectionEndpoint.mfaAcrValue">https://refeds.org/profile/mfa</prop>
 				<prop key="perun.enforceMfa">false</prop>
 			</props>
 		</property>

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
@@ -77,7 +77,6 @@ import cz.metacentrum.perun.core.impl.AuthzResolverImpl;
 import cz.metacentrum.perun.core.impl.AuthzRoles;
 import cz.metacentrum.perun.core.impl.Utils;
 import cz.metacentrum.perun.core.implApi.AuthzResolverImplApi;
-import cz.metacentrum.perun.oidc.UserInfoEndpointCall;
 import cz.metacentrum.perun.registrar.model.Application;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -2639,13 +2638,8 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 			throw new MFAuthenticationException("Cannot verify MFA - issuer is missing.");
 		}
 
-		UserInfoEndpointCall userInfoEndpointCall = new UserInfoEndpointCall();
-		String timestamp = userInfoEndpointCall.getUserInfoEndpointMfaData(accessToken, issuer);
-		if (timestamp != null && !timestamp.isEmpty()) {
-			sess.getPerunPrincipal().getAdditionalInformations().put(MFA_TIMESTAMP, timestamp);
-			if (isAuthorizedByMfa(sess)) {
-				sess.getPerunPrincipal().getRoles().putAuthzRole(Role.MFA);
-			}
+		if (isAuthorizedByMfa(sess)) {
+			sess.getPerunPrincipal().getRoles().putAuthzRole(Role.MFA);
 		}
 	}
 


### PR DESCRIPTION
* mfaTimestamp for additionalInformation is now retrieved from the request headers filled in by Apache server
* removed the logic retrieving MFA timestamp from userinfo endpoint