### PR TITLE
fixup! feat(core): extend authz table with audit attributes

### DIFF
--- a/perun-core/src/main/resources/postgresChangelog.txt
+++ b/perun-core/src/main/resources/postgresChangelog.txt
@@ -9,6 +9,7 @@
 3.2.16
 ALTER TABLE authz ADD COLUMN created_at timestamp default statement_timestamp() not null;
 ALTER TABLE authz ADD column created_by varchar default user not null;
+UPDATE configurations set value='3.2.16' WHERE property='DATABASE VERSION';
 
 3.2.15
 INSERT INTO authz (user_id, role_id) VALUES ((select user_id from user_ext_sources where login_ext='perun' and ext_sources_id=(select id from ext_sources where name='INTERNAL' and type='cz.metacentrum.perun.core.impl.ExtSourceInternal')),(select id from roles where name='perunadmin')) ON CONFLICT DO NOTHING;


### PR DESCRIPTION
* Update DB configuration

DEPLOYMENT NOTE: authz table was updated
ALTER TABLE authz ADD COLUMN created_at timestamp default statement_timestamp() not null; ALTER TABLE authz ADD column created_by varchar default user not null; UPDATE configurations set value='3.2.16' WHERE property='DATABASE VERSION';