### PR TITLE
feat(core): restrict deletion of the attribute definition

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/AttributesManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/AttributesManager.java
@@ -1730,10 +1730,11 @@ public interface AttributesManager {
 	 * <p>
 	 * PRIVILEGE: Only PerunAdmin can delete existing attribute.
 	 *
-	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
-	 * @throws PrivilegeException     if privileges are not given
+	 * @throws InternalErrorException 	if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws PrivilegeException     	if privileges are not given
+	 * @throws RelationExistsException 	if attribute definition has any relation to some application form item or to some service as a required attribute
 	 */
-	void deleteAttribute(PerunSession sess, AttributeDefinition attributeDefinition) throws PrivilegeException, AttributeNotExistsException;
+	void deleteAttribute(PerunSession sess, AttributeDefinition attributeDefinition) throws PrivilegeException, AttributeNotExistsException, RelationExistsException;
 
 	/**
 	 * Deletes the attribute.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
@@ -40,6 +40,7 @@ import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongModuleTypeException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.implApi.modules.attributes.UserVirtualAttributesModuleImplApi;
+import cz.metacentrum.perun.registrar.model.ApplicationForm;
 import cz.metacentrum.perun.utils.graphs.Graph;
 import cz.metacentrum.perun.utils.graphs.GraphTextFormat;
 
@@ -1974,9 +1975,10 @@ public interface AttributesManagerBl {
 	 *
 	 * @param sess
 	 * @param attributeDefinition
-	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws InternalErrorException 	if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws RelationExistsException 	if attribute definition has any relation to some application form item or to some service as a required attribute
 	 */
-	void deleteAttribute(PerunSession sess, AttributeDefinition attributeDefinition);
+	void deleteAttribute(PerunSession sess, AttributeDefinition attributeDefinition) throws RelationExistsException;
 
 	/**
 	 * Delete all authz for the attribute.
@@ -4867,5 +4869,23 @@ public interface AttributesManagerBl {
 	 * @return list of namespaces
 	 */
 	List<String> getAllNamespaces(PerunSession sess);
+
+	/**
+	 * Returns all application forms where the given attribute definition is a source or a destination attribute for any application from item
+	 * @param sess session
+	 * @param attr attribute definition
+	 * @return list of application forms where the given attribute definition has relation to any application form item
+	 */
+	List<ApplicationForm> getAppFormsWhereAttributeRelated(PerunSession sess, AttributeDefinition attr);
+
+	/**
+	 * Returns list of app form items' shortnames for which the given attribute is a source or a destination attribute in the given application form
+	 *
+	 * @param sess session
+	 * @param appFormId id of application form
+	 * @param attr attribute definition
+	 * @return list of shortnames
+	 */
+	List<String> getAppFormItemsForAppFormAndAttribute(PerunSession sess, int appFormId, AttributeDefinition attr);
 }
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -119,6 +119,7 @@ import cz.metacentrum.perun.core.implApi.modules.attributes.AttributesModuleImpl
 import cz.metacentrum.perun.core.implApi.modules.attributes.SkipValueCheckDuringDependencyCheck;
 import cz.metacentrum.perun.core.implApi.modules.attributes.UserVirtualAttributesModuleImplApi;
 import cz.metacentrum.perun.core.implApi.modules.attributes.VirtualAttributesModuleImplApi;
+import cz.metacentrum.perun.registrar.model.ApplicationForm;
 import cz.metacentrum.perun.utils.graphs.Graph;
 import cz.metacentrum.perun.utils.graphs.GraphEdge;
 import cz.metacentrum.perun.utils.graphs.GraphTextFormat;
@@ -2586,9 +2587,27 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	}
 
 	@Override
-	public void deleteAttribute(PerunSession sess, AttributeDefinition attribute) {
-		//Remove services' required attributes
-		//TODO
+	public void deleteAttribute(PerunSession sess, AttributeDefinition attribute) throws RelationExistsException {
+		//Check relation to services' required attributes
+		List<Service> relatedServices = getPerunBl().getServicesManagerBl().getServicesByAttributeDefinition(sess, attribute);
+		if (!relatedServices.isEmpty()) {
+			throw new RelationExistsException("Attribute definition with id: " + attribute.getId() + " is the required attribute for these services: "
+				+ relatedServices.stream().map(service -> service.getName() + " (id: " + service.getId() + ")").toList());
+		}
+
+		//Check relation to any application form as a source or destination attribute
+		List<ApplicationForm> applicationForms = getAppFormsWhereAttributeRelated(sess, attribute);
+		if (!applicationForms.isEmpty()) {
+			throw new RelationExistsException("Attribute definition with id: " + attribute.getId() + " has a relation (as a source or destination attribute) to these application form items: "
+				+ applicationForms.stream().map(appForm -> {
+					String message = "Application form items: " + getAppFormItemsForAppFormAndAttribute(sess, appForm.getId(), attribute);
+					message += appForm.getGroup() == null ?
+					" in the application form in VO with id: " + appForm.getVo().getId() :
+					" in the application form in Group with id: " + appForm.getGroup().getId() + " (under Vo with id: " + appForm.getVo().getId() + ")";
+					return message;
+				})
+				.toList());
+		}
 
 		//Remove attribute and all it's values
 		this.deleteAllAttributeAuthz(sess, attribute);
@@ -8891,6 +8910,18 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	@Override
 	public List<String> getAllNamespaces(PerunSession sess) {
 		return getAttributesManagerImpl().getAllNamespaces(sess).stream().map(friendlyName -> friendlyName.split(":", 2)[1]).sorted().toList();
+	}
+
+	@Override
+	public
+	List<ApplicationForm>getAppFormsWhereAttributeRelated(PerunSession sess, AttributeDefinition attr) {
+		return getAttributesManagerImpl().getAppFormsWhereAttributeRelated(sess, attr);
+	}
+
+	@Override
+	public
+	List<String>getAppFormItemsForAppFormAndAttribute(PerunSession sess, int appFormId, AttributeDefinition attr) {
+		return getAttributesManagerImpl().getAppFormItemsForAppFormAndAttribute(sess, appFormId, attr);
 	}
 
 	// ------------ PRIVATE METHODS FOR ATTRIBUTE DEPENDENCIES LOGIC --------------

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/AttributesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/AttributesManagerEntry.java
@@ -1617,7 +1617,7 @@ public class AttributesManagerEntry implements AttributesManager {
 	}
 
 	@Override
-	public void deleteAttribute(PerunSession sess, AttributeDefinition attribute) throws PrivilegeException, AttributeNotExistsException {
+	public void deleteAttribute(PerunSession sess, AttributeDefinition attribute) throws PrivilegeException, AttributeNotExistsException, RelationExistsException {
 		Utils.checkPerunSession(sess);
 		getAttributesManagerBl().checkAttributeExists(sess, attribute);
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
@@ -37,6 +37,7 @@ import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueExce
 import cz.metacentrum.perun.core.blImpl.AttributesManagerBlImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.AttributesModuleImplApi;
 import cz.metacentrum.perun.core.implApi.modules.attributes.UserVirtualAttributesModuleImplApi;
+import cz.metacentrum.perun.registrar.model.ApplicationForm;
 
 import java.util.HashMap;
 import java.util.List;
@@ -2816,4 +2817,22 @@ public interface AttributesManagerImplApi {
 	 * @return list of namespaces
 	 */
 	List<String> getAllNamespaces(PerunSession sess);
+
+	/**
+	 * Returns all application forms where the given attribute definition is a source or a destination attribute for any application from item
+	 * @param sess session
+	 * @param attr attribute definition
+	 * @return list of application forms where the given attribute definition has relation to any application form item
+	 */
+	List<ApplicationForm> getAppFormsWhereAttributeRelated(PerunSession sess, AttributeDefinition attr);
+
+	/**
+	 * Returns list of app form items' shortnames for which the given attribute is a source or a destination attribute in the given application form
+	 *
+	 * @param sess session
+	 * @param appFormId id of application form
+	 * @param attr attribute definition
+	 * @return list of shortnames
+	 */
+	List<String> getAppFormItemsForAppFormAndAttribute(PerunSession sess, int appFormId, AttributeDefinition attr);
 }

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/AttributesManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/AttributesManagerEntryIntegrationTest.java
@@ -5849,6 +5849,26 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	}
 
+	@Test (expected=RelationExistsException.class)
+	public void deleteAttributeRequiredForService() throws Exception {
+		System.out.println(CLASS_NAME + "deleteAttributeRequiredForService");
+
+		AttributeDefinition attrDef = new AttributeDefinition();
+		attrDef.setDescription("attributesManagerTestAttrDef");
+		attrDef.setFriendlyName("attrDef");
+		attrDef.setNamespace("urn:perun:member:attribute-def:opt");
+		attrDef.setType(String.class.getName());
+		attributesManager.createAttribute(sess, attrDef);
+
+		Service service = setUpService();
+		Service service2 = setUpService2();
+		
+		perun.getServicesManager().addRequiredAttribute(sess, service, attrDef);
+		perun.getServicesManager().addRequiredAttribute(sess, service2, attrDef);
+
+		attributesManager.deleteAttribute(sess, attrDef);
+	}
+
 	@Ignore
 	@Test (expected=RelationExistsException.class)
 	public void deleteAttributeWhenRelationExists() throws Exception {

--- a/perun-registrar-lib/src/test/java/cz/metacentrum/perun/registrar/RegistrarBaseIntegrationTest.java
+++ b/perun-registrar-lib/src/test/java/cz/metacentrum/perun/registrar/RegistrarBaseIntegrationTest.java
@@ -1,6 +1,7 @@
 package cz.metacentrum.perun.registrar;
 
 import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.ExtSource;
 import cz.metacentrum.perun.core.api.ExtSourcesManager;
 import cz.metacentrum.perun.core.api.Group;
@@ -786,6 +787,73 @@ System.out.println("APPS ["+result.size()+"]:" + result);
 		registrarManager.addGroupsToAutoRegistration(session, List.of(group2), embeddedGroupsItem);
 
 		assertEquals(List.of(group2), registrarManager.getGroupsForAutoRegistration(session, vo, embeddedGroupsItem));
+	}
+
+	@Test (expected=RelationExistsException.class)
+	public void deleteAttributeRelatedToVoFormAsDestAttr() throws Exception {
+		System.out.println("RegistrarManager.deleteAttributeRelatedToFormAsDestAttr");
+
+		Vo vo = perun.getVosManagerBl().createVo(session, new Vo(0, "voTest", "voTest"));
+		ApplicationForm form = registrarManager.getFormForVo(vo);
+
+		AttributeDefinition attrDef = new AttributeDefinition();
+		attrDef.setDescription("attributesManagerTestAttrDef");
+		attrDef.setFriendlyName("attrDef");
+		attrDef.setNamespace("urn:perun:member:attribute-def:opt");
+		attrDef.setType(String.class.getName());
+		perun.getAttributesManager().createAttribute(session, attrDef);
+
+		ApplicationFormItem item = new ApplicationFormItem();
+		item.setShortname("displayName");
+		item.setPerunDestinationAttribute("urn:perun:member:attribute-def:opt:attrDef");
+		item.setType(ApplicationFormItem.Type.TEXTFIELD);
+		item.setHidden(ApplicationFormItem.Hidden.ALWAYS);
+		item.setUpdatable(false);
+		item.setRequired(true);
+		registrarManager.addFormItem(session, form, item);
+
+		perun.getAttributesManager().deleteAttribute(session, attrDef);
+	}
+
+	@Test (expected=RelationExistsException.class)
+	public void deleteAttributeRelatedToGroupFormAsSrcAttr() throws Exception {
+		System.out.println("RegistrarManager.deleteAttributeRelatedToFormAsDestAttr");
+
+		Vo vo = perun.getVosManagerBl().createVo(session, new Vo(0, "voTest", "voTest"));
+		Group group = perun.getGroupsManagerBl().createGroup(session, vo, new Group("testGroup", "testGroup description"));
+		registrarManager.createApplicationFormInGroup(session, group);
+		ApplicationForm groupForm = registrarManager.getFormForGroup(group);
+
+		Group group2 = perun.getGroupsManagerBl().createGroup(session, vo, new Group("testGroup2", "testGroup2 description"));
+		registrarManager.createApplicationFormInGroup(session, group2);
+		ApplicationForm groupForm2 = registrarManager.getFormForGroup(group2);
+
+		AttributeDefinition attrDef = new AttributeDefinition();
+		attrDef.setDescription("attributesManagerTestAttrDef");
+		attrDef.setFriendlyName("attrDef");
+		attrDef.setNamespace("urn:perun:member:attribute-def:opt");
+		attrDef.setType(String.class.getName());
+		perun.getAttributesManager().createAttribute(session, attrDef);
+
+		ApplicationFormItem item = new ApplicationFormItem();
+		item.setShortname("displayName");
+		item.setPerunSourceAttribute("urn:perun:member:attribute-def:opt:attrDef");
+		item.setType(ApplicationFormItem.Type.TEXTFIELD);
+		item.setHidden(ApplicationFormItem.Hidden.ALWAYS);
+		item.setUpdatable(false);
+		item.setRequired(true);
+		registrarManager.addFormItem(session, groupForm, item);
+
+		ApplicationFormItem item2 = new ApplicationFormItem();
+		item2.setShortname("displayName2");
+		item2.setPerunDestinationAttribute("urn:perun:member:attribute-def:opt:attrDef");
+		item2.setType(ApplicationFormItem.Type.TEXTFIELD);
+		item2.setHidden(ApplicationFormItem.Hidden.ALWAYS);
+		item2.setUpdatable(false);
+		item2.setRequired(true);
+		registrarManager.addFormItem(session, groupForm2, item2);
+
+		perun.getAttributesManager().deleteAttribute(session, attrDef);
 	}
 
 	@Test(expected = GroupNotAllowedToAutoRegistrationException.class)

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/AttributesManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/AttributesManagerMethod.java
@@ -1450,6 +1450,7 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	 * set for any entity
 	 *
 	 * @param attribute int AttributeDefinition <code>id</code>
+	 * @throw RelationExistsException When attribute definition has any relation to some application form item or to some service as a required attribute
 	 */
 	deleteAttribute {
 


### PR DESCRIPTION
* We want to restrict the deletion of the attribute definition if this attribute is required for any service.
* We want to restrict it also for the case when this attribute is a source or a destination attribute of any application form item in some application form.