### PR TITLE
feat(core): add attribute modules for m365

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_m365AllowedLicensesPriorities.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_m365AllowedLicensesPriorities.java
@@ -1,0 +1,108 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Facility;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityAttributesModuleImplApi;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+
+/**
+ * Checks that value of m365AllowedLicensesPriorities is valid:
+ *   -	does not contain a null key
+ *   -	when a change is made, there is no m365LicenseGroup attribute under the same facility
+ *   	containing a license that no longer exists in this map
+ *
+ * @author Michal Berky <michal.berky@cesnet.cz>
+ */
+public class urn_perun_facility_attribute_def_def_m365AllowedLicensesPriorities extends FacilityAttributesModuleAbstract implements FacilityAttributesModuleImplApi {
+
+	private static final String A_FAC_m365AllowedLicensesPriorities = AttributesManager.NS_FACILITY_ATTR_DEF + ":m365AllowedLicensesPriorities";
+
+	@Override
+	public void checkAttributeSyntax(PerunSessionImpl perunSession, Facility facility, Attribute attribute) throws WrongAttributeValueException {
+		LinkedHashMap<String, String> licensesPriorities = attribute.valueAsMap();
+		if(licensesPriorities == null) return;
+
+		for (String key : licensesPriorities.keySet()) {
+			if (key == null) {
+				throw new WrongAttributeValueException("There can't be a null key in: " + attribute);
+			}
+			String license = licensesPriorities.get(key);
+			if ( license == null || license.isEmpty()) {
+				throw new WrongAttributeValueException("There can't be an empty value in: " + attribute + " for key: " + key);
+			}
+		}
+	}
+
+	@Override
+	public void checkAttributeSemantics(PerunSessionImpl perunSession, Facility facility, Attribute attribute) throws WrongReferenceAttributeValueException, InternalErrorException {
+		LinkedHashMap<String, String> licensesMap = attribute.valueAsMap();
+		List<Resource> resources = perunSession.getPerunBl().getFacilitiesManagerBl().getAssignedResources(perunSession, facility);
+
+		if (licensesMap == null) {
+			handleNullLicensesMap(perunSession, resources, attribute);
+			return;
+		}
+
+		verifyResourcesLicense(perunSession, resources, licensesMap);
+	}
+
+	private void handleNullLicensesMap(PerunSessionImpl perunSession, List<Resource> resources, Attribute attribute) throws WrongReferenceAttributeValueException {
+		if (resources.isEmpty()) return;
+
+		for (Resource res : resources) {
+			if (fetchResourceLicense(perunSession, res) != null) {
+				throw new WrongReferenceAttributeValueException("The attribute '" + attribute +
+					"' is being cleared, but there is still a resource in this facility depending on it: '" + res.getName());
+			}
+		}
+	}
+
+	private String fetchResourceLicense(PerunSessionImpl perunSession, Resource res) throws WrongReferenceAttributeValueException {
+		try {
+			return perunSession.getPerunBl().getAttributesManagerBl().getAttribute(perunSession, res, A_FAC_m365AllowedLicensesPriorities).valueAsString();
+		} catch (AttributeNotExistsException | WrongAttributeAssignmentException e) {
+			throw new WrongReferenceAttributeValueException("Couldn't retrieve m365LicenseGroup from resource " + res.getName(), e);
+		}
+	}
+
+	private void verifyResourcesLicense(PerunSessionImpl perunSession, List<Resource> resources, LinkedHashMap<String, String> licensesMap) throws WrongReferenceAttributeValueException {
+		for (Resource res : resources) {
+			String resourceLicense = fetchResourceLicense(perunSession, res);
+
+			if (resourceLicense != null && !licensesMap.containsValue(resourceLicense)) {
+				throw new WrongReferenceAttributeValueException("The license group: " + resourceLicense + " is still required in this facility by resource: " + res.getName());
+			}
+		}
+	}
+
+	@Override
+	public List<String> getDependencies() {
+		List<String> dependencies = new ArrayList<>();
+		dependencies.add(A_FAC_m365AllowedLicensesPriorities);
+		return dependencies;
+	}
+
+	@Override
+	public AttributeDefinition getAttributeDefinition() {
+		AttributeDefinition attr = new AttributeDefinition();
+		attr.setNamespace(AttributesManager.NS_FACILITY_ATTR_DEF);
+		attr.setFriendlyName("m365AllowedLicensesPriorities");
+		attr.setDisplayName("M365 Allowed Licenses Priorities");
+		attr.setType(LinkedHashMap.class.getName());
+		attr.setDescription("Map of priority number (higher = bigger priority) and license names for M365");
+		return attr;
+	}
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_m365LicenseGroup.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_m365LicenseGroup.java
@@ -1,0 +1,68 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Facility;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceAttributesModuleImplApi;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+
+/**
+ * 	Checks that License group is present in m365AllowedLicensesPriorities map
+ *
+ * @author Michal Berky <michal.berky@cesnet.cz>
+ */
+public class urn_perun_resource_attribute_def_def_m365LicenseGroup extends ResourceAttributesModuleAbstract implements ResourceAttributesModuleImplApi {
+
+	private static final String A_FAC_m365AllowedLicensesPriorities = AttributesManager.NS_FACILITY_ATTR_DEF + ":m365AllowedLicensesPriorities";
+
+	@Override
+	public void checkAttributeSemantics(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+		String licenseGroup = attribute.valueAsString();
+		if (licenseGroup == null || licenseGroup.isEmpty()) {
+			return;
+		}
+
+		try {
+			Facility facility = perunSession.getPerunBl().getResourcesManagerBl().getFacility(perunSession, resource);
+
+			Attribute allowedLicenses = perunSession.getPerunBl().getAttributesManagerBl().getAttribute(
+				perunSession, facility, A_FAC_m365AllowedLicensesPriorities);
+
+			LinkedHashMap<String, String> allowedLicensesMap = allowedLicenses.valueAsMap();
+			if (!allowedLicensesMap.containsValue(licenseGroup)) {
+				throw new WrongReferenceAttributeValueException(attribute, allowedLicenses,
+					"The license group: " + licenseGroup + " is not allowed for this Facility. (Not present in m365ALlowedLicensesPriorities facility attribute)");
+			}
+		} catch (AttributeNotExistsException | WrongAttributeAssignmentException e) {
+			throw new WrongReferenceAttributeValueException("Error checking attribute semantics.", e);
+        }
+	}
+
+	@Override
+	public List<String> getDependencies() {
+		List<String> dependencies = new ArrayList<>();
+		dependencies.add(A_FAC_m365AllowedLicensesPriorities);
+		return dependencies;
+	}
+
+	@Override
+	public AttributeDefinition getAttributeDefinition() {
+		AttributeDefinition attr = new AttributeDefinition();
+		attr.setNamespace(AttributesManager.NS_RESOURCE_ATTR_DEF);
+		attr.setFriendlyName("m365LicenseGroup");
+		attr.setDisplayName("M365 License Group");
+		attr.setType(String.class.getName());
+		attr.setDescription("Specify name of license the group represents");
+		return attr;
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_m365AllowedLicensesPrioritiesTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_m365AllowedLicensesPrioritiesTest.java
@@ -1,0 +1,219 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Facility;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+
+public class urn_perun_facility_attribute_def_def_m365AllowedLicensesPrioritiesTest {
+	private static urn_perun_facility_attribute_def_def_m365AllowedLicensesPriorities classInstance;
+	private static PerunSessionImpl session;
+	private static Facility facility;
+	private static Attribute attributeToCheck;
+
+	@Before
+	public void setUp() {
+		classInstance = new urn_perun_facility_attribute_def_def_m365AllowedLicensesPriorities();
+		session = mock(PerunSessionImpl.class, RETURNS_DEEP_STUBS);
+		facility = new Facility();
+		attributeToCheck = new Attribute();
+		attributeToCheck.setFriendlyName("m365AllowedLicensesPriorities");
+	}
+
+	// SYNTAX CHECKS
+
+	@Test
+	public void testAttributeSyntaxValidMap() throws Exception {
+		System.out.println("testAttributeSyntaxValidMap()");
+
+		LinkedHashMap<String, String> map = new LinkedHashMap<>();
+		map.put("1", "A1");
+		map.put("2", "A2");
+		attributeToCheck.setValue(map);
+		classInstance.checkAttributeSyntax(session, facility, attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testAttributeSyntaxNullKey() throws Exception {
+		System.out.println("testAttributeSyntaxNullKey()");
+
+		LinkedHashMap<String, String> map = new LinkedHashMap<>();
+		map.put(null, "A1");
+		attributeToCheck.setValue(map);
+		classInstance.checkAttributeSyntax(session, facility, attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testAttributeSyntaxNullMapValue() throws Exception {
+		System.out.println("testAttributeSyntaxNullMapValue()");
+
+		LinkedHashMap<String, String> map = new LinkedHashMap<>();
+		map.put("1", "A1");
+		map.put("3", null);
+		attributeToCheck.setValue(map);
+		classInstance.checkAttributeSyntax(session, facility, attributeToCheck);
+	}
+
+	@Test
+	public void testAttributeSyntaxNullValue() throws Exception {
+		System.out.println("testAttributeSyntaxNullValue()");
+
+		attributeToCheck.setValue(null);
+		classInstance.checkAttributeSyntax(session, facility, attributeToCheck);
+	}
+
+	// SEMANTICS CHECKS
+
+	@Test
+	public void testCheckAttributeSemanticsAllLicensesMatch() throws Exception {
+		System.out.println("testCheckAttributeSemanticsAllLicensesMatch()");
+
+		LinkedHashMap<String, String> map = new LinkedHashMap<>();
+		map.put("1", "A1");
+		map.put("2", "A2");
+		attributeToCheck.setValue(map);
+
+		// Mock two resources with matching licences
+		List<Resource> resources = Arrays.asList(mock(Resource.class), mock(Resource.class));
+		when(session.getPerunBl().getFacilitiesManagerBl().getAssignedResources(any(), any())).thenReturn(resources);
+
+		Attribute res1License = new Attribute();
+		Attribute res2License = new Attribute();
+		res1License.setValue("A1");
+		res2License.setValue("A2");
+		when(session.getPerunBl().getAttributesManagerBl().getAttribute(any(), eq(resources.get(0)), any())).thenReturn(res1License);
+		when(session.getPerunBl().getAttributesManagerBl().getAttribute(any(), eq(resources.get(1)), any())).thenReturn(res2License);
+
+		classInstance.checkAttributeSemantics(session, facility, attributeToCheck);
+	}
+
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testCheckAttributeSemanticsLicenseMismatchSingleLicense() throws Exception {
+		System.out.println("testCheckAttributeSemanticsLicenseMismatchSingleLicense()");
+
+		LinkedHashMap<String, String> map = new LinkedHashMap<>();
+		map.put("1", "A1");
+		attributeToCheck.setValue(map);
+
+		// Mock a resource with mismatched license
+		List<Resource> resources = Collections.singletonList(mock(Resource.class));
+		when(session.getPerunBl().getFacilitiesManagerBl().getAssignedResources(any(), any())).thenReturn(resources);
+
+		Attribute resLicense = new Attribute();
+		resLicense.setValue("A2");
+		when(session.getPerunBl().getAttributesManagerBl().getAttribute(any(), eq(resources.get(0)), any())).thenReturn(resLicense);
+
+		classInstance.checkAttributeSemantics(session, facility, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testCheckAttributeSemanticsSingleMismatchedLicense() throws Exception {
+		System.out.println("testCheckAttributeSemanticsSingleMismatchedLicense()");
+
+		LinkedHashMap<String, String> map = new LinkedHashMap<>();
+		map.put("1", "A1");
+		map.put("2", "A2");
+		map.put("3", "A3");
+		attributeToCheck.setValue(map);
+
+		// Mock multiple resources with one of them having a mismatched license
+		Resource res1 = mock(Resource.class);
+		Resource res2 = mock(Resource.class);
+		Resource res3 = mock(Resource.class);
+
+		List<Resource> resources = Arrays.asList(res1, res2, res3);
+		when(session.getPerunBl().getFacilitiesManagerBl().getAssignedResources(any(), any())).thenReturn(resources);
+
+		Attribute res1License = new Attribute();
+		Attribute res2License = new Attribute();
+		Attribute res3License = new Attribute();
+		res1License.setValue("A2");
+		res1License.setValue("A1");
+		res1License.setValue("B42");
+		when(session.getPerunBl().getAttributesManagerBl().getAttribute(any(), eq(resources.get(0)), any())).thenReturn(res1License);
+		when(session.getPerunBl().getAttributesManagerBl().getAttribute(any(), eq(resources.get(1)), any())).thenReturn(res2License);
+		when(session.getPerunBl().getAttributesManagerBl().getAttribute(any(), eq(resources.get(2)), any())).thenReturn(res3License);
+
+		classInstance.checkAttributeSemantics(session, facility, attributeToCheck);
+	}
+
+	@Test
+	public void testCheckAttributeSemanticsNoLicensesNoResources() throws Exception {
+		System.out.println("testCheckAttributeSemanticsNoLicensesNoResources()");
+
+		attributeToCheck.setValue(null);
+		classInstance.checkAttributeSemantics(session, facility, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testCheckAttributeSemanticsNoLicensesResourcesExist() throws Exception {
+		System.out.println("testCheckAttributeSemanticsNoLicensesResourcesExist()");
+
+		attributeToCheck.setValue(null);
+
+		// Mock a resource, its license does not matter
+		List<Resource> resources = Collections.singletonList(mock(Resource.class));
+		when(session.getPerunBl().getFacilitiesManagerBl().getAssignedResources(any(), any())).thenReturn(resources);
+
+		Attribute resLicense = new Attribute();
+		resLicense.setValue("A1");
+		when(session.getPerunBl().getAttributesManagerBl().getAttribute(any(), eq(resources.get(0)), any())).thenReturn(resLicense);
+
+		classInstance.checkAttributeSemantics(session, facility, attributeToCheck);
+	}
+
+	@Test(expected = InternalErrorException.class)
+	public void testCheckAttributeSemanticsExceptionInFetchingResources() throws Exception {
+		System.out.println("testCheckAttributeSemanticsExceptionInFetchingResources()");
+
+		LinkedHashMap<String, String> map = new LinkedHashMap<>();
+		map.put("1", "A1");
+		attributeToCheck.setValue(map);
+
+		// Throw an exception when fetching resources
+		when(session.getPerunBl().getFacilitiesManagerBl().getAssignedResources(any(), any()))
+			.thenThrow(new InternalErrorException(""));
+
+		classInstance.checkAttributeSemantics(session, facility, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testExceptionInFetchingLicenseForResource() throws Exception {
+		System.out.println("testExceptionInFetchingLicenseForResource()");
+
+		LinkedHashMap<String, String> map = new LinkedHashMap<>();
+		map.put("1", "A1");
+		attributeToCheck.setValue(map);
+
+		// Mock a resource
+		Resource resource = mock(Resource.class);
+		List<Resource> resources = Collections.singletonList(resource);
+		when(session.getPerunBl().getFacilitiesManagerBl().getAssignedResources(any(), any())).thenReturn(resources);
+
+		// Throw an exception when fetching a license for the resource
+		when(session.getPerunBl().getAttributesManagerBl().getAttribute(any(), eq(resource), any()))
+			.thenThrow(new AttributeNotExistsException(""));
+
+		classInstance.checkAttributeSemantics(session, facility, attributeToCheck);
+	}
+
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_m365LicenseGroupTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_m365LicenseGroupTest.java
@@ -1,0 +1,125 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.Facility;
+import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.LinkedHashMap;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class urn_perun_resource_attribute_def_def_m365LicenseGroupTest {
+	private static urn_perun_resource_attribute_def_def_m365LicenseGroup classInstance;
+	private static PerunSessionImpl session;
+	private static Resource resource;
+	private static Facility facility;
+	private static Attribute attributeToCheck;
+
+	@Before
+	public void setUp() {
+		classInstance = new urn_perun_resource_attribute_def_def_m365LicenseGroup();
+		session = mock(PerunSessionImpl.class, RETURNS_DEEP_STUBS);
+		resource = new Resource();
+		facility = new Facility();
+		attributeToCheck = new Attribute();
+		attributeToCheck.setFriendlyName("m365LicenseGroup");
+	}
+
+	@Test
+	public void testAttributeSyntaxValid() throws Exception {
+		System.out.println("testAttributeSyntaxValid()");
+
+		attributeToCheck.setValue("LicenseGroupA");
+		classInstance.checkAttributeSyntax(session, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testAttributeSyntaxValidNull() throws Exception {
+		System.out.println("testAttributeSyntaxInvalidNull()");
+
+		attributeToCheck.setValue(null);
+		classInstance.checkAttributeSyntax(session, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testAttributeSyntaxValidEmpty() throws Exception {
+		System.out.println("testAttributeSyntaxInvalidEmpty()");
+
+		attributeToCheck.setValue("");
+		classInstance.checkAttributeSyntax(session, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testAttributeSemanticsNullLicenseGroup() throws Exception {
+		System.out.println("testAttributeSemanticsNullLicenseGroup()");
+
+		attributeToCheck.setValue(null);
+		classInstance.checkAttributeSemantics(session, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testAttributeSemanticsEmptyLicenseGroup() throws Exception {
+		System.out.println("testAttributeSemanticsEmptyLicenseGroup()");
+
+		attributeToCheck.setValue("");
+		classInstance.checkAttributeSemantics(session, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testAttributeSemanticsValidLicenseGroup() throws Exception {
+		System.out.println("testAttributeSemanticsValidLicenseGroup()");
+
+		attributeToCheck.setValue("LicenseGroupA");
+		when(session.getPerunBl().getResourcesManagerBl().getFacility(any(), eq(resource))).thenReturn(facility);
+
+		// Mock allowed licenses for the facility
+		Attribute allowedLicensesAttribute = new Attribute();
+		LinkedHashMap<String, String> allowedLicensesMap = new LinkedHashMap<>();
+		allowedLicensesMap.put("1", "LicenseGroupA");
+		allowedLicensesMap.put("2", "LicenseGroupB");
+		allowedLicensesAttribute.setValue(allowedLicensesMap);
+		when(session.getPerunBl().getAttributesManagerBl().getAttribute(any(), eq(facility), any())).thenReturn(allowedLicensesAttribute);
+
+		classInstance.checkAttributeSemantics(session, resource, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testAttributeSemanticsInvalidLicenseGroup() throws Exception {
+		System.out.println("testAttributeSemanticsInvalidLicenseGroup()");
+
+		attributeToCheck.setValue("LicenseGroupB");
+		when(session.getPerunBl().getResourcesManagerBl().getFacility(any(), eq(resource))).thenReturn(facility);
+
+		// Mock allowed licenses for the facility
+		Attribute allowedLicensesAttribute = new Attribute();
+		LinkedHashMap<String, String> allowedLicensesMap = new LinkedHashMap<>();
+		allowedLicensesMap.put("1", "LicenseGroupA");
+		allowedLicensesAttribute.setValue(allowedLicensesMap);
+		when(session.getPerunBl().getAttributesManagerBl().getAttribute(any(), eq(facility), any())).thenReturn(allowedLicensesAttribute);
+
+		classInstance.checkAttributeSemantics(session, resource, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testAttributeSemanticsExceptionInFetchingLicenses() throws Exception {
+		System.out.println("testAttributeSemanticsExceptionInFetchingLicenses()");
+
+		attributeToCheck.setValue("LicenseGroupA");
+		when(session.getPerunBl().getResourcesManagerBl().getFacility(any(), eq(resource))).thenReturn(facility);
+
+		// Throw an exception when trying to fetch allowed licenses
+		when(session.getPerunBl().getAttributesManagerBl().getAttribute(any(), eq(facility), any())).thenThrow(new AttributeNotExistsException(""));
+
+		classInstance.checkAttributeSemantics(session, resource, attributeToCheck);
+	}
+
+}


### PR DESCRIPTION
* Added new attribute modules for m365LicenseGroup and m365AllowedLicensesPriorities.
* Adhering to rules set in https://perunaai.atlassian.net/jira/software/projects/ST/boards/5?selectedIssue=ST-1226