### PR TITLE
feat(registrar): disable member invitation for incorrect setup

### DIFF
--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -17205,6 +17205,21 @@ paths:
         default:
           $ref: '#/components/responses/ExceptionResponse'
 
+  /json/registrarManager/isInvitationEnabled:
+    get:
+      tags:
+        - RegistrarManager
+      operationId: isInvitationEnabled
+      summary: Checks if invitation is enabled (invitation notification exists, application form exists and application form can be submitted).
+      parameters:
+        - $ref: '#/components/parameters/voId'
+        - $ref: '#/components/parameters/optionalGroupId'
+      responses:
+        '200':
+          $ref: '#/components/responses/BooleanResponse'
+        default:
+          $ref: '#/components/responses/ExceptionResponse'
+
   #################################################
   #                                               #
   # ServicesManager                               #

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/MailManager.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/MailManager.java
@@ -238,4 +238,15 @@ public interface MailManager {
 	 * @throws GroupNotExistsException when group is defined and does not exist
 	 */
 	Boolean invitationFormExists(PerunSession sess, Vo vo, Group group) throws VoNotExistsException, GroupNotExistsException;
+
+	/**
+	 * Checks if invitation is enabled (invitation notification exists, application form exists and application form can be submitted)
+	 *
+	 * @param sess session
+	 * @param vo vo
+	 * @param group group (can be null for vo check)
+	 * @return true if invitation notification exists, application form exists and application form can be submitted
+	 * @throws PerunException exception
+	 */
+	Boolean isInvitationEnabled(PerunSession sess, Vo vo, Group group) throws PerunException;
 }

--- a/perun-registrar-lib/src/test/java/cz/metacentrum/perun/registrar/RegistrarBaseIntegrationTest.java
+++ b/perun-registrar-lib/src/test/java/cz/metacentrum/perun/registrar/RegistrarBaseIntegrationTest.java
@@ -1654,6 +1654,51 @@ System.out.println("APPS ["+result.size()+"]:" + result);
 	}
 
 	@Test
+	public void isInvitationEnabledForGroup() throws Exception {
+		Group groupWithInvitation = perun.getGroupsManagerBl().createGroup(session, vo, new Group("group1", "group with form"));
+		Group groupWithoutInvitation = perun.getGroupsManagerBl().createGroup(session, vo, new Group("group2", "group without form"));
+
+		registrarManager.createApplicationFormInGroup(session, groupWithInvitation);
+		ApplicationForm form = registrarManager.getFormForGroup(groupWithInvitation);
+		ApplicationMail mail = new ApplicationMail(0, INITIAL, form.getId(), MailType.USER_INVITE, true);
+		mailManager.addMail(session, form, mail);
+
+		registrarManager.createApplicationFormInGroup(session, groupWithoutInvitation);
+		ApplicationForm form2 = registrarManager.getFormForGroup(groupWithoutInvitation);
+		ApplicationMail mail2 = new ApplicationMail(0, INITIAL, form2.getId(), MailType.USER_INVITE, true);
+		mailManager.addMail(session, form2, mail2);
+
+		ApplicationFormItem submitButton = new ApplicationFormItem();
+		submitButton.setType(ApplicationFormItem.Type.SUBMIT_BUTTON);
+		submitButton.setShortname("submitButton");
+		registrarManager.addFormItem(session, form, submitButton);
+
+		assertTrue(mailManager.isInvitationEnabled(session, vo, groupWithInvitation));
+		assertFalse(mailManager.isInvitationEnabled(session, vo, groupWithoutInvitation));
+	}
+
+	@Test
+	public void isInvitationEnabledForVo() throws Exception {
+		Vo voWithoutInvitation = perun.getVosManager().createVo(session, new Vo(1234, "test", "test"));
+
+		ApplicationForm form = registrarManager.getFormForVo(vo);
+		ApplicationMail mail = new ApplicationMail(0, INITIAL, form.getId(), MailType.USER_INVITE, true);
+		mailManager.addMail(session, form, mail);
+
+		ApplicationForm form2 = registrarManager.getFormForVo(voWithoutInvitation);
+		ApplicationMail mail2 = new ApplicationMail(0, INITIAL, form2.getId(), MailType.USER_INVITE, true);
+		mailManager.addMail(session, form2, mail2);
+
+		ApplicationFormItem submitButton = new ApplicationFormItem();
+		submitButton.setType(ApplicationFormItem.Type.SUBMIT_BUTTON);
+		submitButton.setShortname("submitButton");
+		registrarManager.addFormItem(session, form, submitButton);
+
+		assertTrue(mailManager.isInvitationEnabled(session, vo, null));
+		assertFalse(mailManager.isInvitationEnabled(session, voWithoutInvitation, null));
+	}
+
+	@Test
 	public void getApplicationsPageMultipleFormItems() throws Exception {
 		System.out.println("getApplicationsPageMultipleFormItems");
 

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/RegistrarManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/RegistrarManagerMethod.java
@@ -187,6 +187,25 @@ public enum RegistrarManagerMethod implements ManagerMethod {
 	},
 
 	/*#
+	 * Checks if invitation is enabled (invitation notification exists, application form exists and application form can be submitted)
+	 *
+	 * @param vo Vo <code>id</code>
+	 * @param group Group <code>id</code>
+	 *
+	 * @return true if invitation notification exists, application form exists and application form can be submitted
+	 */
+	isInvitationEnabled {
+		@Override
+		public Boolean call(ApiCaller ac, Deserializer parms) throws PerunException {
+			return ac.getRegistrarManager().getMailManager().isInvitationEnabled(
+				ac.getSession(),
+				ac.getVoById(parms.readInt("vo")),
+				parms.contains("group") ? ac.getGroupById(parms.readInt("group")) : null
+			);
+		}
+	},
+
+	/*#
 	 * Send invitations with link to VO / Group application form from provided csv data
 	 *
 	 * If VO or Group have non-empty attribute urn:perun:[vo/group]:attribute-def:def:applicationURL


### PR DESCRIPTION
* New method created for GUI which checks if member invitation is possible (invitation notification exists, application form exists and application can be sumbited - submin/auto-submit button exists in the form).
* This check is used also on BE and if this check is false, RegistrarException is thrown.