### PR TITLE
fix(core): ignore already blocked destinations

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/ServicesManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/ServicesManager.java
@@ -89,7 +89,7 @@ public interface ServicesManager {
 	 * @param richDestinations the list of rich destinations
 	 *
 	 */
-	void blockServicesOnDestinations(PerunSession perunSession, List<RichDestination> richDestinations) throws PrivilegeException, DestinationNotExistsException, ServiceAlreadyBannedException, FacilityNotExistsException;
+	void blockServicesOnDestinations(PerunSession perunSession, List<RichDestination> richDestinations) throws PrivilegeException, DestinationNotExistsException, FacilityNotExistsException;
 
 	/**
 	 * Block all services currently assigned on this facility.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ServicesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ServicesManagerEntry.java
@@ -98,9 +98,12 @@ public class ServicesManagerEntry implements ServicesManager {
 	}
 
 	@Override
-	public void blockServicesOnDestinations(PerunSession sess, List<RichDestination> richDestinations) throws PrivilegeException, DestinationNotExistsException, ServiceAlreadyBannedException, FacilityNotExistsException {
+	public void blockServicesOnDestinations(PerunSession sess, List<RichDestination> richDestinations) throws PrivilegeException, DestinationNotExistsException, FacilityNotExistsException {
 		for (RichDestination richDestination : richDestinations) {
-			blockServiceOnDestination(sess, richDestination.getService(), richDestination.getId());
+			try {
+				blockServiceOnDestination(sess, richDestination.getService(), richDestination.getId());
+			} catch (ServiceAlreadyBannedException ignored) {
+			}
 		}
 	}
 

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ServicesManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ServicesManagerEntryIntegrationTest.java
@@ -1193,6 +1193,31 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 	}
 
 	@Test
+	public void blockServiceOnDestinationsAndIgnoreAlreadyBlocked() throws Exception {
+		System.out.println(CLASS_NAME + "blockServiceOnDestinationsAndIgnoreAlreadyBlocked");
+
+		facility = setUpFacility();
+		service = setUpService();
+		List<Destination> destinations = setUpDestinations();
+
+		Destination destination1 = perun.getServicesManager().addDestination(sess, service, facility, destinations.get(0));
+		RichDestination richDestination1 = new RichDestination(destination1, facility, service);
+		Destination destination2 = perun.getServicesManager().addDestination(sess, service, facility, destinations.get(1));
+		RichDestination richDestination2 = new RichDestination(destination2, facility, service);
+
+		List<RichDestination> serviceDestinations = perun.getServicesManagerBl().getAllRichDestinations(sess, facility);
+		assertTrue(serviceDestinations.contains(richDestination1));
+		assertTrue( serviceDestinations.contains(richDestination2));
+
+		perun.getServicesManager().blockServiceOnDestination(sess, service, richDestination1.getId());
+		assertTrue(perun.getServicesManager().isServiceBlockedOnDestination(sess, service, richDestination1.getId()));
+
+		List<RichDestination> destinationsToBlock = Arrays.asList(richDestination1, richDestination2);
+		perun.getServicesManager().blockServicesOnDestinations(sess, destinationsToBlock);
+		assertTrue(perun.getServicesManager().isServiceBlockedOnDestination(sess, service, richDestination2.getId()));
+	}
+
+	@Test
 	public void blockAndUnblockServicesOnFacility() throws Exception {
 		System.out.println(CLASS_NAME + "blockAndUnblockServicesOnFacility");
 


### PR DESCRIPTION
Allow to block multiple destinations at once, even if some are already blocked.