### PR TITLE
chore: change commitlint rules

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -19,7 +19,8 @@
 				"deps",
 				"deps-dev"
 			]
-		]
+		],
+		"body-max-line-length": [2, "always", 200]
 	},
 	"prompt": {
 		"questions": {

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,6 +6,9 @@ on:
 jobs:
   run-commitlint-on-pr:
     runs-on: ubuntu-latest
+    if: |
+      startsWith(github.head_ref, 'dependabot/npm_and_yarn/') != true &&
+      startsWith(github.head_ref, 'renovate/') != true
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
* The body-max-line-length rule was raised from the default 100 characters to 200 characters.
* Branches from the dependabot and renovate are now excluded from the commlint check.