### PR TITLE
fix(core): MFA timeout

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/PerunPrincipal.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/PerunPrincipal.java
@@ -25,7 +25,8 @@ public class PerunPrincipal {
 	// Specifies if the principal has initialized authZResolver
 	private volatile boolean authzInitialized = false;
 	// Keywords of additionalInformations
-	public static final String MFA_TIMESTAMP = "mfaTimestamp";
+	public static final String AUTH_TIME = "authTime";
+	public static final String ACR_MFA = "acrMfa";
 	public static final String ISSUER = "issuer";
 	public static final String ACCESS_TOKEN = "accessToken";
 

--- a/perun-base/src/main/resources/perun-base.xml
+++ b/perun-base/src/main/resources/perun-base.xml
@@ -180,7 +180,7 @@
 				<prop key="perun.userInfoEndpoint.extSourceLogin">eduperson_unique_id, eduperson_principal_name, saml2_nameid_persistent, eduperson_targeted_id, voperson_external_id</prop>
 				<prop key="perun.userInfoEndpoint.extSourceName">target_issuer</prop>
 				<prop key="perun.userInfoEndpoint.extSourceFriendlyName">target_backend, display_name, text</prop>
-				<prop key="perun.introspectionEndpoint.mfaAuthTimeout">24</prop>
+				<prop key="perun.introspectionEndpoint.mfaAuthTimeout">1440</prop>
 				<prop key="perun.introspectionEndpoint.mfaAcrValue">https://refeds.org/profile/mfa</prop>
 				<prop key="perun.enforceMfa">false</prop>
 			</props>

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/exceptions/MfaTimeoutException.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/exceptions/MfaTimeoutException.java
@@ -1,0 +1,19 @@
+package cz.metacentrum.perun.core.api.exceptions;
+
+import cz.metacentrum.perun.core.api.exceptions.rt.PerunRuntimeException;
+
+public class MfaTimeoutException extends PerunRuntimeException {
+	static final long serialVersionUID = 0;
+
+	public MfaTimeoutException(String message) {
+		super(message);
+	}
+
+	public MfaTimeoutException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public MfaTimeoutException(Throwable cause) {
+		super(cause);
+	}
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
@@ -55,6 +55,7 @@ import cz.metacentrum.perun.core.api.exceptions.MemberNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.MfaInvalidRolesException;
 import cz.metacentrum.perun.core.api.exceptions.MfaPrivilegeException;
 import cz.metacentrum.perun.core.api.exceptions.MfaRolePrivilegeException;
+import cz.metacentrum.perun.core.api.exceptions.MfaTimeoutException;
 import cz.metacentrum.perun.core.api.exceptions.PolicyNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ResourceNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.RoleAlreadySetException;
@@ -100,8 +101,9 @@ import java.util.stream.Collectors;
 
 import static cz.metacentrum.perun.core.api.AuthzResolver.MFA_CRITICAL_ATTR;
 import static cz.metacentrum.perun.core.api.PerunPrincipal.ACCESS_TOKEN;
+import static cz.metacentrum.perun.core.api.PerunPrincipal.ACR_MFA;
+import static cz.metacentrum.perun.core.api.PerunPrincipal.AUTH_TIME;
 import static cz.metacentrum.perun.core.api.PerunPrincipal.ISSUER;
-import static cz.metacentrum.perun.core.api.PerunPrincipal.MFA_TIMESTAMP;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
 /**
@@ -2563,7 +2565,7 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 				sess.getPerunPrincipal().getRoles().clear();
 			}
 
-			if (isAuthorizedByMfa(sess)) {
+			if (isAuthorizedByMfa(sess, false)) {
 				sess.getPerunPrincipal().getRoles().putAuthzRole(Role.MFA);
 			}
 		}
@@ -2624,10 +2626,6 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 			throw new MFAuthenticationException("MFA enforcement is turned off");
 		}
 
-		if (!BeansUtils.getCoreConfig().getRequestUserInfoEndpoint()) {
-			throw new MFAuthenticationException("Cannot verify MFA - UserInfo endpoint not configured.");
-		}
-
 		String accessToken = sess.getPerunPrincipal().getAdditionalInformations().get(ACCESS_TOKEN);
 		if (accessToken == null) {
 			throw new MFAuthenticationException("Cannot verify MFA - access token is missing.");
@@ -2638,7 +2636,7 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 			throw new MFAuthenticationException("Cannot verify MFA - issuer is missing.");
 		}
 
-		if (isAuthorizedByMfa(sess)) {
+		if (isAuthorizedByMfa(sess, true)) {
 			sess.getPerunPrincipal().getRoles().putAuthzRole(Role.MFA);
 		}
 	}
@@ -4357,34 +4355,47 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 
 	/**
 	 * Checks, if principal was authorized by Multi-factor authentication.
-	 * The information is resolved in UserInfoEndpointCall and stored in principal's additionalInformations.
-	 * The timestamp of MFA must not be older than mfa timeout set in config.
+	 * The information is resolved from headers (apache IntrospectionEndpoint call) and stored in principal's additionalInformations.
+	 * Check if the auth time + mfa timeout is not older than the current time
+	 * auth time = time of the first authentication
+	 * mfa timeout = amount of time defined in the config for how long the MFA should be valid (since SFA)
 	 *
 	 * @param sess session
+	 * @param throwError if this method should throw errors or just return boolean
 	 * @return true if principal authorized by MFA in allowed limit, false otherwise
 	 */
-	private static boolean isAuthorizedByMfa(PerunSession sess) {
+	private static boolean isAuthorizedByMfa(PerunSession sess, boolean throwError) {
 		if (!BeansUtils.getCoreConfig().isEnforceMfa()) {
 			return false;
 		}
 
-		if (!sess.getPerunPrincipal().getAdditionalInformations().containsKey(MFA_TIMESTAMP)) {
-			return false;
-		}
-
-		String returnedTimestamp = sess.getPerunPrincipal().getAdditionalInformations().get(MFA_TIMESTAMP);
-		Instant parsedReturnedTimestamp;
+		String returnedAuthTime = sess.getPerunPrincipal().getAdditionalInformations().get(AUTH_TIME);
+		Instant parsedReturnedAuthTime;
 		try {
-			parsedReturnedTimestamp = Instant.parse(returnedTimestamp);
+			parsedReturnedAuthTime = Instant.parse(returnedAuthTime);
 		} catch (DateTimeParseException e) {
-			throw new InternalErrorException("MFA timestamp "  + returnedTimestamp + " could not be parsed", e);
+			throw new InternalErrorException("MFA timestamp "  + returnedAuthTime + " could not be parsed", e);
 		}
-		if (parsedReturnedTimestamp.isAfter(Instant.now())) {
-			throw new InternalErrorException("MFA auth timestamp " + returnedTimestamp + " was greater than current time");
+		if (parsedReturnedAuthTime.isAfter(Instant.now())) {
+			throw new InternalErrorException("MFA auth timestamp " + returnedAuthTime + " was greater than current time");
 		}
 
-		long mfaTimeoutInSec = Duration.ofHours(BeansUtils.getCoreConfig().getMfaAuthTimeout()).getSeconds();
-		Instant mfaValidUntil = parsedReturnedTimestamp.plusSeconds(mfaTimeoutInSec);
-		return mfaValidUntil.isAfter(Instant.now());
+		long mfaTimeoutInSec = Duration.ofMinutes(BeansUtils.getCoreConfig().getMfaAuthTimeout()).getSeconds();
+		Instant mfaValidUntil = parsedReturnedAuthTime.plusSeconds(mfaTimeoutInSec);
+
+		// check if the auth time + mfa timeout > the current time
+		if (mfaValidUntil.isAfter(Instant.now())) {
+			// if user has MFA and it is still valid
+			return sess.getPerunPrincipal().getAdditionalInformations().containsKey(ACR_MFA);
+		} else {
+			if (!throwError) return false;
+			if (sess.getPerunPrincipal().getAdditionalInformations().containsKey(ACR_MFA)) {
+				// MFA is no longer valid
+				throw new MfaTimeoutException("Your MFA timestamp " + returnedAuthTime + " is not valid anymore, you'll need to reauthenticate");
+			} else {
+				// user is authenticated by SFA but the mfa timeout would cause an error, so we need to reauthenticate this user
+				throw new MfaTimeoutException("Your single factor authentication timestamp " + returnedAuthTime + " is not valid anymore, you'll need to reauthenticate");
+			}
+		}
 	}
 }


### PR DESCRIPTION
* If MFA is not valid anymore, then the new exception is thrown - it must be specifically managed by client (now just by the new GUI).

BREAKING CHANGE: The unit of the config property 'mfaAuthTimeout' has been changed from hours to minutes (for easier testing).