### PR TITLE
fix(core): admins-related methods

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/AuthzResolver.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/AuthzResolver.java
@@ -1385,6 +1385,39 @@ public class AuthzResolver {
 	}
 
 	/**
+	 * Get all valid user administrators (for group-based rights, status must be VALID for both Vo and group) for complementary object and role.
+	 *
+	 * If <b>onlyDirectAdmins</b> is <b>true</b>, return only direct users of the complementary object for role.
+	 *
+	 * @param sess perun session
+	 * @param complementaryObject for which we will get administrator
+	 * @param role expected role to filter managers by
+	 * @param onlyDirectAdmins if true, get only direct user administrators (if false, get both direct and indirect)
+	 *
+	 * @return list of user administrators for complementary object and role.
+	 */
+	public static List<User> getAdmins(PerunSession sess, PerunBean complementaryObject, String role, boolean onlyDirectAdmins) throws PrivilegeException, RoleCannotBeManagedException {
+		Utils.checkPerunSession(sess);
+		Utils.notNull(role, "role");
+		Utils.notNull(complementaryObject, "complementaryObject");
+
+		if (!roleExists(role)) {
+			throw new InternalErrorException("Role: " + role + " does not exists.");
+		}
+
+		// Authorization
+		try {
+			if(!authorizedToReadRole(sess, complementaryObject, role)) {
+				throw new PrivilegeException("You are not privileged to use the method getRichAdmins.");
+			}
+		} catch (RoleManagementRulesNotExistsException e) {
+			throw new InternalErrorException("Management rules not exist for the role " + role, e);
+		}
+
+		return AuthzResolverBlImpl.getAdmins(sess, complementaryObject, role, onlyDirectAdmins);
+	}
+
+	/**
 	 * Get all authorizedGroups for complementary object and role.
 	 *
 	 * @param sess perun session

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/FacilitiesManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/FacilitiesManager.java
@@ -505,6 +505,7 @@ public interface FacilitiesManager {
 	 * @param onlyDirectAdmins if true, get only direct user administrators (if false, get both direct and indirect)
 	 * @return list of all user administrators of the given facility for supported role
 	 */
+	@Deprecated
 	List<User> getAdmins(PerunSession perunSession, Facility facility, boolean onlyDirectAdmins) throws PrivilegeException, FacilityNotExistsException;
 
 	/**
@@ -521,6 +522,7 @@ public interface FacilitiesManager {
 	 * @param onlyDirectAdmins   if true, get only direct user administrators (if false, get both direct and indirect)
 	 * @return list of RichUser administrators for the facility and supported role with attributes
 	 */
+	@Deprecated
 	List<RichUser> getRichAdmins(PerunSession perunSession, Facility facility, List<String> specificAttributes, boolean allUserAttributes, boolean onlyDirectAdmins) throws UserNotExistsException, PrivilegeException, FacilityNotExistsException;
 
 	/**
@@ -544,6 +546,7 @@ public interface FacilitiesManager {
 	 *
 	 * @return list of Group that are admins in the facility.
 	 */
+	@Deprecated
 	List<Group> getAdminGroups(PerunSession sess, Facility facility) throws PrivilegeException, FacilityNotExistsException;
 
 	/**

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/GroupsManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/GroupsManager.java
@@ -817,6 +817,7 @@ public interface GroupsManager {
 	 * @throws PrivilegeException
 	 * @throws GroupNotExistsException
 	 */
+	@Deprecated
 	List<User> getAdmins(PerunSession perunSession, Group group, boolean onlyDirectAdmins) throws PrivilegeException, GroupNotExistsException;
 
 	/**
@@ -842,6 +843,7 @@ public interface GroupsManager {
 	 * @throws UserNotExistsException
 	 * @throws GroupNotExistsException
 	 */
+	@Deprecated
 	List<RichUser> getRichAdmins(PerunSession perunSession, Group group, List<String> specificAttributes, boolean allUserAttributes, boolean onlyDirectAdmins) throws UserNotExistsException, PrivilegeException, GroupNotExistsException;
 
 	/**
@@ -925,6 +927,7 @@ public interface GroupsManager {
 	 *
 	 * @return list of all group administrators of the given group
 	 */
+	@Deprecated
 	List<Group> getAdminGroups(PerunSession perunSession, Group group) throws PrivilegeException, GroupNotExistsException;
 
 	/**

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/ResourcesManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/ResourcesManager.java
@@ -962,6 +962,7 @@ public interface ResourcesManager {
 	 * @throws PrivilegeException
 	 * @throws ResourceNotExistsException
 	 */
+	@Deprecated
 	List<User> getAdmins(PerunSession perunSession, Resource resource, boolean onlyDirectAdmins) throws PrivilegeException, ResourceNotExistsException;
 
 	/**
@@ -987,6 +988,7 @@ public interface ResourcesManager {
 	 * @throws UserNotExistsException
 	 * @throws ResourceNotExistsException
 	 */
+	@Deprecated
 	List<RichUser> getRichAdmins(PerunSession perunSession, Resource resource, List<String> specificAttributes, boolean allUserAttributes, boolean onlyDirectAdmins) throws UserNotExistsException, PrivilegeException, ResourceNotExistsException;
 
 	/**
@@ -1062,6 +1064,7 @@ public interface ResourcesManager {
 	 * @throws InternalErrorException
 	 * @throws PrivilegeException
 	 */
+	@Deprecated
 	List<Group> getAdminGroups(PerunSession sess, Resource resource) throws PrivilegeException, ResourceNotExistsException;
 
 	/**

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/SecurityTeamsManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/SecurityTeamsManager.java
@@ -129,17 +129,19 @@ public interface SecurityTeamsManager {
 	 * @throws PrivilegeException Can do only PerunAdmin or SecurityAdmin of the SecurityTeam
 	 * @throws SecurityTeamNotExistsException
 	 */
+	@Deprecated
 	List<User> getAdmins(PerunSession perunSession, SecurityTeam securityTeam, boolean onlyDirectAdmins) throws PrivilegeException, SecurityTeamNotExistsException;
 
 	/**
 	 * Gets list of all group administrators of the SecurityTeam.
 	 *
 	 * @param sess
-	 * @param SecurityTeam
+	 * @param securityTeam
 	 * @return list of Group that are admins in the SecurityTeam.
 	 * @throws InternalErrorException
 	 * @throws PrivilegeException
 	 */
+	@Deprecated
 	List<Group> getAdminGroups(PerunSession sess, SecurityTeam securityTeam) throws PrivilegeException, SecurityTeamNotExistsException;
 
 	/**

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/VosManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/VosManager.java
@@ -311,6 +311,7 @@ public interface VosManager {
 	 * @throws RoleNotSupportedException
 	 * @throws VoNotExistsException
 	 */
+	@Deprecated
 	List<User> getAdmins(PerunSession perunSession, Vo vo, String role, boolean onlyDirectAdmins) throws PrivilegeException, VoNotExistsException, RoleNotSupportedException;
 
 	/**
@@ -337,6 +338,7 @@ public interface VosManager {
 	 * @throws RoleNotSupportedException
 	 * @throws UserNotExistsException
 	 */
+	@Deprecated
 	List<RichUser> getRichAdmins(PerunSession perunSession, Vo vo, String role, List<String> specificAttributes, boolean allUserAttributes, boolean onlyDirectAdmins) throws PrivilegeException, VoNotExistsException, RoleNotSupportedException, UserNotExistsException;
 
 	/**
@@ -355,6 +357,7 @@ public interface VosManager {
 	 * @throws PrivilegeException
 	 * @throws RoleNotSupportedException
 	 */
+	@Deprecated
 	List<Group> getAdminGroups(PerunSession perunSession, Vo vo, String role) throws PrivilegeException, VoNotExistsException, RoleNotSupportedException;
 
 	/**

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
@@ -2223,6 +2223,29 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 	}
 
 	/**
+	 * Get all valid user administrators (for group-based rights, status must be VALID for both Vo and group) for complementary object and role.
+	 *
+	 * If <b>onlyDirectAdmins</b> is <b>true</b>, return only direct users of the complementary object for role.
+	 *
+	 * @param sess perun session
+	 * @param complementaryObject for which we will get administrator
+	 * @param role expected role to filter managers by
+	 * @param onlyDirectAdmins if true, get only direct user administrators (if false, get both direct and indirect)
+	 *
+	 * @return list of user administrators for complementary object and role.
+	 */
+	public static List<User> getAdmins(PerunSession sess, PerunBean complementaryObject, String role, boolean onlyDirectAdmins) throws RoleCannotBeManagedException {
+
+		if (!objectAndRoleManageableByEntity(userObjectType, complementaryObject, role)) {
+			throw new RoleCannotBeManagedException(role, complementaryObject);
+		}
+
+		Map<String, Integer> mappingOfValues = createMappingToReadRoleOnObject(complementaryObject, role);
+
+		return authzResolverImpl.getAdmins(mappingOfValues, onlyDirectAdmins);
+	}
+
+	/**
 	 * Get all valid richUser administrators (for group-based rights, status must be VALID for both Vo and group) for complementary object and role without any attributes.
 	 *
 	 * @param sess perun session

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/FacilitiesManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/FacilitiesManagerMethod.java
@@ -6,7 +6,9 @@ import cz.metacentrum.perun.core.api.*;
 import java.util.ArrayList;
 import java.util.List;
 
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.PerunException;
+import cz.metacentrum.perun.core.api.exceptions.RoleCannotBeManagedException;
 import cz.metacentrum.perun.rpc.ApiCaller;
 import cz.metacentrum.perun.rpc.ManagerMethod;
 import cz.metacentrum.perun.core.api.exceptions.RpcException;
@@ -1119,14 +1121,14 @@ public enum FacilitiesManagerMethod implements ManagerMethod {
 
 		@Override
 		public List<User> call(ApiCaller ac, Deserializer parms) throws PerunException {
-
-			if(parms.contains("onlyDirectAdmins")) {
-				return ac.getFacilitiesManager().getAdmins(ac.getSession(),
-						getFacility(ac, parms),
-						parms.readBoolean("onlyDirectAdmins"));
-			} else {
-				return ac.getFacilitiesManager().getAdmins(ac.getSession(),
-						getFacility(ac, parms));
+			try {
+				if(parms.contains("onlyDirectAdmins")) {
+					return AuthzResolver.getAdmins(ac.getSession(), getFacility(ac, parms), Role.FACILITYADMIN, parms.readBoolean("onlyDirectAdmins"));
+				} else {
+					return AuthzResolver.getAdmins(ac.getSession(), getFacility(ac, parms), Role.FACILITYADMIN, false);
+				}
+			} catch (RoleCannotBeManagedException ex) {
+				throw new InternalErrorException(ex);
 			}
 		}
 	},
@@ -1142,9 +1144,11 @@ public enum FacilitiesManagerMethod implements ManagerMethod {
 
 		@Override
 		public List<User> call(ApiCaller ac, Deserializer parms) throws PerunException {
-
-			return ac.getFacilitiesManager().getDirectAdmins(ac.getSession(),
-					getFacility(ac, parms));
+			try {
+				return AuthzResolver.getAdmins(ac.getSession(), getFacility(ac, parms), Role.FACILITYADMIN, true);
+			} catch (RoleCannotBeManagedException ex) {
+				throw new InternalErrorException(ex);
+			}
 		}
 	},
 
@@ -1164,9 +1168,11 @@ public enum FacilitiesManagerMethod implements ManagerMethod {
 
 		@Override
 		public List<Group> call(ApiCaller ac, Deserializer parms) throws PerunException {
-
-			return ac.getFacilitiesManager().getAdminGroups(ac.getSession(),
-					getFacility(ac, parms));
+			try {
+				return AuthzResolver.getAdminGroups(ac.getSession(), getFacility(ac, parms), Role.FACILITYADMIN);
+			} catch (RoleCannotBeManagedException ex) {
+				throw new InternalErrorException(ex);
+			}
 		}
 	},
 
@@ -1220,16 +1226,24 @@ public enum FacilitiesManagerMethod implements ManagerMethod {
 
 		@Override
 		public List<RichUser> call(ApiCaller ac, Deserializer parms) throws PerunException {
-
-			if(parms.contains("onlyDirectAdmins")) {
-				return ac.getFacilitiesManager().getRichAdmins(ac.getSession(),
+			try {
+				if(parms.contains("onlyDirectAdmins")) {
+					return AuthzResolver.getRichAdmins(ac.getSession(),
 						getFacility(ac, parms),
 						parms.readList("specificAttributes", String.class),
-						parms.readBoolean("allUserAttributes"),
-						parms.readBoolean("onlyDirectAdmins"));
-			} else {
-				return ac.getFacilitiesManager().getRichAdmins(ac.getSession(),
-						getFacility(ac, parms));
+						Role.FACILITYADMIN,
+						parms.readBoolean("onlyDirectAdmins"),
+						parms.readBoolean("allUserAttributes"));
+				} else {
+					return AuthzResolver.getRichAdmins(ac.getSession(),
+						getFacility(ac, parms),
+						new ArrayList<>(),
+						Role.FACILITYADMIN,
+						false,
+						false);
+				}
+			} catch (RoleCannotBeManagedException ex) {
+				throw new InternalErrorException(ex);
 			}
 		}
 	},
@@ -1252,9 +1266,16 @@ public enum FacilitiesManagerMethod implements ManagerMethod {
 
 		@Override
 		public List<RichUser> call(ApiCaller ac, Deserializer parms) throws PerunException {
-
-			return ac.getFacilitiesManager().getRichAdminsWithAttributes(ac.getSession(),
-					getFacility(ac, parms));
+			try {
+				return AuthzResolver.getRichAdmins(ac.getSession(),
+					getFacility(ac, parms),
+					new ArrayList<>(),
+					Role.FACILITYADMIN,
+					false,
+					true);
+			} catch (RoleCannotBeManagedException ex) {
+				throw new InternalErrorException(ex);
+			}
 		}
 	},
 
@@ -1278,10 +1299,16 @@ public enum FacilitiesManagerMethod implements ManagerMethod {
 
 		@Override
 		public List<RichUser> call(ApiCaller ac, Deserializer parms) throws PerunException {
-
-			return ac.getFacilitiesManager().getRichAdminsWithSpecificAttributes(ac.getSession(),
+			try {
+				return AuthzResolver.getRichAdmins(ac.getSession(),
 					getFacility(ac, parms),
-					parms.readList("specificAttributes", String.class));
+					parms.readList("specificAttributes", String.class),
+					Role.FACILITYADMIN,
+					false,
+					false);
+			} catch (RoleCannotBeManagedException ex) {
+				throw new InternalErrorException(ex);
+			}
 		}
 	},
 
@@ -1307,10 +1334,16 @@ public enum FacilitiesManagerMethod implements ManagerMethod {
 
 		@Override
 		public List<RichUser> call(ApiCaller ac, Deserializer parms) throws PerunException {
-
-			return ac.getFacilitiesManager().getDirectRichAdminsWithSpecificAttributes(ac.getSession(),
+			try {
+				return AuthzResolver.getRichAdmins(ac.getSession(),
 					getFacility(ac, parms),
-					parms.readList("specificAttributes", String.class));
+					parms.readList("specificAttributes", String.class),
+					Role.FACILITYADMIN,
+					true,
+					false);
+			} catch (RoleCannotBeManagedException ex) {
+				throw new InternalErrorException(ex);
+			}
 		}
 	},
 


### PR DESCRIPTION
- Added getAdmins method into AuthzResolver.
- Admins-related methods in managers use universal methods from AuthzResolver.

BREAKING CHANGE: Methods for obtaining admins return only users with valid status in the authorized group and the corresponding VO.