### PR TITLE
feat: 🎸 Allow multiple reg. modules to be configured

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/registrar/model/ApplicationForm.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/registrar/model/ApplicationForm.java
@@ -2,6 +2,10 @@ package cz.metacentrum.perun.registrar.model;
 
 import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.Vo;
+import org.springframework.util.StringUtils;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Application form of a VO. Use {@link cz.metacentrum.perun.registrar.RegistrarManager#getFormItems} for items.
@@ -16,7 +20,7 @@ public class ApplicationForm {
 	private boolean automaticApproval;
 	private boolean automaticApprovalExtension;
 	private boolean automaticApprovalEmbedded;
-	private String moduleClassName;
+	private final List<String> moduleClassNames = new ArrayList<>();
 
 	public ApplicationForm() {
 	}
@@ -69,12 +73,29 @@ public class ApplicationForm {
 		this.automaticApprovalEmbedded = automaticApprovalEmbedded;
 	}
 
-	public String getModuleClassName() {
-		return moduleClassName;
+	public List<String> getModuleClassNames() {
+		return new ArrayList<>(moduleClassNames);
 	}
 
-	public void setModuleClassName(String moduleClassName) {
-		this.moduleClassName = moduleClassName;
+	public void setModuleClassNames(List<String> moduleClassNames) {
+		this.moduleClassNames.clear();
+		for (String moduleClassName : moduleClassNames) {
+			if (StringUtils.hasText(moduleClassName)) {
+				this.moduleClassNames.add(moduleClassName);
+			}
+		}
+	}
+
+	public void addModuleClassName(String moduleClassName) {
+		if (StringUtils.hasText(moduleClassName)) {
+			this.moduleClassNames.add(moduleClassName);
+		}
+	}
+
+	public void removeModuleClassName(String moduleClassName) {
+		if (StringUtils.hasText(moduleClassName)) {
+			this.moduleClassNames.remove(moduleClassName);
+		}
 	}
 
 	/**
@@ -94,7 +115,7 @@ public class ApplicationForm {
 			", group='" + getGroup() + '\'' +
 			", automaticApproval='" + isAutomaticApproval() + '\'' +
 			", automaticApprovalExtension='" + isAutomaticApprovalExtension() + '\'' +
-			", moduleClassName='" + getModuleClassName() + '\'' +
+			", moduleClassNames='" + getModuleClassNames() + '\'' +
 			"]";
 	}
 

--- a/perun-base/src/test/resources/test-schema.sql
+++ b/perun-base/src/test/resources/test-schema.sql
@@ -1,4 +1,4 @@
--- database version 3.2.17 (don't forget to update insert statement at the end of file)
+-- database version 3.2.18 (don't forget to update insert statement at the end of file)
 CREATE EXTENSION IF NOT EXISTS "unaccent";
 CREATE EXTENSION IF NOT EXISTS "pgcrypto";
 
@@ -539,7 +539,7 @@ create table application_form (
 								   automatic_approval boolean default false not null, --approval of application is automatic
 								   automatic_approval_extension boolean default false not null, --approval of extension is automatic
 								   automatic_approval_embedded boolean default false not null, --approval of embedded application is automatic
-								   module_name varchar,  --name of module which processes application
+								   module_names varchar,      --name of modules (separated by comma) which are called when processing application
 								   group_id integer,          --identifier of group (groups.id) if application is for group
 								   created_by_uid integer,
 								   modified_by_uid integer,
@@ -1908,7 +1908,7 @@ create index idx_fk_attr_critops ON attribute_critical_actions(attr_id);
 create index app_state_idx ON application (state);
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.2.17');
+insert into configurations values ('DATABASE VERSION','3.2.18');
 -- insert membership types
 insert into membership_types (id, membership_type, description) values (1, 'DIRECT', 'Member is directly added into group');
 insert into membership_types (id, membership_type, description) values (2, 'INDIRECT', 'Member is added indirectly through UNION relation');

--- a/perun-cli/Perun/beans/ApplicationForm.pm
+++ b/perun-cli/Perun/beans/ApplicationForm.pm
@@ -59,14 +59,14 @@ sub TO_JSON
                 $automaticApprovalExtension = undef;
         }
 
-        my $moduleClassName;
-        if (defined($self->{_moduleClassName})) {
-                $moduleClassName = "$self->{_moduleClassName}";
+        my @moduleClassNames;
+        if (defined($self->{_moduleClassNames})) {
+                @moduleClassNames = @{$self->{_moduleClassNames}};
         } else {
-                $moduleClassName = undef;
+                @moduleClassNames = undef;
         }
 
-        return { id => $id, vo => $vo, group => $group, automaticApproval => $automaticApproval, automaticApprovalExtension => $automaticApprovalExtension, moduleClassName => $moduleClassName };
+        return { id => $id, vo => $vo, group => $group, automaticApproval => $automaticApproval, automaticApprovalExtension => $automaticApprovalExtension, moduleClassNames => \@moduleClassNames };
 }
 
 sub getId
@@ -138,17 +138,17 @@ sub setAutomaticApprovalExtension
 
 }
 
-sub getModuleClassName
+sub getModuleClassNames
 {
         my $self = shift;
 
-        return $self->{_moduleClassName};
+        return $self->{_moduleClassNames};
 }
 
-sub setModuleClassName
+sub setModuleClassNames
 {
         my $self = shift;
-        $self->{_moduleClassName} = shift;
+        $self->{_moduleClassNames} = shift;
 }
 
 1;

--- a/perun-cli/updateForm
+++ b/perun-cli/updateForm
@@ -16,7 +16,7 @@ sub help {
 	--groupId        | -g group id
 	--autApproval    | -a automatic approval (1/0)
 	--autApprovalExt | -e automatic approval extension (1/0)
-	--moduleName     | -n name of module
+	--moduleNames    | -n name of module, can be specified multiple times
 	--batch          | -b batch
 	--help           | -h prints this help
 
@@ -24,17 +24,17 @@ sub help {
 }
 
 our $batch;
-my ($voId, $groupId, $moduleName, $app, $appE);
+my ($voId, $groupId, @moduleNames, $app, $appE);
 GetOptions ("help|h" => sub {
 		print help();
 		exit 0;
 	},
-	"batch|b"            => \$batch,
-	"voId|g=i"           => \$voId,
-	"groupId|g=i"        => \$groupId,
-	"autApproval|a=s"    => \$app,
-	"autApprovalExt|e=s" => \$appE,
-	"moduleName|n=s"     => \$moduleName ) || die help();
+	"batch|b"              => \$batch,
+	"voId|g=i"             => \$voId,
+	"groupId|g=i"          => \$groupId,
+	"autApproval|a=s"      => \$app,
+	"autApprovalExt|e=s"   => \$appE,
+	'moduleNames|n=s@{1,}' => \@moduleNames ) || die help();
 
 # Check options
 if (not defined $groupId and not defined $voId) { die "ERROR: voId or groupId is required \n";}
@@ -56,9 +56,9 @@ if (defined $app) {
 if (defined $appE) {
 	$applicationForm->setAutomaticApprovalExtension($appE);
 }	
-if (defined $moduleName) {
-	$applicationForm->setModuleClassName($moduleName);
-}	
+if (defined \@moduleNames) {
+	$applicationForm->setModuleClassNames(\@moduleNames);
+}
 
 $registrarAgent->updateForm( form => $applicationForm );
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/GroupsManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/GroupsManagerImpl.java
@@ -53,6 +53,7 @@ import javax.sql.DataSource;
 import java.sql.Array;
 import java.sql.ResultSet;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -89,7 +90,7 @@ public class GroupsManagerImpl implements GroupsManagerImplApi {
 	protected final static String assignedGroupMappingSelectQuery = groupMappingSelectQuery + ", groups_resources_state.status as groups_resources_state_status, " +
 		"groups_resources_automatic.auto_assign_subgroups as auto_assign_subgroups, groups_resources_state.failure_cause as groups_resources_state_failure_cause, groups_resources_automatic.source_group_id as groups_resources_automatic_source_group_id";
 
-	private static final String applicationFormMappingSelectQuery = "id,vo_id,group_id,automatic_approval,automatic_approval_extension,automatic_approval_embedded,module_name from application_form";
+	private static final String applicationFormMappingSelectQuery = "id,vo_id,group_id,automatic_approval,automatic_approval_extension,automatic_approval_embedded,module_names from application_form";
 
 	// http://static.springsource.org/spring/docs/3.0.x/spring-framework-reference/html/jdbc.html
 	private final JdbcPerunTemplate jdbc;
@@ -1405,7 +1406,9 @@ public class GroupsManagerImpl implements GroupsManagerImplApi {
 				form.setAutomaticApproval(resultSet.getBoolean("automatic_approval"));
 				form.setAutomaticApprovalExtension(resultSet.getBoolean("automatic_approval_extension"));
 				form.setAutomaticApprovalEmbedded(resultSet.getBoolean("automatic_approval_embedded"));
-				form.setModuleClassName(resultSet.getString("module_name"));
+				if (resultSet.getString("module_names") != null) {
+					form.setModuleClassNames(Arrays.asList(resultSet.getString("module_names").split(",")));
+				}
 				Vo vo = new Vo();
 				vo.setId(resultSet.getInt("vo_id"));
 				form.setVo(vo);

--- a/perun-core/src/main/resources/postgresChangelog.txt
+++ b/perun-core/src/main/resources/postgresChangelog.txt
@@ -6,6 +6,10 @@
 -- Directly under version number should be version commands. They will be executed in the order they are written here.
 -- Comments are prefixed with -- and can be written only between version blocks, that means not in the lines with commands. They have to be at the start of the line.
 
+3.2.18
+ALTER TABLE application_form RENAME COLUMN module_name TO module_names;
+UPDATE configurations SET value='3.2.18' WHERE property='DATABASE VERSION';
+
 3.2.17
 ALTER TABLE attribute_critical_actions ADD COLUMN global boolean default false not null;
 UPDATE configurations SET value='3.2.17' WHERE property='DATABASE VERSION';

--- a/perun-db/postgres.sql
+++ b/perun-db/postgres.sql
@@ -1,4 +1,4 @@
--- database version 3.2.17 (don't forget to update insert statement at the end of file)
+-- database version 3.2.18 (don't forget to update insert statement at the end of file)
 
 -- VOS - virtual organizations
 create table vos (
@@ -537,7 +537,7 @@ create table application_form (
 	automatic_approval boolean default false not null, --approval of application is automatic
 	automatic_approval_extension boolean default false not null, --approval of extension is automatic
 	automatic_approval_embedded boolean default false not null, --approval of embedded application is automatic
-	module_name varchar,  --name of module which processes application
+	module_names varchar,      --name of modules (separated by comma) which are called when processing application
 	group_id integer,          --identifier of group (groups.id) if application is for group
 	created_by_uid integer,
 	modified_by_uid integer,
@@ -2017,7 +2017,7 @@ grant all on blocked_logins to perun;
 grant all on auto_registration_groups to perun;
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.2.17');
+insert into configurations values ('DATABASE VERSION','3.2.18');
 
 -- insert membership types
 insert into membership_types (id, membership_type, description) values (1, 'DIRECT', 'Member is directly added into group');

--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -1021,7 +1021,10 @@ components:
         automaticApproval: { type: boolean }
         automaticApprovalExtension: { type: boolean }
         automaticApprovalEmbedded: { type: boolean }
-        moduleClassName: { type: string }
+        moduleClassNames:
+          type: array
+          items:
+            type: string
 
     Type:
       type: string

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
@@ -140,6 +140,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -861,7 +862,9 @@ public class RegistrarManagerImpl implements RegistrarManager {
 				form.setAutomaticApproval(resultSet.getBoolean("automatic_approval"));
 				form.setAutomaticApprovalExtension(resultSet.getBoolean("automatic_approval_extension"));
 				form.setAutomaticApprovalEmbedded(resultSet.getBoolean("automatic_approval_embedded"));
-				form.setModuleClassName(resultSet.getString("module_name"));
+				if (resultSet.getString("module_names") != null) {
+					form.setModuleClassNames(Arrays.asList(resultSet.getString("module_names").split(",")));
+				}
 				form.setVo(vo);
 				return form;
 			}, vo.getId());
@@ -885,7 +888,9 @@ public class RegistrarManagerImpl implements RegistrarManager {
 				form.setAutomaticApproval(resultSet.getBoolean("automatic_approval"));
 				form.setAutomaticApprovalExtension(resultSet.getBoolean("automatic_approval_extension"));
 				form.setAutomaticApprovalEmbedded(resultSet.getBoolean("automatic_approval_embedded"));
-				form.setModuleClassName(resultSet.getString("module_name"));
+				if (resultSet.getString("module_names") != null) {
+					form.setModuleClassNames(Arrays.asList(resultSet.getString("module_names").split(",")));
+				}
 				form.setGroup(group);
 				try {
 					form.setVo(vosManager.getVoById(registrarSession, group.getVoId()));
@@ -912,7 +917,9 @@ public class RegistrarManagerImpl implements RegistrarManager {
 				form1.setAutomaticApproval(resultSet.getBoolean("automatic_approval"));
 				form1.setAutomaticApprovalExtension(resultSet.getBoolean("automatic_approval_extension"));
 				form1.setAutomaticApprovalEmbedded(resultSet.getBoolean("automatic_approval_embedded"));
-				form1.setModuleClassName(resultSet.getString("module_name"));
+				if (resultSet.getString("module_names") != null) {
+					form1.setModuleClassNames(Arrays.asList(resultSet.getString("module_names").split(",")));
+				}
 				try {
 					form1.setVo(vosManager.getVoById(sess, resultSet.getInt("vo_id")));
 				} catch (Exception ex) {
@@ -959,7 +966,9 @@ public class RegistrarManagerImpl implements RegistrarManager {
 				form1.setAutomaticApproval(resultSet.getBoolean("automatic_approval"));
 				form1.setAutomaticApprovalExtension(resultSet.getBoolean("automatic_approval_extension"));
 				form1.setAutomaticApprovalEmbedded(resultSet.getBoolean("automatic_approval_embedded"));
-				form1.setModuleClassName(resultSet.getString("module_name"));
+				if (resultSet.getString("module_names") != null) {
+					form1.setModuleClassNames(Arrays.asList(resultSet.getString("module_names").split(",")));
+				}
 				try {
 					form1.setVo(vosManager.getVoById(sess, resultSet.getInt("vo_id")));
 				} catch (Exception ex) {
@@ -1251,8 +1260,8 @@ public class RegistrarManagerImpl implements RegistrarManager {
 
 		perun.getAuditer().log(user, new FormUpdated((form)));
 		return jdbc.update(
-				"update application_form set automatic_approval=?, automatic_approval_extension=?, automatic_approval_embedded=?, module_name=? where id=?",
-				form.isAutomaticApproval(), form.isAutomaticApprovalExtension(), form.isAutomaticApprovalEmbedded(), form.getModuleClassName(), form.getId());
+				"update application_form set automatic_approval=?, automatic_approval_extension=?, automatic_approval_embedded=?, module_names=? where id=?",
+				form.isAutomaticApproval(), form.isAutomaticApprovalExtension(), form.isAutomaticApprovalEmbedded(), String.join(",", form.getModuleClassNames()), form.getId());
 	}
 
 	@Transactional
@@ -1514,14 +1523,16 @@ public class RegistrarManagerImpl implements RegistrarManager {
 			}
 
 			// call registrar module before auto validation so createAction is trigerred first
-			RegistrarModule module;
+			Set<RegistrarModule> modules;
 			if (application.getGroup() != null) {
-				module = getRegistrarModule(getFormForGroup(application.getGroup()));
+				modules = getRegistrarModules(getFormForGroup(application.getGroup()));
 			} else {
-				module = getRegistrarModule(getFormForVo(application.getVo()));
+				modules = getRegistrarModules(getFormForVo(application.getVo()));
 			}
-			if (module != null) {
-				module.createApplication(session, application, data);
+			if (!modules.isEmpty()) {
+				for (RegistrarModule module: modules) {
+					module.createApplication(session, application, data);
+				}
 			}
 
 		} catch (ApplicationNotCreatedException ex) {
@@ -1695,14 +1706,16 @@ public class RegistrarManagerImpl implements RegistrarManager {
 			perun.getAuditer().log(sess, new ApplicationRejected(app));
 
 			// call registrar module
-			RegistrarModule module;
+			Set<RegistrarModule> modules;
 			if (app.getGroup() != null) {
-				module = getRegistrarModule(getFormForGroup(app.getGroup()));
+				modules = getRegistrarModules(getFormForGroup(app.getGroup()));
 			} else {
-				module = getRegistrarModule(getFormForVo(app.getVo()));
+				modules = getRegistrarModules(getFormForVo(app.getVo()));
 			}
-			if (module != null) {
-				module.rejectApplication(sess, app, reason);
+			if (!modules.isEmpty()) {
+				for (RegistrarModule module: modules) {
+					module.rejectApplication(sess, app, reason);
+				}
 			}
 
 			// send mail
@@ -1966,16 +1979,16 @@ public class RegistrarManagerImpl implements RegistrarManager {
 		PerunPrincipal applicationPrincipal = new PerunPrincipal(app.getCreatedBy(), app.getExtSourceName(), app.getExtSourceType(), app.getExtSourceLoa(), additionalAttributes);
 
 		// get registrar module
-		RegistrarModule module;
+		Set<RegistrarModule> modules;
 		if (app.getGroup() != null) {
-			module = getRegistrarModule(getFormForGroup(app.getGroup()));
+			modules = getRegistrarModules(getFormForGroup(app.getGroup()));
 		} else {
-			module = getRegistrarModule(getFormForVo(app.getVo()));
+			modules = getRegistrarModules(getFormForVo(app.getVo()));
 		}
-
-		if (module != null) {
-			// call custom logic before approving
-			module.beforeApprove(sess, app);
+		if (!modules.isEmpty()) {
+			for (RegistrarModule module: modules) {
+				module.beforeApprove(sess, app);
+			}
 		}
 
 		// mark as APPROVED
@@ -2208,8 +2221,10 @@ public class RegistrarManagerImpl implements RegistrarManager {
 		}
 
 		// CONTINUE FOR BOTH APP TYPES
-		if (module != null) {
-			module.approveApplication(sess, app);
+		if (!modules.isEmpty()) {
+			for (RegistrarModule module: modules) {
+				module.approveApplication(sess, app);
+			}
 		}
 
 
@@ -2241,16 +2256,16 @@ public class RegistrarManagerImpl implements RegistrarManager {
 		}
 
 		// get registrar module
-		RegistrarModule module;
+		Set<RegistrarModule> modules;
 		if (application.getGroup() != null) {
-			module = getRegistrarModule(getFormForGroup(application.getGroup()));
+			modules = getRegistrarModules(getFormForGroup(application.getGroup()));
 		} else {
-			module = getRegistrarModule(getFormForVo(application.getVo()));
+			modules = getRegistrarModules(getFormForVo(application.getVo()));
 		}
-
-		if (module != null) {
-			// call custom logic before approving
-			module.canBeApproved(session, application);
+		if (!modules.isEmpty()) {
+			for (RegistrarModule module: modules) {
+				module.canBeApproved(session, application);
+			}
 		}
 
 		// generally for Group applications:
@@ -2764,8 +2779,12 @@ public class RegistrarManagerImpl implements RegistrarManager {
 		// throws exception if user couldn't submit application - no reason to get form
 		checkDuplicateRegistrationAttempt(sess, appType, form);
 
-		RegistrarModule module = getRegistrarModule(form);
-		if (module != null) module.canBeSubmitted(sess, appType, federValues);
+		Set<RegistrarModule> modules = getRegistrarModules(form);;
+		if (!modules.isEmpty()) {
+			for (RegistrarModule module: modules) {
+				module.canBeSubmitted(sess , appType, federValues);
+			}
+		}
 
 		// PROCEED
 		Map<String, String> parsedName = extractNames(federValues);
@@ -2981,8 +3000,11 @@ public class RegistrarManagerImpl implements RegistrarManager {
 			}
 		}
 
-		if (module != null) {
-			module.processFormItemsWithData(sess, appType, form, itemsWithValues);
+
+		if (!modules.isEmpty()) {
+			for (RegistrarModule module: modules) {
+				module.processFormItemsWithData(sess, appType, form, itemsWithValues);
+			}
 		}
 
 		if (!noPrefilledUneditableRequiredItems.isEmpty()) {
@@ -4192,34 +4214,34 @@ public class RegistrarManagerImpl implements RegistrarManager {
 	 * @param form application form
 	 * @return RegistrarModule if present or null
 	 */
-	private RegistrarModule getRegistrarModule(ApplicationForm form) {
-
+	private Set<RegistrarModule> getRegistrarModules(ApplicationForm form) {
 		if (form == null) {
 			// wrong input
 			log.error("[REGISTRAR] Application form is null when getting it's registrar module.");
 			throw new NullPointerException("Application form is null when getting it's registrar module.");
 		}
 
-		if (form.getModuleClassName() != null && !form.getModuleClassName().trim().isEmpty()) {
+		Set<RegistrarModule> modules = new LinkedHashSet<>();
+		if (!form.getModuleClassNames().isEmpty()) {
 
 			RegistrarModule module = null;
 
-			try {
-				log.debug("[REGISTRAR] Attempting to instantiate class: {}", MODULE_PACKAGE_PATH + form.getModuleClassName());
-				module = (RegistrarModule) Class.forName(MODULE_PACKAGE_PATH + form.getModuleClassName()).newInstance();
-				module.setRegistrar(registrarManager);
-			} catch (Exception ex) {
-				log.error("[REGISTRAR] Exception when instantiating module.", ex);
-				return module;
+			for (String regModule : form.getModuleClassNames()) {
+				try {
+					log.debug("[REGISTRAR] Attempting to instantiate class: {}{}", MODULE_PACKAGE_PATH, regModule);
+					module = (RegistrarModule) Class.forName(MODULE_PACKAGE_PATH + regModule)
+						.getDeclaredConstructor().newInstance();
+					module.setRegistrar(registrarManager);
+				} catch (Exception ex) {
+					log.error("[REGISTRAR] Exception when instantiating module. Skipping module {}{}",
+						MODULE_PACKAGE_PATH, regModule, ex);
+					continue;
+				}
+				log.debug("[REGISTRAR] Class {}{} successfully created.", MODULE_PACKAGE_PATH, regModule);
+				modules.add(module);
 			}
-			log.debug("[REGISTRAR] Class {} successfully created.", MODULE_PACKAGE_PATH + form.getModuleClassName());
-
-			return module;
-
 		}
-
-		return null;
-
+		return modules;
 	}
 
 	/**
@@ -5251,7 +5273,7 @@ public class RegistrarManagerImpl implements RegistrarManager {
 
 	private static final String APP_TYPE_SELECT = "select apptype from application_form_item_apptypes";
 
-	private static final String FORM_SELECT = "select id,vo_id,group_id,automatic_approval,automatic_approval_extension,automatic_approval_embedded,module_name from application_form";
+	private static final String FORM_SELECT = "select id,vo_id,group_id,automatic_approval,automatic_approval_extension,automatic_approval_embedded,module_names from application_form";
 
 	private static final String FORM_ITEM_SELECT = "select id,ordnum,shortname,required,type,fed_attr,src_attr,dst_attr,regex,hidden,disabled,hidden_dependency_item_id,disabled_dependency_item_id,updatable from application_form_items";
 

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/EscPithiaOrganizations.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/EscPithiaOrganizations.java
@@ -31,7 +31,6 @@ import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.bl.PerunBl;
 import cz.metacentrum.perun.core.blImpl.AuthzResolverBlImpl;
-import cz.metacentrum.perun.registrar.exceptions.FormNotExistsException;
 import cz.metacentrum.perun.registrar.exceptions.RegistrarException;
 import cz.metacentrum.perun.registrar.model.Application;
 import cz.metacentrum.perun.registrar.model.ApplicationForm;
@@ -123,7 +122,7 @@ public class EscPithiaOrganizations extends DefaultRegistrarModule {
 			ApplicationForm newForm = null;
 			try {
 				newForm = registrar.getFormForGroup(organizationAdminsGroup);
-				newForm.setModuleClassName("EscPithiaOrganizationAdmins");
+				newForm.setModuleClassNames(List.of("EscPithiaOrganizationAdmins"));
 				registrar.updateForm(session, newForm);
 			} catch (PerunException e) {
 				throw new InternalErrorException("Can't set registration module to the admins groups!", e);

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/RegistrarManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/RegistrarManagerMethod.java
@@ -421,7 +421,7 @@ public enum RegistrarManagerMethod implements ManagerMethod {
 	/*#
 	 * Updates the form attributes, not the form items.
 	 * - update automatic approval style
-	 * - update module_name
+	 * - update module_names
 	 *
 	 * @param form ApplicationForm Application form JSON object
 	 * @return ApplicationForm Updated application form or null when update failed

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/registrarManager/GetApplicationForm.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/registrarManager/GetApplicationForm.java
@@ -146,9 +146,9 @@ public class GetApplicationForm implements JsonCallback {
 					ft.setHTML(1, 0, "<strong>EXTENSION: </strong>");
 					if (groupForm && hasEmbeddedGroupApplication) {
 						ft.setHTML(2, 0, "<strong>EMBEDDED: </strong>");
-						ft.setHTML(3, 0, "<strong>Module name: </strong>");
+						ft.setHTML(3, 0, "<strong>Module names (comma separated list): </strong>");
 					} else {
-						ft.setHTML(2, 0, "<strong>Module name: </strong>");
+						ft.setHTML(2, 0, "<strong>Module names (comma separated list): </strong>");
 					}
 
 
@@ -156,7 +156,7 @@ public class GetApplicationForm implements JsonCallback {
 					final ListBox lbInit = new ListBox();
 					final ListBox lbExt = new ListBox();
 					final ListBox lbEmbed = new ListBox();
-					final TextBox className = new TextBox();
+					final TextBox classNames = new TextBox();
 
 					lbInit.addItem("Automatic", "true");
 					lbInit.addItem("Manual", "false");
@@ -173,7 +173,7 @@ public class GetApplicationForm implements JsonCallback {
 					} else {
 						lbExt.setSelectedIndex(1);
 					}
-					className.setText(form.getModuleClassName());
+					classNames.setText(form.getModuleClassNames());
 
 					ft.setWidget(0, 1, lbInit);
 					ft.setWidget(1, 1, lbExt);
@@ -188,9 +188,9 @@ public class GetApplicationForm implements JsonCallback {
 						}
 
 						ft.setWidget(2, 1, lbEmbed);
-						ft.setWidget(3, 1, className);
+						ft.setWidget(3, 1, classNames);
 					} else {
-						ft.setWidget(2, 1, className);
+						ft.setWidget(2, 1, classNames);
 					}
 
 					// click on save
@@ -210,7 +210,7 @@ public class GetApplicationForm implements JsonCallback {
 							if (groupForm && hasEmbeddedGroupApplication) {
 								form.setAutomaticApprovalEmbedded(Boolean.parseBoolean(lbEmbed.getValue(lbEmbed.getSelectedIndex())));
 							}
-							form.setModuleClassName(className.getText().trim());
+							form.setModuleClassNames(classNames.getText().trim());
 							request.updateForm(form);
 						}
 					};
@@ -223,7 +223,7 @@ public class GetApplicationForm implements JsonCallback {
 			button.addClickHandler(ch);
 
 			String appStyle = "<strong>Approval style: </strong>";
-			String module = "</br><strong>Module name: </strong>" + SafeHtmlUtils.fromString(form.getModuleClassName()).asString();
+			String module = "</br><strong>Module names: </strong>" + SafeHtmlUtils.fromString(form.getModuleClassNames()).asString();
 
 			if (form.getAutomaticApproval()==true) {
 				appStyle = appStyle + "<span style=\"color:red;\">Automatic</span> (INITIAL)";
@@ -279,7 +279,7 @@ public class GetApplicationForm implements JsonCallback {
 
 			button.setEnabled(false);
 			String appStyle = "<strong>Approval style: </strong> Form doesn't exists.";
-			String module = "</br><strong>Module name: </strong> Form doesn't exists.";
+			String module = "</br><strong>Module names: </strong> Form doesn't exists.";
 
 			content.setHTML(0, 0, appStyle + module);
 			content.setWidget(0, 1, button);

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/ApplicationForm.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/ApplicationForm.java
@@ -45,9 +45,9 @@ public class ApplicationForm extends JavaScriptObject {
 			return this.automaticApproval;
 		}-*/;
 
-		public final native String getModuleClassName() /*-{
-			if (!this.moduleClassName) return "";
-			return this.moduleClassName;
+		public final native String getModuleClassNames() /*-{
+			if (!this.moduleClassNames) return "";
+			return this.moduleClassNames.join(",");
 		}-*/;
 
 		/**
@@ -92,8 +92,8 @@ public class ApplicationForm extends JavaScriptObject {
 			this.automaticApprovalEmbedded = automatic;
 		}-*/;
 
-		public final native void setModuleClassName(String name) /*-{
-			this.moduleClassName = name;
+		public final native void setModuleClassNames(String names) /*-{
+			this.moduleClassNames = names.split(",");
 		}-*/;
 
 		/**


### PR DESCRIPTION
Instead of specifying single registrar module, allow to specify multiple. When storign in database, specified names are concatenated using `,` as separator. In from handling (any), instead of operating with single module, loop over all specified modules and try to process appropriate action (e.g. call `beforeApprove(...)`). Also updates Perl libs.

BREAKING CHANGE: 🧨 ApplicationForm bean property `moduleClassName` replaced with `moduleClassNames`. Type has changed from String to List<String>. Includes database version update and column `module_name` of `application_form` table being renamed to `module_names`.

DEPLOYMENT NOTE: requires database update. UI version have to work with updated model of ApplicationForm (`moduleClassName` replaced with field `moduleClassNames`).