### PR TITLE
fix(registrar): transaction for approving multiple applications

### DIFF
--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
@@ -1745,11 +1745,10 @@ public class RegistrarManagerImpl implements RegistrarManager {
 	}
 
 	@Override
-	@Transactional(rollbackFor = Exception.class)
 	public void rejectApplications(PerunSession sess, List<Integer> applicationIds, String reason) throws PerunException {
 		Collections.sort(applicationIds, Collections.reverseOrder());
 		for (Integer id : applicationIds) {
-			rejectApplication(sess, id, reason);
+			registrarManager.rejectApplication(sess, id, reason);
 		}
 	}
 
@@ -1851,7 +1850,6 @@ public class RegistrarManagerImpl implements RegistrarManager {
 	}
 
 	@Override
-	@Transactional(rollbackFor = Exception.class)
 	public void approveApplications(PerunSession sess, List<Integer> applicationIds) throws PerunException {
 		Collections.sort(applicationIds);
 		for (Integer id : applicationIds) {


### PR DESCRIPTION
- Approval or rejection of multiple applications can't run in a single transaction since it is subject to non-revertible effects (like sending emails).
- We can't afford to rollback action on X applications just because one of them failed.
- GUI should be probably updated to handle this change and maybe also server can provide better feedback.