### PR TITLE
feat: enable facility search for SP reg role

### DIFF
--- a/perun-base/src/main/resources/perun-roles.yml
+++ b/perun-base/src/main/resources/perun-roles.yml
@@ -729,6 +729,7 @@ perun_policies:
       - FACILITYADMIN:
       - FACILITYOBSERVER:
       - PERUNOBSERVER:
+      - SPREGAPPLICATION:
       - PROXY:
     include_policies:
       - default_policy
@@ -738,6 +739,7 @@ perun_policies:
       - FACILITYADMIN: Facility
       - FACILITYOBSERVER: Facility
       - PERUNOBSERVER:
+      - SPREGAPPLICATION:
       - PROXY:
     include_policies:
       - default_policy


### PR DESCRIPTION
we need the SP reg app user (role) to be able to call getFacilitiesByAttributeWithAttributes and get all facilities (with attributes that it has already rights to read)

currently it can only search facilities of which it is a facility manager