### PR TITLE
fix(core): change autoRegistrationEnabled attribute value

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_virt_autoRegistrationEnabled.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_virt_autoRegistrationEnabled.java
@@ -4,9 +4,6 @@ import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.Group;
-import cz.metacentrum.perun.core.api.Vo;
-import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
-import cz.metacentrum.perun.core.api.exceptions.VoNotExistsException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.GroupVirtualAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.GroupVirtualAttributesModuleImplApi;
@@ -16,24 +13,8 @@ public class urn_perun_group_attribute_def_virt_autoRegistrationEnabled extends 
 	@Override
 	public Attribute getAttributeValue(PerunSessionImpl sess, Group group, AttributeDefinition attributeDefinition) {
 		Attribute attribute = new Attribute(attributeDefinition);
-		Boolean value = null;
-		if (isAutoRegistrationActiveInVo(sess, group)) {
-			value = sess.getPerunBl().getGroupsManagerBl().isGroupForAnyAutoRegistration(sess, group);
-		}
-		attribute.setValue(value);
+		attribute.setValue(sess.getPerunBl().getGroupsManagerBl().isGroupForAnyAutoRegistration(sess, group));
 		return attribute;
-	}
-
-
-	private boolean isAutoRegistrationActiveInVo(PerunSessionImpl sess, Group group) {
-		Vo vo;
-		try {
-			vo = sess.getPerunBl().getVosManagerBl().getVoById(sess, group.getVoId());
-		} catch (VoNotExistsException e) {
-			throw new InternalErrorException(e);
-		}
-
-		return sess.getPerunBl().getVosManagerBl().usesEmbeddedGroupRegistrations(sess, vo);
 	}
 
 	@Override

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_virt_autoRegistrationEnabledTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_virt_autoRegistrationEnabledTest.java
@@ -38,10 +38,6 @@ public class urn_perun_group_attribute_def_virt_autoRegistrationEnabledTest {
 		System.out.println("testAutoRegistrationEnabledGetAttributeValue()");
 		when(session.getPerunBl().getGroupsManagerBl().isGroupForAnyAutoRegistration(session, groupA))
 				.thenReturn(true);
-		when(session.getPerunBl().getVosManagerBl().getVoById(session, groupA.getVoId()))
-				.thenReturn(vo);
-		when(session.getPerunBl().getVosManagerBl().usesEmbeddedGroupRegistrations(session, vo))
-				.thenReturn(true);
 
 		Boolean attributeValue = classInstance.getAttributeValue(session, groupA, attrDef).valueAsBoolean();
 		assertThat(attributeValue)
@@ -53,28 +49,9 @@ public class urn_perun_group_attribute_def_virt_autoRegistrationEnabledTest {
 		System.out.println("testAutoRegistrationDisabledAttributeValue()");
 		when(session.getPerunBl().getGroupsManagerBl().isGroupForAnyAutoRegistration(session, groupB))
 				.thenReturn(false);
-		when(session.getPerunBl().getVosManagerBl().getVoById(session, groupB.getVoId()))
-				.thenReturn(vo);
-		when(session.getPerunBl().getVosManagerBl().usesEmbeddedGroupRegistrations(session, vo))
-				.thenReturn(true);
 
 		Boolean attributeValue = classInstance.getAttributeValue(session, groupB, attrDef).valueAsBoolean();
 		assertThat(attributeValue)
 				.isFalse();
-	}
-
-	@Test
-	public void testAutoRegistrationNotUsed() throws Exception {
-		System.out.println("testAutoRegistrationNotUsed()");
-		when(session.getPerunBl().getGroupsManagerBl().isGroupForAnyAutoRegistration(session, groupB))
-				.thenReturn(false);
-		when(session.getPerunBl().getVosManagerBl().getVoById(session, groupB.getVoId()))
-				.thenReturn(vo);
-		when(session.getPerunBl().getVosManagerBl().usesEmbeddedGroupRegistrations(session, vo))
-				.thenReturn(false);
-
-		Boolean attributeValue = classInstance.getAttributeValue(session, groupB, attrDef).valueAsBoolean();
-		assertThat(attributeValue)
-				.isNull();
 	}
 }


### PR DESCRIPTION
* Since the autoRegistraion is not related just to organization anymore, it makes sense to fill the value of autoRegistraionEnabled attribute according to the isGroupForAnyAutoRegistration() method.
* Related tests were simplified.