### PR TITLE
chore: include perun-auditlogger app in release

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -125,6 +125,9 @@
 						"path": "perun-ldapc/target/perun-ldapc.jar"
 					},
 					{
+						"path": "perun-auditlogger/target/perun-auditlogger.jar"
+					},
+					{
 						"path": "perun-web-gui/target/perun-web-gui.war"
 					},
 					{


### PR DESCRIPTION
We need this app to be deployed on some installations, hence it must be included in the release.