### PR TITLE
feat(core): extend method getRichAdmins for group to optionally include also indirect admins

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/GroupsManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/GroupsManager.java
@@ -818,10 +818,10 @@ public interface GroupsManager {
 	List<User> getAdmins(PerunSession perunSession, Group group, boolean onlyDirectAdmins) throws PrivilegeException, GroupNotExistsException;
 
 	/**
-	 * Gets list of all richUser administrators of this group.
+	 * Gets list of all richUser administrators of this group with a specified role.
 	 * If some group is administrator of the given group, all VALID members are included in the list.
 	 *
-	 * Supported roles: GroupAdmin
+	 * Supported roles: GroupAdmin, GroupObserver, GroupMembershipManager
 	 *
 	 * If "onlyDirectAdmins" is "true", return only direct users of the group for supported role with specific attributes.
 	 * If "allUserAttributes" is "true", do not specify attributes through list and return them all in objects richUser. Ignoring list of specific attributes.
@@ -832,6 +832,7 @@ public interface GroupsManager {
 	 * @param specificAttributes list of specified attributes which are needed in object richUser
 	 * @param allUserAttributes if true, get all possible user attributes and ignore list of specificAttributes (if false, get only specific attributes)
 	 * @param onlyDirectAdmins if true, get only direct user administrators (if false, get both direct and indirect)
+	 * @param role specified role
 	 *
 	 * @return list of RichUser administrators for the group and supported role with attributes
 	 *
@@ -840,7 +841,7 @@ public interface GroupsManager {
 	 * @throws UserNotExistsException
 	 * @throws GroupNotExistsException
 	 */
-	List<RichUser> getRichAdmins(PerunSession perunSession, Group group, List<String> specificAttributes, boolean allUserAttributes, boolean onlyDirectAdmins) throws UserNotExistsException, PrivilegeException, GroupNotExistsException;
+	List<RichUser> getRichAdmins(PerunSession perunSession, Group group, List<String> specificAttributes, boolean allUserAttributes, boolean onlyDirectAdmins, String role) throws UserNotExistsException, PrivilegeException, GroupNotExistsException;
 
 	/**
 	 * Get list of all richGroups with selected attributes assigned to resource.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/GroupsManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/GroupsManagerBl.java
@@ -847,28 +847,29 @@ public interface GroupsManagerBl {
 	List<Group> getAllSubGroups(PerunSession sess, Group parentGroup);
 
 	/**
-	 * Gets list of all administrators of this group.
+	 * Gets list of all administrators of this group with a specified role.
 	 * If some group is administrator of the given group, all VALID members are included in the list.
 	 *
 	 * If onlyDirectAdmins is true, return only direct users of the group for supported role.
 	 *
-	 * Supported roles: GroupAdmin
+	 * Supported roles: GroupAdmin, GroupObserver, GroupMembershipManager
 	 *
 	 * @param perunSession
 	 * @param group
 	 * @param onlyDirectAdmins if true, get only direct user administrators (if false, get both direct and indirect)
+	 * @param role specified role
 	 *
 	 * @return list of all user administrators of the given group for supported role
 	 *
 	 * @throws InternalErrorException
 	 */
-	List<User> getAdmins(PerunSession perunSession, Group group, boolean onlyDirectAdmins);
+	List<User> getAdmins(PerunSession perunSession, Group group, boolean onlyDirectAdmins, String role);
 
 	/**
-	 * Gets list of all richUser administrators of this group.
+	 * Gets list of all richUser administrators of this group with a specified role.
 	 * If some group is administrator of the given group, all VALID members are included in the list.
 	 *
-	 * Supported roles: GroupAdmin
+	 * Supported roles: GroupAdmin, GroupObserver, GroupMembershipManager
 	 *
 	 * If "onlyDirectAdmins" is "true", return only direct users of the group for supported role with specific attributes.
 	 * If "allUserAttributes" is "true", do not specify attributes through list and return them all in objects richUser. Ignoring list of specific attributes.
@@ -879,13 +880,14 @@ public interface GroupsManagerBl {
 	 * @param specificAttributes list of specified attributes which are needed in object richUser
 	 * @param allUserAttributes if true, get all possible user attributes and ignore list of specificAttributes (if false, get only specific attributes)
 	 * @param onlyDirectAdmins if true, get only direct user administrators (if false, get both direct and indirect)
+	 * @param role specified role
 	 *
 	 * @return list of RichUser administrators for the group and supported role with attributes
 	 *
 	 * @throws InternalErrorException
 	 * @throws UserNotExistsException
 	 */
-	List<RichUser> getRichAdmins(PerunSession perunSession, Group group, List<String> specificAttributes, boolean allUserAttributes, boolean onlyDirectAdmins) throws UserNotExistsException;
+	List<RichUser> getRichAdmins(PerunSession perunSession, Group group, List<String> specificAttributes, boolean allUserAttributes, boolean onlyDirectAdmins, String role) throws UserNotExistsException;
 
 	/**
 	 * Gets list of all user administrators of this group.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
@@ -1534,17 +1534,17 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 	}
 
 	@Override
-	public List<User> getAdmins(PerunSession perunSession, Group group, boolean onlyDirectAdmins) {
+	public List<User> getAdmins(PerunSession perunSession, Group group, boolean onlyDirectAdmins, String role) {
 		if(onlyDirectAdmins) {
-			return getGroupsManagerImpl().getDirectAdmins(perunSession, group);
+			return getGroupsManagerImpl().getDirectAdmins(perunSession, group, role);
 		} else {
-			return getGroupsManagerImpl().getAdmins(perunSession, group);
+			return getGroupsManagerImpl().getAdmins(perunSession, group, role);
 		}
 	}
 
 	@Override
-	public List<RichUser> getRichAdmins(PerunSession perunSession, Group group, List<String> specificAttributes, boolean allUserAttributes, boolean onlyDirectAdmins) throws UserNotExistsException {
-		List<User> users = this.getAdmins(perunSession, group, onlyDirectAdmins);
+	public List<RichUser> getRichAdmins(PerunSession perunSession, Group group, List<String> specificAttributes, boolean allUserAttributes, boolean onlyDirectAdmins, String role) throws UserNotExistsException {
+		List<User> users = this.getAdmins(perunSession, group, onlyDirectAdmins, role);
 		List<RichUser> richUsers;
 
 		if(allUserAttributes) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/GroupsManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/GroupsManagerEntry.java
@@ -765,11 +765,11 @@ public class GroupsManagerEntry implements GroupsManager {
 			throw new PrivilegeException(perunSession, "getAdmins");
 		}
 
-		return getGroupsManagerBl().getAdmins(perunSession, group, onlyDirectAdmins);
+		return getGroupsManagerBl().getAdmins(perunSession, group, onlyDirectAdmins, Role.GROUPADMIN);
 	}
 
 	@Override
-	public List<RichUser> getRichAdmins(PerunSession perunSession, Group group, List<String> specificAttributes, boolean allUserAttributes, boolean onlyDirectAdmins) throws PrivilegeException, GroupNotExistsException, UserNotExistsException {
+	public List<RichUser> getRichAdmins(PerunSession perunSession, Group group, List<String> specificAttributes, boolean allUserAttributes, boolean onlyDirectAdmins, String role) throws PrivilegeException, GroupNotExistsException, UserNotExistsException {
 		Utils.checkPerunSession(perunSession);
 		getGroupsManagerBl().checkGroupExists(perunSession, group);
 		//list of specific attributes must be not null if filtering is needed
@@ -782,7 +782,7 @@ public class GroupsManagerEntry implements GroupsManager {
 			throw new PrivilegeException(perunSession, "getRichAdmins");
 		}
 
-		return getPerunBl().getUsersManagerBl().filterOnlyAllowedAttributes(perunSession, getGroupsManagerBl().getRichAdmins(perunSession, group, specificAttributes, allUserAttributes, onlyDirectAdmins));
+		return getPerunBl().getUsersManagerBl().filterOnlyAllowedAttributes(perunSession, getGroupsManagerBl().getRichAdmins(perunSession, group, specificAttributes, allUserAttributes, onlyDirectAdmins, role));
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_group_attribute_def_virt_isGroupAdmin.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_group_attribute_def_virt_isGroupAdmin.java
@@ -5,6 +5,7 @@ import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.Member;
+import cz.metacentrum.perun.core.api.Role;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
@@ -28,7 +29,7 @@ public class urn_perun_member_group_attribute_def_virt_isGroupAdmin extends Memb
         User newUser;
         Attribute attribute = new Attribute(attributeDefinition);
 
-        userAdminList = sess.getPerunBl().getGroupsManagerBl().getAdmins(sess, group, false);
+        userAdminList = sess.getPerunBl().getGroupsManagerBl().getAdmins(sess, group, false, Role.GROUPADMIN);
         newUser = sess.getPerunBl().getUsersManagerBl().getUserByMember(sess, member);
 
         if (userAdminList.contains(newUser)) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/GroupsManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/GroupsManagerImplApi.java
@@ -13,6 +13,7 @@ import cz.metacentrum.perun.core.api.Paginated;
 import cz.metacentrum.perun.core.api.Perun;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.Role;
 import cz.metacentrum.perun.core.api.SecurityTeam;
 import cz.metacentrum.perun.core.api.Status;
 import cz.metacentrum.perun.core.api.User;
@@ -472,6 +473,20 @@ public interface GroupsManagerImplApi {
 	List<User> getAdmins(PerunSession perunSession, Group group);
 
 	/**
+	 * Gets list of all administrators of this group with a specified role.
+	 * If some group is administrator of the given group, all VALID members are included in the list.
+	 *
+	 * @param perunSession
+	 * @param group
+	 * @param role
+	 *
+	 * @return list of all administrators with a specified role
+	 *
+	 * @throws InternalErrorException
+	 */
+	List<User> getAdmins(PerunSession perunSession, Group group, String role);
+
+	/**
 	 * Gets list of direct user administrators of this group.
 	 * 'Direct' means, there aren't included users, who are members of group administrators, in the returned list.
 	 *
@@ -484,6 +499,20 @@ public interface GroupsManagerImplApi {
 	 */
 	List<User> getDirectAdmins(PerunSession perunSession, Group group);
 
+	/**
+	 * Gets list of direct user administrators of this group with a specified role.
+	 * 'Direct' means, there aren't included users, who are members of group administrators, in the returned list.
+	 *
+	 * @param perunSession
+	 * @param group
+	 * @param role
+	 *
+	 * @throws InternalErrorException
+	 *
+	 * @return list of direct administrators with a specified role
+	 */
+	List<User> getDirectAdmins(PerunSession perunSession, Group group, String role);
+
 	/** Gets list of all group administrators of this group.
 	 *
 	 * @param perunSession
@@ -494,6 +523,18 @@ public interface GroupsManagerImplApi {
 	 * @throws InternalErrorException
 	 */
 	List<Group> getGroupAdmins(PerunSession perunSession, Group group);
+
+	/** Gets list of all group administrators of this group with a specified role
+	 *
+	 * @param perunSession
+	 * @param group
+	 * @param role
+	 *
+	 * @return list of all group administrators with a specified role
+	 *
+	 * @throws InternalErrorException
+	 */
+	List<Group> getGroupAdmins(PerunSession perunSession, Group group, String role);
 
 	/**
 	 * Check if group exists in underlaying data source.

--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -849,6 +849,14 @@ components:
       discriminator:
         propertyName: beanName
 
+    GroupAdminRoles:
+      type: string
+      description: 'admin roles for a Group'
+      enum:
+        - "GROUPADMIN"
+        - "GROUPOBSERVER"
+        - "GROUPMEMBERSHIPMANAGER"
+
     PaginatedRichGroups:
       properties:
         offset: { type: integer }
@@ -13652,6 +13660,29 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/ListOfRichGroupsResponse'
+        default:
+          $ref: '#/components/responses/ExceptionResponse'
+
+  /json/groupsManager/getRichAdmins:
+    get:
+      tags:
+        - GroupsManager
+      operationId: getRichAdminsForGroup
+      description: |
+        Gets list of all richUser administrators of this group with a specified role.
+        If some group is administrator of the given group, all VALID members are included in the list.
+        Supported roles: GROUPADMIN, GROUPOBSERVER, GROUPMEMBERSHIPMANAGER
+        If "onlyDirectAdmins" is "true", return only direct users of the group for supported role with specific attributes.
+        If "allUserAttributes" is "true", do not specify attributes through list and return them all in objects richUser. Ignoring list of specific attributes.
+      parameters:
+        - $ref: '#/components/parameters/groupId'
+        - $ref: '#/components/parameters/specificAttributes'
+        - { name: allUserAttributes, schema: { type: boolean }, in: query, required: true, description: 'if == true, get all possible user attributes and ignore list of specificAttributes (if false, get only specific attributes)' }
+        - { name: onlyDirectAdmins, schema: { type: boolean }, in: query, required: true, description: 'if == true, get only direct vo administrators (if false, get both direct and indirect)' }
+        - { name: role, schema: { $ref: '#/components/schemas/GroupAdminRoles' }, in: query, required: true, description: 'role name' }
+      responses:
+        '200':
+          $ref: '#/components/responses/ListOfRichUsersResponse'
         default:
           $ref: '#/components/responses/ExceptionResponse'
 

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/GroupsManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/GroupsManagerMethod.java
@@ -14,6 +14,7 @@ import cz.metacentrum.perun.core.api.MembershipType;
 import cz.metacentrum.perun.core.api.RichGroup;
 import cz.metacentrum.perun.core.api.RichMember;
 import cz.metacentrum.perun.core.api.RichUser;
+import cz.metacentrum.perun.core.api.Role;
 import cz.metacentrum.perun.core.api.Status;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.Vo;
@@ -1123,6 +1124,25 @@ public enum GroupsManagerMethod implements ManagerMethod {
 	 * @return List<RichUser> list of RichUser administrators for the group and supported role with attributes
 	 */
 	/*#
+	 * Get list of all richUser administrators for the group and supported role with specific attributes.
+	 * If some group is administrator of the given group, all VALID members are included in the list.
+	 *
+	 * @throw GroupNotExistsException When the group doesn't exist
+	 *
+	 * Supported roles: GroupAdmin, GroupObserver, GroupMembershipManager
+	 *
+	 * If "onlyDirectAdmins" is == true, return only direct admins of the group for supported role with specific attributes.
+	 * If "allUserAttributes" is == true, do not specify attributes through list and return them all in objects richUser. Ignoring list of specific attributes.
+	 *
+	 * @param group int Group <code>id</code>
+	 * @param specificAttributes List<String> list of specified attributes which are needed in object richUser
+	 * @param allUserAttributes int if == true, get all possible user attributes and ignore list of specificAttributes (if false, get only specific attributes)
+	 * @param onlyDirectAdmins int if == true, get only direct group administrators (if false, get both direct and indirect)
+	 * @param role specified role
+	 *
+	 * @return List<RichUser> list of RichUser administrators for the group and supported role with attributes
+	 */
+	/*#
 	 * Get all Group admins as RichUsers
 	 *
 	 * @throw GroupNotExistsException When the group doesn't exist
@@ -1140,7 +1160,8 @@ public enum GroupsManagerMethod implements ManagerMethod {
 						ac.getGroupById(parms.readInt("group")),
 						parms.readList("specificAttributes", String.class),
 						parms.readBoolean("allUserAttributes"),
-						parms.readBoolean("onlyDirectAdmins"));
+						parms.readBoolean("onlyDirectAdmins"),
+						parms.contains("role") ? parms.readString("role") : Role.GROUPADMIN);
 			} else {
 				return ac.getGroupsManager().getRichAdmins(ac.getSession(),
 						ac.getGroupById(parms.readInt("group")));


### PR DESCRIPTION
* Method getRichAdmins was extended to optionally include also indirect admins.
* This method now also have a parameter to define group related role (GROUPADMIN, GROUPOBSERVER, GROUPMEMBERSHIPMANAGER).