### PR TITLE
feat(core): add logback-journal appender dependency

### DIFF
--- a/perun-base/pom.xml
+++ b/perun-base/pom.xml
@@ -73,6 +73,14 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-logging</artifactId>
 		</dependency>
+		<!-- logback appender for writing into systemd-journald which in turn writes into syslog
+			see https://github.com/gnieh/logback-journal
+			-->
+		<dependency>
+			<groupId>org.gnieh</groupId>
+			<artifactId>logback-journal</artifactId>
+			<version>${logback-journal.version}</version>
+		</dependency>
 
 		<!-- OTHER -->
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,7 @@
 		<jcip.version>1.0</jcip.version>
 		<jdom.version>1.0</jdom.version>
 		<json.version>20220924</json.version>
+		<logback-journal.version>0.3.0</logback-journal.version>
 		<reflections.version>0.9.11</reflections.version>
 		<testcontainers.version>1.18.3</testcontainers.version>
 	</properties>


### PR DESCRIPTION
Added library org.gnieh:logback-journal that provides implementation of a LogBack appender that writes into systemd-journald logging system service on linux.