### PR TITLE
feat(core): add getAssociatedResources to RPC and openapi

### DIFF
--- a/perun-base/src/main/resources/perun-roles.yml
+++ b/perun-base/src/main/resources/perun-roles.yml
@@ -6209,6 +6209,15 @@ perun_policies:
     include_policies:
       - default_policy
 
+  getAssociatedResources_Facility_User_policy:
+    policy_roles:
+      - FACILITYADMIN: Facility
+      - FACILITYOBSERVER: Facility
+      - SELF: User
+      - PERUNOBSERVER:
+    include_policies:
+      - default_policy
+
   findUsers_String_policy:
     policy_roles:
       - PERUNOBSERVER:

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/UsersManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/UsersManager.java
@@ -717,6 +717,21 @@ public interface UsersManager {
 	List<RichResource> getAssignedRichResources(PerunSession sess, User user) throws UserNotExistsException, PrivilegeException;
 
 	/**
+	 * Return all resources of specified facility with which user is associated through all his members.
+	 * Does not require ACTIVE group-resource assignment.
+	 *
+	 * @param sess
+	 * @param facility
+	 * @param user
+	 * @return All resources with which user is associated
+	 *
+	 * @throws UserNotExistsException
+	 * @throws FacilityNotExistsException
+	 * @throws PrivilegeException
+	 */
+	List<Resource> getAssociatedResources(PerunSession sess, Facility facility, User user) throws UserNotExistsException, FacilityNotExistsException, PrivilegeException;
+
+	/**
 	 * Returns list of users who matches the searchString, searching name, id, uuid, email, logins.
 	 *
 	 * @param sess

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
@@ -840,6 +840,20 @@ public class UsersManagerEntry implements UsersManager {
 	}
 
 	@Override
+	public List<Resource> getAssociatedResources(PerunSession sess, Facility facility, User user) throws UserNotExistsException, FacilityNotExistsException, PrivilegeException {
+		Utils.checkPerunSession(sess);
+
+		if(!AuthzResolver.authorizedInternal(sess, "getAssociatedResources_Facility_User_policy", facility, user)) {
+			throw new PrivilegeException(sess, "getAssociatedResources");
+		}
+
+		getUsersManagerBl().checkUserExists(sess, user);
+		perunBl.getFacilitiesManagerBl().checkFacilityExists(sess, facility);
+
+		return getUsersManagerBl().getAssociatedResources(sess, facility, user);
+	}
+
+	@Override
 	public List<User> findUsers(PerunSession sess, String searchString) throws PrivilegeException {
 		Utils.checkPerunSession(sess);
 

--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -9554,6 +9554,21 @@ paths:
         default:
           $ref: '#/components/responses/ExceptionResponse'
 
+  /json/usersManager/getAssociatedResources:
+    get:
+      tags:
+        - UsersManager
+      operationId: getAssociatedResourcesForUser
+      summary: Get all resources associated with the user on the facility
+      parameters:
+        - $ref: '#/components/parameters/facilityId'
+        - $ref: '#/components/parameters/userId'
+      responses:
+        '200':
+          $ref: '#/components/responses/ListOfResourcesResponse'
+        default:
+          $ref: '#/components/responses/ExceptionResponse'
+
   /json/usersManager/getUsersByIds:
     get:
       tags:

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/UsersManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/UsersManagerMethod.java
@@ -1120,6 +1120,26 @@ public enum UsersManagerMethod implements ManagerMethod {
 	},
 
 	/*#
+	 * Return all resources of specified facility with which user is associated through all his members.
+	 * Does not require ACTIVE group-resource assignment.
+	 *
+	 * @param facility int Facility <code>id</code>
+	 * @param user int User <code>id</code>
+	 * @return List<RichResource> All resources with which user is associated
+	 */
+
+	getAssociatedResources {
+
+		@Override
+		public List<Resource> call(ApiCaller ac, Deserializer parms) throws PerunException {
+			Facility facility = ac.getFacilityById(parms.readInt("facility"));
+			User user = ac.getUserById(parms.readInt("user"));
+			return ac.getUsersManager().getAssociatedResources(ac.getSession(), facility, user);
+		}
+	},
+
+
+	/*#
 	 * Checks if the login is available in the namespace. Return 1 if yes, 0 if no.
 	 *
 	 * @param loginNamespace String Namespace


### PR DESCRIPTION
* getAssociatedResources returns all resources to which the user is assigned to on that facility (regardless of group-resource status)
* this is necessary to support the new 'Assignments' admin page in new GUI