### PR TITLE
fix(core): allow perun observer to call getAllNamespaces method

### DIFF
--- a/perun-base/src/main/resources/perun-roles.yml
+++ b/perun-base/src/main/resources/perun-roles.yml
@@ -345,7 +345,8 @@ perun_policies:
       - default_policy
 
   getAllNamespaces_policy:
-    policy_roles: [ ]
+    policy_roles:
+      - PERUNOBSERVER:
     include_policies:
       - default_policy
 


### PR DESCRIPTION
* Now is thrown an error for perun observer on Blocked logins page in GUI due to the current policy.