### PR TITLE
fix(core): add right for GROUPMEMBERSHIPMANAGER to invite members

### DIFF
--- a/perun-base/src/main/resources/perun-roles.yml
+++ b/perun-base/src/main/resources/perun-roles.yml
@@ -7933,6 +7933,7 @@ perun_policies:
       - PERUNOBSERVER:
       - GROUPADMIN: Group
       - GROUPOBSERVER: Group
+      - GROUPMEMBERSHIPMANAGER: Group
     include_policies:
       - default_policy
 


### PR DESCRIPTION
* For member invitaton to group is checked if group form exists. Group membership manager did not have rights to get this form.