### PR TITLE
fix(registrar): pass registrar session when submitting embedded appli…

### DIFF
--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
@@ -1955,7 +1955,7 @@ public class RegistrarManagerImpl implements RegistrarManager {
 				groupApplication.setExtSourceType(app.getExtSourceType());
 				groupApplication.setCreatedBy("Automatically generated");
 
-				submitApplication(sess, groupApplication, new ArrayList<>());
+				submitApplication(registrarSession, groupApplication, new ArrayList<>());
 			} catch (Exception e) {
 				log.error("Error submitting embedded application {}", e);
 				failedGroups.put(group.getId(), e.getMessage());
@@ -3057,7 +3057,7 @@ public class RegistrarManagerImpl implements RegistrarManager {
 			// If the item has no options for the user to offer (bcs user is already member in all possible options,
 			// remove it from the form completely
 			if (StringUtils.isBlank(item.getFormItem().getI18n().get(ApplicationFormItem.EN).getOptions())) {
-				it.remove();
+				itemsIt.remove();
 			}
 		}
 
@@ -3313,8 +3313,11 @@ public class RegistrarManagerImpl implements RegistrarManager {
 					// pass not member and have only approved or rejected apps
 				}
 			}
-			// if false, throws exception with reason for GUI
-			membersManager.canBeMemberWithReason(sess, vo, user, String.valueOf(extSourceLoa));
+			// check for embedded applications was already done in original app, this would always fail because of registrar session
+			if (!AppType.EMBEDDED.equals(appType)) {
+				// if false, throws exception with reason for GUI
+				membersManager.canBeMemberWithReason(sess, vo, user, String.valueOf(extSourceLoa));
+			}
 		}
 		// if extension, user != null !!
 		if (AppType.EXTENSION.equals(appType)) {


### PR DESCRIPTION
…cations

* We passed session of approving person but used methods are relying on the fact, that session is properly related to the person submitting its own application.
* This now fails to submit embedded application for a group if approving person is a member of such group - even if application is related to a different user.
* Usage of internal registrar session should be more appropriate
* Do not check VO LOA membership rules for embedded applications, this is already checked in base applications
* Fixed typo that prevented application form to load in registrar if the application was "EXTENSION" and included embedded groups item
* Original PR by https://github.com/zlamalp