### PR TITLE
feat(core): synchronize group membership status

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/Candidate.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/Candidate.java
@@ -23,6 +23,7 @@ public class Candidate extends User {
 	private UserExtSource userExtSource;
 	private List<UserExtSource> additionalUserExtSources;
 	private Map<String, String> attributes;
+	private String expectedSyncGroupStatus;
 
 	public Candidate() {
 	}
@@ -60,6 +61,7 @@ public class Candidate extends User {
 		this.setTitleBefore(candidateSync.getTitleBefore());
 		this.setServiceUser(candidateSync.isServiceUser());
 		this.setSponsoredUser(candidateSync.isSponsoredUser());
+		this.setExpectedSyncGroupStatus(candidateSync.getExpectedSyncGroupStatus());
 
 		attributes = candidateSync.getAttributes();
 		userExtSource = candidateSync.getRichUserExtSource().asUserExtSource();
@@ -217,4 +219,11 @@ public class Candidate extends User {
 		return true;
 	}
 
+	public String getExpectedSyncGroupStatus() {
+		return expectedSyncGroupStatus;
+	}
+
+	public void setExpectedSyncGroupStatus(String expectedSyncGroupStatus) {
+		this.expectedSyncGroupStatus = expectedSyncGroupStatus;
+	}
 }

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/CandidateSync.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/CandidateSync.java
@@ -15,6 +15,7 @@ public class CandidateSync extends User {
 	private RichUserExtSource richUserExtSource;
 	private List<RichUserExtSource> additionalRichUserExtSources;
 	private Map<String, String> attributes;
+	private String expectedSyncGroupStatus;
 
 	public CandidateSync() {
 	}
@@ -27,6 +28,7 @@ public class CandidateSync extends User {
 		this.setTitleBefore(candidate.getTitleBefore());
 		this.setServiceUser(candidate.isServiceUser());
 		this.setSponsoredUser(candidate.isSponsoredUser());
+		this.setExpectedSyncGroupStatus(candidate.getExpectedSyncGroupStatus());
 		setAttributes(candidate.getAttributes());
 		setRichUserExtSource(new RichUserExtSource(candidate.getUserExtSource(), new ArrayList<>()));
 		if (candidate.getAdditionalUserExtSources() != null) {
@@ -57,6 +59,14 @@ public class CandidateSync extends User {
 
 	public void setAdditionalRichUserExtSources(List<RichUserExtSource> additionalRichUserExtSources) {
 		this.additionalRichUserExtSources = additionalRichUserExtSources;
+	}
+
+	public String getExpectedSyncGroupStatus() {
+		return expectedSyncGroupStatus;
+	}
+
+	public void setExpectedSyncGroupStatus(String expectedSyncGroupStatus) {
+		this.expectedSyncGroupStatus = expectedSyncGroupStatus;
 	}
 
 	public List<RichUserExtSource> getUserExtSources() {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/GroupsManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/GroupsManagerBl.java
@@ -2078,6 +2078,17 @@ public interface GroupsManagerBl {
 	void reactivateMember(PerunSession sess, Member member, Group group) throws MemberNotExistsException;
 
 	/**
+	 * Inactivates member in group and sets its status to EXPIRED.
+	 *
+	 * @param sess perun session
+	 * @param member member
+	 * @param group group
+	 * @throws InternalErrorException internal error
+	 * @throws MemberNotExistsException if given member is not direct member of given group
+	 */
+	void inactivateMember(PerunSession sess, Member member, Group group) throws MemberNotExistsException;
+
+	/**
 	 * Returns all groups which can be registered into during vo registration.
 	 *
 	 * @param sess session

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ExtSourcesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ExtSourcesManagerBlImpl.java
@@ -40,7 +40,6 @@ import org.slf4j.LoggerFactory;
 
 import javax.sql.DataSource;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -357,6 +356,7 @@ public class ExtSourcesManagerBlImpl implements ExtSourcesManagerBl {
 		candidateSync.setMiddleName(subjectData.get("middleName"));
 		candidateSync.setTitleAfter(subjectData.get("titleAfter"));
 		candidateSync.setTitleBefore(subjectData.get("titleBefore"));
+		candidateSync.setExpectedSyncGroupStatus(subjectData.get("status"));
 
 		// Set service user
 		if(subjectData.get("isServiceUser") == null) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
@@ -3376,12 +3376,15 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 									log.info("Switching member id {} into INVALID state from DISABLED, because there was problem with attributes {}.", richMember.getId(), e);
 								}
 							}
+							// also synchronize the group status
+							synchronizeGroupStatus(sess, richMember, subjectFromLoginSource.get("status"), group);
 							idsOfUsersInGroup.remove(user.getId());
 						} else {
 							//he is not yet in group, so we need to create a candidate
 							Candidate candidate = new Candidate(user, source);
 							//for lightweight synchronization we want to skip all update of attributes
 							candidate.setAttributes(new HashMap<>());
+							candidate.setExpectedSyncGroupStatus(subjectFromLoginSource.get("status"));
 							candidatesToAdd.add(candidate);
 						}
 						break;
@@ -3805,8 +3808,53 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 		//Synchronize userExtSources (add not existing)
 		addUserExtSources(sess, candidate, memberToUpdate);
 
+		if (isDirectGroupMember(sess, group, memberToUpdate)) {
+			synchronizeGroupStatus(sess, memberToUpdate, candidate.getExpectedSyncGroupStatus(), group);
+		}
+
 		//Set correct member Status
 		updateMemberStatus(sess, memberToUpdate);
+	}
+
+	/**
+	 * Update a group member status based on the status in candidate object.
+	 * The member-group expiration attribute is set to now when expiring a member
+	 * and updated based on the group policy if validating a member.
+	 *
+	 * @param sess perun session
+	 * @param memberToSynchronize member being synchronized
+	 * @param newStatusString the group status from the extSource
+	 * @param group the group being synchronized
+	 */
+	private void synchronizeGroupStatus(PerunSession sess, Member memberToSynchronize, String newStatusString, Group group) {
+		MemberGroupStatus previousStatus = getDirectMemberGroupStatus(sess, memberToSynchronize, group);
+		MemberGroupStatus newStatus;
+		if (newStatusString == null) {
+			// default policy is VALID
+			newStatus = MemberGroupStatus.VALID;
+		}
+		else if (newStatusString.equals("VALID")) {
+			newStatus = MemberGroupStatus.VALID;
+		} else if (newStatusString.equals("EXPIRED")) {
+			newStatus = MemberGroupStatus.EXPIRED;
+		} else {
+			// unknown status value default policy VALID
+			log.warn("Unknown value {} of status while synchronizing group {} for user {}.", newStatusString, group.getName(), memberToSynchronize.getUserId());
+			newStatus = MemberGroupStatus.VALID;
+		}
+		if (newStatus.equals(MemberGroupStatus.EXPIRED) && !MemberGroupStatus.EXPIRED.equals(previousStatus)) {
+			try {
+				inactivateMember(sess, memberToSynchronize, group);
+			} catch (MemberNotExistsException e) {
+				throw new InternalErrorException(e);
+			}
+		} else if (newStatus.equals(MemberGroupStatus.VALID) && !MemberGroupStatus.VALID.equals(previousStatus)) {
+			try {
+				reactivateMember(sess, memberToSynchronize, group);
+			} catch (MemberNotExistsException e) {
+				throw new InternalErrorException(e);
+			}
+		}
 	}
 
 	/**
@@ -4097,6 +4145,7 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 					// Shouldn't happen, group should always exist
 					throw new ConsistencyErrorException(ex);
 				}
+				synchronizeGroupStatus(sess, member, candidate.getExpectedSyncGroupStatus(), group);
 			}
 			log.info("Group synchronization {}: New member id {} added.", group, member.getId());
 		} catch (AlreadyMemberException e) {
@@ -5933,6 +5982,23 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 		} catch (ExtendMembershipException ex) {
 			// This exception should not be thrown for null membershipExpiration attribute
 			throw new InternalErrorException(ex);
+		}
+	}
+
+	@Override
+	public void inactivateMember(PerunSession sess, Member member, Group group) throws MemberNotExistsException {
+		if (!isDirectGroupMember(sess, group, member)) {
+			throw new MemberNotExistsException("Member does not belong to this group");
+		}
+
+		expireMemberInGroup(sess, member, group);
+		// set member expiration to now
+		Attribute memberExpirationAttr = getMemberExpiration(sess, member, group);
+		memberExpirationAttr.setValue(LocalDate.now().toString());
+		try {
+			getPerunBl().getAttributesManagerBl().setAttribute(sess, member, group, memberExpirationAttr);
+		} catch (WrongAttributeValueException | WrongReferenceAttributeValueException | WrongAttributeAssignmentException | MemberGroupMismatchException e) {
+			throw new InternalErrorException(e);
 		}
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceSql.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceSql.java
@@ -129,7 +129,7 @@ public class ExtSourceSql extends ExtSourceImpl implements ExtSourceSimpleApi {
 	}
 
 	// database columns for base attributes
-	private static final String[] BASE_COLUMNS = new String[]{"login", "firstName", "lastName", "middleName", "titleBefore", "titleAfter"};
+	private static final String[] BASE_COLUMNS = new String[]{"login", "firstName", "lastName", "middleName", "titleBefore", "titleAfter", "status"};
 	private final static String[] GROUP_COLUMNS = new String[]{GroupsManagerBlImpl.GROUP_LOGIN, GroupsManagerBlImpl.GROUP_NAME, GroupsManagerBlImpl.PARENT_GROUP_LOGIN, GroupsManagerBlImpl.GROUP_DESCRIPTION};
 	// column name should be matched case-insensitively
 	private static String matchingBaseColumnName(String s) {

--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -1318,6 +1318,7 @@ components:
         userExtSource: { $ref: '#/components/schemas/UserExtSource' }
         additionalUserExtSources: { type: array, items: { $ref: '#/components/schemas/UserExtSource' } }
         attributes: { type: object, additionalProperties: { type: string } }
+        expectedSyncGroupStatus: { type: string }
       discriminator:
         propertyName: beanName
 


### PR DESCRIPTION
- The status of a group member is also synchronized for SQL extSource
- The default value (status column not found, unknown value) is valid
- When a previously valid member is synchronized to expired
the groupMembershipExpiration attr is set to current date
- When a new/current member is being set to valid the attr is
set based on the group policy accordingly

DEPLOYMENT NOTE: possibility to synchronize group status.
Expects "status" column in SQLExtSource with values "EXPIRED" or "VALID".
Candidate object extended with expectedSyncGroupStatus property.