### PR TITLE
fix(core): handle missing referer header

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
@@ -2599,10 +2599,12 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 		Map<String, List<String>> appAllowedRoles = BeansUtils.getCoreConfig().getAppAllowedRoles();
 		for (String reg : appAllowedRoles.keySet()) {
 			Pattern pattern = Pattern.compile(reg);
-			if (pattern.matcher(sess.getPerunPrincipal().getReferer()).matches()) {
-				for (String role : roles.getRolesNames()) {
-					if (!appAllowedRoles.get(reg).contains(role)) {
-						roles.remove(role);
+			if (!isBlank(sess.getPerunPrincipal().getReferer())) {
+				if (pattern.matcher(sess.getPerunPrincipal().getReferer()).matches()) {
+					for (String role : roles.getRolesNames()) {
+						if (!appAllowedRoles.get(reg).contains(role)) {
+							roles.remove(role);
+						}
 					}
 				}
 			}


### PR DESCRIPTION
- If missing in source request read value is NULL and not empty, hence creating matcher on the pattern fails.
- Perform matching only if there is non-empty input.