### PR TITLE
feat: use journald instead of syslog in perun-auditlogger

### DIFF
--- a/perun-auditlogger/src/main/java/cz/metacentrum/perun/auditlogger/logger/impl/EventLoggerImpl.java
+++ b/perun-auditlogger/src/main/java/cz/metacentrum/perun/auditlogger/logger/impl/EventLoggerImpl.java
@@ -1,9 +1,7 @@
 package cz.metacentrum.perun.auditlogger.logger.impl;
 
-import cz.metacentrum.perun.audit.events.AuditEvent;
 import cz.metacentrum.perun.auditlogger.logger.EventLogger;
 import cz.metacentrum.perun.auditlogger.service.AuditLoggerManager;
-import cz.metacentrum.perun.auditparser.AuditParser;
 import cz.metacentrum.perun.core.api.AuditMessage;
 import cz.metacentrum.perun.core.api.Perun;
 import cz.metacentrum.perun.core.api.PerunSession;
@@ -37,9 +35,9 @@ public class EventLoggerImpl implements EventLogger, Runnable {
 
 	private static final DateFormat DATE_FORMAT = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss");
 
-	private static final String SYSLOG_LOGGER_NAME = "syslog-logger";
+	private static final String AUDIT_LOGGER_NAME = "journal-audit";
 
-	private static final Logger syslog = LoggerFactory.getLogger(SYSLOG_LOGGER_NAME);
+	private static final Logger journal = LoggerFactory.getLogger(AUDIT_LOGGER_NAME);
 
 	private static final Map<Class<?>,Class<?>> mixinMap = new HashMap<>();
 	private static final ObjectMapper mapper = new ObjectMapper();
@@ -108,7 +106,7 @@ public class EventLoggerImpl implements EventLogger, Runnable {
 							log.debug("SKIP FLAG WARNING: lastProcessedIdNumber: {} - newMessageNumber: {} = {}",
 									lastProcessedIdNumber, message.getId(), (lastProcessedIdNumber - message.getId()));
 					}
-					//IMPORTANT STEP2: send all messages to syslog
+					//IMPORTANT STEP2: send all messages to journal
 					if(this.logMessage(message) == 0) {
 						messagesIterator.remove();
 						lastProcessedIdNumber = message.getId();
@@ -149,7 +147,7 @@ public class EventLoggerImpl implements EventLogger, Runnable {
 	@Override
 	public int logMessage(AuditMessage message) {
 		try {
-			syslog.info(mapper.writeValueAsString(message));
+			journal.info(mapper.writeValueAsString(message));
 		} catch (JsonProcessingException e) {
 			return -1;
 		}

--- a/perun-auditlogger/src/main/java/cz/metacentrum/perun/auditlogger/service/impl/AuditLoggerManagerImpl.java
+++ b/perun-auditlogger/src/main/java/cz/metacentrum/perun/auditlogger/service/impl/AuditLoggerManagerImpl.java
@@ -20,18 +20,18 @@ public class AuditLoggerManagerImpl implements AuditLoggerManager {
 
 	private final static String DEFAULT_CONSUMER_NAME = "auditlogger";
 	private final static String DEFAULT_STATE_FILE = "./auditlogger.state";
-	
+
 	private Thread eventProcessorThread;
 	@Autowired
 	private EventLogger eventLogger;
-	@Autowired 
+	@Autowired
 	private Properties propertiesBean;
-	
+
 	private PerunPrincipal perunPrincipal;
 	private Perun perunBl;
 	private PerunSession perunSession;
 
-	
+
 	public void startProcessingEvents() {
 		eventProcessorThread = new Thread(eventLogger);
 		eventProcessorThread.start();

--- a/perun-auditlogger/src/main/resources/logback.xml
+++ b/perun-auditlogger/src/main/resources/logback.xml
@@ -2,18 +2,12 @@
 
 	<contextName>perun-auditlogger</contextName>
 
-	<!-- variables defining the destination for syslog messages -->
-	<variable name="SYSLOG_HOST" value="${auditlogger.syslog.host:-localhost}" />
-	<variable name="SYSLOG_FACILITY" value="${auditlogger.syslog.facility:-LOCAL0}" />
-
 	<!-- variable defining the directory where log files will be put, takes system property perun.log -->
 	<variable name="LOGDIR" value="${perun.log:-/var/log/perun/}" />
 
 	<!-- production setting for format of log lines -->
 	<variable name="ENCODER_PATTERN" value="%date [%thread] %-5level %logger{35} - %msg%n"/>
 
-	<!-- variables configuring syslog parameters -->
-	
 	<appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="perun-auditlogger">
 		<file>${LOGDIR}perun-auditlogger.log</file>
 		<!-- see https://logback.qos.ch/manual/appenders.html#SizeAndTimeBasedRollingPolicy -->
@@ -28,24 +22,27 @@
 		</encoder>
 	</appender>
 
-	<appender class="ch.qos.logback.classic.net.SyslogAppender" name="syslog-appender">
-	    <syslogHost>${SYSLOG_HOST}</syslogHost>
-    	<facility>${SYSLOG_FACILITY}</facility>
-    	<suffixPattern>%msg</suffixPattern>
-    	<throwableExcluded>true</throwableExcluded>
-	</appender>
-	
 	<root level="info">
 		<appender-ref ref="perun-auditlogger"/>
 	</root>
 
 	<logger name="cz.metacentrum.perun.auditlogger" level="debug"/>
-	
-	<logger name="syslog-logger" level="debug" additivity="false">
-		<appender-ref ref="syslog-appender" />
-	</logger>
 
 	<!-- keep Spring quiet -->
 	<logger name="org.springframework" level="warn"/>
+
+	<!-- Actual audit messages logging -->
+	<appender class="org.gnieh.logback.SystemdJournalAppender" name="journal-audit">
+		<syslogIdentifier>perun_audit</syslogIdentifier>
+		<logLoggerName>true</logLoggerName>
+		<logStacktrace>false</logStacktrace>
+		<encoder>
+			<pattern>%msg</pattern>
+		</encoder>
+	</appender>
+
+	<logger name="journal-audit" level="info" additivity="false">
+		<appender-ref ref="journal-audit" />
+	</logger>
 
 </configuration>

--- a/perun-auditlogger/src/main/resources/perun-auditlogger.xml
+++ b/perun-auditlogger/src/main/resources/perun-auditlogger.xml
@@ -28,8 +28,8 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 	<bean id="defaultProperties" class="org.springframework.beans.factory.config.PropertiesFactoryBean">
 		<property name="properties">
 			<props>
-				<prop key="auditlogger.syslog.host">localhost</prop>
-				<prop key="auditlogger.syslog.facility">LOCAL0</prop>
+				<prop key="auditlogger.consumer">auditlogger</prop>
+				<prop key="auditlogger.statefile">./perun-auditlogger-last-state</prop>
 			</props>
 		</property>
 	</bean>


### PR DESCRIPTION
Removed all usage and references to syslog, since it was replaced with journald logging.

BREAKING CHANGE: Auditlogger no longer writes audit messages to the syslog. All configuration related to usage of syslog is ignored and can be removed from /etc/perun/perun-auditlogger and /etc/perun/perun-auditlogger.properties. Make sure journald is present and configured on the machine before deploying.