### PR TITLE
fix(registrar): pass registrar session when submitting embedded applications

### DIFF
--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
@@ -1955,7 +1955,7 @@ public class RegistrarManagerImpl implements RegistrarManager {
 				groupApplication.setExtSourceType(app.getExtSourceType());
 				groupApplication.setCreatedBy("Automatically generated");
 
-				submitApplication(sess, groupApplication, new ArrayList<>());
+				submitApplication(registrarSession, groupApplication, new ArrayList<>());
 			} catch (Exception e) {
 				failedGroups.put(group.getId(), e.getMessage());
 			}


### PR DESCRIPTION
- We passed session of approving person but used methods are relying on the fact, that session is properly related to the person submitting its own application.
- This now fails to submit embedded application for a group if approving person is a member of such group - even if application is related to a different user.
- Usage of internal registrar session should be more appropriate, but should be thoroughly tested!