### PR TITLE
fix(registrar): auto-approve only IdP MUNI applications in CeitecNcbr

### DIFF
--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/CeitecNcbr.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/CeitecNcbr.java
@@ -8,11 +8,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Module for CEITEC@MUNI and NCBR@MUNI VOs at CESNET instance of Perun.
+ * Module for NCBR@MUNI VOs at CESNET instance.
  *
  * The module
- * 1. Allows (auto)approval of applications with LoA = 2.
- * 2. Enforce manual approval of applications with LoA = 0, 1.
+ * 1. Allows (auto)approval of applications by users from IdP MUNI
+ * 2. Enforce manual approval of applications by users from different IdPs
  *
  * @author Pavel Zlámal <zlamal@cesnet.cz>
  */
@@ -20,11 +20,13 @@ public class CeitecNcbr extends DefaultRegistrarModule {
 
 	final static Logger log = LoggerFactory.getLogger(CeitecNcbr.class);
 
+	private final static String IDP_MU = "https://idp2.ics.muni.cz/idp/shibboleth";
+
 	@Override
 	public void canBeApproved(PerunSession session, Application app) throws PerunException {
 
-		if (app.getExtSourceLoa() == 2) return;
-		throw new CantBeApprovedException("Application can't be approved automatically. LoA is: "+app.getExtSourceLoa()+". Please double check users identity before manual/force approval.", "", "", "", true, app.getId());
+		if (IDP_MU.equals(app.getExtSourceName())) return;
+		throw new CantBeApprovedException("Application can't be approved automatically. User has not used IdP MUNI to log in. Please double check users identity before manual/force approval.", "", "", "", true, app.getId());
 
 	}
 


### PR DESCRIPTION
- Removed usage of LoA, we are now using IdP MUNI as marker for auto-approvable applications.