### PR TITLE
fix: fixed definition of logback in perun-auditlogger

### DIFF
--- a/perun-auditlogger/src/main/resources/logback.xml
+++ b/perun-auditlogger/src/main/resources/logback.xml
@@ -35,7 +35,6 @@
 	<appender class="org.gnieh.logback.SystemdJournalAppender" name="journal-audit">
 		<syslogIdentifier>perun_audit</syslogIdentifier>
 		<logLoggerName>true</logLoggerName>
-		<logStacktrace>false</logStacktrace>
 		<encoder>
 			<pattern>%msg</pattern>
 		</encoder>


### PR DESCRIPTION
Removed problematic property