### PR TITLE
fix(core): approve applications order

### DIFF
--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
@@ -1829,7 +1829,9 @@ public class RegistrarManagerImpl implements RegistrarManager {
 	}
 
 	@Override
+	@Transactional(rollbackFor = Exception.class)
 	public void approveApplications(PerunSession sess, List<Integer> applicationIds) throws PerunException {
+		Collections.sort(applicationIds);
 		for (Integer id : applicationIds) {
 			approveApplication(sess, id);
 		}


### PR DESCRIPTION
Sort application before approving.
First, approve applications to VOs and then to groups.