### PR TITLE
feat(core): allow members to read their group expiration

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -7494,6 +7494,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		policies.add(Triple.of(Role.GROUPMEMBERSHIPMANAGER, WRITE, RoleObject.Group));
 		policies.add(Triple.of(Role.VOADMIN, READ, RoleObject.Vo));
 		policies.add(Triple.of(Role.VOADMIN, WRITE, RoleObject.Vo));
+		policies.add(Triple.of(Role.SELF, READ, RoleObject.User));
 		attributes.put(attr, createInitialPolicyCollections(policies));
 
 		//urn:perun:vo:attribute-def:def:blockManualMemberAdding


### PR DESCRIPTION
* fixes a bug, where users couldn't extend membership in a group through the profile app