### PR TITLE
feat: 🎸 Filter out embedded groups where user is member + new method groupsManager/getGroupsWhereUserIsActiveMember

### DIFF
--- a/perun-base/src/main/resources/perun-roles.yml
+++ b/perun-base/src/main/resources/perun-roles.yml
@@ -2216,6 +2216,15 @@ perun_policies:
     include_policies:
       - default_policy
 
+  getGroupsWhereUserIsActiveMember_User_Vo_policy:
+    policy_roles:
+      - SELF: User
+      - PERUNOBSERVER:
+      - VOOBSERVER: Vo
+      - VOADMIN: Vo
+    include_policies:
+      - default_policy
+
   getRichGroupsAssignedToResourceWithAttributesByNames_Resource_List<String>_policy:
     policy_roles:
       - RESOURCESELFSERVICE: Resource

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/GroupsManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/GroupsManager.java
@@ -1513,4 +1513,14 @@ public interface GroupsManager {
 	 * @throws PrivilegeException if unauthorized
 	 */
 	List<Group> getAllAllowedGroupsToHierarchicalVo(PerunSession sess, Vo vo, Vo memberVo) throws VoNotExistsException, PrivilegeException;
+
+	/**
+	 * Returns groups in which the user is active member. Groups are looked up only for the specified VO
+	 * @param session session
+	 * @param user user object
+	 * @param vo VO object
+	 * @return List of groups
+	 */
+	List<Group> getGroupsWhereUserIsActiveMember(PerunSession session, User user, Vo vo) throws VoNotExistsException, UserNotExistsException, PrivilegeException;
+
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/GroupsManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/GroupsManagerBl.java
@@ -2191,4 +2191,13 @@ public interface GroupsManagerBl {
 	 */
 	List<Group> getAllAllowedGroupsToHierarchicalVo(PerunSession sess, Vo vo, Vo memberVo);
 
+	/**
+	 * Returns groups in which the user is active member. Groups are looked up only for the specified VO.
+	 *
+	 * @param sess session
+	 * @param user user object
+	 * @param vo VO object
+	 * @return List of groups
+	 */
+	List<Group> getGroupsWhereUserIsActiveMember(PerunSession sess, User user, Vo vo);
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
@@ -6084,4 +6084,11 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 	public List<Group> getAllAllowedGroupsToHierarchicalVo(PerunSession sess, Vo vo, Vo memberVo) {
 		return this.groupsManagerImpl.getAllAllowedGroupsToHierarchicalVo(sess, vo, memberVo);
 	}
+
+	@Override
+	public List<Group> getGroupsWhereUserIsActiveMember(PerunSession sess, User user, Vo vo) {
+		List<Group> groups = this.groupsManagerImpl.getGroupsWhereUserIsActiveMember(sess, user, vo);
+		groups.removeIf(g -> VosManager.MEMBERS_GROUP.equals(g.getName()));
+		return groups;
+	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/GroupsManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/GroupsManagerEntry.java
@@ -1746,4 +1746,18 @@ public class GroupsManagerEntry implements GroupsManager {
 
 		return getGroupsManagerBl().getAllAllowedGroupsToHierarchicalVo(sess, vo, memberVo);
 	}
+
+	@Override
+	public List<Group> getGroupsWhereUserIsActiveMember(PerunSession sess, User user, Vo vo)
+		throws VoNotExistsException, UserNotExistsException, PrivilegeException {
+		Utils.checkPerunSession(sess);
+		getPerunBl().getVosManagerBl().checkVoExists(sess, vo);
+		getPerunBl().getUsersManagerBl().checkUserExists(sess, user);
+
+		if (!AuthzResolver.authorizedInternal(sess, "getGroupsWhereUserIsActiveMember_User_Vo_policy", user, vo)) {
+			throw new PrivilegeException(sess, "getGroupsWhereUserIsActiveMember");
+		}
+
+		return getGroupsManagerBl().getGroupsWhereUserIsActiveMember(sess, user, vo);
+	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/GroupsManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/GroupsManagerImpl.java
@@ -1469,6 +1469,18 @@ public class GroupsManagerImpl implements GroupsManagerImplApi {
 		}
 	}
 
+	@Override
+	public List<Group> getGroupsWhereUserIsActiveMember(PerunSession sess, User user, Vo vo) {
+		try {
+			return jdbc.query("SELECT " + groupMappingSelectQuery + " FROM groups WHERE groups.vo_id=? AND groups.id IN " +
+				"(SELECT groups_members.group_id FROM groups_members WHERE groups_members.source_group_status = ? AND groups_members.member_id IN " +
+					"(SELECT members.id FROM members WHERE members.user_id = ? AND members.vo_id = ?))",
+				GROUP_MAPPER, vo.getId(), MemberGroupStatus.VALID.getCode(), user.getId(), vo.getId());
+		}  catch (RuntimeException e) {
+			throw new InternalErrorException(e);
+		}
+	}
+
 	private String getSQLWhereForGroupsPage(GroupsPageQuery query, MapSqlParameterSource namedParams) {
 		if (isEmpty(query.getSearchString())) {
 			return "";

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/GroupsManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/GroupsManagerImplApi.java
@@ -1025,4 +1025,15 @@ public interface GroupsManagerImplApi {
 	 * @return list of allowed groups to hierarchical VO
 	 */
 	List<Group> getAllAllowedGroupsToHierarchicalVo(PerunSession sess, Vo vo, Vo memberVo);
+
+
+	/**
+	 * Returns groups in which the user is active member. Groups are looked up only for the specified VO.
+	 *
+	 * @param sess session
+	 * @param user user object
+	 * @param vo VO object
+	 * @return List of groups
+	 */
+	List<Group> getGroupsWhereUserIsActiveMember(PerunSession sess, User user, Vo vo);
 }

--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -13888,7 +13888,6 @@ paths:
           $ref: '#/components/responses/ListOfGroupsResponse'
         default:
           $ref: '#/components/responses/ExceptionResponse'
-
   /json/groupsManager/getGroupsWhereMemberIsActive:
     get:
       tags:
@@ -13897,6 +13896,20 @@ paths:
       summary: Returns list of groups where member is in active state.
       parameters:
         - $ref: '#/components/parameters/memberId'
+      responses:
+        '200':
+          $ref: '#/components/responses/ListOfGroupsResponse'
+        default:
+          $ref: '#/components/responses/ExceptionResponse'
+  /json/groupsManager/getGroupsWhereUserIsActiveMember:
+    get:
+      tags:
+        - GroupsManager
+      operationId: getGroupsWhereUserIsActiveMember
+      summary: Returns list of groups where user is member in active state. Groups are looked up only for the specfied VO.
+      parameters:
+        - $ref: '#/components/parameters/userId'
+        - $ref: '#/components/parameters/voId'
       responses:
         '200':
           $ref: '#/components/responses/ListOfGroupsResponse'

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/GroupsManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/GroupsManagerMethod.java
@@ -1881,6 +1881,28 @@ public enum GroupsManagerMethod implements ManagerMethod {
 	},
 
 	/*#
+	 * Returns all user's groups where user is in active state (is valid there) and are subgroups of the specified VO
+	 * Excluded members group.
+	 *
+	 * @throw UserNotExistsException When the user does not exist
+	 * @throw VoNotExistsException When the vo doesn't exist
+	 *
+	 * @param user int <code>id</code> of user
+	 * @param vo int <code>id</code> of vo in which groups are looked up
+	 * @return List<Group> Groups where user is in active state (valid), if the user is member of the given vo
+	 */
+	getGroupsWhereUserIsActiveMember {
+		@Override
+		public List<Group> call(ApiCaller ac, Deserializer parms) throws PerunException {
+			return ac.getGroupsManager().getGroupsWhereUserIsActiveMember(
+				ac.getSession(),
+				ac.getUserById(parms.readInt("user")),
+				ac.getVoById(parms.readInt("vo"))
+			);
+		}
+	},
+
+	/*#
 	 * Return all members of the group who are active (valid) in the group.
 	 *
 	 * Do not return expired members of the group.


### PR DESCRIPTION
- added new method to RPC groupsManager/getGroupsWhereUserIsActiveMember
- implementation of filtering out groups in which the user is already member for EMBEDDED GROUPS form item
  - if left with no groups to choose, the input is removed from the form displayed to the user