### PR TITLE
feat(core): bulk-up public ssh key validation

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/SSHKeyNotValidException.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/SSHKeyNotValidException.java
@@ -1,0 +1,34 @@
+package cz.metacentrum.perun.core.api.exceptions;
+
+/**
+ * Validation of SSH key failed for some reason
+ *
+ * @author David Flor <davidflor@seznam.cz>
+ */
+public class SSHKeyNotValidException extends PerunException {
+
+	/**
+	 * Simple constructor with a message
+	 * @param message message with details about the cause
+	 */
+	public SSHKeyNotValidException(String message) {
+		super(message);
+	}
+
+	/**
+	 * Constructor with a message and Throwable object
+	 * @param message message with details about the cause
+	 * @param cause Throwable that caused throwing of this exception
+	 */
+	public SSHKeyNotValidException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	/**
+	 * Constructor with a Throwable object
+	 * @param cause Throwable that caused throwing of this exception
+	 */
+	public SSHKeyNotValidException(Throwable cause) {
+		super(cause);
+	}
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/UsersManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/UsersManager.java
@@ -25,6 +25,7 @@ import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
 import cz.metacentrum.perun.core.api.exceptions.RelationExistsException;
 import cz.metacentrum.perun.core.api.exceptions.RelationNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ResourceNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.SSHKeyNotValidException;
 import cz.metacentrum.perun.core.api.exceptions.ServiceNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.SpecificUserAlreadyRemovedException;
 import cz.metacentrum.perun.core.api.exceptions.SpecificUserExpectedException;
@@ -1336,6 +1337,15 @@ public interface UsersManager {
 	 * @return String return new preferred email
 	 */
 	String validatePreferredEmailChange(PerunSession sess, User user, String token) throws PrivilegeException, UserNotExistsException, WrongAttributeAssignmentException, AttributeNotExistsException, WrongReferenceAttributeValueException, WrongAttributeValueException;
+
+	/**
+	 * Validate ssh public key, throws exception if validation fails
+	 *
+	 * @param sess sess
+	 * @param sshKey ssh public key to verify
+	 * @throws SSHKeyNotValidException when validation fails
+	 */
+	void validateSSHKey(PerunSession sess, String sshKey) throws SSHKeyNotValidException;
 
 	/**
 	 * Return list of email addresses of user, which are

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
@@ -45,6 +45,7 @@ import cz.metacentrum.perun.core.api.exceptions.PasswordStrengthException;
 import cz.metacentrum.perun.core.api.exceptions.PasswordStrengthFailedException;
 import cz.metacentrum.perun.core.api.exceptions.RelationExistsException;
 import cz.metacentrum.perun.core.api.exceptions.RelationNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.SSHKeyNotValidException;
 import cz.metacentrum.perun.core.api.exceptions.SpecificUserAlreadyRemovedException;
 import cz.metacentrum.perun.core.api.exceptions.SpecificUserOwnerAlreadyRemovedException;
 import cz.metacentrum.perun.core.api.exceptions.UserAlreadyRemovedException;
@@ -1518,6 +1519,15 @@ public interface UsersManagerBl {
 	 * @throws WrongReferenceAttributeValueException
 	 */
 	String validatePreferredEmailChange(PerunSession sess, User user, String token) throws WrongAttributeValueException, WrongAttributeAssignmentException, AttributeNotExistsException, WrongReferenceAttributeValueException;
+
+	/**
+	 * Validate ssh public key, throws exception if validation fails
+	 *
+	 * @param sess sess
+	 * @param sshKey ssh public key to verify
+	 * @throws SSHKeyNotValidException when validation fails
+	 */
+	void validateSSHKey(PerunSession sess, String sshKey) throws SSHKeyNotValidException;
 
 	/**
 	 * Return list of email addresses of user, which are

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
@@ -70,6 +70,7 @@ import cz.metacentrum.perun.core.api.exceptions.PasswordStrengthException;
 import cz.metacentrum.perun.core.api.exceptions.PasswordStrengthFailedException;
 import cz.metacentrum.perun.core.api.exceptions.RelationExistsException;
 import cz.metacentrum.perun.core.api.exceptions.RelationNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.SSHKeyNotValidException;
 import cz.metacentrum.perun.core.api.exceptions.SpecificUserAlreadyRemovedException;
 import cz.metacentrum.perun.core.api.exceptions.SpecificUserOwnerAlreadyRemovedException;
 import cz.metacentrum.perun.core.api.exceptions.UserAlreadyRemovedException;
@@ -92,6 +93,7 @@ import cz.metacentrum.perun.core.bl.AttributesManagerBl;
 import cz.metacentrum.perun.core.bl.PerunBl;
 import cz.metacentrum.perun.core.bl.UsersManagerBl;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import cz.metacentrum.perun.core.impl.SSHValidator;
 import cz.metacentrum.perun.core.impl.Utils;
 import cz.metacentrum.perun.core.impl.modules.pwdmgr.GenericPasswordManagerModule;
 import cz.metacentrum.perun.core.implApi.UsersManagerImplApi;
@@ -1908,6 +1910,11 @@ public class UsersManagerBlImpl implements UsersManagerBl {
 		getUsersManagerImpl().removeAllPreferredEmailChangeRequests(sess, user);
 
 		return email;
+	}
+
+	@Override
+	public void validateSSHKey(PerunSession sess, String sshKey) throws SSHKeyNotValidException {
+		Utils.validateSSHPublicKey(sshKey);
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
@@ -58,6 +58,7 @@ import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
 import cz.metacentrum.perun.core.api.exceptions.RelationExistsException;
 import cz.metacentrum.perun.core.api.exceptions.RelationNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ResourceNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.SSHKeyNotValidException;
 import cz.metacentrum.perun.core.api.exceptions.ServiceNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.SpecificUserAlreadyRemovedException;
 import cz.metacentrum.perun.core.api.exceptions.SpecificUserExpectedException;
@@ -1558,6 +1559,13 @@ public class UsersManagerEntry implements UsersManager {
 		}
 
 		return getPerunBl().getUsersManagerBl().validatePreferredEmailChange(sess, user, token);
+	}
+
+	@Override
+	public void validateSSHKey(PerunSession sess, String sshKey) throws SSHKeyNotValidException {
+		Utils.checkPerunSession(sess);
+
+		getPerunBl().getUsersManagerBl().validateSSHKey(sess, sshKey);
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/SSHValidator.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/SSHValidator.java
@@ -1,0 +1,337 @@
+package cz.metacentrum.perun.core.impl;
+
+import com.google.api.client.util.Base64;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.SSHKeyNotValidException;
+import org.bouncycastle.jce.ECNamedCurveTable;
+import org.bouncycastle.jce.spec.ECNamedCurveParameterSpec;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.math.BigInteger;
+import java.nio.file.Files;
+import java.security.AlgorithmParameters;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.DSAPublicKeySpec;
+import java.security.spec.ECGenParameterSpec;
+import java.security.spec.ECParameterSpec;
+import java.security.spec.ECPoint;
+import java.security.spec.ECPublicKeySpec;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.InvalidParameterSpecException;
+import java.security.spec.RSAPublicKeySpec;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Validates SSH keys using predefined rules and the `ssh-keygen` tool as a final check
+ *
+ * @author David Flor <davidflor@seznam.cz>
+ */
+public class SSHValidator {
+
+	private static final Logger log = LoggerFactory.getLogger(SSHValidator.class);
+
+	private static final String SSH_RSA = "ssh-rsa";
+	private static final String SSH_DSS = "ssh-dss";
+	private static final String ECDSA_SHA2_NISTP256 = "ecdsa-sha2-nistp256";
+	private static final String ECDSA_SHA2_NISTP384 = "ecdsa-sha2-nistp384";
+	private static final String ECDSA_SHA2_NISTP521 = "ecdsa-sha2-nistp521";
+	private static final String SSH_ED25519 = "ssh-ed25519";
+	private static final String SSH_ED25519_CERT = "ssh-ed25519-cert-v01@openssh.com";
+	private static final String SK_SSH_ED25519 = "sk-ssh-ed25519@openssh.com";
+	private static final String SK_SSH_ED25519_CERT = "sk-ssh-ed25519-cert-v01@openssh.com";
+	private static final String SK_ECDSA_SHA2_NISTP256 = "sk-ecdsa-sha2-nistp256@openssh.com";
+	private static final String SSH_RSA_CERT = "ssh-rsa-cert-v01@openssh.com";
+	private static final String SSH_DSS_CERT = "ssh-dss-cert-v01@openssh.com";
+	private static final String ECDSA_SHA2_NISTP256_CERT = "ecdsa-sha2-nistp256-cert-v01@openssh.com";
+	private static final String ECDSA_SHA2_NISTP384_CERT = "ecdsa-sha2-nistp384-cert-v01@openssh.com";
+	private static final String ECDSA_SHA2_NISTP521_CERT = "ecdsa-sha2-nistp521-cert-v01@openssh.com";
+	private static final String SK_ECDSA_SHA2_NISTP256_CERT = "sk-ecdsa-sha2-nistp256-cert-v01@openssh.com";
+
+	private static final List<String> ALLOWED_SSH_TYPES = List.of(
+		SSH_RSA,
+		SSH_DSS,
+		ECDSA_SHA2_NISTP256,
+		ECDSA_SHA2_NISTP384,
+		ECDSA_SHA2_NISTP521,
+		SSH_ED25519,
+		SSH_ED25519_CERT,
+		SK_SSH_ED25519,
+		SK_SSH_ED25519_CERT,
+		SK_ECDSA_SHA2_NISTP256,
+		SSH_RSA_CERT,
+		SSH_DSS_CERT,
+		ECDSA_SHA2_NISTP256_CERT,
+		ECDSA_SHA2_NISTP384_CERT,
+		ECDSA_SHA2_NISTP521_CERT,
+		SK_ECDSA_SHA2_NISTP256_CERT);
+
+	// for now without cert variant
+	private static final List<String> RSA_SSH_TYPES = List.of(
+		SSH_RSA);
+
+	// for now without cert variant
+	private static final List<String> ECDSA_SSH_TYPES = List.of(
+		ECDSA_SHA2_NISTP256,
+		ECDSA_SHA2_NISTP384,
+		ECDSA_SHA2_NISTP521,
+		SK_ECDSA_SHA2_NISTP256);
+
+	// for now without cert variant
+	private static final List<String> DSA_SSH_TYPES = List.of(
+		SSH_DSS);
+
+
+	/**
+	 * Checks whether is the SSH key in the correct format.
+	 *
+	 * @param sshKey SSH key to be checked
+	 * @throws SSHKeyNotValidException that is thrown whenever SSH key is not in correct format
+	 */
+	public static void validateSSH(String sshKey) throws SSHKeyNotValidException {
+		if (sshKey == null || sshKey.isEmpty()) {
+			throw new SSHKeyNotValidException("SSH key has to cannot be empty or null");
+		}
+		try {
+			sshKey = removeSSHKeyCommandPrefix(sshKey);
+			int[] pos = {0};
+			byte[] sshBase64KeyBytes;
+
+			String[] sshKeyParts = sshKey.split(" ");
+			if (sshKeyParts.length < 2) {
+				throw new SSHKeyNotValidException("SSH public key has to consists at least from the key type and the Base64 encoded public key.");
+			}
+
+			String sshKeyType = sshKeyParts[0];
+			if (!ALLOWED_SSH_TYPES.contains(sshKeyType)) {
+				throw new SSHKeyNotValidException("The " + sshKeyType + " key type is not allowed. Allowed types are: " + ALLOWED_SSH_TYPES + ".");
+			}
+
+			try {
+				sshBase64KeyBytes = Base64.decodeBase64(sshKeyParts[1]);
+			} catch (Exception exception) {
+				throw new SSHKeyNotValidException("Provided Base64 encoded public key is not valid.");
+			}
+
+			String sshBase64KeyType = decodeType(sshBase64KeyBytes, pos);
+			if (!sshBase64KeyType.equals(sshKeyType)) {
+				throw new SSHKeyNotValidException("SSH types are not same. Type defined before the Base64 is: " + sshKeyType + " and type inside the Base64 is: " + sshBase64KeyType + ".");
+			}
+
+			try {
+				if (RSA_SSH_TYPES.contains(sshKeyType)) {
+					decodeRSA(sshBase64KeyBytes, pos);
+				} else if (DSA_SSH_TYPES.contains(sshKeyType)) {
+					decodeDSA(sshBase64KeyBytes, pos);
+				} else if (ECDSA_SSH_TYPES.contains(sshKeyType)) {
+					decodeEcdsa(sshBase64KeyBytes, pos);
+				}
+			} catch (Exception ex) {
+				throw new SSHKeyNotValidException("Provided Base64 encoded public key is not valid.");
+			}
+		} catch (Exception e) {
+			throw new SSHKeyNotValidException("Invalid SSH key format:  " + e.getMessage());
+		}
+		// check one more time with ssh-keygen for edge cases
+		runSshKeygen(sshKey);
+	}
+
+	/**
+	 * Validates ssh public key using the ssh-keygen tool
+	 *
+	 * @param sshKey ssh public key to verify
+	 * @throws SSHKeyNotValidException when validation fails
+	 */
+	private static void runSshKeygen(String sshKey) throws SSHKeyNotValidException {
+		File tempSSH = null;
+		try {
+			tempSSH = File.createTempFile("perunSSHAttr", ".txt");
+
+			try (BufferedWriter bw = new BufferedWriter(new FileWriter(tempSSH))) {
+				bw.write(sshKey);
+			}
+			ProcessBuilder pb = new ProcessBuilder("ssh-keygen", "-l", "-f", tempSSH.getAbsolutePath());
+			Process process = pb.start();
+
+			// String result = new String(process.getInputStream().readAllBytes());
+			String error = new String(process.getErrorStream().readAllBytes());
+
+			int returnCode = process.waitFor();
+			if (returnCode != 0) {
+				log.error("SSH validation error: " + error + " for key: " + sshKey + " with error code: " + returnCode);
+				if (returnCode == 255) {
+					throw new SSHKeyNotValidException("Provided SSH key is not valid");
+				}
+				throw new SSHKeyNotValidException("SSH validation failed with: " + error);
+			}
+		} catch (IOException | InterruptedException ex) {
+			throw new InternalErrorException("File error while verifying ssh key");
+		} finally {
+			try {
+				if (tempSSH != null) Files.deleteIfExists(tempSSH.toPath());
+			} catch (IOException ex) {
+				log.error("Failed to remove file: " + tempSSH.getAbsolutePath() + " after verifying ssh key");
+				throw new InternalErrorException("Couldn't delete files after verifying ssh key");
+			}
+		}
+	}
+
+	/**
+	 * Removes any potential command prefix before the ssh key
+	 *
+	 * @param sshKey raw ssh key value from the attribute
+	 * @return SSH key without the command prefix
+	 */
+	private static String removeSSHKeyCommandPrefix(String sshKey) {
+		// entries in authorized_keys are of this format (from man page):
+		// "Public keys consist of the following space-separated fields: options, keytype, base64-encoded key, comment.
+		// The options field is optional."
+
+		// split on spaces outside of quotes
+		String[] sshKeyParts = sshKey.split(" (?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)");
+
+		// check whether key has options, cut them if so
+		if (!ALLOWED_SSH_TYPES.contains(sshKeyParts[0])) {
+			String[] keyPartsWithoutPrefix = Arrays.copyOfRange(sshKeyParts, 1, sshKeyParts.length);
+			return String.join(" ", keyPartsWithoutPrefix);
+		}
+		return sshKey;
+
+	}
+
+	/**
+	 * Checks whether is the key in the correct ecdsa format.
+	 *
+	 * @param bytes Data of SSH key encoded in Base64
+	 * @param pos   Position in the 'bytes'
+	 * @throws NoSuchAlgorithmException Should never occur since hardcoded value is used
+	 * @throws InvalidKeySpecException  Thrown if the used algorithm does not match the EC specification
+	 */
+	private static void decodeEcdsa(byte[] bytes, int[] pos) throws NoSuchAlgorithmException, InvalidKeySpecException {
+		// Based on RFC 5656, section 3.1 (https://tools.ietf.org/html/rfc5656#section-3.1)
+		String identifier = decodeType(bytes, pos);
+		BigInteger publicKey = decodeBigInt(bytes, pos);
+		ECPoint ecPoint = getECPoint(publicKey, identifier);
+		ECParameterSpec ecParameterSpec = getECParameterSpec(identifier);
+		ECPublicKeySpec spec = new ECPublicKeySpec(ecPoint, ecParameterSpec);
+		KeyFactory.getInstance("EC").generatePublic(spec);
+	}
+
+	/**
+	 * Checks whether is the key in the correct dsa format.
+	 *
+	 * @param bytes Data of SSH key encoded in Base64
+	 * @param pos   Position in the 'bytes'
+	 * @throws NoSuchAlgorithmException Should never occur since hardcoded value is used
+	 * @throws InvalidKeySpecException  Thrown if the used algorithm does not match the DSA specification
+	 */
+	private static void decodeDSA(byte[] bytes, int[] pos) throws NoSuchAlgorithmException, InvalidKeySpecException {
+		BigInteger p = decodeBigInt(bytes, pos);
+		BigInteger q = decodeBigInt(bytes, pos);
+		BigInteger g = decodeBigInt(bytes, pos);
+		BigInteger y = decodeBigInt(bytes, pos);
+		DSAPublicKeySpec spec = new DSAPublicKeySpec(y, p, q, g);
+		KeyFactory.getInstance("DSA").generatePublic(spec);
+	}
+
+	/**
+	 * Checks whether is the key in the correct rsa format.
+	 *
+	 * @param bytes Data of SSH key encoded in Base64
+	 * @param pos   Position in the 'bytes'
+	 * @throws NoSuchAlgorithmException Should never occur since hardcoded value is used
+	 * @throws InvalidKeySpecException  Thrown if the used algorithm does not match the RSA specification
+	 */
+	private static void decodeRSA(byte[] bytes, int[] pos) throws NoSuchAlgorithmException, InvalidKeySpecException {
+		BigInteger exponent = decodeBigInt(bytes, pos);
+		BigInteger modulus = decodeBigInt(bytes, pos);
+		RSAPublicKeySpec spec = new RSAPublicKeySpec(modulus, exponent);
+		KeyFactory.getInstance("RSA").generatePublic(spec);
+	}
+
+	/**
+	 * Provides means to get from a parsed Q value to the X and Y point values.
+	 * that can be used to create and ECPoint compatible with ECPublicKeySpec.
+	 *
+	 * @param q          According to RFC 5656:
+	 *                   "Q is the public key encoded from an elliptic curve point into an octet string"
+	 * @param identifier According to RFC 5656:
+	 *                   "The string [identifier] is the identifier of the elliptic curve domain parameters."
+	 * @return An ECPoint suitable for creating a JCE ECPublicKeySpec.
+	 */
+	private static ECPoint getECPoint(BigInteger q, String identifier) {
+		String name = identifier.replace("nist", "sec") + "r1";
+		ECNamedCurveParameterSpec ecSpec = ECNamedCurveTable.getParameterSpec(name);
+		org.bouncycastle.math.ec.ECPoint point = ecSpec.getCurve().decodePoint(q.toByteArray());
+		BigInteger x = point.getAffineXCoord().toBigInteger();
+		BigInteger y = point.getAffineYCoord().toBigInteger();
+		return new ECPoint(x, y);
+	}
+
+	/**
+	 * Gets the curve parameters for the given key type identifier.
+	 *
+	 * @param identifier According to RFC 5656:
+	 *                   "The string [identifier] is the identifier of the elliptic curve domain parameters."
+	 * @return An ECParameterSpec suitable for creating a JCE ECPublicKeySpec.
+	 */
+	private static ECParameterSpec getECParameterSpec(String identifier) {
+		try {
+			// http://www.bouncycastle.org/wiki/pages/viewpage.action?pageId=362269#SupportedCurves(ECDSAandECGOST)-NIST(aliasesforSECcurves)
+			String name = identifier.replace("nist", "sec") + "r1";
+			AlgorithmParameters parameters = AlgorithmParameters.getInstance("EC");
+			parameters.init(new ECGenParameterSpec(name));
+			return parameters.getParameterSpec(ECParameterSpec.class);
+		} catch (InvalidParameterSpecException | NoSuchAlgorithmException e) {
+			throw new IllegalArgumentException("Unable to parse curve parameters: ", e);
+		}
+	}
+
+	/**
+	 * Decodes type of SSh key encoded in provided data
+	 *
+	 * @param bytes Data of SSH key encoded in Base64
+	 * @param pos   Position in the 'bytes'
+	 * @return Type of SSH key
+	 */
+	private static String decodeType(byte[] bytes, int[] pos) {
+		int len = decodeInt(bytes, pos);
+		String type = new String(bytes, pos[0], len);
+		pos[0] += len;
+		return type;
+	}
+
+	/**
+	 * Decodes integer part encoded in provided data. Usually used when validating concrete SSH algorithm.
+	 *
+	 * @param bytes Data of SSH key encoded in Base64
+	 * @param pos   Position in the 'bytes'
+	 * @return Integer part of SSH key
+	 */
+	private static int decodeInt(byte[] bytes, int[] pos) {
+		return ((bytes[pos[0]++] & 0xFF) << 24) | ((bytes[pos[0]++] & 0xFF) << 16)
+			| ((bytes[pos[0]++] & 0xFF) << 8) | (bytes[pos[0]++] & 0xFF);
+	}
+
+	/**
+	 * Decodes big integer part encoded in provided data. Usually used when validating concrete SSH algorithm.
+	 *
+	 * @param bytes Data of SSH key encoded in Base64
+	 * @param pos   Position in the 'bytes'
+	 * @return Big integer part of SSH key
+	 */
+	private static BigInteger decodeBigInt(byte[] bytes, int[] pos) {
+		int len = decodeInt(bytes, pos);
+		byte[] bigIntBytes = new byte[len];
+		System.arraycopy(bytes, pos[0], bigIntBytes, 0, len);
+		pos[0] += len;
+		return new BigInteger(bigIntBytes);
+	}
+
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Utils.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Utils.java
@@ -29,6 +29,7 @@ import cz.metacentrum.perun.core.api.exceptions.NumbersNotAllowedException;
 import cz.metacentrum.perun.core.api.exceptions.ParseUserNameException;
 import cz.metacentrum.perun.core.api.exceptions.ParserException;
 import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
+import cz.metacentrum.perun.core.api.exceptions.SSHKeyNotValidException;
 import cz.metacentrum.perun.core.api.exceptions.SpaceNotAllowedException;
 import cz.metacentrum.perun.core.api.exceptions.SpecialCharsNotAllowedException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
@@ -1977,6 +1978,10 @@ public class Utils {
 		if (secondaryRegex != null && !secondaryRegex.isEmpty()) {
 			validateGroupName(name, secondaryRegex);
 		}
+	}
+
+	public static void validateSSHPublicKey(String sshKey) throws SSHKeyNotValidException {
+		SSHValidator.validateSSH(sshKey);
 	}
 
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_sshPublicKey.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_sshPublicKey.java
@@ -1,87 +1,22 @@
 package cz.metacentrum.perun.core.impl.modules.attributes;
 
-import com.google.api.client.util.Base64;
 import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import cz.metacentrum.perun.core.impl.Utils;
 import cz.metacentrum.perun.core.implApi.modules.attributes.UserAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.UserAttributesModuleImplApi;
-import org.bouncycastle.jce.ECNamedCurveTable;
-import org.bouncycastle.jce.spec.ECNamedCurveParameterSpec;
 
-import java.math.BigInteger;
-import java.security.AlgorithmParameters;
-import java.security.KeyFactory;
-import java.security.NoSuchAlgorithmException;
-import java.security.spec.DSAPublicKeySpec;
-import java.security.spec.ECParameterSpec;
-import java.security.spec.ECPoint;
-import java.security.spec.RSAPublicKeySpec;
-import java.security.spec.ECPublicKeySpec;
-import java.security.spec.InvalidKeySpecException;
-import java.security.spec.ECGenParameterSpec;
-import java.security.spec.InvalidParameterSpecException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 /**
  * @author Jakub Peschel <jakubpeschel@gmail.com>
  */
 public class urn_perun_user_attribute_def_def_sshPublicKey extends UserAttributesModuleAbstract implements UserAttributesModuleImplApi {
-
-	private static final String SSH_RSA = "ssh-rsa";
-	private static final String SSH_DSS = "ssh-dss";
-	private static final String ECDSA_SHA2_NISTP256 = "ecdsa-sha2-nistp256";
-	private static final String ECDSA_SHA2_NISTP384 = "ecdsa-sha2-nistp384";
-	private static final String ECDSA_SHA2_NISTP521 = "ecdsa-sha2-nistp521";
-	private static final String SSH_ED25519 = "ssh-ed25519";
-	private static final String SSH_ED25519_CERT = "ssh-ed25519-cert-v01@openssh.com";
-	private static final String SK_SSH_ED25519 = "sk-ssh-ed25519@openssh.com";
-	private static final String SK_SSH_ED25519_CERT = "sk-ssh-ed25519-cert-v01@openssh.com";
-	private static final String SK_ECDSA_SHA2_NISTP256 = "sk-ecdsa-sha2-nistp256@openssh.com";
-	private static final String SSH_RSA_CERT = "ssh-rsa-cert-v01@openssh.com";
-	private static final String SSH_DSS_CERT = "ssh-dss-cert-v01@openssh.com";
-	private static final String ECDSA_SHA2_NISTP256_CERT = "ecdsa-sha2-nistp256-cert-v01@openssh.com";
-	private static final String ECDSA_SHA2_NISTP384_CERT = "ecdsa-sha2-nistp384-cert-v01@openssh.com";
-	private static final String ECDSA_SHA2_NISTP521_CERT = "ecdsa-sha2-nistp521-cert-v01@openssh.com";
-	private static final String SK_ECDSA_SHA2_NISTP256_CERT = "sk-ecdsa-sha2-nistp256-cert-v01@openssh.com";
-
-	private static final List<String> ALLOWED_SSH_TYPES = List.of(
-		SSH_RSA,
-		SSH_DSS,
-		ECDSA_SHA2_NISTP256,
-		ECDSA_SHA2_NISTP384,
-		ECDSA_SHA2_NISTP521,
-		SSH_ED25519,
-		SSH_ED25519_CERT,
-		SK_SSH_ED25519,
-		SK_SSH_ED25519_CERT,
-		SK_ECDSA_SHA2_NISTP256,
-		SSH_RSA_CERT,
-		SSH_DSS_CERT,
-		ECDSA_SHA2_NISTP256_CERT,
-		ECDSA_SHA2_NISTP384_CERT,
-		ECDSA_SHA2_NISTP521_CERT,
-		SK_ECDSA_SHA2_NISTP256_CERT);
-
-	// for now without cert variant
-	private static final List<String> RSA_SSH_TYPES = List.of(
-		SSH_RSA);
-
-	// for now without cert variant
-	private static final List<String> ECDSA_SSH_TYPES = List.of(
-		ECDSA_SHA2_NISTP256,
-		ECDSA_SHA2_NISTP384,
-		ECDSA_SHA2_NISTP521,
-		SK_ECDSA_SHA2_NISTP256);
-
-	// for now without cert variant
-	private static final List<String> DSA_SSH_TYPES = List.of(
-		SSH_DSS);
 
 	@Override
 	public void checkAttributeSyntax(PerunSessionImpl perunSession, User user, Attribute attribute) throws WrongAttributeValueException {
@@ -95,8 +30,7 @@ public class urn_perun_user_attribute_def_def_sshPublicKey extends UserAttribute
 				if (sshKey.contains("\n"))
 					throw new WrongAttributeValueException(attribute, user, "One of keys in attribute contains new line character. New line character is not allowed here.");
 				try {
-					sshKey = removeSSHKeyCommandPrefix(sshKey);
-					validateSSH(sshKey);
+					Utils.validateSSHPublicKey(sshKey);
 				} catch (Exception e) {
 					throw new WrongAttributeValueException(attribute, user, "Invalid SSH key format: " + e.getMessage());
 				}
@@ -104,202 +38,6 @@ public class urn_perun_user_attribute_def_def_sshPublicKey extends UserAttribute
 		}
 	}
 
-	/**
-	 * Removes any potential command prefix before the ssh key
-	 *
-	 * @param sshKey raw ssh key value from the attribute
-	 * @return SSH key without the command prefix
-	 */
-	private String removeSSHKeyCommandPrefix(String sshKey) {
-		// entries in authorized_keys are of this format (from man page):
-		// "Public keys consist of the following space-separated fields: options, keytype, base64-encoded key, comment.
-		// The options field is optional."
-
-		// split on spaces outside of quotes
-		String[] sshKeyParts = sshKey.split(" (?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)");
-
-		// check whether key has options, cut them if so
-		if (!ALLOWED_SSH_TYPES.contains(sshKeyParts[0])) {
-			String[] keyPartsWithoutPrefix = Arrays.copyOfRange(sshKeyParts, 1, sshKeyParts.length);
-			return String.join(" ", keyPartsWithoutPrefix);
-		}
-		return sshKey;
-
-	}
-
-	/**
-	 * Checks whether is the SSH key in the correct format.
-	 *
-	 * @param sshKey SSH key to be checked
-	 * @throws Exception that is thrown whenever SSH key is not in correct format
-	 */
-	private void validateSSH(String sshKey) throws Exception {
-		int[] pos = {0};
-		byte[] sshBase64KeyBytes;
-
-		String[] sshKeyParts = sshKey.split(" ");
-		if (sshKeyParts.length < 2) {
-			throw new IllegalArgumentException("SSH public key has to consists at least from the key type and the Base64 encoded public key.");
-		}
-
-		String sshKeyType = sshKeyParts[0];
-		if (!ALLOWED_SSH_TYPES.contains(sshKeyType)) {
-			throw new IllegalArgumentException("The " + sshKeyType + " key type is not allowed. Allowed types are: " + ALLOWED_SSH_TYPES + ".");
-		}
-
-		try {
-			sshBase64KeyBytes = Base64.decodeBase64(sshKeyParts[1]);
-		} catch (Exception exception) {
-			throw new IllegalArgumentException("Provided Base64 encoded public key is not valid.");
-		}
-
-		String sshBase64KeyType = decodeType(sshBase64KeyBytes, pos);
-		if (!sshBase64KeyType.equals(sshKeyType)) {
-			throw new IllegalArgumentException("SSH types are not same. Type defined before the Base64 is: " + sshKeyType + " and type inside the Base64 is: " + sshBase64KeyType + ".");
-		}
-
-		try {
-			if (RSA_SSH_TYPES.contains(sshKeyType)) {
-				decodeRSA(sshBase64KeyBytes, pos);
-			} else if (DSA_SSH_TYPES.contains(sshKeyType)) {
-				decodeDSA(sshBase64KeyBytes, pos);
-			} else if (ECDSA_SSH_TYPES.contains(sshKeyType)) {
-				decodeEcdsa(sshBase64KeyBytes, pos);
-			}
-		} catch (Exception ex) {
-			throw new IllegalArgumentException("Provided Base64 encoded public key is not valid.");
-		}
-
-	}
-
-	/**
-	 * Checks whether is the key in the correct ecdsa format.
-	 *
-	 * @param bytes Data of SSH key encoded in Base64
-	 * @param pos   Position in the 'bytes'
-	 * @throws NoSuchAlgorithmException Should never occur since hardcoded value is used
-	 * @throws InvalidKeySpecException  Thrown if the used algorithm does not match the EC specification
-	 */
-	private void decodeEcdsa(byte[] bytes, int[] pos) throws NoSuchAlgorithmException, InvalidKeySpecException {
-		// Based on RFC 5656, section 3.1 (https://tools.ietf.org/html/rfc5656#section-3.1)
-		String identifier = decodeType(bytes, pos);
-		BigInteger publicKey = decodeBigInt(bytes, pos);
-		ECPoint ecPoint = getECPoint(publicKey, identifier);
-		ECParameterSpec ecParameterSpec = getECParameterSpec(identifier);
-		ECPublicKeySpec spec = new ECPublicKeySpec(ecPoint, ecParameterSpec);
-		KeyFactory.getInstance("EC").generatePublic(spec);
-	}
-
-	/**
-	 * Checks whether is the key in the correct dsa format.
-	 *
-	 * @param bytes Data of SSH key encoded in Base64
-	 * @param pos   Position in the 'bytes'
-	 * @throws NoSuchAlgorithmException Should never occur since hardcoded value is used
-	 * @throws InvalidKeySpecException  Thrown if the used algorithm does not match the DSA specification
-	 */
-	private void decodeDSA(byte[] bytes, int[] pos) throws NoSuchAlgorithmException, InvalidKeySpecException {
-		BigInteger p = decodeBigInt(bytes, pos);
-		BigInteger q = decodeBigInt(bytes, pos);
-		BigInteger g = decodeBigInt(bytes, pos);
-		BigInteger y = decodeBigInt(bytes, pos);
-		DSAPublicKeySpec spec = new DSAPublicKeySpec(y, p, q, g);
-		KeyFactory.getInstance("DSA").generatePublic(spec);
-	}
-
-	/**
-	 * Checks whether is the key in the correct rsa format.
-	 *
-	 * @param bytes Data of SSH key encoded in Base64
-	 * @param pos   Position in the 'bytes'
-	 * @throws NoSuchAlgorithmException Should never occur since hardcoded value is used
-	 * @throws InvalidKeySpecException  Thrown if the used algorithm does not match the RSA specification
-	 */
-	private void decodeRSA(byte[] bytes, int[] pos) throws NoSuchAlgorithmException, InvalidKeySpecException {
-		BigInteger exponent = decodeBigInt(bytes, pos);
-		BigInteger modulus = decodeBigInt(bytes, pos);
-		RSAPublicKeySpec spec = new RSAPublicKeySpec(modulus, exponent);
-		KeyFactory.getInstance("RSA").generatePublic(spec);
-	}
-
-	/**
-	 * Provides means to get from a parsed Q value to the X and Y point values.
-	 * that can be used to create and ECPoint compatible with ECPublicKeySpec.
-	 *
-	 * @param q          According to RFC 5656:
-	 *                   "Q is the public key encoded from an elliptic curve point into an octet string"
-	 * @param identifier According to RFC 5656:
-	 *                   "The string [identifier] is the identifier of the elliptic curve domain parameters."
-	 * @return An ECPoint suitable for creating a JCE ECPublicKeySpec.
-	 */
-	private ECPoint getECPoint(BigInteger q, String identifier) {
-		String name = identifier.replace("nist", "sec") + "r1";
-		ECNamedCurveParameterSpec ecSpec = ECNamedCurveTable.getParameterSpec(name);
-		org.bouncycastle.math.ec.ECPoint point = ecSpec.getCurve().decodePoint(q.toByteArray());
-		BigInteger x = point.getAffineXCoord().toBigInteger();
-		BigInteger y = point.getAffineYCoord().toBigInteger();
-		return new ECPoint(x, y);
-	}
-
-	/**
-	 * Gets the curve parameters for the given key type identifier.
-	 *
-	 * @param identifier According to RFC 5656:
-	 *                   "The string [identifier] is the identifier of the elliptic curve domain parameters."
-	 * @return An ECParameterSpec suitable for creating a JCE ECPublicKeySpec.
-	 */
-	private ECParameterSpec getECParameterSpec(String identifier) {
-		try {
-			// http://www.bouncycastle.org/wiki/pages/viewpage.action?pageId=362269#SupportedCurves(ECDSAandECGOST)-NIST(aliasesforSECcurves)
-			String name = identifier.replace("nist", "sec") + "r1";
-			AlgorithmParameters parameters = AlgorithmParameters.getInstance("EC");
-			parameters.init(new ECGenParameterSpec(name));
-			return parameters.getParameterSpec(ECParameterSpec.class);
-		} catch (InvalidParameterSpecException | NoSuchAlgorithmException e) {
-			throw new IllegalArgumentException("Unable to parse curve parameters: ", e);
-		}
-	}
-
-	/**
-	 * Decodes type of SSh key encoded in provided data
-	 *
-	 * @param bytes Data of SSH key encoded in Base64
-	 * @param pos   Position in the 'bytes'
-	 * @return Type of SSH key
-	 */
-	private String decodeType(byte[] bytes, int[] pos) {
-		int len = decodeInt(bytes, pos);
-		String type = new String(bytes, pos[0], len);
-		pos[0] += len;
-		return type;
-	}
-
-	/**
-	 * Decodes integer part encoded in provided data. Usually used when validating concrete SSH algorithm.
-	 *
-	 * @param bytes Data of SSH key encoded in Base64
-	 * @param pos   Position in the 'bytes'
-	 * @return Integer part of SSH key
-	 */
-	private int decodeInt(byte[] bytes, int[] pos) {
-		return ((bytes[pos[0]++] & 0xFF) << 24) | ((bytes[pos[0]++] & 0xFF) << 16)
-			| ((bytes[pos[0]++] & 0xFF) << 8) | (bytes[pos[0]++] & 0xFF);
-	}
-
-	/**
-	 * Decodes big integer part encoded in provided data. Usually used when validating concrete SSH algorithm.
-	 *
-	 * @param bytes Data of SSH key encoded in Base64
-	 * @param pos   Position in the 'bytes'
-	 * @return Big integer part of SSH key
-	 */
-	private BigInteger decodeBigInt(byte[] bytes, int[] pos) {
-		int len = decodeInt(bytes, pos);
-		byte[] bigIntBytes = new byte[len];
-		System.arraycopy(bytes, pos[0], bigIntBytes, 0, len);
-		pos[0] += len;
-		return new BigInteger(bigIntBytes);
-	}
 
 	@Override
 	public AttributeDefinition getAttributeDefinition() {

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/UtilsIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/UtilsIntegrationTest.java
@@ -15,6 +15,7 @@ import cz.metacentrum.perun.core.api.UsersManager;
 import cz.metacentrum.perun.core.api.Vo;
 import cz.metacentrum.perun.core.api.exceptions.IllegalArgumentException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.SSHKeyNotValidException;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -659,6 +660,24 @@ public class UtilsIntegrationTest extends AbstractPerunIntegrationTest {
 		Host host = new Host();
 		host.setHostname("invalid");
 		Utils.checkHostname(host);
+	}
+
+	@Test
+	public void validateSSHPublicKey() {
+		System.out.println("Utils.validateSShKeyInvalid");
+		String invalid1 = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCYZTcdI8iZFJ2c63iN0kMhpcEGuE054DCJh8gCBhyOKQn6LH3wBX/U6RERh+1UmWkblEnQM3B2vEnSGRgNfG7KQgi2xSMHlb4KO1wNB6mOwNV4a+rX115ncWxHwR+7UZPYEmafXX5WZWzT3mzvHWRLZvw87uD7FLWqFGAbEwdvinHIB4tLvCcnLSc+O9xmdZVMKbiuCIO/odhqmfUM4RD7htaBL/ZSFZn5fen5wo9xhTd2Z7fTOALPbRkG5uIWMo7TiiLNWlo9f1sao1zNmNxZrUpgbL7mUJwWz1Wor8hlOCIbjHYySFK8vz6ziqbOHh2/8DVEqAh/dEJMhVhY9rHUDjbfjOrCMswF9NWRO4Gmsn9ARHRwXN2Gq3bu6cJ6L7h5YuBH93+QtZZhYm34JfNNsZnCsaz4g0aTUwD4UtZ7kxqMMf0xE7ndc7y4wCI7+kHn/nPamtSCFT8Pgg8WfDF22S4ouZcRVS9eU1O8a/fn0dpL77wmY8rvCDyzX3VhUAHfp9YHYPB1rVRN/9tLR2wpwHHhDz758750bin/tkp7QHCJ+27vqLU3RX/ZTFjUeNX2HeHpfQEy5jyptSZgfmbnmljqOfVpDgyQ2Wvc+prN6iTjDmsaTZrY0AIQq9EUVYFLFXhqo2x3tYcC7bmlFfRE8Dl5klpfniRNOWLnMdvXcw";
+		String invalid2 = "ssh-rsa 2048 10:e7:0a:ff:be:c3:c9:fb:2b:06:f3:07:ac:68:43:02";
+		String validECDSA = "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBGgt1/rkRvQJp92tP8uxLJfy340lJGSSxsPp3+W1JdMbk+S2qIPwM5o/oblTjGhVRzKcas4pLrBz7L/Mxn6D6qw= martin@martin-ThinkPad-T480";
+		String validED25519 = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJhGU1cLG0UldPhYxbEjKcZmFSZsGznmAYvra2QPls7a martin@martin-ThinkPad-T480";
+		String validRSA = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC7FPq20sXf+83P/mvfEBntaGUkVJu36X2gLIi5TioYPSqGVIPV+ztnhNUuJHQZ3HYRDhGw/5c32mIYKQvsAB0T/WT6hgs9zVHU1s5ieJSduxx9DqbEkHaZUirmukd8uF97QJm6Ve/cvS3YUb3yxWXcRiJX5jy1aRazoJgm/Vocgz/1PHInq46IQUN6I62ge7u5YrpSxym6Ehw8ZGCr7QyIyg5TdNVbK4flkf6LM/uKh0JuODfm+/R/3TjzbR/7oDzfkQR4TZE3sCHXpSEwaHbb4SM6if1di2PKefhlx9m7w0oMwaE6Epoq/US1FHxR0up+PQYqqwE+/fi9C88byT1Kjz7xpC3IV0bOdeP6nDcLDYsKssgotqU0YIrBCTes/an1efe1jrYZQvr54XvKNFWUnJsMJLosT2ZCWkNCyyrnL9V+KEJ07Qb4NAXfgcrVakP/6647FAXCgyY8Len9c/0aTn7SVd1aC3aTGRvLtvPNPzhbDJGKzjPs90So0GZ+q7s= martin@martin-ThinkPad-T480";
+
+		assertThatExceptionOfType(SSHKeyNotValidException.class).isThrownBy(() -> Utils.validateSSHPublicKey(invalid1));
+
+		assertThatExceptionOfType(SSHKeyNotValidException.class).isThrownBy(() -> Utils.validateSSHPublicKey(invalid2));
+
+		assertThatNoException().isThrownBy(() -> Utils.validateSSHPublicKey(validECDSA));
+		assertThatNoException().isThrownBy(() -> Utils.validateSSHPublicKey(validED25519));
+		assertThatNoException().isThrownBy(() -> Utils.validateSSHPublicKey(validRSA));
 	}
 
 	private Vo setUpVo() throws Exception {

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/UsersManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/UsersManagerMethod.java
@@ -1642,6 +1642,23 @@ public enum UsersManagerMethod implements ManagerMethod {
 	},
 
 	/*#
+	 * Validate ssh public key, throws exception if validation fails
+	 *
+	 *
+	 * @param sshKey String public ssh key to validate
+	 *
+	 * @throw SSHKeyNotValidException when validation fails
+	 */
+	validateSSHKey {
+		@Override
+		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
+			parms.stateChangingCheck();
+			ac.getUsersManager().validateSSHKey(ac.getSession(), parms.readString("sshKey"));
+			return null;
+		}
+	},
+
+	/*#
 	 * Return list of email addresses of user, which are
 	 * awaiting validation and are inside time window
 	 * for validation.


### PR DESCRIPTION
* validation of public ssh keys in the attributes now also includes a call of ssh-keygen
* this should catch some edge case invalid keys
* extracted the validation method to RPC to call from WUI

DEPLOYMENT NOTE: the `ssh-keygen` tool has to be available on instance machines