### PR TITLE
feat(core): extend authz table with audit attributes

### DIFF
--- a/perun-base/src/test/resources/test-schema.sql
+++ b/perun-base/src/test/resources/test-schema.sql
@@ -1,4 +1,4 @@
--- database version 3.2.15 (don't forget to update insert statement at the end of file)
+-- database version 3.2.16 (don't forget to update insert statement at the end of file)
 CREATE EXTENSION IF NOT EXISTS "unaccent";
 CREATE EXTENSION IF NOT EXISTS "pgcrypto";
 
@@ -1600,6 +1600,8 @@ create table authz (
 						modified_by_uid integer,
 						authorized_group_id integer, --identifier of whole authorized group
 						security_team_id integer,	--identifier of security team
+						created_at timestamp default statement_timestamp() not null,
+						created_by varchar default user not null,
 						constraint authz_role_fk foreign key (role_id) references roles(id),
 						constraint authz_user_fk foreign key (user_id) references users(id),
 						constraint authz_authz_group_fk foreign key (authorized_group_id) references groups(id),
@@ -1905,7 +1907,7 @@ create index idx_fk_attr_critops ON attribute_critical_actions(attr_id);
 create index app_state_idx ON application (state);
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.2.15');
+insert into configurations values ('DATABASE VERSION','3.2.16');
 -- insert membership types
 insert into membership_types (id, membership_type, description) values (1, 'DIRECT', 'Member is directly added into group');
 insert into membership_types (id, membership_type, description) values (2, 'INDIRECT', 'Member is added indirectly through UNION relation');

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AuthzResolverImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AuthzResolverImpl.java
@@ -38,6 +38,7 @@ import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.SingleColumnRowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
 
 import javax.sql.DataSource;
 import java.util.ArrayList;
@@ -449,7 +450,8 @@ public class AuthzResolverImpl implements AuthzResolverImplApi {
 	@Override
 	public void addAdmin(PerunSession sess, Facility facility, User user) throws AlreadyAdminException {
 		try {
-			jdbc.update("insert into authz (user_id, role_id, facility_id) values (?, (select id from roles where name=?), ?)", user.getId(), Role.FACILITYADMIN.toLowerCase(), facility.getId());
+			jdbc.update("insert into authz (user_id, role_id, facility_id, created_by, created_by_uid)" +
+				" values (?, (select id from roles where name=?), ?, ?, ?)", user.getId(), Role.FACILITYADMIN.toLowerCase(), facility.getId(), sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getUserId());
 		} catch (DataIntegrityViolationException e) {
 			throw new AlreadyAdminException("User id=" + user.getId() + " is already admin of the facility " + facility, e, user, facility);
 		} catch (RuntimeException e) {
@@ -460,7 +462,8 @@ public class AuthzResolverImpl implements AuthzResolverImplApi {
 	@Override
 	public void addAdmin(PerunSession sess, Facility facility, Group group) throws AlreadyAdminException {
 		try {
-			jdbc.update("insert into authz (authorized_group_id, role_id, facility_id) values (?, (select id from roles where name=?), ?)", group.getId(), Role.FACILITYADMIN.toLowerCase(), facility.getId());
+			jdbc.update("insert into authz (authorized_group_id, role_id, facility_id, created_by, created_by_uid)" +
+				" values (?, (select id from roles where name=?), ?, ?, ?)", group.getId(), Role.FACILITYADMIN.toLowerCase(), facility.getId(), sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getUserId());
 		} catch (DataIntegrityViolationException e) {
 			throw new AlreadyAdminException("Group id=" + group.getId() + " is already admin of the facility " + facility, e, group, facility);
 		} catch (RuntimeException e) {
@@ -493,7 +496,8 @@ public class AuthzResolverImpl implements AuthzResolverImplApi {
 	@Override
 	public void addAdmin(PerunSession sess, Resource resource, User user) throws AlreadyAdminException {
 		try {
-			jdbc.update("insert into authz (user_id, role_id, resource_id, vo_id, facility_id) values (?, (select id from roles where name=?), ?, ?, ?)", user.getId(), Role.RESOURCEADMIN.toLowerCase(), resource.getId(), resource.getVoId(), resource.getFacilityId());
+			jdbc.update("insert into authz (user_id, role_id, resource_id, vo_id, facility_id, created_by, created_by_uid)" +
+				" values (?, (select id from roles where name=?), ?, ?, ?, ?, ?)", user.getId(), Role.RESOURCEADMIN.toLowerCase(), resource.getId(), resource.getVoId(), resource.getFacilityId(), sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getUserId());
 		} catch (DataIntegrityViolationException e) {
 			throw new AlreadyAdminException("User id=" + user.getId() + " is already admin of the resource " + resource, e, user, resource);
 		} catch (RuntimeException e) {
@@ -504,7 +508,8 @@ public class AuthzResolverImpl implements AuthzResolverImplApi {
 	@Override
 	public void addAdmin(PerunSession sess, Resource resource, Group group) throws AlreadyAdminException {
 		try {
-			jdbc.update("insert into authz (authorized_group_id, role_id, resource_id, vo_id, facility_id) values (?, (select id from roles where name=?), ?, ?, ?)", group.getId(), Role.RESOURCEADMIN.toLowerCase(), resource.getId(), resource.getVoId(), resource.getFacilityId());
+			jdbc.update("insert into authz (authorized_group_id, role_id, resource_id, vo_id, facility_id, created_by, created_by_uid)" +
+				" values (?, (select id from roles where name=?), ?, ?, ?, ?, ?)", group.getId(), Role.RESOURCEADMIN.toLowerCase(), resource.getId(), resource.getVoId(), resource.getFacilityId(), sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getUserId());
 		} catch (DataIntegrityViolationException e) {
 			throw new AlreadyAdminException("Group id=" + group.getId() + " is already admin of the resource " + resource, e, group, resource);
 		} catch (RuntimeException e) {
@@ -537,7 +542,8 @@ public class AuthzResolverImpl implements AuthzResolverImplApi {
 	@Override
 	public void addAdmin(PerunSession sess, User sponsoredUser, User user) throws AlreadyAdminException {
 		try {
-			jdbc.update("insert into authz (user_id, role_id, sponsored_user_id) values (?, (select id from roles where name=?), ?)", user.getId(), Role.SPONSOR.toLowerCase(), sponsoredUser.getId());
+			jdbc.update("insert into authz (user_id, role_id, sponsored_user_id, created_by, created_by_uid)" +
+				" values (?, (select id from roles where name=?), ?, ?, ?)", user.getId(), Role.SPONSOR.toLowerCase(), sponsoredUser.getId(), sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getUserId());
 		} catch (DataIntegrityViolationException e) {
 			throw new AlreadyAdminException("User id=" + user.getId() + " is already sponsor of the sponsoredUser " + sponsoredUser, e, user, sponsoredUser);
 		} catch (RuntimeException e) {
@@ -548,7 +554,8 @@ public class AuthzResolverImpl implements AuthzResolverImplApi {
 	@Override
 	public void addAdmin(PerunSession sess, User sponsoredUser, Group group) throws AlreadyAdminException {
 		try {
-			jdbc.update("insert into authz (authorized_group_id, role_id, sponsored_user_id) values (?, (select id from roles where name=?), ?)", group.getId(), Role.SPONSOR.toLowerCase(), sponsoredUser.getId());
+			jdbc.update("insert into authz (authorized_group_id, role_id, sponsored_user_id, created_by, created_by_uid)" +
+				" values (?, (select id from roles where name=?), ?, ?, ?)", group.getId(), Role.SPONSOR.toLowerCase(), sponsoredUser.getId(), sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getUserId());
 		} catch (DataIntegrityViolationException e) {
 			throw new AlreadyAdminException("Group id=" + group.getId() + " is already sponsor of the sponsoredUser " + sponsoredUser, e, group, sponsoredUser);
 		} catch (RuntimeException e) {
@@ -582,8 +589,9 @@ public class AuthzResolverImpl implements AuthzResolverImplApi {
 	public void addAdmin(PerunSession sess, Group group, User user) throws AlreadyAdminException {
 		try {
 			// Add GROUPADMIN role + groupId and voId
-			jdbc.update("insert into authz (user_id, role_id, group_id, vo_id) values (?, (select id from roles where name=?), ?, ?)",
-				user.getId(), Role.GROUPADMIN.toLowerCase(), group.getId(), group.getVoId());
+			jdbc.update("insert into authz (user_id, role_id, group_id, vo_id, created_by, created_by_uid)" +
+					" values (?, (select id from roles where name=?), ?, ?, ?, ?)",
+				user.getId(), Role.GROUPADMIN.toLowerCase(), group.getId(), group.getVoId(), sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getUserId());
 		} catch (DataIntegrityViolationException e) {
 			throw new AlreadyAdminException("User id=" + user.getId() + " is already admin in group " + group, e, user, group);
 		} catch (RuntimeException e) {
@@ -594,8 +602,9 @@ public class AuthzResolverImpl implements AuthzResolverImplApi {
 	@Override
 	public void addAdmin(PerunSession sess, Group group, Group authorizedGroup) throws AlreadyAdminException {
 		try {
-			jdbc.update("insert into authz (authorized_group_id, role_id, group_id, vo_id) values (?, (select id from roles where name=?), ?, ?)",
-				authorizedGroup.getId(), Role.GROUPADMIN.toLowerCase(), group.getId(), group.getVoId());
+			jdbc.update("insert into authz (authorized_group_id, role_id, group_id, vo_id, created_by, created_by_uid)" +
+					" values (?, (select id from roles where name=?), ?, ?, ?, ?)",
+				authorizedGroup.getId(), Role.GROUPADMIN.toLowerCase(), group.getId(), group.getVoId(), sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getUserId());
 		} catch (DataIntegrityViolationException e) {
 			throw new AlreadyAdminException("Group id=" + authorizedGroup.getId() + " is already group admin in group " + group, e, authorizedGroup, group);
 		} catch (RuntimeException e) {
@@ -630,8 +639,9 @@ public class AuthzResolverImpl implements AuthzResolverImplApi {
 	@Override
 	public void addAdmin(PerunSession sess, SecurityTeam securityTeam, User user) throws AlreadyAdminException {
 		try {
-			jdbc.update("insert into authz (user_id, role_id, security_team_id) values (?, (select id from roles where name=?), ?)", user.getId(),
-				Role.SECURITYADMIN.toLowerCase(), securityTeam.getId());
+			jdbc.update("insert into authz (user_id, role_id, security_team_id, created_by, created_by_uid)" +
+					" values (?, (select id from roles where name=?), ?, ?, ?)", user.getId(),
+				Role.SECURITYADMIN.toLowerCase(), securityTeam.getId(), sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getUserId());
 		} catch (DataIntegrityViolationException e) {
 			throw new AlreadyAdminException("User id=" + user.getId() + " is already admin in securityTeam " + securityTeam, e, user, securityTeam);
 		} catch (RuntimeException e) {
@@ -642,8 +652,9 @@ public class AuthzResolverImpl implements AuthzResolverImplApi {
 	@Override
 	public void addAdmin(PerunSession sess, SecurityTeam securityTeam, Group group) throws AlreadyAdminException {
 		try {
-			jdbc.update("insert into authz (authorized_group_id, role_id, security_team_id) values (?, (select id from roles where name=?), ?)", group.getId(),
-				Role.SECURITYADMIN.toLowerCase(), securityTeam.getId());
+			jdbc.update("insert into authz (authorized_group_id, role_id, security_team_id, created_by, created_by_uid)" +
+					" values (?, (select id from roles where name=?), ?, ?, ?)", group.getId(),
+				Role.SECURITYADMIN.toLowerCase(), securityTeam.getId(), sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getUserId());
 		} catch (DataIntegrityViolationException e) {
 			throw new AlreadyAdminException("Group id=" + group.getId() + " is already admin in securityTeam " + securityTeam, e, group, securityTeam);
 		} catch (RuntimeException e) {
@@ -676,7 +687,8 @@ public class AuthzResolverImpl implements AuthzResolverImplApi {
 	@Override
 	public void makeUserPerunAdmin(PerunSession sess, User user) throws AlreadyAdminException {
 		try {
-			jdbc.update("insert into authz (user_id, role_id) values (?, (select id from roles where name=?))", user.getId(), Role.PERUNADMIN.toLowerCase());
+			jdbc.update("insert into authz (user_id, role_id, created_by, created_by_uid)" +
+				" values (?, (select id from roles where name=?), ?, ?)", user.getId(), Role.PERUNADMIN.toLowerCase(), sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getUserId());
 		} catch (DataIntegrityViolationException e) {
 			throw new AlreadyAdminException("User id=" + user.getId() + " is already perun admin", e, user, Role.PERUNADMIN);
 		} catch (RuntimeException e) {
@@ -687,7 +699,8 @@ public class AuthzResolverImpl implements AuthzResolverImplApi {
 	@Override
 	public void makeUserPerunObserver(PerunSession sess, User user) throws AlreadyAdminException {
 		try {
-			jdbc.update("insert into authz (user_id, role_id) values (?, (select id from roles where name=?))", user.getId(), Role.PERUNOBSERVER.toLowerCase());
+			jdbc.update("insert into authz (user_id, role_id, created_by, created_by_uid)" +
+				" values (?, (select id from roles where name=?), ?, ?)", user.getId(), Role.PERUNOBSERVER.toLowerCase(), sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getUserId());
 		} catch (DataIntegrityViolationException e) {
 			throw new AlreadyAdminException("User id=" + user.getId() + " is already perun observer", e, user, Role.PERUNOBSERVER);
 		} catch (RuntimeException e) {
@@ -698,7 +711,8 @@ public class AuthzResolverImpl implements AuthzResolverImplApi {
 	@Override
 	public void makeAuthorizedGroupPerunObserver(PerunSession sess, Group authorizedGroup) throws AlreadyAdminException {
 		try {
-			jdbc.update("insert into authz (authorized_group_id, role_id) values (?, (select id from roles where name=?))", authorizedGroup.getId(), Role.PERUNOBSERVER.toLowerCase());
+			jdbc.update("insert into authz (authorized_group_id, role_id, created_by, created_by_uid)" +
+				" values (?, (select id from roles where name=?), ?, ?)", authorizedGroup.getId(), Role.PERUNOBSERVER.toLowerCase(), sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getUserId());
 		} catch (DataIntegrityViolationException e) {
 			throw new AlreadyAdminException("Group id=" + authorizedGroup.getId() + " is already perun observer", e, authorizedGroup, Role.PERUNOBSERVER);
 		} catch (RuntimeException e) {
@@ -742,7 +756,8 @@ public class AuthzResolverImpl implements AuthzResolverImplApi {
 	@Override
 	public void makeUserCabinetAdmin(PerunSession sess, User user) {
 		try {
-			jdbc.update("insert into authz (user_id, role_id) values (?, (select id from roles where name=?))", user.getId(), Role.CABINETADMIN.toLowerCase());
+			jdbc.update("insert into authz (user_id, role_id, created_by, created_by_uid)" +
+				" values (?, (select id from roles where name=?), ?, ?)", user.getId(), Role.CABINETADMIN.toLowerCase(), sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getUserId());
 		} catch (RuntimeException e) {
 			throw new InternalErrorException(e);
 		}
@@ -765,8 +780,8 @@ public class AuthzResolverImpl implements AuthzResolverImplApi {
 			throw new IllegalArgumentException("Role " + role + " cannot be set on VO");
 		}
 		try {
-			jdbc.update("insert into authz (user_id, role_id, vo_id) values (?, (select id from roles where name=?), ?)", user.getId(),
-				role.toLowerCase(), vo.getId());
+			jdbc.update("insert into authz (user_id, role_id, vo_id, created_by, created_by_uid)  values (?, (select id from roles where name=?), ?, ?, ?)",
+				user.getId(), role.toLowerCase(), vo.getId(), sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getUserId());
 		} catch (DataIntegrityViolationException e) {
 			throw new AlreadyAdminException("User id=" + user.getId() + " is already " + role + " in vo " + vo, e, user, vo, role);
 		} catch (RuntimeException e) {
@@ -780,8 +795,9 @@ public class AuthzResolverImpl implements AuthzResolverImplApi {
 			throw new IllegalArgumentException("Role " + role + " cannot be set on VO");
 		}
 		try {
-			jdbc.update("insert into authz (role_id, vo_id, authorized_group_id) values ((select id from roles where name=?), ?, ?)",
-				role.toLowerCase(), vo.getId(), group.getId());
+			jdbc.update("insert into authz (role_id, vo_id, authorized_group_id, created_by, created_by_uid)" +
+					" values ((select id from roles where name=?), ?, ?, ?, ?)",
+				role.toLowerCase(), vo.getId(), group.getId(), sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getUserId());
 		} catch (DataIntegrityViolationException e) {
 			throw new AlreadyAdminException("Group id=" + group.getId() + " is already " + role + " in vo " + vo, e, group, vo, role);
 		} catch (RuntimeException e) {
@@ -857,8 +873,8 @@ public class AuthzResolverImpl implements AuthzResolverImplApi {
 			throw new InternalErrorException("Role " + role + " cannot be set on resource.");
 		}
 		try {
-			jdbc.update("insert into authz (user_id, role_id, resource_id, vo_id, facility_id) values (?, (select id from roles where name=?), ?, ?, ?)", user.getId(),
-				role.toLowerCase(), resource.getId(), resource.getVoId(), resource.getFacilityId());
+			jdbc.update("insert into authz (user_id, role_id, resource_id, vo_id, facility_id, created_by, created_by_uid) values (?, (select id from roles where name=?), ?, ?, ?, ?, ?)", user.getId(),
+				role.toLowerCase(), resource.getId(), resource.getVoId(), resource.getFacilityId(), sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getUserId());
 		} catch (DataIntegrityViolationException e) {
 			throw new AlreadyAdminException("User id=" + user.getId() + " is already " + role + " in resource " + resource, e, user, resource, role);
 		} catch (RuntimeException e) {
@@ -872,8 +888,9 @@ public class AuthzResolverImpl implements AuthzResolverImplApi {
 			throw new IllegalArgumentException("Role " + role + " cannot be set on resource.");
 		}
 		try {
-			jdbc.update("insert into authz (role_id, resource_id, authorized_group_id, vo_id, facility_id) values ((select id from roles where name=?), ?, ?, ?, ?)",
-				role.toLowerCase(), resource.getId(), group.getId(), resource.getVoId(), resource.getFacilityId());
+			jdbc.update("insert into authz (role_id, resource_id, authorized_group_id, vo_id, facility_id, created_by, created_by_uid)" +
+					" values ((select id from roles where name=?), ?, ?, ?, ?, ?, ?)",
+				role.toLowerCase(), resource.getId(), group.getId(), resource.getVoId(), resource.getFacilityId(), sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getUserId());
 		} catch (DataIntegrityViolationException e) {
 			throw new AlreadyAdminException("Group id=" + group.getId() + " is already " + role + " in resource " + resource, e, group, resource, role);
 		} catch (RuntimeException e) {
@@ -988,10 +1005,15 @@ public class AuthzResolverImpl implements AuthzResolverImplApi {
 
 	@Override
 	public void setRole(PerunSession sess, Map<String, Integer> mappingOfValues, String role) throws RoleAlreadySetException {
-		String query = prepareQueryToSetRole(mappingOfValues);
+		Map<String, Object> genericMappingOfValues = prepareMappingToSetRole(mappingOfValues);
+		genericMappingOfValues.put("created_by", sess.getPerunPrincipal().getActor());
+		genericMappingOfValues.put("created_by_uid", sess.getPerunPrincipal().getUserId());
 
+		SimpleJdbcInsert insert = new SimpleJdbcInsert(jdbc);
+		insert.withTableName("authz");
+		insert.usingColumns(genericMappingOfValues.keySet().toArray(new String[0]));
 		try {
-			jdbc.update(query);
+			insert.execute(genericMappingOfValues);
 		} catch (DataIntegrityViolationException e) {
 			throw new RoleAlreadySetException(role);
 		} catch (RuntimeException e) {
@@ -1165,12 +1187,8 @@ public class AuthzResolverImpl implements AuthzResolverImplApi {
 	 * @param mappingOfValues from which will be the query created
 	 * @return sql query
 	 */
-	private String prepareQueryToSetRole(Map<String, Integer> mappingOfValues) {
-		String columnsFromMapping;
-		String valuesFromMapping;
-		List<String> columnNames = new ArrayList<>();
-		List<String> columnValues = new ArrayList<>();
-
+	private Map<String, Object> prepareMappingToSetRole(Map<String, Integer> mappingOfValues) {
+		Map<String, Object> genericMappingOfValues = new HashMap<>();
 		for (String columnName : mappingOfValues.keySet()) {
 
 			if (columnName == null || mappingOfValues.get(columnName) == null) {
@@ -1181,14 +1199,10 @@ public class AuthzResolverImpl implements AuthzResolverImplApi {
 			if (!matcher.matches()) {
 				throw new InternalErrorException("Cannot create a query to set role, because column name: " + columnName + " contains forbidden characters. Allowed are only [1-9a-zA-Z_].");
 			}
-			columnNames.add(columnName);
-			columnValues.add(mappingOfValues.get(columnName).toString());
+			genericMappingOfValues.put(columnName, mappingOfValues.get(columnName));
 		}
 
-		columnsFromMapping = StringUtils.join(columnNames, ",");
-		valuesFromMapping = StringUtils.join(columnValues, ",");
-
-		return "insert into authz (" + columnsFromMapping + ") values (" + valuesFromMapping + ")";
+		return genericMappingOfValues;
 	}
 
 	/**

--- a/perun-core/src/main/resources/postgresChangelog.txt
+++ b/perun-core/src/main/resources/postgresChangelog.txt
@@ -6,6 +6,10 @@
 -- Directly under version number should be version commands. They will be executed in the order they are written here.
 -- Comments are prefixed with -- and can be written only between version blocks, that means not in the lines with commands. They have to be at the start of the line.
 
+3.2.16
+ALTER TABLE authz ADD COLUMN created_at timestamp default statement_timestamp() not null;
+ALTER TABLE authz ADD column created_by varchar default user not null;
+
 3.2.15
 INSERT INTO authz (user_id, role_id) VALUES ((select user_id from user_ext_sources where login_ext='perun' and ext_sources_id=(select id from ext_sources where name='INTERNAL' and type='cz.metacentrum.perun.core.impl.ExtSourceInternal')),(select id from roles where name='perunadmin')) ON CONFLICT DO NOTHING;
 UPDATE configurations set value='3.2.15' WHERE property='DATABASE VERSION';

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/api/AuthzResolverIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/api/AuthzResolverIntegrationTest.java
@@ -1200,6 +1200,7 @@ public class AuthzResolverIntegrationTest extends AbstractPerunIntegrationTest {
 		when(mockedPerunPrincipal.isAuthzInitialized()).thenReturn(true);
 		when(mockedPerunPrincipal.getRoles()).thenReturn(new AuthzRoles(Role.VOADMIN, testVo));
 		when(mockedPerunPrincipal.getRolesUpdatedAt()).thenReturn(System.currentTimeMillis());
+		when(mockedPerunPrincipal.getActor()).thenReturn("test");
 
 		PerunSession testSession = new PerunSessionImpl(sess.getPerun(), mockedPerunPrincipal, sess.getPerunClient());
 
@@ -1249,6 +1250,7 @@ public class AuthzResolverIntegrationTest extends AbstractPerunIntegrationTest {
 		when(mockedPerunPrincipal.isAuthzInitialized()).thenReturn(true);
 		when(mockedPerunPrincipal.getRoles()).thenReturn(new AuthzRoles(Role.VOADMIN, testVo));
 		when(mockedPerunPrincipal.getRolesUpdatedAt()).thenReturn(System.currentTimeMillis());
+		when(mockedPerunPrincipal.getActor()).thenReturn("test");
 		PerunSession testSession = new PerunSessionImpl(sess.getPerun(), mockedPerunPrincipal, sess.getPerunClient());
 
 		AuthzResolver.setRole(testSession, testGroup, testVo, Role.VOADMIN);
@@ -1287,6 +1289,7 @@ public class AuthzResolverIntegrationTest extends AbstractPerunIntegrationTest {
 		when(mockedPerunPrincipal.isAuthzInitialized()).thenReturn(true);
 		when(mockedPerunPrincipal.getRoles()).thenReturn(new AuthzRoles(Role.VOADMIN, testVo));
 		when(mockedPerunPrincipal.getRolesUpdatedAt()).thenReturn(System.currentTimeMillis());
+		when(mockedPerunPrincipal.getActor()).thenReturn("test");
 		PerunSession testSession = new PerunSessionImpl(sess.getPerun(), mockedPerunPrincipal, sess.getPerunClient());
 
 		AuthzResolver.setRole(testSession, testUser, testVo, Role.VOADMIN);
@@ -1331,6 +1334,7 @@ public class AuthzResolverIntegrationTest extends AbstractPerunIntegrationTest {
 		when(mockedPerunPrincipal.isAuthzInitialized()).thenReturn(true);
 		when(mockedPerunPrincipal.getRoles()).thenReturn(new AuthzRoles(Role.VOADMIN, testVo));
 		when(mockedPerunPrincipal.getRolesUpdatedAt()).thenReturn(System.currentTimeMillis());
+		when(mockedPerunPrincipal.getActor()).thenReturn("test");
 		PerunSession testSession = new PerunSessionImpl(sess.getPerun(), mockedPerunPrincipal, sess.getPerunClient());
 
 		AuthzResolver.setRole(testSession, testUser, testVo, Role.VOADMIN);

--- a/perun-db/postgres.sql
+++ b/perun-db/postgres.sql
@@ -1,4 +1,4 @@
--- database version 3.2.15 (don't forget to update insert statement at the end of file)
+-- database version 3.2.16 (don't forget to update insert statement at the end of file)
 
 -- VOS - virtual organizations
 create table vos (
@@ -1597,6 +1597,8 @@ create table authz (
 	modified_by_uid integer,
 	authorized_group_id integer, --identifier of whole authorized group
 	security_team_id integer,	--identifier of security team
+	created_at timestamp default statement_timestamp() not null,
+	created_by varchar default user not null,
 	constraint authz_role_fk foreign key (role_id) references roles(id),
 	constraint authz_user_fk foreign key (user_id) references users(id),
 	constraint authz_authz_group_fk foreign key (authorized_group_id) references groups(id),
@@ -2014,7 +2016,7 @@ grant all on blocked_logins to perun;
 grant all on auto_registration_groups to perun;
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.2.15');
+insert into configurations values ('DATABASE VERSION','3.2.16');
 
 -- insert membership types
 insert into membership_types (id, membership_type, description) values (1, 'DIRECT', 'Member is directly added into group');


### PR DESCRIPTION
Added created_at, created_by, and created_by_uid columns to authz table and modified the inserts to include them. The setRole method modified to use prepared statement since user supplied input will be in the statement.