### PR TITLE
feat(engine): pass service name to send/gen script when using generic…

### DIFF
--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/GenWorkerImpl.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/GenWorkerImpl.java
@@ -46,8 +46,13 @@ public class GenWorkerImpl extends AbstractWorker<Task> implements GenWorker {
 
 		log.info("[{}] Executing GEN worker for Task with Service ID: {} and Facility ID: {}.",
 				getTask().getId(), getTask().getServiceId(), getTask().getFacilityId());
-
-		ProcessBuilder pb = new ProcessBuilder(service.getScript(), "-c", "-f", String.valueOf(getTask().getFacilityId()));
+		ProcessBuilder pb;
+		if (service.getScript().equals("./" + service.getName())) {
+			pb = new ProcessBuilder(service.getScript(), "-c", "-f", String.valueOf(getTask().getFacilityId()));
+		} else {
+			// if calling some generic script, also pass name of the service to avoid gen folder collision
+			pb = new ProcessBuilder(service.getScript(), "-c", "-f", String.valueOf(getTask().getFacilityId()), "-s", service.getName());
+		}
 
 		try {
 

--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/SendWorkerImpl.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/SendWorkerImpl.java
@@ -69,14 +69,24 @@ public class SendWorkerImpl extends AbstractWorker<SendTask> implements SendWork
 		log.info("[{}] Executing SEND worker for Task with Service ID: {} and Facility ID: {} and Destination: {}",
 				sendTask.getTask().getId(), sendTask.getTask().getServiceId(), sendTask.getTask().getFacilityId(),
 				sendTask.getDestination().getDestination());
-
-		ProcessBuilder pb = new ProcessBuilder(
+		ProcessBuilder pb;
+		if (service.getScript().equals("./" + service.getName())) {
+			pb = new ProcessBuilder(
 				service.getScript(),
 				task.getFacility().getName(),
 				sendTask.getDestination().getDestination(),
 				sendTask.getDestination().getType()
-		);
-
+			);
+		} else {
+			// if calling some generic script, also pass name of the service to allow correct gen folder selection
+			pb = new ProcessBuilder(
+				service.getScript(),
+				task.getFacility().getName(),
+				sendTask.getDestination().getDestination(),
+				sendTask.getDestination().getType(),
+				service.getName()
+			);
+		}
 		try {
 
 			// start the script and wait for results


### PR DESCRIPTION
… scripts

* the name of the propagated service is passed to gen/scripts, which then use this information for gen folder creation
* this is necessary when one facility has multiple services utilizing the same generic script