### PR TITLE
feat(core): mfa categories use namespace as key

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_mfaEnforceSettings.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_mfaEnforceSettings.java
@@ -149,8 +149,9 @@ public class urn_perun_user_attribute_def_def_mfaEnforceSettings extends UserAtt
 
 		Attribute mfaCategory = null;
 		try {
-			Map<String, Attribute> mfaCategories = perunSession.getPerunBl().getAttributesManagerBl().getEntitylessAttributesWithKeys(perunSession, AttributesManager.NS_ENTITYLESS_ATTR_DEF + ":mfaCategories", Collections.singletonList("categories"));
-			mfaCategory = mfaCategories.get("categories");
+			String param = attribute.getFriendlyNameParameter();
+			Map<String, Attribute> mfaCategories = perunSession.getPerunBl().getAttributesManagerBl().getEntitylessAttributesWithKeys(perunSession, AttributesManager.NS_ENTITYLESS_ATTR_DEF + ":mfaCategories", Collections.singletonList(param));
+			mfaCategory = mfaCategories.get(param);
 		} catch (AttributeNotExistsException e) {
 			throw new WrongReferenceAttributeValueException("Attribute mfa categories does not exist.");
 		}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_mfaEnforceSettingsTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_mfaEnforceSettingsTest.java
@@ -31,6 +31,7 @@ public class urn_perun_user_attribute_def_def_mfaEnforceSettingsTest {
 		session = mock(PerunSessionImpl.class, RETURNS_DEEP_STUBS);
 		user = new User();
 		attributeToCheck = new Attribute();
+		attributeToCheck.setFriendlyName("mfaEnforceSettings:test");
 
 
 		Attribute mockMfaCategories = new Attribute();
@@ -54,7 +55,7 @@ public class urn_perun_user_attribute_def_def_mfaEnforceSettingsTest {
 			"    }" + "  " +
 			"}");
 		when(session.getPerunBl().getAttributesManagerBl().getEntitylessAttributesWithKeys(any(), any(), any()))
-			.thenReturn(Collections.singletonMap("categories", mockMfaCategories));
+			.thenReturn(Collections.singletonMap(attributeToCheck.getFriendlyNameParameter(), mockMfaCategories));
 	}
 
 	@Test


### PR DESCRIPTION
* in all cases use namespace as a key to entityless attribute mfaCategories