### PR TITLE
refactor(core): do not create certificate IdP identity for e-INFRA CZ

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/EinfraPasswordManagerModule.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/EinfraPasswordManagerModule.java
@@ -165,17 +165,6 @@ public class EinfraPasswordManagerModule extends GenericPasswordManagerModule {
 					//this is OK
 				}
 
-				// Store E-INFRA CERT IdP UES
-				extSource = perunBl.getExtSourcesManagerBl().getExtSourceByName(sess, "https://idp-cert.e-infra.cz/idp/");
-				ues = new UserExtSource(extSource, userLogin + "@idp-cert.e-infra.cz");
-				ues.setLoa(0);
-
-				try {
-					perunBl.getUsersManagerBl().addUserExtSource(sess, user, ues);
-				} catch (UserExtSourceExistsException ex) {
-					//this is OK
-				}
-
 				// Store also Kerberos logins
 				Attribute kerberosLoginsAttr = perunBl.getAttributesManagerBl().getAttribute(sess, user, AttributesManager.NS_USER_ATTR_DEF + ":" + "kerberosLogins");
 				if (kerberosLoginsAttr != null && kerberosLoginsAttr.getValue() != null) {

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/Metacentrum.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/Metacentrum.java
@@ -58,8 +58,7 @@ public class Metacentrum extends DefaultRegistrarModule {
 	protected final static String A_USER_IS_CESNET_ELIGIBLE_LAST_SEEN = AttributesManager.NS_USER_ATTR_DEF+":isCesnetEligibleLastSeen";
 	private final static String A_MEMBER_MEMBERSHIP_EXPIRATION = AttributesManager.NS_MEMBER_ATTR_DEF+":membershipExpiration";
 	protected final static String METACENTRUM_IDP = "https://login.ics.muni.cz/idp/shibboleth";
-	protected final static String EINFRA_IDP = "https://https://idp.e-infra.cz/idp/";
-	protected final static String EINFRA_IDP_CERT = "https://idp-cert.e-infra.cz/idp/";
+	protected final static String EINFRA_IDP = "https://idp.e-infra.cz/idp/";
 
 	/**
 	 * Add all new Metacentrum members to "storage" group.
@@ -142,7 +141,7 @@ public class Metacentrum extends DefaultRegistrarModule {
 			// user is already in e-INFRA CZ
 		} catch (ExtendMembershipException e) {
 			// can't be member of e-INFRA CZ, shouldn't happen
-			log.error("{} member can't be added to \"e-INFRA CZ\": {}", vo.getName(), e);
+			log.error("{} member can't be added to \"e-INFRA CZ\"", vo.getName(), e);
 		}
 
 		// Support statistic groups
@@ -206,8 +205,7 @@ public class Metacentrum extends DefaultRegistrarModule {
 					"NOT_ELIGIBLE_METAIDP", null, null);
 		}
 
-		if (EINFRA_IDP.equals(session.getPerunPrincipal().getExtSourceName()) ||
-				EINFRA_IDP_CERT.equals(session.getPerunPrincipal().getExtSourceName())) {
+		if (EINFRA_IDP.equals(session.getPerunPrincipal().getExtSourceName())) {
 			throw new CantBeSubmittedException("You are currently logged-in using e-INFRA CZ IdP." +
 					"It can't be used to register or extend membership in Metacentrum. Please close browser and log-in using different identity provider.",
 					"NOT_ELIGIBLE_EINFRAIDP", null, null);

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/MetacentrumSocial.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/MetacentrumSocial.java
@@ -24,7 +24,6 @@ import org.slf4j.LoggerFactory;
 import java.util.Map;
 
 import static cz.metacentrum.perun.registrar.modules.Metacentrum.EINFRA_IDP;
-import static cz.metacentrum.perun.registrar.modules.Metacentrum.EINFRA_IDP_CERT;
 import static cz.metacentrum.perun.registrar.modules.Metacentrum.METACENTRUM_IDP;
 
 /**
@@ -74,8 +73,7 @@ public class MetacentrumSocial extends DefaultRegistrarModule {
 					"NOT_ELIGIBLE_METAIDP", null, null);
 		}
 
-		if (EINFRA_IDP.equals(session.getPerunPrincipal().getExtSourceName()) ||
-				EINFRA_IDP_CERT.equals(session.getPerunPrincipal().getExtSourceName())) {
+		if (EINFRA_IDP.equals(session.getPerunPrincipal().getExtSourceName())) {
 			throw new CantBeSubmittedException("You are currently logged-in using e-INFRA CZ IdP." +
 					"It can't be used to register or extend membership in Metacentrum. Please close browser and log-in using different identity provider.",
 					"NOT_ELIGIBLE_EINFRAIDP", null, null);


### PR DESCRIPTION
- IdP "e-INFRA CZ (certificate)" is no longer supported, so we don't have to create that arbitrary identity when new login is registered.

DEPLOYMENT NOTE: Remove all user identities for "https://idp-cert.e-infra.cz/idp/" IdP (ExtSource).